### PR TITLE
Add cycle guard to `TensorGeneratorFactory.getGenerator` recursion (`wala/ML#435`)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2112,6 +2112,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_not_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
   }
 
+  /**
+   * Regression test for wala/ML#435: a {@code @tf.function}-decorated Python function that returns
+   * a recursive call to itself used to drive {@link
+   * com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator(
+   * com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable,
+   * com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder)} into unbounded recursion
+   * via the return-value follow-through and the assignment-graph predecessor walk, ending in {@code
+   * StackOverflowError}. The cycle guard added in this PR returns {@code null} when a {@code
+   * PointsToSetVariable} is re-encountered along a single dispatch chain. With the cycle guard in
+   * place, the recursive call's return value still resolves through its base-case branch — the
+   * input {@code tf.constant(1)} (a scalar int32 tensor) flows back to {@code f}'s parameter.
+   */
+  @Test
+  public void testRecursiveFunction()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_recursive_function.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
   @Test
   public void testAdd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2113,16 +2113,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Regression test for wala/ML#435: a {@code @tf.function}-decorated Python function that returns
-   * a recursive call to itself used to drive {@link
+   * Regression test for wala/ML#435: a recursive Python function whose return value flows back into
+   * itself used to drive {@link
    * com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator(
    * com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable,
    * com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder)} into unbounded recursion
    * via the return-value follow-through and the assignment-graph predecessor walk, ending in {@code
    * StackOverflowError}. The cycle guard added in this PR returns {@code null} when a {@code
-   * PointsToSetVariable} is re-encountered along a single dispatch chain. With the cycle guard in
+   * PointsToSetVariable} is re-encountered along the current call chain. With the cycle guard in
    * place, the recursive call's return value still resolves through its base-case branch — the
    * input {@code tf.constant(1)} (a scalar int32 tensor) flows back to {@code f}'s parameter.
+   *
+   * <p>The Python test deliberately omits the {@code @tf.function} decorator. Empirically, the
+   * regression reproduces without it (verified by reverting the cycle guard locally — this test
+   * still SOes), and the decorated form would re-trace the recursive call at runtime and hit
+   * Python's recursion limit before the assertions could run. The undecorated form lets {@code
+   * python3.10} execute the file to completion with the {@code shape}/{@code dtype} assertions on
+   * {@code result} exercised.
    */
   @Test
   public void testRecursiveFunction()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -445,12 +445,11 @@ public class TensorGeneratorFactory {
    * PropagationCallGraphBuilder)}. Threads a set of already-visited sources through the recursive
    * walk so that self-referential functions (e.g. an {@code @tf.function}-decorated Python function
    * that returns a recursive call to itself) don't drive {@code getGenerator} into unbounded
