### PR TITLE
Replace deploy target with GitHub packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
   </properties>
   <distributionManagement>
     <repository>
-      <id>internal.repo</id>
-      <name>Temporary Staging Repository</name>
-      <url>file://${project.build.directory}/mvn-repo</url>
+      <id>github</id>
+      <name>GitHub ponder-lab Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/ponder-lab/ML</url>
     </repository>
   </distributionManagement>
   <modules>


### PR DESCRIPTION
We're not using the local staging area at the moment, and we can't have two deploy targets.