### PR TITLE
Ensure ML tests has non-empty JAR

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/pom.xml
+++ b/com.ibm.wala.cast.python.ml.test/pom.xml
@@ -60,6 +60,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
     </plugins>
+    <sourceDirectory>source</sourceDirectory>
     <testSourceDirectory>source</testSourceDirectory>
   </build>
 </project>


### PR DESCRIPTION
Otherwise, we get a warning in Maven saying the JAR will be empty.