### PR TITLE
Use Jython instead of Jython3

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/pom.xml
+++ b/com.ibm.wala.cast.python.ml.test/pom.xml
@@ -9,7 +9,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>com.ibm.wala.cast.python.jython3.test</artifactId>
+      <artifactId>com.ibm.wala.cast.python.jython.test</artifactId>
       <version>0.3.0-SNAPSHOT</version>
     </dependency>
    <dependency>

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
@@ -27,6 +27,9 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 		});
 	}
 	
+	/**
+	 * FIXME: Point to master branch of nilearn once https://github.com/ponder-lab/ML/issues/4 is fixed.
+	 */
 	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/d43706724a72df089080f62d9f1d9c319fa391b7/examples/03_connectivity/plot_group_level_connectivity.py";
 	
 	@Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestNeuroImageExamples.java
@@ -15,7 +15,6 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 
 	private static final String Ex1URL = "https://raw.githubusercontent.com/corticometrics/neuroimage-tensorflow/master/train.py";
 	
-	@Ignore // FIXME: Reinstate this test once https://github.com/wala/ML/issues/42 is fixed.
 	@Test
 	public void testEx1CG() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 		checkTensorOps(Ex1URL, (PropagationCallGraphBuilder cgBuilder, CallGraph CG, TensorTypeAnalysis result) -> {
@@ -28,7 +27,7 @@ public class TestNeuroImageExamples extends TestPythonMLCallGraphShape {
 		});
 	}
 	
-	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/master/examples/03_connectivity/plot_group_level_connectivity.py";
+	private static final String Ex2URL = "https://raw.githubusercontent.com/nilearn/nilearn/d43706724a72df089080f62d9f1d9c319fa391b7/examples/03_connectivity/plot_group_level_connectivity.py";
 	
 	@Test
 	public void testEx2CG() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>com.ibm.wala.cast.python.jython3</artifactId>
+      <artifactId>com.ibm.wala.cast.python.jython</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
- Use Jython instead of Jython 3 in the Python ML test and Python ML
- Remove the ignore from Test `testEx1CG`
- Reinstate the passing input for `testEx2CG`