### PR TITLE
Reverting input to pass build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 jdk: openjdk11
 before_install:
  - git clone --depth=50 https://github.com/wala/IDE /tmp/IDE
- - git clone https://github.com/juliandolby/jython3.git /tmp/jython3
+ - git clone https://github.com/tatianacv/jython3.git /tmp/jython3
 install:
  - pushd /tmp/jython3
  - ant

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
@@ -27,7 +27,7 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 		});
 	}
 	
-	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/master/examples/03_connectivity/plot_group_level_connectivity.py";
+	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/d43706724a72df089080f62d9f1d9c319fa391b7/examples/03_connectivity/plot_group_level_connectivity.py";
 	
 	@Test
 	public void testEx2CG() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
@@ -27,7 +27,7 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 		});
 	}
 	
-	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/d43706724a72df089080f62d9f1d9c319fa391b7/examples/03_connectivity/plot_group_level_connectivity.py";
+	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/master/examples/03_connectivity/plot_group_level_connectivity.py";
 	
 	@Test
 	public void testEx2CG() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {


### PR DESCRIPTION
Workaround for #4.

Reverting to previous input that didn't contain Python 3.6-specific code.