### PR TITLE
Map Python `Boolean` constants to `tf.bool` dtype in `getDTypesOfValue` (`wala/ML#447`)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -89,6 +89,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType SCALAR_TENSOR_OF_STRING = new TensorType(STRING, emptyList());
 
+  private static final TensorType SCALAR_TENSOR_OF_BOOL = new TensorType(BOOL, emptyList());
+
+  private static final TensorType TENSOR_3_BOOL = new TensorType(BOOL, asList(new NumericDim(3)));
+
   private static final TensorType TENSOR_1_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
 
@@ -3953,6 +3957,27 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testReduceSum3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_reduce_sum.py", "h", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  /**
+   * Regression test for `wala/ML#447`: scalar `tf.constant(<bool>)` exercises the {@link
+   * java.lang.Boolean} arm of {@code TensorGenerator.getDTypesOfValue}. Without it, dtype inference
+   * threw {@code IllegalStateException: Unknown constant type: class java.lang.Boolean}.
+   */
+  @Test
+  public void testBoolConstant()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_bool_constant.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_BOOL)));
+  }
+
+  /**
+   * List-of-bool form of {@link #testBoolConstant} — exercises the recursive {@code
+   * getDTypesOfValue} call (line 1625) on a list whose elements are `Boolean` constants.
+   */
+  @Test
+  public void testBoolConstant2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_bool_constant.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_3_BOOL)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -5,6 +5,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT_OP_CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_CHOOSE_FROM_DATASETS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_SAMPLE_FROM_DATASETS_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
@@ -1583,6 +1584,16 @@ public abstract class TensorGenerator {
           LOGGER.info(
               "Inferred dtype: "
                   + STRING
+                  + " for source: "
+                  + this.getSource()
+                  + " from value: "
+                  + value
+                  + ".");
+        } else if (value instanceof Boolean) {
+          ret.add(BOOL);
+          LOGGER.info(
+              "Inferred dtype: "
+                  + BOOL
                   + " for source: "
                   + this.getSource()
                   + " from value: "

--- a/com.ibm.wala.cast.python.test/data/tf2_test_bool_constant.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_bool_constant.py
@@ -1,0 +1,24 @@
+# Regression test for `wala/ML#447`: `tf.constant(<bool>)` and
+# `tf.constant([<bool>, ...])` exercise the `Boolean` arm of
+# `TensorGenerator.getDTypesOfValue`. Without that arm, dtype inference
+# threw `IllegalStateException: Unknown constant type: class java.lang.Boolean`.
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+x = tf.constant(True)
+assert x.shape == ()
+assert x.dtype == tf.bool
+f(x)
+
+y = tf.constant([True, False, True])
+assert y.shape == (3,)
+assert y.dtype == tf.bool
+g(y)


### PR DESCRIPTION
## Summary

`TensorGenerator.getDTypesOfValue` already maps `Float`/`Double` → `FLOAT32`, `Integer`/`Long` → `INT32`, `String` → `STRING`, but had no `Boolean` case. Any `tf.constant(True)` or `tf.constant([True, False])` reaching dtype inference threw:

```
java.lang.IllegalStateException: Unknown constant type: class java.lang.Boolean.
    at TensorGenerator.getDTypesOfValue(TensorGenerator.java:1592)
    at Constant.getDefaultDTypes(Constant.java:65)
```

`tf.reduce_all` is the natural consumer (boolean-only reduction), but any boolean tensor literal hits this path.

## Change

Add `Boolean.class -> BOOL` (the enum constant already exists in `DType`). 11 lines including the matching `LOGGER.info` formatting that the surrounding cases use.

Also adds an Ariadne-side regression test for the new arm so the fix can't regress silently — see "Test Plan" below.

## Test Plan

- [x] **Ariadne-side `TestTensorflow2Model.testBoolConstant` / `testBoolConstant2`** added in this PR. They exercise both `tf.constant(True)` (scalar) and `tf.constant([True, False, True])` (list, also exercising the recursive `getDTypesOfValue` call at line 1625). Both pass with this PR; both error with `IllegalStateException` without it.
- [x] **Downstream verification (Hybridize):** `HybridizeFunctionRefactoringTest.testReduceAll` (which lives in `ponder-lab/Hybridize-Functions-Refactoring`, not this repo) previously surfaced this `IllegalStateException` through Hybridize's analysis path. With this PR consumed via `0.42.0-SNAPSHOT`, the ISE no longer fires.
- [x] Compile + Spotless clean.

Closes wala/ML#447.
