### PR TITLE
IllegalState when importing a second-level API directly

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -80,6 +80,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2o.py", "add", 2, 2, 3);
     testTf2("tf2p.py", "value_index", 2, 2, 3);
     testTf2("tf2q.py", "add", 2, 2, 3);
+    testTf2("tf2r.py", "add", 2, 2, 3);
   }
 
   private void testTf2(

--- a/com.ibm.wala.cast.python.test/data/tf2r.py
+++ b/com.ibm.wala.cast.python.test/data/tf2r.py
@@ -1,0 +1,7 @@
+from tensorflow import random
+
+def add(a, b):
+  return a + b
+
+
+c = add(random.uniform([1, 2]), random.uniform([2, 2]))


### PR DESCRIPTION
Refer to #28

Using `random.uniform` which we already have included in `master`.