### PR TITLE
Track tensors returned by `tf.reshape()`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2759,6 +2759,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_decorated_functions.py", "test_function4", 1, 1, 2);
   }
 
+  @Test
+  public void testReshape() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_reshape.py", "f", 1, 1, 2);
+  }
+
   private void test(
       String filename,
       String functionName,

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape.py
@@ -1,0 +1,12 @@
+# https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reshape
+
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+t1 = tf.ones([2, 3])
+t2 = tf.reshape(t1, [6])
+f(t2)


### PR DESCRIPTION
Fixes https://github.com/wala/ML/issues/195.