### PR TITLE
Update .travis.yml to use RulePhaser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
  - pushd /tmp/jython3
  - ant
  - pushd dist
- - mvn install:install-file -Dfile=jython-dev.jar -DgroupId=org.python -DartifactId=jython3 -Dversion=0.0.9-SNAPSHOT -Dpackaging=jar
+ - mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
+ - popd
  - popd
  - pushd /tmp/IDE/com.ibm.wala.cast.lsp
  - mvn clean install -B -q -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ language: java
 jdk: openjdk11
 before_install:
  - git clone --depth=50 https://github.com/wala/IDE /tmp/IDE
- - git clone https://github.com/juliandolby/jython3.git /tmp/jython3
+ - git clone https://github.com/maldil/RulePharser.git /tmp/RulePharser
 install:
- - pushd /tmp/jython3
+ - pushd /tmp/RulePharser
  - ant
- - pushd dist
- - mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true
- - popd
+ - mvn install:install-file -Dfile=dist/jython-dev.jar -DgroupId=org.python -DartifactId=jython3 -Dversion=0.0.9-SNAPSHOT -Dpackaging=jar
  - popd
  - pushd /tmp/IDE/com.ibm.wala.cast.lsp
  - mvn clean install -B -q -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: java
 jdk: openjdk11
 before_install:
  - git clone --depth=50 https://github.com/wala/IDE /tmp/IDE
- - git clone https://github.com/maldil/RulePharser.git /tmp/RulePharser
+ - git clone https://github.com/maldil/RulePharser.git /tmp/jython3
 install:
- - pushd /tmp/RulePharser
+ - pushd /tmp/jython3
  - ant
  - mvn install:install-file -Dfile=dist/jython-dev.jar -DgroupId=org.python -DartifactId=jython3 -Dversion=0.0.9-SNAPSHOT -Dpackaging=jar
  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_install:
 install:
  - pushd /tmp/jython3
  - ant
- - mvn install:install-file -Dfile=dist/jython-dev.jar -DgroupId=org.python -DartifactId=jython3 -Dversion=0.0.9-SNAPSHOT -Dpackaging=jar
+ - pushd dist
+ - mvn install:install-file -Dfile=jython-dev.jar -DgroupId=org.python -DartifactId=jython3 -Dversion=0.0.9-SNAPSHOT -Dpackaging=jar
  - popd
  - pushd /tmp/IDE/com.ibm.wala.cast.lsp
  - mvn clean install -B -q -DskipTests

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
@@ -27,7 +27,7 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 		});
 	}
 	
-	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/d43706724a72df089080f62d9f1d9c319fa391b7/examples/03_connectivity/plot_group_level_connectivity.py";
+	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/master/examples/03_connectivity/plot_group_level_connectivity.py";
 	
 	@Test
 	public void testEx2CG() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {


### PR DESCRIPTION
As we can see in https://app.travis-ci.com/github/tatianacv/ML/builds/262877013#L46319, when using Rule Phaser, we still get the error `NoViableAltException` when changing the input URL.