### PR TITLE
Fix `tf.estimator.EstimatorSpec` modeling: allocation, field sets, missing binding (`wala/ML#429`)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3827,6 +3827,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_reduce_mean.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
   }
 
+  /**
+   * Verifies that {@code tf.estimator.EstimatorSpec(...)} produces a fresh allocation with each
+   * named parameter stored as a field on the result. The test reads {@code spec.loss} and asserts
+   * that it round-trips back to the original {@code loss_tensor} (a scalar float32). If
+   * EstimatorSpec is mis-modeled as "return one of the inputs" instead of "fresh allocation with
+   * field sets," the read would either return the wrong dtype or fail to resolve. Exercises the
+   * binding + body fix from wala/ML#429.
+   */
+  @Test
+  public void testEstimatorSpec()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_estimator_spec.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
   @Test
   public void testReduceMean2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -81,6 +81,9 @@
         <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run" />
         <new def="Estimator" class="Ltensorflow/estimator/Estimator" />
         <putfield class="LRoot" field="Estimator" fieldType="LRoot" ref="estimator" value="Estimator" />
+        <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — return type of model_fn. -->
+        <new def="EstimatorSpec" class="Ltensorflow/estimator/EstimatorSpec" />
+        <putfield class="LRoot" field="EstimatorSpec" fieldType="LRoot" ref="estimator" value="EstimatorSpec" />
         <new def="GradientTape" class="Ltensorflow/GradientTape" />
         <putfield class="LRoot" field="GradientTape" fieldType="LRoot" ref="x" value="GradientTape" />
         <!-- https://www.tensorflow.org/api_docs/python/tf#newaxis — at runtime this is `None` (used in subscripts like `x[..., tf.newaxis]` to insert a size-1 dimension). Modeled as an allocation of the sentinel class `Ltensorflow/newaxis` so `NdarraySubscriptOperation.classifyField` can recognize it
@@ -950,8 +953,16 @@
         </method>
       </class>
       <class name="EstimatorSpec" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — fresh allocation (not pass-through) so the resulting spec is a distinct object from any input. Each named parameter is stored as a field on the result, mirroring the namedtuple shape of the real API. See wala/ML#429. -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self mode predictions loss train_op eval_metric_ops export_outputs">
-          <return value="eval_metric_ops" />
+          <new def="res" class="Ltensorflow/estimator/EstimatorSpec" />
+          <putfield class="LRoot" field="mode" fieldType="LRoot" ref="res" value="mode" />
+          <putfield class="LRoot" field="predictions" fieldType="LRoot" ref="res" value="predictions" />
+          <putfield class="LRoot" field="loss" fieldType="LRoot" ref="res" value="loss" />
+          <putfield class="LRoot" field="train_op" fieldType="LRoot" ref="res" value="train_op" />
+          <putfield class="LRoot" field="eval_metric_ops" fieldType="LRoot" ref="res" value="eval_metric_ops" />
+          <putfield class="LRoot" field="export_outputs" fieldType="LRoot" ref="res" value="export_outputs" />
+          <return value="res" />
         </method>
       </class>
       <class name="numpy_input_fn" allocatable="true">

--- a/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Real-world usage: model_fn returns an EstimatorSpec carrying loss/train_op/etc.
+loss_tensor = tf.constant(1.0)
+
+spec = tf.estimator.EstimatorSpec(
+    mode="train",
+    predictions=None,
+    loss=loss_tensor,
+    train_op=None,
+    eval_metric_ops={},
+    export_outputs=None,
+)
+
+# spec.loss must resolve to the original loss_tensor allocation
+# (a scalar float32). If EstimatorSpec is mis-modeled as "return one of the
+# inputs" instead of "fresh allocation with field sets," this read won't
+# round-trip correctly.
+read_loss = spec.loss
+f(read_loss)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
@@ -7,6 +7,9 @@ def f(a):
 
 # Real-world usage: model_fn returns an EstimatorSpec carrying loss/train_op/etc.
 loss_tensor = tf.constant(1.0)
+assert isinstance(loss_tensor, tf.Tensor)
+assert loss_tensor.shape == ()
+assert loss_tensor.dtype == tf.float32
 
 spec = tf.estimator.EstimatorSpec(
     mode="train",
@@ -22,4 +25,7 @@ spec = tf.estimator.EstimatorSpec(
 # inputs" instead of "fresh allocation with field sets," this read won't
 # round-trip correctly.
 read_loss = spec.loss
+assert isinstance(read_loss, tf.Tensor)
+assert read_loss.shape == ()
+assert read_loss.dtype == tf.float32
 f(read_loss)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec.py
@@ -12,7 +12,7 @@ assert loss_tensor.shape == ()
 assert loss_tensor.dtype == tf.float32
 
 spec = tf.estimator.EstimatorSpec(
-    mode="train",
+    mode=tf.estimator.ModeKeys.EVAL,
     predictions=None,
     loss=loss_tensor,
     train_op=None,


### PR DESCRIPTION
## Summary

Fixes the `EstimatorSpec` semantic gap from [wala/ML#429](https://github.com/wala/ML/issues/429), plus a deeper bug surfaced during the fix work: the top-level binding for `tf.estimator.EstimatorSpec` was missing entirely.

## Changes

1. **Adds the missing top-level binding** (right after the existing `Estimator` binding at lines 82-83):
   ```xml
   <new def="EstimatorSpec" class="Ltensorflow/estimator/EstimatorSpec" />
   <putfield class="LRoot" field="EstimatorSpec" fieldType="LRoot" ref="estimator" value="EstimatorSpec" />
   ```

2. **Replaces the `<class name="EstimatorSpec">` body** to allocate a fresh `EstimatorSpec` instance and store each named parameter as a field on the result.

3. **Adds `testEstimatorSpec` + `tf2_test_estimator_spec.py`** — end-to-end test verifying that `spec.loss` round-trips back to the original `loss_tensor` (a scalar float32). The test would fail under either the old binding gap (class wouldn't resolve from `tf.estimator.EstimatorSpec`) or the old body (field wouldn't be set).

## Why Both Fixes Are Needed Together

The original modeling has both a missing binding AND a wrong body. Even if the body were fixed in isolation, user code calling `tf.estimator.EstimatorSpec(...)` would still not resolve to the class. Fixing only the binding without the body would resolve to the class but the result would still alias one of the inputs. The two fixes are coupled — and the test exercises both.

## Validation

```
$ mvn -pl com.ibm.wala.cast.python.ml.test test -Dtest=TestTensorflow2Model#testEstimatorSpec
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Related

- wala/ML#429 — the issue this fix addresses (sub-issue of wala/ML#428).
- wala/ML#430 — sibling issue covering the same "return-an-input-without-allocating" pattern in `gradient`, `parse_single_example`, `shuffle_batch`. Same fix template applies.
- ponder-lab/ML#186 — the `ComparisonOperation` POC for wala/ML#427.
