### PR TITLE
Restore `tf.reduce_sum` binding and add isolated tests

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3870,6 +3870,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   @Test
+  public void testReduceSum()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceSum2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceSum3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum.py", "h", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  @Test
   public void testGradient()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_gradient.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3888,6 +3888,40 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   @Test
+  public void testReduceSum4()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum_kwargs.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceSum5()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum_kwargs.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceSum6()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum_kwargs.py", "h", 1, 1, Map.of(2, Set.of(TENSOR_1_2_FLOAT32)));
+  }
+
+  /**
+   * Exercises the {@code tf.math.reduce_sum} (ref="math") binding via {@code
+   * tf.math.reduce_sum(input_tensor=x, axis=1, keepdims=True)}.
+   */
+  @Test
+  public void testReduceSum7()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum_kwargs.py", "i", 1, 1, Map.of(2, Set.of(TENSOR_2_1_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceSum8()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_sum_kwargs.py", "j", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  @Test
   public void testGradient()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_gradient.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -151,6 +151,11 @@
         <new def="reduce_mean" class="Ltensorflow/math/reduce_mean" />
         <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="x" value="reduce_mean" />
         <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="math" value="reduce_mean" />
+        <!-- `tf.reduce_sum` is an alias for `tf.math.reduce_sum`. Mirror the `reduce_mean` pattern (alias under both `tensorflow` and `tensorflow.math`) so attribute lookups on either path resolve to the same `Ltensorflow/math/reduce_sum` class — which `ReduceSum.java` (registered in `TensorGeneratorFactory`)
+          dispatches on. -->
+        <new def="reduce_sum" class="Ltensorflow/math/reduce_sum" />
+        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="x" value="reduce_sum" />
+        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="math" value="reduce_sum" />
         <!-- `tf.argmax` is an alias for `tf.math.argmax` in real TensorFlow. Expose the same `tensorflow/math/argmax` class under both the top-level `tensorflow` namespace and `tensorflow.math` so attribute lookups on either path resolve. See wala/ML#386. -->
         <new def="argmax" class="Ltensorflow/math/argmax" />
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="x" value="argmax" />

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_sum.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_sum.py
@@ -1,0 +1,32 @@
+# From https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_sum#for_example
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def h(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+
+r1 = tf.reduce_sum(x)
+assert r1.shape == ()
+assert r1.dtype == tf.float32
+f(r1)
+
+r2 = tf.reduce_sum(x, 0)
+assert r2.shape == (2,)
+assert r2.dtype == tf.float32
+g(r2)
+
+r3 = tf.reduce_sum(x, 1)
+assert r3.shape == (2,)
+assert r3.dtype == tf.float32
+h(r3)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_sum_kwargs.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_sum_kwargs.py
@@ -1,0 +1,57 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def h(a):
+    pass
+
+
+def i(a):
+    pass
+
+
+def j(a):
+    pass
+
+
+# tf.constant keyword args
+x = tf.constant(value=[[1.0, 1.0], [2.0, 2.0]], dtype=tf.float32)
+
+# 1. Keyword args
+r1 = tf.reduce_sum(input_tensor=x, axis=0)
+assert r1.shape == (2,)
+assert r1.dtype == tf.float32
+f(r1)
+
+# 2. Mixed (pos + kw)
+r2 = tf.reduce_sum(x, axis=1)
+assert r2.shape == (2,)
+assert r2.dtype == tf.float32
+g(r2)
+
+# 3. Mixed (pos + kw) with keepdims
+r3 = tf.reduce_sum(x, 0, keepdims=True)
+assert r3.shape == (1, 2)
+assert r3.dtype == tf.float32
+h(r3)
+
+# 4. tf.math.reduce_sum keyword args (exercises the ref="math" binding)
+r4 = tf.math.reduce_sum(input_tensor=x, axis=1, keepdims=True)
+assert r4.shape == (2, 1)
+assert r4.dtype == tf.float32
+i(r4)
+
+# 5. tf.constant with shape kwarg
+# [1, 2, 3, 4] -> shape [2, 2]
+y = tf.constant(value=[1.0, 2.0, 3.0, 4.0], shape=[2, 2])
+r5 = tf.reduce_sum(y)
+assert r5.shape == ()
+assert r5.dtype == tf.float32
+j(r5)


### PR DESCRIPTION
## Summary

The `tf.reduce_sum` / `tf.math.reduce_sum` putfield bindings on the `tensorflow` module's `import` method were lost during branch-267 work and never restored. Without them, `tf.reduce_sum(...)` call sites never resolve to `Ltensorflow/math/reduce_sum`, so `TensorGeneratorFactory.create` never instantiates `ReduceSum`, and the analysis silently treats the return as untyped.

There were no isolated tests for `tf.reduce_sum` in the repo, so no CI signal flagged the regression. The two existing usages in test data (`train.py:314`, `tensorboard_example.py:121`) are buried inside larger expressions in functions that aren't the subject of any test's tensor-count assertion, so the missing binding has been silently latent.

## Lifecycle Of The Regression

| Date | Commit | What |
|---|---|---|
| 2026-02-07 | `d9d6209e` "Fix tf.reshape shape inference and enable Reshape generator" | Added the `tf.reduce_sum` bindings + class as part of broader generator-coverage work |
| 2026-02-11 | `8e526936` "Put back more changes." | Removed both bindings and class |
| 2026-02-11 (same day) | `793ea260` "Test updates." (body: "Re-add some changes for `reduce_mean`, etc.") | Re-added the class only — bindings missed during a re-add focused on `reduce_mean` |
| 2026-04-25 | `5467c89a` (PR wala/ML#156) | Squash-merged branch-267 to master, carrying the class-without-binding state |

So the missing binding looks like an oversight from a rapid same-day cleanup focused on `reduce_mean`, not a deliberate architectural choice.

## Test Plan

- [x] On `master`, the new `testReduceSum*` methods fail with `expected:<1> but was:<0>` (the analysis sees zero tensor parameters in `f`/`g`/`h` because the `reduce_sum` return isn't tracked as a tensor).
- [x] With this PR, all three pass.

Reproduce:

```bash
mvn -pl com.ibm.wala.cast.python.ml.test -am test \
    -Dtest='TestTensorflow2Model#testReduceSum*' \
    -Dsurefire.failIfNoSpecifiedTests=false
```

## Changes

- **`com.ibm.wala.cast.python.ml/data/tensorflow.xml`**: restore the three putfield lines on the `tensorflow` import method (alias under both `tensorflow` and `tensorflow.math`, mirroring the `reduce_mean` pattern). Added a comment explaining the alias rationale and the connection to `ReduceSum.java`.
- **`com.ibm.wala.cast.python.test/data/tf2_test_reduce_sum.py`**: new test data file mirroring `tf2_test_reduce_mean.py`'s three-case structure (scalar reduce, axis=0, axis=1).
- **`com.ibm.wala.cast.python.ml.test/.../TestTensorflow2Model.java`**: add `testReduceSum`, `testReduceSum2`, `testReduceSum3` modeled on `testReduceMean*`.

## Out Of Scope

- A broader audit of *other* TF API bindings that may have been similarly lost during branch-267 cleanup. There are likely more (the `read_data` marker pattern in classes that exist without bindings is a fingerprint to grep for). Tracked separately at [wala/ML#422](https://github.com/wala/ML/issues/422).
