### PR TITLE
Tests and changes for decorators

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -810,6 +810,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   @Test
+  public void testDecorator11()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_testing_decorator11.py", "C.returned", 1, 1, 3);
+  }
+
+  @Test
   public void testDataset()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     // FIXME: Test tf2_test_dataset.py really has three tensors in its dataset. We are currently

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2720,6 +2720,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testDecoratedMethod10() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_decorated_method10.py", "f", 1, 1, 2);
   }
+  
+  @Test
+  public void testDecoratedMethod11() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method11.py", "f", 1, 1, 2);
+  }
 
   private void test(
       String filename,

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2667,6 +2667,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   @Test
+  public void testAbstractMethod3() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_abstract_method3.py", "C.f", 1, 1, 3);
+  }
+
+  @Test
   public void testDecoratedMethod() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_decorated_method.py", "f", 1, 1, 2);
   }
@@ -2699,6 +2704,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testDecoratedMethod7() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_decorated_method7.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod8() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method8.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod9() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method9.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod10() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method10.py", "f", 1, 1, 2);
   }
 
   private void test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2730,7 +2730,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testDecoratedMethod12() throws ClassHierarchyException, CancelException, IOException {
-	// NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/188 is fixed.
+    // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/188 is fixed.
     test("tf2_test_decorated_method12.py", "f", 0, 0);
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2720,7 +2720,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testDecoratedMethod10() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_decorated_method10.py", "f", 1, 1, 2);
   }
-  
+
   @Test
   public void testDecoratedMethod11() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_decorated_method11.py", "f", 1, 1, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2734,6 +2734,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_decorated_method12.py", "f", 0, 0);
   }
 
+  @Test
+  public void testDecoratedMethod13() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method13.py", "f", 1, 1, 2);
+  }
+
   private void test(
       String filename,
       String functionName,

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2666,6 +2666,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_abstract_method2.py", "C.f", 1, 1, 3);
   }
 
+  @Test
+  public void testDecoratedMethod() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod2() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method2.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod3() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method3.py", "raffi", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod4() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method4.py", "raffi", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod5() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method5.py", "raffi", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod6() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method6.py", "f", 1, 1, 2);
+  }
+
+  @Test
+  public void testDecoratedMethod7() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_decorated_method7.py", "f", 1, 1, 2);
+  }
+
   private void test(
       String filename,
       String functionName,

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2711,9 +2711,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_decorated_method8.py", "f", 1, 1, 2);
   }
 
+  /** This decorator isn't defined. Thus, we shouldn't have a CG node for it. */
   @Test
   public void testDecoratedMethod9() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_decorated_method9.py", "f", 1, 1, 2);
+    test("tf2_test_decorated_method9.py", "f", 0, 0);
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2728,6 +2728,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_decorated_method11.py", "f", 1, 1, 2);
   }
 
+  @Test
+  public void testDecoratedMethod12() throws ClassHierarchyException, CancelException, IOException {
+	// NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/188 is fixed.
+    test("tf2_test_decorated_method12.py", "f", 0, 0);
+  }
+
   private void test(
       String filename,
       String functionName,

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2678,7 +2678,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testDecoratedMethod2() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_decorated_method2.py", "f", 1, 1, 2);
+    // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/188 is fixed.
+    test("tf2_test_decorated_method2.py", "f", 0, 0);
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2690,7 +2690,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testDecoratedMethod3() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_decorated_method3.py", "raffi", 1, 1, 2);
+    // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/190 is fixed.
+    test("tf2_test_decorated_method3.py", "raffi", 0, 0);
   }
 
   @Test
@@ -2726,7 +2727,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testDecoratedMethod10() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_decorated_method10.py", "f", 1, 1, 2);
+    // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/190 is fixed.
+    test("tf2_test_decorated_method10.py", "f", 0, 0);
   }
 
   @Test
