### PR TITLE
Add test having a decorated function with a tensor parameter

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -105,6 +105,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2r.py", "add", 2, 3, 2, 3);
     // TODO: Uncomment below test when https://github.com/wala/ML/issues/65 is fixed.
     // testTf2("tf2s.py", "add", 2, 3, 2, 3);
+    testTf2("tf2t.py", "add", 2, 3, 2, 3);
   }
 
   private void testTf2(

--- a/com.ibm.wala.cast.python.test/data/tf2t.py
+++ b/com.ibm.wala.cast.python.test/data/tf2t.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+
+@tf.function
+def add(a, b):
+  return a + b
+
+a = tf.range(3, 18, 3)
+b = tf.range(5)
+c = add(a, b)


### PR DESCRIPTION
Adding this test in Ariadne so we can compare it with https://github.com/ponder-lab/Hybridize-Functions-Refactoring/pull/237