### PR TITLE
Fix `NullPointerException` in `Constant.getDefaultShapes`/`getDefaultDTypes` when value points-to set is empty (`wala/ML#434`)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
@@ -46,7 +46,9 @@ public class Constant extends TensorGenerator {
             builder, this.getValueParameterPosition(), this.getValueParameterName());
     Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pointsToSet);
     // An empty result means the shape could not be inferred — treat as unknown (null / ⊤).
-    return shapes.isEmpty() ? null : shapes;
+    // `getShapesOfValue` documents that it returns `null` (not an empty set) when the
+    // value's points-to set is empty; honor that contract instead of NPE-ing.
+    return (shapes == null || shapes.isEmpty()) ? null : shapes;
   }
 
   /**
@@ -64,7 +66,9 @@ public class Constant extends TensorGenerator {
     // An empty result means the dtype could not be inferred — treat as unknown
     // (⊤), mirroring the ⊤ treatment in getDefaultShapes. A `tf.constant` is
     // always a tensor; we just cannot pin down its dtype.
-    return dTypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dTypes;
+    // `getDTypesOfValue` documents that it returns `null` (not an empty set) when
+    // the value's points-to set is empty; honor that contract instead of NPE-ing.
+    return (dTypes == null || dTypes.isEmpty()) ? EnumSet.of(DType.UNKNOWN) : dTypes;
   }
 
   protected int getValueArgumentValueNumber() {


### PR DESCRIPTION
## Summary

Two-line fix for [wala/ML#434](https://github.com/wala/ML/issues/434). `TensorGenerator.getShapesOfValue` and `getDTypesOfValue` document — and intentionally implement — a `null` return for the "empty points-to set" case (with `LOGGER.fine(... "Returning null (unknown).")`). The two `Constant`-side callers documented the same intent in their comments ("treat as unknown (null / ⊤)") but called `.isEmpty()` on the returned `Set` without guarding for null, NPE-ing on the documented-null path.

## Change

```diff
   Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pointsToSet);
   // An empty result means the shape could not be inferred — treat as unknown (null / ⊤).
-  return shapes.isEmpty() ? null : shapes;
+  // `getShapesOfValue` documents that it returns `null` (not an empty set) when the
+  // value's points-to set is empty; honor that contract instead of NPE-ing.
+  return (shapes == null || shapes.isEmpty()) ? null : shapes;
```

Same null-or-empty guard at `getDefaultDTypes:67`. No API change. No behavior change on the non-empty path.

## Why It Wasn't Caught

The author's existing test suite doesn't surface this because Ariadne's master `tensorflow.xml` keeps the reachable allocation graph narrow enough that `tf.constant`'s value parameter never has an empty points-to set in practice. The bug is exposed when a consumer's XML adds new top-level `<new>` allocation sites that widen what flows into `tf.constant`.

The Hybridize-Functions-Refactoring `tensorflow.xml` (which carries fork-side hand-extensions like \`io\`, \`TextLineDataset\`, \`TFRecordDataset\`, \`TPUStrategy\`, \`OneDeviceStrategy\`, and \`math_ops\` aliases) reaches this path. Both Hybridize's own test suite (26 NPEs in `HybridizeFunctionRefactoringTest`) and Ariadne's `TestMNISTExamples.testEx5CG` regress to NPE at `Constant.java:49` when that XML is dropped in.

## Validation

- **Master XML + this fix:** `mvn -pl com.ibm.wala.cast.python.ml.test -am test` — 608 tests, 0 failures, 0 errors, 3 skipped. No regression.
- **Hybridize-converged XML + this fix:** the 26 NPE-bucket failures in `HybridizeFunctionRefactoringTest` and `TestMNISTExamples.testEx5CG` no longer NPE. (A separate downstream `PythonInvokeInstruction.getUse` assertion fires on `testEx5CG` after the NPE clears — that's a different, unrelated bug; tracking separately.)

## Closes

- wala/ML#434