@@ -2742,7 +2744,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testDecoratedMethod13() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_decorated_method13.py", "f", 1, 1, 2);
+    // NOTE: Change to 1, 1, 2 once https://github.com/wala/ML/issues/190 is fixed.
+    test("tf2_test_decorated_method13.py", "f", 0, 0);
   }
 
   private void test(

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -268,10 +268,27 @@
       </method>
     </class>
     <package name="tensorflow/class">
+      <class name="Function" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
+          <return value="test" />
+        </method>
+      </class>
       <class name="function" allocatable="true">
         <!-- These parameters are from TensorFlow v.2.9 https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function -->
         <method name="do" descriptor="()LRoot;" numArgs="11" paramNames="self func input_signature autograph jit_compile reduce_retracing experimental_implements experimental_autograph_options experimental_relax_shapes experimental_compile experimental_follow_type_hints">
-          <return value="func" />
+          <new def="params" class="Ltensorflow/class/Function" />
+          <putfield class="LRoot" field="func" fieldType="LRoot" ref="params" value="func" />
+          <putfield class="LRoot" field="input_signature" fieldType="LRoot" ref="params" value="input_signature" />
+          <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="params" value="autograph" />
+          <putfield class="LRoot" field="jit_compile" fieldType="LRoot" ref="params" value="jit_compile" />
+          <putfield class="LRoot" field="reduce_retracing" fieldType="LRoot" ref="params" value="reduce_retracing" />
+          <putfield class="LRoot" field="experimental_implements" fieldType="LRoot" ref="params" value="experimental_implements" />
+          <putfield class="LRoot" field="experimental_autograph_options" fieldType="LRoot" ref="params" value="experimental_autograph_options" />
+          <putfield class="LRoot" field="experimental_relax_shapes" fieldType="LRoot" ref="params" value="experimental_relax_shapes" />
+          <putfield class="LRoot" field="experimental_compile" fieldType="LRoot" ref="params" value="experimental_compile" />
+          <putfield class="LRoot" field="experimental_follow_type_hints" fieldType="LRoot" ref="params" value="experimental_follow_type_hints" />
+          <return value="params" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -268,27 +268,10 @@
       </method>
     </class>
     <package name="tensorflow/class">
-      <class name="Function" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
-        </method>
-      </class>
       <class name="function" allocatable="true">
         <!-- These parameters are from TensorFlow v.2.9 https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function -->
-        <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="func input_signature autograph jit_compile reduce_retracing experimental_implements experimental_autograph_options experimental_relax_shapes experimental_compile experimental_follow_type_hints">
-          <new def="params" class="Ltensorflow/class/Function" />
-          <putfield class="LRoot" field="func" fieldType="LRoot" ref="params" value="func" />
-          <putfield class="LRoot" field="input_signature" fieldType="LRoot" ref="params" value="input_signature" />
-          <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="params" value="autograph" />
-          <putfield class="LRoot" field="jit_compile" fieldType="LRoot" ref="params" value="jit_compile" />
-          <putfield class="LRoot" field="reduce_retracing" fieldType="LRoot" ref="params" value="reduce_retracing" />
-          <putfield class="LRoot" field="experimental_implements" fieldType="LRoot" ref="params" value="experimental_implements" />
-          <putfield class="LRoot" field="experimental_autograph_options" fieldType="LRoot" ref="params" value="experimental_autograph_options" />
-          <putfield class="LRoot" field="experimental_relax_shapes" fieldType="LRoot" ref="params" value="experimental_relax_shapes" />
-          <putfield class="LRoot" field="experimental_compile" fieldType="LRoot" ref="params" value="experimental_compile" />
-          <putfield class="LRoot" field="experimental_follow_type_hints" fieldType="LRoot" ref="params" value="experimental_follow_type_hints" />
-          <return value="params" />
+        <method name="do" descriptor="()LRoot;" numArgs="11" paramNames="self func input_signature autograph jit_compile reduce_retracing experimental_implements experimental_autograph_options experimental_relax_shapes experimental_compile experimental_follow_type_hints">
+          <return value="func" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_abstract_method3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_abstract_method3.py
@@ -1,0 +1,14 @@
+# From https://blog.teclado.com/python-abc-abstract-base-classes/#introducing-abstract-classes.
+import tensorflow as tf
+from abc import ABC, abstractmethod
+
+
+class C(ABC):
+
+    @abstractmethod
+    def f(self, x):
+        assert isinstance(x, tf.Tensor)
+
+
+c = C()
+c.f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method10.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method10.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def mama(my_func):
+    return my_func
+
+
+@mama
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method11.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method11.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+import pytest
+
+
+@pytest.mark.skip
+def f(a):
+    assert isinstance(a, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method12.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method12.py
@@ -1,3 +1,5 @@
+# Test https://github.com/wala/ML/issues/188.
+
 import tensorflow as tf
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method12.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method12.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+
+
+def mama(test=None):
+    assert test == "Hello"
+
+    def _mama(func):
+
+        def core(*args, **kwargs):
+            assert isinstance(args[0], tf.Tensor)
+            return func(*args, **kwargs)
+
+        return core
+
+    return _mama
+
+
+@mama(test="Hello")
+def f(x):
+    assert isinstance(x, tf.Tensor)
+    return 5
+
+
+res = f(tf.constant(1))
+assert res == 5

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method13.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method13.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def mama(my_func=None):
+    return my_func
+
+
+@mama
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method2.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def mama(fun):
+
+    def wrapper_fun(*args, **kwargs):
+        assert isinstance(args[0], tf.Tensor)
+        fun(*args, **kwargs)
+
+    return wrapper_fun
+
+
+@mama
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method2.py
@@ -1,3 +1,5 @@
+# Test for https://github.com/wala/ML/issues/188.
+
 import tensorflow as tf
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method3.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def mama(fun):
+    return fun
+
+
+@mama
+def raffi(x):
+    assert isinstance(x, tf.Tensor)
+
+
+raffi(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method4.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def mama(fun):
+    return fun
+
+
+def raffi(x):
+    assert isinstance(x, tf.Tensor)
+
+
+raffi(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method5.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method5.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def mama(fun):
+    return fun
+
+
+def raffi(x):
+    assert isinstance(x, tf.Tensor)
+
+
+mama(raffi(tf.constant(1)))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method6.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def mama(fun):
+
+    def wrapper_fun(*args, **kwargs):
+        assert isinstance(args[0], tf.Tensor)
+        fun(*args, **kwargs)
+
+    return wrapper_fun
+
+
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method7.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method7.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def mama(fun):
+
+    def wrapper_fun(*args, **kwargs):
+        assert isinstance(args[0], tf.Tensor)
+        fun(*args, **kwargs)
+
+    return wrapper_fun
+
+
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+mama(f(tf.constant(1)))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method8.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method8.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method9.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_method9.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+
+
+@mama
+def f(x):
+    assert isinstance(x, tf.Tensor)
+
+
+f(tf.constant(1))

--- a/com.ibm.wala.cast.python.test/data/tf2_testing_decorator11.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_testing_decorator11.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+class C:
+
+    @tf.function()
+    def returned(self, a):
+        assert isinstance(a, tf.Tensor)
+        return a
+
+
+a = tf.range(5)
+assert isinstance(a, tf.Tensor)
+c = C()
+b = c.returned(a)
+assert isinstance(b, tf.Tensor)

--- a/com.ibm.wala.cast.python/data/pytest.xml
+++ b/com.ibm.wala.cast.python/data/pytest.xml
@@ -10,6 +10,8 @@
         <putfield class="LRoot" field="mark" fieldType="LRoot" ref="x" value="mark" />
         <new def="parametrize" class="Lpytest/class/parametrize" />
         <putfield class="LRoot" field="parametrize" fieldType="LRoot" ref="mark" value="parametrize" />
+        <new def="skip" class="Lpytest/class/skip" />
+        <putfield class="LRoot" field="skip" fieldType="LRoot" ref="mark" value="skip" />
         <return value="x" />
       </method>
     </class>
@@ -26,6 +28,21 @@
           <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
           <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
           <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
+          <return value="closure" />
+        </method>
+      </class>
+      <class name="Skip" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
+          <return value="test" />
+        </method>
+      </class>
+      <class name="skip" allocatable="true">
+        <!-- https://docs.pytest.org/en/8.2.x/reference/reference.html#pytest.mark.skip -->
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self reason">
+          <new def="closure" class="Lpytest/class/Skip" />
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="reason" />
           <return value="closure" />
         </method>
       </class>

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -312,6 +312,7 @@ public abstract class PythonAnalysisEngine<T>
     addSummaryBypassLogic(options, "flask.xml");
     addSummaryBypassLogic(options, "pandas.xml");
     addSummaryBypassLogic(options, "functools.xml");
+    addSummaryBypassLogic(options, "pytest.xml");
   }
 
   @Override

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -375,7 +375,11 @@ public class PythonCAstToIRTranslator extends AstTranslator {
             .dynamicAnnotations()
             .forEach(
                 a -> {
-                  visit(a, context, this);
+                  // If we visit `a`, we get an unnecessary invocation of the decorator with never
+                  // any arguments. Instead, visit it's child, which should be the decorator
+                  // "variable."
+                  CAstNode child = a.getChild(0);
+                  visit(child, context, this);
                   int pos = context.cfg().getCurrentInstruction();
                   CallSiteReference site = new DynamicCallSiteReference(PythonTypes.CodeBody, pos);
                   context
@@ -386,7 +390,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
                               result,
                               context.currentScope().allocateTempValue(),
                               site,
-                              new int[] {context.getValue(a), result},
+                              new int[] {context.getValue(child), result},
                               new Pair[0]));
                 });
       }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -386,9 +386,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
                               result,
                               context.currentScope().allocateTempValue(),
                               site,
-                              // NOTE: This won't work if there are decorator parameters. See
-                              // https://github.com/wala/ML/issues/189.
-                              new int[] {context.getValue(a.getChild(0)), result},
+                              new int[] {context.getValue(a), result},
                               new Pair[0]));
                 });
       }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -375,11 +375,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
             .dynamicAnnotations()
             .forEach(
                 a -> {
-                  // If we visit `a`, we get an unnecessary invocation of the decorator with never
-                  // any arguments. Instead, visit it's child, which should be the decorator
-                  // "variable."
-                  CAstNode child = a.getChild(0);
-                  visit(child, context, this);
+                  visit(a, context, this);
                   int pos = context.cfg().getCurrentInstruction();
                   CallSiteReference site = new DynamicCallSiteReference(PythonTypes.CodeBody, pos);
                   context
@@ -390,7 +386,9 @@ public class PythonCAstToIRTranslator extends AstTranslator {
                               result,
                               context.currentScope().allocateTempValue(),
                               site,
-                              new int[] {context.getValue(child), result},
+                              // NOTE: This won't work if there are decorator parameters. See
+                              // https://github.com/wala/ML/issues/189.
+                              new int[] {context.getValue(a.getChild(0)), result},
                               new Pair[0]));
                 });
       }


### PR DESCRIPTION
- Decorator testing.
- Actually capture the decorated function for @tf.function decorated functions.
- Add `pytest.mark.skip` summary.
- Use pytest summary for all Python analysis. There are some decorators it may work for.
  - Test pytest decorator.