### PR TITLE
Forget about `from_tensor_slices()` for now.

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -204,6 +204,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     // tests below.
     testTf2("tf2_test_dataset.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_dataset2.py", "add", 2, 2, 2, 3);
+    testTf2("tf2_test_dataset3.py", "add", 2, 2, 2, 3);
+    testTf2("tf2_test_dataset4.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_tensor_list.py", "add", 2, 3, 2, 3);
     testTf2("tf2_test_tensor_list2.py", "add", 0, 2);
     testTf2("tf2_test_tensor_list3.py", "add", 0, 2);

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -804,8 +804,13 @@
       </class>
 
       <class name="shuffle" allocatable="true">
+        <method name="read_dataset" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/data/Dataset" />
+          <return value="x" />
+        </method>
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
-          <return value="self" />
+          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <return value="x" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -790,13 +790,22 @@
     <package name="tensorflow/data">
       <class name="Dataset" allocatable="true">
         <method name="read_dataset" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/data/shuffle/shuffle" />
+          <new def="x" class="Lobject" />
           <return value="x" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self variant_tensor">
           <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="self" value="x" />
-          <return value="arg0" />
+
+          <new def="shuffle" class="Ltensorflow/data/shuffle" />
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="shuffle" />
+
+          <return value="x" />
+        </method>
+      </class>
+
+      <class name="shuffle" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
+          <return value="self" />
         </method>
       </class>
     </package>
@@ -808,14 +817,6 @@
           <getfield class="LRoot" field="data" fieldType="LRoot" ref="arg1" def="data" />
           <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="xx" arg1="data" arg2="3" numArgs="3" def="v" />
           <return value="v" />
-        </method>
-      </class>
-    </package>
-
-    <package name="tensorflow/data/shuffle">
-      <class name="shuffle" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
-          <return value="self" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -790,7 +790,7 @@
     <package name="tensorflow/data">
       <class name="Dataset" allocatable="true">
         <method name="read_dataset" descriptor="()LRoot;">
-          <new def="x" class="Lobject" />
+          <new def="x" class="Ltensorflow/data/Dataset" />
           <return value="x" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self variant_tensor">

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -10,15 +10,6 @@
         <new def="train" class="Lobject" />
         <putfield class="LRoot" field="train" fieldType="LRoot" ref="x" value="train" />
 
-        <new def="data" class="Lobject" />
-        <putfield class="LRoot" field="data" fieldType="LRoot" ref="x" value="data" />
-
-        <new def="Dataset" class="Ltensorflow/data/Dataset" />
-        <putfield class="LRoot" field="Dataset" fieldType="LRoot" ref="data" value="Dataset" />
-
-        <new def="from_tensor_slices" class="Ltensorflow/data/Dataset/from_tensor_slices" />
-        <putfield class="LRoot" field="from_tensor_slices" fieldType="LRoot" ref="Dataset" value="from_tensor_slices" />
-
         <new def="function" class="Ltensorflow/class/function" />
         <putfield class="LRoot" field="function" fieldType="LRoot" ref="x" value="function" />
 
@@ -45,6 +36,9 @@
         <new def="estimator" class="Lobject" />
         <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator" />
 
+        <new def="data" class="Lobject" />
+        <putfield class="LRoot" field="data" fieldType="LRoot" ref="x" value="data" />
+
         <new def="distribute" class="Lobject" />
         <putfield class="LRoot" field="distribute" fieldType="LRoot" ref="x" value="distribute" />
 
@@ -69,6 +63,9 @@
 
         <new def="Estimator" class="Ltensorflow/estimator/Estimator" />
         <putfield class="LRoot" field="Estimator" fieldType="LRoot" ref="estimator" value="Estimator" />
+
+        <new def="Dataset" class="Ltensorflow/data/Dataset" />
+        <putfield class="LRoot" field="Dataset" fieldType="LRoot" ref="data" value="Dataset" />
 
         <new def="MirroredStrategy" class="Ltensorflow/distribute/MirroredStrategy" />
         <putfield class="LRoot" field="MirroredStrategy" fieldType="LRoot" ref="distribute" value="MirroredStrategy" />
@@ -334,29 +331,6 @@
 
     <package name="keras/objects">
       <class name="feature" allocatable="true" />
-    </package>
-
-    <package name="tensorflow/data">
-      <class name="Dataset" allocatable="true">
-        <method name="do" descriptor="()LRoot;">
-          <new def="dset" class="Lobject" />
-          <return value="dset" />
-        </method>
-      </class>
-    </package>
-
-    <package name="tensorflow/data/Dataset">
-      <class name="from_tensor_slices" allocatable="true">
-        <!-- "read_dataset" means that this function reads a tensor iterable. -->
-        <method name="read_dataset" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/data/Dataset" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensors name">
-          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
-        </method>
-      </class>
     </package>
 
     <package name="tensorflow/functions">
@@ -813,6 +787,20 @@
       </class>
     </package>
 
+    <package name="tensorflow/data">
+      <class name="Dataset" allocatable="true">
+        <method name="read_dataset" descriptor="()LRoot;">
+          <new def="x" class="Ltensorflow/data/shuffle/shuffle" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self variant_tensor">
+          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="self" value="x" />
+          <return value="arg0" />
+        </method>
+      </class>
+    </package>
+
     <package name="tensorflow/estimator/train">
       <class name="train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3">