-   * recursion via the return-value follow-through ({@link
-   * #getGeneratorForInvoke(PointsToSetVariable, SSAAbstractInvokeInstruction, CGNode, int,
-   * PropagationCallGraphBuilder, Set)} body) and the assignment-graph predecessor walk (the {@code
-   * ReturnValueKey} fallback). When a {@link PointsToSetVariable} is re-encountered along a single
-   * dispatch chain, this method returns {@code null} so the outer dispatch loop can try other
-   * candidate callees / predecessors. See wala/ML#435.
+   * recursion via the return-value follow-through in this method's {@code
+   * SSAAbstractInvokeInstruction} handling branch and the assignment-graph predecessor walk (the
+   * {@code ReturnValueKey} fallback). When a {@link PointsToSetVariable} is re-encountered along a
+   * single dispatch chain, this method returns {@code null} so the outer dispatch loop can try
+   * other candidate callees / predecessors. See wala/ML#435.
    */
   private static TensorGenerator getGenerator(
       PointsToSetVariable source,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -443,13 +443,18 @@ public class TensorGeneratorFactory {
   /**
    * Cycle-guarded internal version of {@link #getGenerator(PointsToSetVariable,
    * PropagationCallGraphBuilder)}. Threads a set of already-visited sources through the recursive
-   * walk so that self-referential functions (e.g. an {@code @tf.function}-decorated Python function
-   * that returns a recursive call to itself) don't drive {@code getGenerator} into unbounded
-   * recursion via the return-value follow-through in this method's {@code
-   * SSAAbstractInvokeInstruction} handling branch and the assignment-graph predecessor walk (the
-   * {@code ReturnValueKey} fallback). When a {@link PointsToSetVariable} is re-encountered along a
-   * single dispatch chain, this method returns {@code null} so the outer dispatch loop can try
-   * other candidate callees / predecessors. See wala/ML#435.
+   * walk so that self-referential functions (e.g. a recursive Python function whose return value
+   * flows back into itself) don't drive {@code getGenerator} into unbounded recursion via the
+   * return-value follow-through in this method's {@code SSAAbstractInvokeInstruction} handling
+   * branch and the assignment-graph predecessor walk (the {@code ReturnValueKey} fallback). When a
+   * {@link PointsToSetVariable} is re-encountered along the current call chain, this method returns
+   * {@code null} so the outer dispatch loop can try other candidate callees / predecessors. See
+   * wala/ML#435.
+   *
+   * @implNote {@code visited} is used as a DFS recursion-stack set: a source is added on entry and
+   *     removed in a {@code finally} block before returning. This means only true cycles on the
+   *     current call path short-circuit; sibling sub-dispatches in the same top-level call can
+   *     re-visit a source freely without losing precision.
    */
   private static TensorGenerator getGenerator(
       PointsToSetVariable source,
@@ -466,6 +471,23 @@ public class TensorGeneratorFactory {
                   + "; returning null so dispatch can try other branches.");
       return null;
     }
+    final PointsToSetVariable visitedSource = source;
+    try {
+      return getGeneratorBody(source, builder, visited);
+    } finally {
+      visited.remove(visitedSource);
+    }
+  }
+
+  /**
+   * Body of the cycle-guarded {@link #getGenerator(PointsToSetVariable,
+   * PropagationCallGraphBuilder, Set)}, extracted so the cycle guard can wrap the entire dispatch
+   * in a single {@code try}/{@code finally} (add on entry, remove on exit).
+   */
+  private static TensorGenerator getGeneratorBody(
+      PointsToSetVariable source,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
     PointerKey k = source.getPointerKey();
     if (k instanceof LocalPointerKey) {
       LocalPointerKey lpk = (LocalPointerKey) k;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -403,9 +403,11 @@ public class TensorGeneratorFactory {
    * source. See wala/ML#363.
    */
   private static TensorGenerator tryGetGenerator(
-      PointsToSetVariable source, PropagationCallGraphBuilder builder) {
+      PointsToSetVariable source,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
     try {
-      return getGenerator(source, builder);
+      return getGenerator(source, builder, visited);
     } catch (IllegalArgumentException e) {
       LOGGER.log(Level.FINE, "tryGetGenerator: swallowed IAE for source=" + source, e);
       return null;
@@ -435,7 +437,36 @@ public class TensorGeneratorFactory {
    */
   public static TensorGenerator getGenerator(
       PointsToSetVariable source, PropagationCallGraphBuilder builder) {
+    return getGenerator(source, builder, HashSetFactory.make());
+  }
+
+  /**
+   * Cycle-guarded internal version of {@link #getGenerator(PointsToSetVariable,
+   * PropagationCallGraphBuilder)}. Threads a set of already-visited sources through the recursive
+   * walk so that self-referential functions (e.g. an {@code @tf.function}-decorated Python function
+   * that returns a recursive call to itself) don't drive {@code getGenerator} into unbounded
+   * recursion via the return-value follow-through ({@link
+   * #getGeneratorForInvoke(PointsToSetVariable, SSAAbstractInvokeInstruction, CGNode, int,
+   * PropagationCallGraphBuilder, Set)} body) and the assignment-graph predecessor walk (the {@code
+   * ReturnValueKey} fallback). When a {@link PointsToSetVariable} is re-encountered along a single
+   * dispatch chain, this method returns {@code null} so the outer dispatch loop can try other
+   * candidate callees / predecessors. See wala/ML#435.
+   */
+  private static TensorGenerator getGenerator(
+      PointsToSetVariable source,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
     source = findCreator(source, builder);
+    if (!visited.add(source)) {
+      final PointsToSetVariable cycleSource = source;
+      LOGGER.log(
+          Level.FINE,
+          () ->
+              "getGenerator: cycle detected at source="
+                  + cycleSource
+                  + "; returning null so dispatch can try other branches.");
+      return null;
+    }
     PointerKey k = source.getPointerKey();
     if (k instanceof LocalPointerKey) {
       LocalPointerKey lpk = (LocalPointerKey) k;
@@ -462,7 +493,7 @@ public class TensorGeneratorFactory {
                 builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, iterableVn);
             PointsToSetVariable iterableSrc = getPointsToSetVariable(iterableKey, builder);
             return (iterableSrc != null)
-                ? new EnumerateGenerator(source, tryGetGenerator(iterableSrc, builder))
+                ? new EnumerateGenerator(source, tryGetGenerator(iterableSrc, builder, visited))
                 : null;
           }
 
@@ -477,7 +508,7 @@ public class TensorGeneratorFactory {
                 builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, iterableVn);
             PointsToSetVariable iterableSrc = getPointsToSetVariable(iterableKey, builder);
             return (iterableSrc != null)
-                ? new IteratorGenerator(source, tryGetGenerator(iterableSrc, builder))
+                ? new IteratorGenerator(source, tryGetGenerator(iterableSrc, builder, visited))
                 : null;
           }
 
@@ -528,7 +559,7 @@ public class TensorGeneratorFactory {
                 builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, iterableVn);
             PointsToSetVariable iterableSrc = getPointsToSetVariable(iterableKey, builder);
             if (iterableSrc == null) return null;
-            TensorGenerator containerGenerator = tryGetGenerator(iterableSrc, builder);
+            TensorGenerator containerGenerator = tryGetGenerator(iterableSrc, builder, visited);
 
             while (containerGenerator instanceof DelegatingTensorGenerator) {
               containerGenerator = ((DelegatingTensorGenerator) containerGenerator).getUnderlying();
@@ -564,7 +595,7 @@ public class TensorGeneratorFactory {
                             .getPointerKeyForLocal(creatorNode, 2);
                     PointsToSetVariable iterArgSrc = getPointsToSetVariable(iterArgKey, builder);
                     if (iterArgSrc != null) {
-                      containerGenerator = tryGetGenerator(iterArgSrc, builder);
+                      containerGenerator = tryGetGenerator(iterArgSrc, builder, visited);
                       if (containerGenerator != null) break;
                     }
                   }
@@ -584,7 +615,7 @@ public class TensorGeneratorFactory {
             // unresolved callee doesn't abort dispatch for the whole source — the outer
             // loop should try the remaining candidate callees, and failing that fall through
             // to the `ReturnValueKey` / assignment-graph fallback below. See wala/ML#363.
-            TensorGenerator fromRet = tryGetGenerator(retSrc, builder);
+            TensorGenerator fromRet = tryGetGenerator(retSrc, builder, visited);
             if (fromRet != null) return fromRet;
           }
         }
@@ -596,7 +627,7 @@ public class TensorGeneratorFactory {
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, iterableVn);
         PointsToSetVariable iterableSrc = getPointsToSetVariable(iterableKey, builder);
         if (iterableSrc == null) return null;
-        TensorGenerator containerGenerator = tryGetGenerator(iterableSrc, builder);
+        TensorGenerator containerGenerator = tryGetGenerator(iterableSrc, builder, visited);
 
         // We have a generator for the container (the object being iterated over).
         // If the container is a `Dataset` (e.g., `tf.data.Dataset`), its generator
@@ -617,7 +648,7 @@ public class TensorGeneratorFactory {
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, objRef);
         PointsToSetVariable objSrc = getPointsToSetVariable(objKey, builder);
         if (objSrc == null) return null;
-        TensorGenerator containerGenerator = tryGetGenerator(objSrc, builder);
+        TensorGenerator containerGenerator = tryGetGenerator(objSrc, builder, visited);
 
         TensorGenerator effectiveGenerator = containerGenerator;
         boolean changed = true;
@@ -900,7 +931,7 @@ public class TensorGeneratorFactory {
             it.hasNext(); ) {
           PointsToSetVariable pred = it.next();
           try {
-            TensorGenerator gen = getGenerator(pred, builder);
+            TensorGenerator gen = getGenerator(pred, builder, visited);
             if (gen != null) {
               return gen;
             }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_recursive_function.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_recursive_function.py
@@ -1,0 +1,30 @@
+# Regression test for wala/ML#435: a `@tf.function`-decorated Python function that
+# returns a recursive call to itself used to drive
+# `TensorGeneratorFactory.getGenerator` into unbounded recursion via the
+# return-value follow-through and the assignment-graph predecessor walk, ending
+# in `StackOverflowError`. The cycle guard added in this PR returns null
+# (unknown) when a `PointsToSetVariable` is re-encountered along a single
+# dispatch chain, so the analysis terminates instead of overflowing.
+#
+# Note: the runtime call below catches `RecursionError` because TensorFlow
+# re-traces the recursive function on each call, hitting Python's default
+# recursion limit. The static analysis path is what this test exercises.
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+@tf.function
+def recursive_fn(n):
+    if n > 0:
+        return recursive_fn(n - 1)
+    return n
+
+
+try:
+    result = recursive_fn(tf.constant(1))
+    f(result)
+except RecursionError:
+    pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_recursive_function.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_recursive_function.py
@@ -1,14 +1,11 @@
-# Regression test for wala/ML#435: a `@tf.function`-decorated Python function that
-# returns a recursive call to itself used to drive
+# Regression test for wala/ML#435: a recursive Python function whose return
+# value flows back into itself used to drive
 # `TensorGeneratorFactory.getGenerator` into unbounded recursion via the
-# return-value follow-through and the assignment-graph predecessor walk, ending
-# in `StackOverflowError`. The cycle guard added in this PR returns null
-# (unknown) when a `PointsToSetVariable` is re-encountered along a single
-# dispatch chain, so the analysis terminates instead of overflowing.
-#
-# Note: the runtime call below catches `RecursionError` because TensorFlow
-# re-traces the recursive function on each call, hitting Python's default
-# recursion limit. The static analysis path is what this test exercises.
+# return-value follow-through and the assignment-graph predecessor walk,
+# ending in `StackOverflowError`. The cycle guard added in this PR returns
+# null (unknown) when a `PointsToSetVariable` is re-encountered along a single
+# dispatch chain, so the analysis terminates and the base-case value
+# (a scalar int32 tensor) flows back to `f`'s parameter.
 import tensorflow as tf
 
 
@@ -16,15 +13,14 @@ def f(a):
     pass
 
 
-@tf.function
 def recursive_fn(n):
     if n > 0:
         return recursive_fn(n - 1)
     return n
 
 
-try:
-    result = recursive_fn(tf.constant(1))
-    f(result)
-except RecursionError:
-    pass
+result = recursive_fn(tf.constant(1))
+assert isinstance(result, tf.Tensor)
+assert result.shape == ()
+assert result.dtype == tf.int32
+f(result)


### PR DESCRIPTION
## Summary

Adds a DFS recursion-stack cycle guard to `TensorGeneratorFactory.getGenerator` and `tryGetGenerator` so self-referential Python functions don't drive the dispatcher into unbounded recursion. Closes [wala/ML#435](https://github.com/wala/ML/issues/435).

## Problem

For a recursive Python function whose return value flows back into itself, e.g.:

```python
def recursive_fn(n):
    if n > 0:
        return recursive_fn(n - 1)
    return n
```

the generator dispatch bounces between two recursive call sites:

- The invoke branch's return-value follow-through (`tryGetGenerator(retSrc, builder)` for the callee's return-value points-to set).
- The `ReturnValueKey` fallback's assignment-graph predecessor walk (`getGenerator(pred, builder)`).

The recursive call's return value is its own assignment-graph predecessor, so the two sites chase each other indefinitely until `StackOverflowError`. Affects all 9 `testRecursionN` cases in `HybridizeFunctionRefactoringTest`. Empirically verified to reproduce *without* the `@tf.function` decorator (reverting the cycle guard locally on this branch makes the regression test SO regardless of whether the test function is decorated).

## Fix

Thread a `Set<PointsToSetVariable> visited` through both `getGenerator` and `tryGetGenerator`. Use the standard DFS pattern: `add` on entry, `remove` in a `finally` block. After `findCreator` normalizes the source, `visited.add(source)` short-circuits to `null` if we re-encounter the same source on the *current call chain*; the `remove` ensures sibling sub-dispatches in the same top-level call can re-visit the source freely (no precision loss). Returning `null` is consistent with the existing "unresolved branch shouldn't abort dispatch" intent in `tryGetGenerator`'s Javadoc (see wala/ML#363) — the outer dispatch loop tries other candidate callees / predecessors / property-name dispatches.

- Public 2-arg `getGenerator(source, builder)` keeps its existing contract; delegates to a new private 3-arg overload with a fresh `HashSetFactory.make()` set per top-level call.
- Internal cycle guard wraps the body via `try { getGeneratorBody(...) } finally { visited.remove(source) }` — extracted helper avoids touching every internal `return` statement.
- All 9 internal recursion sites thread `visited`: `tryGetGenerator` delegation, `EnumerateGenerator`/`IteratorGenerator` iteration arg, `NEXT_BUILTIN` container generator, `NEXT_BUILTIN` field-indirection iter-arg, return-value follow-through, `EachElementGet` container generator, `PythonPropertyRead` object generator, and the assignment-graph predecessor walk.
- Per-dispatch-tree state, so concurrent top-level callers are unaffected.

## Regression Test

Adds `tf2_test_recursive_function.py` + `TestTensorflow2Model#testRecursiveFunction`. The Python file deliberately omits `@tf.function`:

- The bug reproduces without it (verified — see Problem section).
- The decorated form would re-trace the recursive call at runtime and exhaust Python's recursion limit before `assert isinstance(result, tf.Tensor)` / `shape == ()` / `dtype == tf.int32` could run, defeating the "file runs to completion under `python3.10`" requirement.

The test asserts `f`'s parameter resolves to `SCALAR_TENSOR_OF_INT32` — the base-case `tf.constant(1)` value flowing back through the recursion. Without the cycle guard this SOes; with it, the analysis terminates and identifies the correct tensor type.

## Validation

- `mvn -pl com.ibm.wala.cast.python.ml.test -am test` (master XML + this fix): 612 tests, 0 failures, 0 errors, 3 skipped. No regression.
- Cycle-guard-revert experiment (cherry-pick of test-only changes onto master without the cycle guard): `testRecursiveFunction` fails with `StackOverflowError` — confirms the test exercises the regression.
- Downstream verification (the 9 `testRecursionN` SOs in Hybridize-Functions-Refactoring) will run once Ariadne is re-released with this fix and Hybridize bumps the version.

## Closes

- wala/ML#435
