### PR TITLE
Add `ComparisonOperation` generator (`tf.equal` returns `tf.bool`) — POC for wala/ML#427

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -75,6 +75,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final String UINT_8 = DType.UINT8.name().toLowerCase();
 
+  private static final String BOOL = DType.BOOL.name().toLowerCase();
+
   private static final String STRING = DType.STRING.name().toLowerCase();
 
   private static final TensorType MNIST_INPUT = mnistInput();
@@ -324,6 +326,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4)));
+
+  private static final TensorType TENSOR_2_2_BOOL =
+      new TensorType(BOOL, asList(new NumericDim(2), new NumericDim(2)));
 
   private static final TensorType TENSOR_4_FLOAT64 =
       new TensorType(FLOAT_64, asList(new NumericDim(4)));
@@ -2081,6 +2086,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testSigmoid2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_sigmoid2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_4_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.equal} returns a {@code tf.bool}-dtype tensor with the broadcasted
+   * shape of its inputs, regardless of input dtype. Exercises the {@link ComparisonOperation}
+   * generator (introduced for wala/ML#427) — the dtype must be BOOL even though both operands are
+   * float32.
+   */
+  @Test
+  public void testEqual()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2100,6 +2100,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
   }
 
+  /**
+   * Same as {@link #testEqual} but for {@code tf.not_equal} — verifies the {@link
+   * ComparisonOperation} dispatch scales beyond a single op. Establishes the pattern for the
+   * remaining comparison ops ({@code tf.less}, {@code tf.less_equal}, {@code tf.greater}, {@code
+   * tf.greater_equal}).
+   */
+  @Test
+  public void testNotEqual()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_not_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
   @Test
   public void testAdd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -159,6 +159,10 @@
         <new def="equal" class="Ltensorflow/math/equal" />
         <putfield class="LRoot" field="equal" fieldType="LRoot" ref="x" value="equal" />
         <putfield class="LRoot" field="equal" fieldType="LRoot" ref="math" value="equal" />
+        <!-- `tf.not_equal` is the elementwise inverse of `tf.equal`; same alias structure. -->
+        <new def="not_equal" class="Ltensorflow/math/not_equal" />
+        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="x" value="not_equal" />
+        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math" value="not_equal" />
         <new def="placeholder" class="Ltensorflow/functions/placeholder" />
         <putfield class="LRoot" field="placeholder" fieldType="LRoot" ref="x" value="placeholder" />
         <new def="examples" class="Lobject" />
@@ -493,6 +497,16 @@
         </method>
       </class>
       <class name="equal" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;" numArgs="1">
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
+          <return value="xx" />
+        </method>
+      </class>
+      <class name="not_equal" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ComparisonOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ComparisonOperation.java
@@ -1,0 +1,30 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Element-wise comparison operations in TensorFlow ({@code tf.equal}, {@code tf.not_equal}, {@code
+ * tf.less}, {@code tf.less_equal}, {@code tf.greater}, {@code tf.greater_equal}).
+ *
+ * <p>Differs from {@link ElementWiseOperation} only in dtype: comparison ops always produce a
+ * {@code tf.bool}-dtype tensor regardless of input dtypes, per the TensorFlow API contract. Shape
+ * inference is the same broadcast behavior inherited from {@link ElementWiseOperation}.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/equal">tf.math.equal</a>.
+ * @see <a href="https://github.com/wala/ML/issues/427">wala/ML#427</a>.
+ */
+public class ComparisonOperation extends ElementWiseOperation {
+
+  public ComparisonOperation(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.BOOL);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -63,6 +63,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MULTIPLY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NDARRAY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NORMAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NORMAL_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NOT_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NUMPY_ARRAY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NUMPY_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ONES;
@@ -872,6 +873,8 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);
     else if (isType(calledFunction, EQUAL.getDeclaringClass()))
