### PR TITLE
Tolerate unknown constant types in `TensorGenerator.getDTypesOfValue`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1599,8 +1599,24 @@ public abstract class TensorGenerator {
                   + " from value: "
                   + value
                   + ".");
-        } else if (value != null)
-          throw new IllegalStateException("Unknown constant type: " + value.getClass() + ".");
+        } else if (value != null) {
+          // Unrecognized value type. Return UNKNOWN to match the existing
+          // dtype-lattice contract (UNKNOWN = ⊤) instead of aborting the
+          // analysis with IllegalStateException. Same shape as the prior
+          // Boolean-case fix (#447): missing types should fall through to
+          // ⊤ in the lattice rather than terminate the analysis.
+          ret.add(com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN);
+          final Object capturedValue = value;
+          LOGGER.fine(
+              () ->
+                  "Unrecognized constant type for source: "
+                      + this.getSource()
+                      + " value: "
+                      + capturedValue
+                      + " ("
+                      + capturedValue.getClass()
+                      + "); using UNKNOWN dtype.");
+        }
       } else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
         TypeReference reference = asin.getConcreteType().getReference();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1607,16 +1607,14 @@ public abstract class TensorGenerator {
           // `{INT32, UNKNOWN}` and mislead downstream consumers). Same shape
           // as the prior Boolean-case fix (#447): missing types should fall
           // through to ⊤ in the lattice rather than terminate the analysis.
-          final Object capturedValue = value;
           LOGGER.fine(
-              () ->
-                  "Unrecognized constant type for source: "
-                      + this.getSource()
-                      + " value: "
-                      + capturedValue
-                      + " ("
-                      + capturedValue.getClass()
-                      + "); collapsing to ⊤ (UNKNOWN dtype).");
+              "Unrecognized constant type for source: "
+                  + this.getSource()
+                  + " value: "
+                  + value
+                  + " ("
+                  + value.getClass()
+                  + "); collapsing to ⊤ (UNKNOWN dtype).");
           return EnumSet.of(UNKNOWN);
         }
       } else if (valueIK instanceof AllocationSiteInNode) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -9,6 +9,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FIELD_REFERENCE_TO_DTYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.PLACEHOLDER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORFLOW_TYPE;
@@ -1600,12 +1601,12 @@ public abstract class TensorGenerator {
                   + value
                   + ".");
         } else if (value != null) {
-          // Unrecognized value type. Return UNKNOWN to match the existing
-          // dtype-lattice contract (UNKNOWN = ⊤) instead of aborting the
-          // analysis with IllegalStateException. Same shape as the prior
-          // Boolean-case fix (#447): missing types should fall through to
-          // ⊤ in the lattice rather than terminate the analysis.
-          ret.add(com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN);
+          // Unrecognized value type. ⊤ subsumes any concrete dtype already
+          // accumulated, so short-circuit with EnumSet.of(UNKNOWN) instead of
+          // adding UNKNOWN to `ret` (which would yield mixed sets like
+          // `{INT32, UNKNOWN}` and mislead downstream consumers). Same shape
+          // as the prior Boolean-case fix (#447): missing types should fall
+          // through to ⊤ in the lattice rather than terminate the analysis.
           final Object capturedValue = value;
           LOGGER.fine(
               () ->
@@ -1615,7 +1616,8 @@ public abstract class TensorGenerator {
                       + capturedValue
                       + " ("
                       + capturedValue.getClass()
-                      + "); using UNKNOWN dtype.");
+                      + "); collapsing to ⊤ (UNKNOWN dtype).");
+          return EnumSet.of(UNKNOWN);
         }
       } else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1601,21 +1601,21 @@ public abstract class TensorGenerator {
                   + value
                   + ".");
         } else if (value != null) {
-          // Unrecognized value type. ⊤ subsumes any concrete dtype already
-          // accumulated, so short-circuit with EnumSet.of(UNKNOWN) instead of
-          // adding UNKNOWN to `ret` (which would yield mixed sets like
-          // `{INT32, UNKNOWN}` and mislead downstream consumers). Same shape
-          // as the prior Boolean-case fix (#447): missing types should fall
-          // through to ⊤ in the lattice rather than terminate the analysis.
-          LOGGER.fine(
+          // Unrecognized value type. Add UNKNOWN to `ret` and let the
+          // end-of-function lattice-collapse normalize: if any path produces
+          // UNKNOWN, the final result is {UNKNOWN} regardless of what other
+          // iterations contributed. Same shape as the prior Boolean-case fix
+          // (#447): missing types should fall through to ⊤ in the lattice
+          // rather than terminate the analysis.
+          ret.add(UNKNOWN);
+          LOGGER.info(
               "Unrecognized constant type for source: "
                   + this.getSource()
                   + " value: "
                   + value
                   + " ("
                   + value.getClass()
-                  + "); collapsing to ⊤ (UNKNOWN dtype).");
-          return EnumSet.of(UNKNOWN);
+                  + "); contributing UNKNOWN dtype.");
         }
       } else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
@@ -1695,6 +1695,14 @@ public abstract class TensorGenerator {
       }
     }
 
+    // Normalize the lattice: ⊤ subsumes any concrete dtype, so if any
+    // contributing path produced UNKNOWN (either directly via the
+    // unrecognized-constant short-circuit above, or via a recursive call
+    // for list/tuple element dtypes that propagated UNKNOWN through
+    // `ret.addAll(...)`), collapse to {UNKNOWN}. Without this, recursive
+    // accumulation could yield mixed sets like `{INT32, UNKNOWN}` and
+    // mislead downstream consumers.
+    if (ret.contains(UNKNOWN)) return EnumSet.of(UNKNOWN);
     return ret;
   }
 


### PR DESCRIPTION
## Summary

The dtype-inference loop in `TensorGenerator.getDTypesOfValue` maps recognized Python literal types (`Float`/`Double`/`Integer`/`Long`/`String`/`Boolean`) to their TF DTypes. Anything else throws `IllegalStateException("Unknown constant type: ...")` and aborts the entire analysis on a recoverable case.

Return `EnumSet.of(UNKNOWN)` for unrecognized value types instead — matching the existing dtype lattice (`UNKNOWN` = ⊤) and the same posture as the prior `Boolean`-case fix (#447). Missing types should fall through to ⊤ rather than terminate the analysis. Short-circuit on the first unrecognized type so the result is always either *all-concrete* or *just `UNKNOWN`*, never a mixed set like `{INT32, UNKNOWN}`.

## Why

Robustness improvement orthogonal to #437. Surfaced during #437's investigation as a class of crashes hit by an early dispatch experiment (`Constant`-based fallback for unmigrated APIs); that experiment was dropped in favor of the `ReadDataFallback` shape (#196) which bypasses `getDTypesOfValue` entirely. The original IAE is no longer the immediate path for #437, but it's a latent footgun: any future generator that calls `getDTypesOfValue` with an unrecognized value type would still abort the entire analysis instead of degrading gracefully.

This PR is the defensive fix; it doesn't depend on or compete with #196.

## Test Plan

- [x] Full Ariadne `com.ibm.wala.cast.python.ml.test` suite green: `Tests run: 622, Failures: 0, Errors: 0, Skipped: 3`.
- [x] Spotless clean.
- [x] Copilot review (lambda not needed for cheap log message; short-circuit instead of mixing dtypes) addressed.
