### PR TITLE
Use `${maven.multiModuleProjectDirectory}/spotless.xml.prefs` for robust resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                 <eclipseWtp>
                   <type>XML</type>
                   <files>
-                    <file>./spotless.xml.prefs</file>
+                    <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
                 <trimTrailingWhitespace/>


### PR DESCRIPTION
Re-opening of [#188](https://github.com/ponder-lab/ML/pull/188), which was inadvertently closed when its branch (`chore/spotless-prefs-multi-module-path`) was deleted during cleanup of a sibling upstream PR. Same content, new branch (`-fork` suffix to disambiguate from the upstream-targeted PR's branch of the same prefix).

## Problem

`pom.xml` references the Spotless prefs file with a relative path:

```xml
<eclipseWtp>
  <type>XML</type>
  <files>
    <file>./spotless.xml.prefs</file>
  </files>
</eclipseWtp>
```

Relative paths resolve against Maven's current working directory at invocation time. Works from the multi-module root but can fail from elsewhere — submodule's `basedir`, IDE's per-module run, nested Maven invocation.

## Fix

Use `${maven.multiModuleProjectDirectory}` for invocation-context-independent resolution:

```xml
<file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
```

Same pattern downstream consumers like `ponder-lab/Hybridize-Functions-Refactoring` already use.

## Verification

```
$ mvn spotless:check                                       # from root: BUILD SUCCESS
$ mvn -pl com.ibm.wala.cast.python.ml spotless:check       # submodule-targeted: BUILD SUCCESS
```

## Related

- wala/ML#432 — same fix on upstream (correctly branched from `wala/master`).