+      return new ComparisonOperation(source);
+    else if (isType(calledFunction, NOT_EQUAL.getDeclaringClass()))
       return new ComparisonOperation(source);
     else if (isType(calledFunction, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
         || isType(calledFunction, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -872,7 +872,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);
     else if (isType(calledFunction, EQUAL.getDeclaringClass()))
-      return new ElementWiseOperation(source);
+      return new ComparisonOperation(source);
     else if (isType(calledFunction, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
         || isType(calledFunction, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))
       return new SoftmaxCrossEntropy(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -34,6 +34,7 @@ public class TensorFlowTypes extends PythonTypes {
     INT32(true, false, 32),
     INT64(true, false, 64),
     UINT8(true, false, 8),
+    BOOL(false, false, 1),
     STRING(false, false, 0),
     UNKNOWN(false, false, 0);
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -828,6 +828,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EQUAL_SIGNATURE = "tf.equal()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/not_equal. */
+  public static final MethodReference NOT_EQUAL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/not_equal")),
+          AstMethodReference.fnSelector);
+
+  private static final String NOT_EQUAL_SIGNATURE = "tf.not_equal()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/cast. */
   public static final MethodReference CAST =
       MethodReference.findOrCreate(
@@ -1075,6 +1084,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(PLACEHOLDER.getDeclaringClass(), PLACEHOLDER_SIGNATURE),
           Map.entry(ARGMAX.getDeclaringClass(), ARGMAX_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
+          Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(CAST.getDeclaringClass(), CAST_SIGNATURE),
           Map.entry(
               SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass(),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_equal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_equal.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.equal(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_not_equal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_not_equal.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.not_equal(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)


### PR DESCRIPTION
## Summary

POC implementing the `ComparisonOperation` generator design proposed in [wala/ML#427](https://github.com/wala/ML/issues/427). Wires `tf.equal` to return a `tf.bool`-dtype tensor instead of inheriting the X operand's dtype from `ElementWiseOperation`.

Drafted overnight while the consumer-side `tensorflow.xml` reconciliation continues — keeps the broader port (wala/ML#428) supplied with proven generator designs as needed.

## Changes

- **`DType.BOOL`** added to `TensorFlowTypes.DType` enum (between `UINT8` and `STRING`). Conversion-isolated like `STRING`/`UNKNOWN` — non-numeric, only converts to itself. No behavior change for existing code.
- **`ComparisonOperation`** — new generator class extending `ElementWiseOperation`. Single override: `getDefaultDTypes` returns `EnumSet.of(DType.BOOL)`. Inherits broadcast shape inference unchanged.
- **`TensorGeneratorFactory.getGenerator`** — dispatch for `EQUAL.getDeclaringClass()` now creates `ComparisonOperation` instead of `ElementWiseOperation`.
- **`tf2_test_equal.py`** + **`testEqual`** — end-to-end coverage. `tf.equal` of two float32 2x2 tensors → bool 2x2 tensor (`TENSOR_2_2_BOOL`).

## Scope (Intentionally Minimal)

`EQUAL` and `NOT_EQUAL` are rewired through `ComparisonOperation`. Remaining comparison ops (`tf.less`, `tf.less_equal`, `tf.greater`, `tf.greater_equal`) need new `MethodReference` constants in `TensorFlowTypes` AND corresponding XML bindings — that's follow-on work that benefits from this PR's design being proven against two ops first.

The broader `DType.BOOL` plumbing (a `FieldReference` + `FIELD_REFERENCE_TO_DTYPE` entry + `tf.bool` putfield, mirroring `float32`/`string`) so that user code can pass `dtype=tf.bool` and have the dtype-arg path resolve to `DType.BOOL`, is also out of scope here — this PR only addresses the *result* dtype of comparison ops. Tracked separately for the same wala/ML#427 family.

## Validation

```
$ mvn -pl com.ibm.wala.cast.python.ml.test test -Dtest=TestTensorflow2Model#testEqual
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Test Plan

- [x] `testEqual` passes (verified locally).
- [ ] Verify no regression in existing tests (would benefit from full `mvn verify` in CI).
- [ ] Once merged, verify `wala/ML#427`'s argmax-int64 sibling case can use the same override-`getDefaultDTypes`-to-fixed-dtype pattern.

## Related

- wala/ML#427 — proposes the `ComparisonOperation` design this implements (sub-issue of wala/ML#428).
- wala/ML#428 — parent port issue. Uses this design when porting Hybridize-only `tf.less` (one of the 27 `ref="math"` extensions) to Ariadne master, and analogously for any other comparison ops surfaced.

Drafted as a working POC. Final upstream PR (against `wala/ML`) will need user review per the established workflow.

