### PR TITLE
Adding APIs that return tensor objects

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -94,7 +94,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 					}
 
 					if ((ni.getCallSite().getDeclaredTarget().getName().toString().equals("read_data")
-							|| Objects.equal(tensorFlowAPI, "ones")) && ni.getException() != vn) {
+							|| Objects.equal(tensorFlowAPI, "ones")) && ni.getException() != vn
+							|| Objects.equal(tensorFlowAPI, "Variable") && ni.getException() != vn
+							|| Objects.equal(tensorFlowAPI, "constant") && ni.getException() != vn
+							|| Objects.equal(tensorFlowAPI, "random.uniform") && ni.getException() != vn) {
 						sources.add(src);
 					}
 				}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -94,10 +94,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 					}
 
 					if ((ni.getCallSite().getDeclaredTarget().getName().toString().equals("read_data")
-							|| Objects.equal(tensorFlowAPI, "ones")) && ni.getException() != vn
-							|| Objects.equal(tensorFlowAPI, "Variable") && ni.getException() != vn
-							|| Objects.equal(tensorFlowAPI, "zeros") && ni.getException() != vn
-							|| Objects.equal(tensorFlowAPI, "constant") && ni.getException() != vn) {
+							|| Objects.equal(tensorFlowAPI, "ones") || Objects.equal(tensorFlowAPI, "Variable")
+							|| Objects.equal(tensorFlowAPI, "zeros") || Objects.equal(tensorFlowAPI, "constant"))
+							&& ni.getException() != vn) {
 						sources.add(src);
 					}
 				}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -96,8 +96,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 					if ((ni.getCallSite().getDeclaredTarget().getName().toString().equals("read_data")
 							|| Objects.equal(tensorFlowAPI, "ones")) && ni.getException() != vn
 							|| Objects.equal(tensorFlowAPI, "Variable") && ni.getException() != vn
-							|| Objects.equal(tensorFlowAPI, "constant") && ni.getException() != vn
-							|| Objects.equal(tensorFlowAPI, "random.uniform") && ni.getException() != vn) {
+							|| Objects.equal(tensorFlowAPI, "constant") && ni.getException() != vn) {
 						sources.add(src);
 					}
 				}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -96,6 +96,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 					if ((ni.getCallSite().getDeclaredTarget().getName().toString().equals("read_data")
 							|| Objects.equal(tensorFlowAPI, "ones")) && ni.getException() != vn
 							|| Objects.equal(tensorFlowAPI, "Variable") && ni.getException() != vn
+							|| Objects.equal(tensorFlowAPI, "zeros") && ni.getException() != vn
 							|| Objects.equal(tensorFlowAPI, "constant") && ni.getException() != vn) {
 						sources.add(src);
 					}


### PR DESCRIPTION
We are adding the following APIs that return tensor objects: 

1. `Variable`
2. `zeros`
3. `constant`