### PR TITLE
Enhance TF2 tests

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.test;
 
+import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -20,7 +21,6 @@ import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -304,15 +304,13 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
 
     // get the tensor variables for the function.
     Set<TensorVariable> functionTensorVariables =
-        functionSignatureToTensorVariables.getOrDefault(functionSignature, Collections.emptySet());
+        functionSignatureToTensorVariables.getOrDefault(functionSignature, emptySet());
 
     assertEquals(expectedNumberOfTensorVariables, functionTensorVariables.size());
 
     // get the pointer keys for the function.
     Set<LocalPointerKey> functionParameterPointerKeys =
-        functionSignatureToPointerKeys
-            .getOrDefault(functionSignature, Collections.emptySet())
-            .stream()
+        functionSignatureToPointerKeys.getOrDefault(functionSignature, emptySet()).stream()
             .filter(LocalPointerKey::isParameter)
             .collect(Collectors.toSet());
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -326,6 +326,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
             .collect(Collectors.toSet());
 
     assertEquals(expectedTensorParameterValueNumbers.length, actualParameterValueNumberSet.size());
+
     Arrays.stream(expectedTensorParameterValueNumbers)
         .forEach(
             ev ->

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -309,18 +309,19 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     assertEquals(expectedNumberOfTensorVariables, functionTensorVariables.size());
 
     // get the pointer keys for the function.
-    Set<LocalPointerKey> functionPointerKeys =
-        functionSignatureToPointerKeys.getOrDefault(functionSignature, Collections.emptySet());
+    Set<LocalPointerKey> functionParameterPointerKeys =
+        functionSignatureToPointerKeys
+            .getOrDefault(functionSignature, Collections.emptySet())
+            .stream()
+            .filter(LocalPointerKey::isParameter)
+            .collect(Collectors.toSet());
 
     // check tensor parameters.
-    assertEquals(
-        expectedNumberOfTensorParameters,
-        functionPointerKeys.stream().filter(LocalPointerKey::isParameter).count());
+    assertEquals(expectedNumberOfTensorParameters, functionParameterPointerKeys.size());
 
     // check value numbers.
     Set<Integer> actualParameterValueNumberSet =
-        functionPointerKeys.stream()
-            .filter(LocalPointerKey::isParameter)
+        functionParameterPointerKeys.stream()
             .map(LocalPointerKey::getValueNumber)
             .collect(Collectors.toSet());
 


### PR DESCRIPTION
- Only function parameters.
- Add space.
- Use static import.
