### PR TITLE
Pass problematic tests

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -17,6 +17,7 @@ import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -245,7 +246,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     final String functionSignature = "script " + filename + "." + functionName + ".do()LRoot;";
 
     // get the pointer keys for the function.
-    Set<LocalPointerKey> functionPointerKeys = methodSignatureToPointerKeys.get(functionSignature);
+    Set<LocalPointerKey> functionPointerKeys = methodSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
     assertEquals(expectedNumberOfTensorParameters, functionPointerKeys.size());
@@ -261,7 +262,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         .forEach(ev -> actualValueNumberSet.contains(ev));
 
     // get the tensor variables for the function.
-    Set<TensorVariable> functionTensors = methodSignatureToTensorVariables.get(functionSignature);
+    Set<TensorVariable> functionTensors = methodSignatureToTensorVariables.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
     assertEquals(expectedNumberOfTensorParameters, functionTensors.size());

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -106,7 +106,11 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2p2.py", "value_index", 2, 4, 2, 3);
     testTf2("tf2q.py", "add", 2, 3, 2, 3);
     testTf2("tf2r.py", "add", 2, 3, 2, 3);
-    testTf2("tf2s.py", "add", 0, 0); // NOTE: Set the expected number of tensor parameters, variables, and tensor parameter value numbers to 2, 3, and 2 and 3, respectively, when https://github.com/wala/ML/issues/65 is fixed.
+    testTf2(
+        "tf2s.py", "add", 0,
+        0); // NOTE: Set the expected number of tensor parameters, variables, and tensor parameter
+    // value numbers to 2, 3, and 2 and 3, respectively, when
+    // https://github.com/wala/ML/issues/65 is fixed.
     testTf2("tf2t.py", "add", 2, 3, 2, 3);
     testTf2("tf2u.py", "add", 2, 3, 2, 3);
     testTf2("tf2u2.py", "add", 2, 3, 2, 3);
@@ -245,7 +249,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     final String functionSignature = "script " + filename + "." + functionName + ".do()LRoot;";
 
     // get the pointer keys for the function.
-    Set<LocalPointerKey> functionPointerKeys = methodSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
+    Set<LocalPointerKey> functionPointerKeys =
+        methodSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
     assertEquals(expectedNumberOfTensorParameters, functionPointerKeys.size());
@@ -261,7 +266,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         .forEach(ev -> actualValueNumberSet.contains(ev));
 
     // get the tensor variables for the function.
-    Set<TensorVariable> functionTensors = methodSignatureToTensorVariables.getOrDefault(functionSignature, Collections.emptySet());
+    Set<TensorVariable> functionTensors =
+        methodSignatureToTensorVariables.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
     assertEquals(expectedNumberOfTensorParameters, functionTensors.size());

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -106,8 +106,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2p2.py", "value_index", 2, 4, 2, 3);
     testTf2("tf2q.py", "add", 2, 3, 2, 3);
     testTf2("tf2r.py", "add", 2, 3, 2, 3);
-    // TODO: Uncomment below test when https://github.com/wala/ML/issues/65 is fixed.
-    // testTf2("tf2s.py", "add", 2, 3, 2, 3);
+    testTf2("tf2s.py", "add", 0, 0); // NOTE: Set the expected number of tensor parameters, variables, and tensor parameter value numbers to 2, 3, and 2 and 3, respectively, when https://github.com/wala/ML/issues/65 is fixed.
     testTf2("tf2t.py", "add", 2, 3, 2, 3);
     testTf2("tf2u.py", "add", 2, 3, 2, 3);
     testTf2("tf2u2.py", "add", 2, 3, 2, 3);


### PR DESCRIPTION
That way, when we fix the bug, the tests will fail, in which case we will know that our fix is working. Also, we won't forget to uncomment the problematic tests.