### PR TITLE
Deal with the average_gradients function in the mutligpu test

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -259,6 +259,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_add5.py", "f", 1, 1, 2);
     testTf2("tf2_test_add6.py", "f", 1, 1, 2);
     testTf2("multigpu_training.py", "run_optimization", 2, 4, 2, 3);
+    testTf2("multigpu_training.py", "average_gradients", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "f", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "g", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "h", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -238,10 +238,10 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
         "neural_network.py",
         "cross_entropy_loss",
         1,
-        4,
+        8,
         3); // NOTE: Change to 2 tensor parameters once https://github.com/wala/ML/issues/127 is
     // fixed. Values 2 and 3 will correspond to the tensor parameters.
-    testTf2("neural_network.py", "run_optimization", 2, 2, 2, 3);
+    testTf2("neural_network.py", "run_optimization", 2, 3, 2, 3);
     testTf2(
         "neural_network.py",
         "accuracy",

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -217,7 +217,11 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_dataset10.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_tensor_list.py", "add", 2, 2, 2, 3);
     testTf2("tf2_test_tensor_list2.py", "add", 0, 0);
-    testTf2("tf2_test_tensor_list3.py", "add", 0, 0);
+    testTf2(
+        "tf2_test_tensor_list3.py",
+        "add",
+        0,
+        0); // NOTE: Change to 2, 2, 2, 3 once https://github.com/wala/ML/issues/136 is fixed.
     testTf2("tf2_test_tensor_list4.py", "add", 0, 0);
     testTf2("tf2_test_tensor_list5.py", "add", 0, 0);
     testTf2("tf2_test_model_call.py", "SequentialModel.__call__", 1, 1, 3);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -271,6 +271,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_gradient2.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply2.py", "f", 1, 1, 2);
+    testTf2("tf2_test_sparse_softmax_cross_entropy_with_logits.py", "f", 1, 1, 2);
   }
 
   private void testTf2(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -263,7 +263,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_add5.py", "f", 1, 1, 2);
     testTf2("tf2_test_add6.py", "f", 1, 1, 2);
     testTf2("multigpu_training.py", "run_optimization", 2, 4, 2, 3);
-    testTf2("multigpu_training.py", "average_gradients", 1, 1, 2);
+    testTf2("multigpu_training.py", "average_gradients", 0, 0); // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/136 is fixed.
     testTf2("tf2_test_reduce_mean.py", "f", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "g", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "h", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -262,7 +262,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_reduce_mean.py", "f", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "g", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "h", 1, 1, 2);
-    testTf2("tf2_test_gradient.py", "f", 1, 1, 2);
+    testTf2("tf2_test_gradient.py", "f", 0, 0); // NOTE: Change to 1 parameter once https://github.com/wala/ML/issues/135 is fixed.
     testTf2("tf2_test_gradient2.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply2.py", "f", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -267,11 +267,7 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_reduce_mean.py", "f", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "g", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "h", 1, 1, 2);
-    testTf2(
-        "tf2_test_gradient.py",
-        "f",
-        0,
-        0); // NOTE: Change to 1 parameter once https://github.com/wala/ML/issues/135 is fixed.
+    testTf2("tf2_test_gradient.py", "f", 1, 1, 2);
     testTf2("tf2_test_gradient2.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply2.py", "f", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflowModel.java
@@ -262,7 +262,11 @@ public class TestTensorflowModel extends TestPythonMLCallGraphShape {
     testTf2("tf2_test_reduce_mean.py", "f", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "g", 1, 1, 2);
     testTf2("tf2_test_reduce_mean.py", "h", 1, 1, 2);
-    testTf2("tf2_test_gradient.py", "f", 0, 0); // NOTE: Change to 1 parameter once https://github.com/wala/ML/issues/135 is fixed.
+    testTf2(
+        "tf2_test_gradient.py",
+        "f",
+        0,
+        0); // NOTE: Change to 1 parameter once https://github.com/wala/ML/issues/135 is fixed.
     testTf2("tf2_test_gradient2.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply.py", "f", 1, 1, 2);
     testTf2("tf2_test_multiply2.py", "f", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -75,6 +75,8 @@
         <putfield class="LRoot" field="conv3d" fieldType="LRoot" ref="nn" value="conv3d" />
         <new def="softmax" class="Ltensorflow/functions/softmax" />
         <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax" />
+        <new def="sparse_softmax_cross_entropy_with_logits" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits" />
+        <putfield class="LRoot" field="sparse_softmax_cross_entropy_with_logits" fieldType="LRoot" ref="nn" value="sparse_softmax_cross_entropy_with_logits" />
         <new def="sigmoid" class="Ltensorflow/math/sigmoid" />
         <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="nn" value="sigmoid" />
         <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="math" value="sigmoid" />
@@ -695,6 +697,12 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/softmax -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self logits axis name">
           <return value="logits" />
+        </method>
+      </class>
+      <class name="sparse_softmax_cross_entropy_with_logits" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self labels logits name">
+          <return value="labels" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -754,7 +754,7 @@
       <class name="gradient" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self target sources output_gradients unconnected_gradients">
-          <return value="sources" />
+          <return value="target" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -762,7 +762,7 @@
       <class name="gradient" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self target sources output_gradients unconnected_gradients">
-          <return value="target" />
+          <return value="sources" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sparse_softmax_cross_entropy_with_logits.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sparse_softmax_cross_entropy_with_logits.py
@@ -1,0 +1,15 @@
+# from https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits
+
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+logits = tf.constant([[2., -5., .5, -.1],
+                      [0., 0., 1.9, 1.4],
+                      [-100., 100., -100., -100.]])
+labels = tf.constant([0, 3, 1])
+f(tf.nn.sparse_softmax_cross_entropy_with_logits(
+    labels=labels, logits=logits.numpy()))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sparse_softmax_cross_entropy_with_logits.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sparse_softmax_cross_entropy_with_logits.py
@@ -7,9 +7,8 @@ def f(a):
     pass
 
 
-logits = tf.constant([[2., -5., .5, -.1],
-                      [0., 0., 1.9, 1.4],
-                      [-100., 100., -100., -100.]])
+logits = tf.constant(
+    [[2.0, -5.0, 0.5, -0.1], [0.0, 0.0, 1.9, 1.4], [-100.0, 100.0, -100.0, -100.0]]
+)
 labels = tf.constant([0, 3, 1])
-f(tf.nn.sparse_softmax_cross_entropy_with_logits(
-    labels=labels, logits=logits.numpy()))
+f(tf.nn.sparse_softmax_cross_entropy_with_logits(labels=labels, logits=logits.numpy()))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tensor_list3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tensor_list3.py
@@ -1,3 +1,5 @@
+# Test https://github.com/wala/ML/issues/136.
+
 import tensorflow as tf
 
 


### PR DESCRIPTION
- Switch `gradient()` to return the target.
- Apply spotless.
- Add new test.
- Add `tf.nn.sparse_softmax_cross_entropy_with_logits()`.
- Revert "Switch `gradient()` to return the target."
- Mark test that tests https://github.com/wala/ML/issues/136.
- Apply spotless.
- Update tests to reflect new API.
- Update test in light of https://github.com/wala/ML/issues/136.
- Revert "Switch `gradient()` to return the target."