@@ -820,6 +808,14 @@
           <getfield class="LRoot" field="data" fieldType="LRoot" ref="arg1" def="data" />
           <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="xx" arg1="data" arg2="3" numArgs="3" def="v" />
           <return value="v" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/data/shuffle">
+      <class name="shuffle" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
+          <return value="self" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -76,6 +76,9 @@
         <new def="numpy_input_fn" class="Ltensorflow/estimator/numpy_input_fn" />
         <putfield class="LRoot" field="numpy_input_fn" fieldType="LRoot" ref="inputs" value="numpy_input_fn" />
 
+        <new def="from_tensor_slices" class="Ltensorflow/data/Dataset/from_tensor_slices" />
+        <putfield class="LRoot" field="from_tensor_slices" fieldType="LRoot" ref="Dataset" value="from_tensor_slices" />
+
         <new def="reshape" class="Ltensorflow/functions/reshape" />
         <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape" />
 
@@ -789,28 +792,36 @@
 
     <package name="tensorflow/data">
       <class name="Dataset" allocatable="true">
+        <!-- "read_dataset" means that this function reads a tensor iterable. -->
         <method name="read_dataset" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/data/Dataset" />
-          <return value="x" />
+          <new def="shuffle" class="Ltensorflow/data/shuffle" />
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="arg0" value="shuffle" />
+          <return value="arg0" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self variant_tensor">
           <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-
-          <new def="shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="shuffle" />
-
           <return value="x" />
         </method>
       </class>
 
       <class name="shuffle" allocatable="true">
-        <method name="read_dataset" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/data/Dataset" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#shuffle -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
-          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <!-- FIXME: Workaround for https://github.com/wala/ML/issues/127. This method (shuffle) doesn't really return a "new" dataset but rather a modified version of the receiver.
+            But, the receiver isn't available without a trampoline AFAIK. -->
+          <new def="x" class="Ltensorflow/data/Dataset" />
+          <call class="Ltensorflow/data/Dataset" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="x" def="xx" />
+          <return value="xx" />
+        </method>
+      </class>
+    </package>
+
+    <package name="tensorflow/data/Dataset">
+      <class name="from_tensor_slices" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensors name">
+          <new def="x" class="Ltensorflow/data/Dataset" />
+          <call class="Ltensorflow/data/Dataset" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="x" def="xx" />
+          <return value="xx" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -133,7 +133,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
-   * Returns true iff the fiven {@link SSAInstruction} creates an iterable of tensors.
+   * Returns true iff the given {@link SSAInstruction} creates an iterable of tensors.
    *
    * @param instruction The {@link SSAInstruction} in question.
    * @param node The {@link CGNode} of the function containing the given {@link SSAInstruction}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -120,7 +120,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           EachElementGetInstruction eachElementGetInstruction = (EachElementGetInstruction) inst;
 
           // Find the potential tensor iterable creation site.
-          SSAInstruction def = du.getDef(eachElementGetInstruction.getUse(0));
+          int use = eachElementGetInstruction.getUse(0);
+          SSAInstruction def = du.getDef(use);
 
           if (createsTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
             sources.add(src);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -119,11 +119,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           // We are potentially pulling a tensor out of a tensor iterable.
           EachElementGetInstruction eachElementGetInstruction = (EachElementGetInstruction) inst;
 
-          // Find the potential tensor iterable creation site.
+          // Find the potential tensor iterable definition.
           int use = eachElementGetInstruction.getUse(0);
           SSAInstruction def = du.getDef(use);
 
-          if (createsTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
+          if (definesTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
             sources.add(src);
             logger.info("Added dataflow source from tensor iterable: " + src + ".");
           }
@@ -134,16 +134,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
-   * Returns true iff the given {@link SSAInstruction} creates an iterable of tensors.
+   * Returns true iff the given {@link SSAInstruction} defines an iterable of tensors.
    *
    * @param instruction The {@link SSAInstruction} in question.
    * @param node The {@link CGNode} of the function containing the given {@link SSAInstruction}.
    * @param callGraph The {@link CallGraph} that includes a node corresponding to the given {@link
    *     SSAInstruction}.
    * @param pointerAnalysis The {@link PointerAnalysis} built from the given {@link CallGraph}.
-   * @return True iff the given {@link SSAInstruction} creates an iterable over tensors.
+   * @return True iff the given {@link SSAInstruction} defines an iterable over tensors.
    */
-  private static boolean createsTensorIterable(
+  private static boolean definesTensorIterable(
       SSAInstruction instruction,
       CGNode node,
       CallGraph callGraph,

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset3.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def add(a, b):
+  return a + b
+
+
+dataset = tf.data.Dataset(None)  # This is actually illegal since this ctor is not publicly visible.
+
+for element in dataset:
+    c = add(element, element)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset4.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def add(a, b):
+  return a + b
+
+
+dataset = tf.data.Dataset(None).shuffle(3)  # This is actually illegal since this ctor is not publicly visible.
+
+for element in dataset:
+    c = add(element, element)


### PR DESCRIPTION
Instead, use the `Dataset()` ctor directly. It's not legal, because somehow that ctor isn't publicly accessible. But, doing so may give us a feel of how we can integrate the dataset operation chaining.
