### PR TITLE
Add interprocedural dataset support

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -262,7 +262,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
           if (pointerKey instanceof LocalPointerKey) {
             LocalPointerKey localPointerKey = (LocalPointerKey) pointerKey;
 
-            // get the call graph node associated with the
+            // get the call graph node associated with the pointer key.
             CGNode node = localPointerKey.getNode();
 
             // get the method associated with the call graph node.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -303,7 +303,9 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         methodSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
-    assertEquals(expectedNumberOfTensorParameters, functionPointerKeys.stream().filter(LocalPointerKey::isParameter).count());
+    assertEquals(
+        expectedNumberOfTensorParameters,
+        functionPointerKeys.stream().filter(LocalPointerKey::isParameter).count());
 
     // check value numbers.
     Set<Integer> actualValueNumberSet =

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -302,7 +302,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         methodSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
 
     // check tensor parameters.
-    assertEquals(expectedNumberOfTensorParameters, functionPointerKeys.size());
+    assertEquals(expectedNumberOfTensorParameters, functionPointerKeys.stream().filter(LocalPointerKey::isParameter).count());
 
     // check value numbers.
     Set<Integer> actualValueNumberSet =
@@ -317,12 +317,5 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
                 assertTrue(
                     "Expecting " + actualValueNumberSet + " to contain " + ev + ".",
                     actualValueNumberSet.contains(ev)));
-
-    // get the tensor variables for the function.
-    Set<TensorVariable> functionTensors =
-        methodSignatureToTensorVariables.getOrDefault(functionSignature, Collections.emptySet());
-
-    // check tensor parameters.
-    assertEquals(expectedNumberOfTensorParameters, functionTensors.size());
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -207,6 +207,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_dataset3.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_dataset4.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_dataset5.py", "add", 2, 2, 2, 3);
+    testTf2("tf2_test_dataset6.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_tensor_list.py", "add", 2, 3, 2, 3);
     testTf2("tf2_test_tensor_list2.py", "add", 0, 2);
     testTf2("tf2_test_tensor_list3.py", "add", 0, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -220,8 +220,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_model_call4.py", "SequentialModel.__call__", 1, 4, 3);
     testTf2("tf2_test_callbacks.py", "replica_fn", 1, 3, 2);
     testTf2("tf2_test_callbacks2.py", "replica_fn", 1, 4, 2);
-    testTf2("tensorflow_gan_tutorial.py", "train_step", 1, 10, 7);
-    testTf2("tensorflow_gan_tutorial2.py", "train_step", 1, 10, 7);
+    testTf2("tensorflow_gan_tutorial.py", "train_step", 1, 10, 2);
+    testTf2("tensorflow_gan_tutorial2.py", "train_step", 1, 10, 2);
   }
 
   private void testTf2(
@@ -309,17 +309,17 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         functionPointerKeys.stream().filter(LocalPointerKey::isParameter).count());
 
     // check value numbers.
-    Set<Integer> actualValueNumberSet =
-        functionPointerKeys.stream()
+    Set<Integer> actualParameterValueNumberSet =
+        functionPointerKeys.stream().filter(LocalPointerKey::isParameter)
             .map(LocalPointerKey::getValueNumber)
             .collect(Collectors.toSet());
 
-    assertEquals(expectedTensorParameterValueNumbers.length, actualValueNumberSet.size());
+    assertEquals(expectedTensorParameterValueNumbers.length, actualParameterValueNumberSet.size());
     Arrays.stream(expectedTensorParameterValueNumbers)
         .forEach(
             ev ->
                 assertTrue(
-                    "Expecting " + actualValueNumberSet + " to contain " + ev + ".",
-                    actualValueNumberSet.contains(ev)));
+                    "Expecting " + actualParameterValueNumberSet + " to contain " + ev + ".",
+                    actualParameterValueNumberSet.contains(ev)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -310,7 +310,8 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 
     // check value numbers.
     Set<Integer> actualParameterValueNumberSet =
-        functionPointerKeys.stream().filter(LocalPointerKey::isParameter)
+        functionPointerKeys.stream()
+            .filter(LocalPointerKey::isParameter)
             .map(LocalPointerKey::getValueNumber)
             .collect(Collectors.toSet());
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -208,6 +208,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_dataset4.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_dataset5.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_dataset6.py", "add", 2, 2, 2, 3);
+    testTf2("tf2_test_dataset7.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_tensor_list.py", "add", 2, 3, 2, 3);
     testTf2("tf2_test_tensor_list2.py", "add", 0, 2);
     testTf2("tf2_test_tensor_list3.py", "add", 0, 2);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -123,6 +123,15 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           int use = eachElementGetInstruction.getUse(0);
           SSAInstruction def = du.getDef(use);
 
+          if (def == null)
+            logger.warning(
+                () ->
+                    "Can't find potential tensor iterable definition for use: "
+                        + use
+                        + " of instruction: "
+                        + eachElementGetInstruction
+                        + ".");
+
           if (definesTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
             sources.add(src);
             logger.info("Added dataflow source from tensor iterable: " + src + ".");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET;
 import static com.ibm.wala.cast.types.AstMethodReference.fnReference;
 
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
@@ -123,16 +124,33 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           int use = eachElementGetInstruction.getUse(0);
           SSAInstruction def = du.getDef(use);
 
-          if (def == null)
+          if (def == null) {
             logger.warning(
                 () ->
                     "Can't find potential tensor iterable definition for use: "
                         + use
                         + " of instruction: "
                         + eachElementGetInstruction
-                        + ".");
+                        + ". Trying interprocedural analysis...");
 
-          if (definesTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
+            // Look up the use in the pointer analysis to see if it points to a dataset.
+            PointerKey usePointerKey =
+                pointerAnalysis.getHeapModel().getPointerKeyForLocal(localPointerKeyNode, use);
+
+            for (InstanceKey ik : pointerAnalysis.getPointsToSet(usePointerKey)) {
+              if (ik instanceof AllocationSiteInNode) {
+                AllocationSiteInNode asin = (AllocationSiteInNode) ik;
+                IClass concreteType = asin.getConcreteType();
+                TypeReference reference = concreteType.getReference();
+
+                if (reference.equals(DATASET)) {
+                  sources.add(src);
+                  logger.info("Added dataflow source from tensor dataset: " + src + ".");
+                  break;
+                }
+              }
+            }
+          } else if (definesTensorIterable(def, localPointerKeyNode, callGraph, pointerAnalysis)) {
             sources.add(src);
             logger.info("Added dataflow source from tensor iterable: " + src + ".");
           }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1,0 +1,18 @@
+package com.ibm.wala.cast.python.ml.types;
+
+import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
+
+/**
+ * Types found in the TensorFlow library.
+ *
+ * @author <a href="mailto:khatchd@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TensorFlowTypes extends PythonTypes {
+
+  public static final TypeReference DATASET =
+      TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Ltensorflow/data/Dataset"));
+
+  private TensorFlowTypes() {}
+}

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset6.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def add(a, b):
+    return a + b
+
+
+def func(ds):
+    for element in ds:
+        c = add(element, element)
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3]).shuffle(3).batch(2)
+func(dataset)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset7.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset7.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+@tf.function
+def add(a, b):
+    return a + b
+
+
+def func(ds):
+    for element in ds:
+        c = add(element, element)
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3]).shuffle(3).batch(2)
+func(dataset)


### PR DESCRIPTION
- Fallback to interprocedural analysis if we can't find the dataset iterable using intraprocedural analysis.
- Fix several test bugs.
