### PR TITLE
Restrict CI workflow permissions to least-privilege

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,9 @@ on:
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') }} # Cancel if not a tag push.
+permissions:
+  contents: read
+  packages: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds an explicit `permissions:` block to `continuous-integration.yml` at the workflow level.
- Resolves CodeQL alert `actions/missing-workflow-permissions` (alert #4 on this repo).

The only `write` scope needed is `packages: write`, used by the `mvn deploy` step to publish to GitHub Packages on master pushes. Everything else (checkout, build, test, codecov upload) needs only `contents: read`.

## Test Plan

- [ ] CI green on this PR (`build`, `Analyze (java-kotlin)`, `Analyze (python)`, `Analyze (actions)`).
- [ ] Verify on a follow-up master push that the deploy step still succeeds (it relies on `secrets.GITHUB_TOKEN` + `packages: write`).