### PR TITLE
Add `ReadDataFallback` for `read_data`-pattern XML classes (#437)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1980,11 +1980,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testNeuralNetwork4()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // Count bumped 6 → 14 by `ReadDataFallback` (#437): `accuracy()` uses
+    // `tf.argmax(...)` which is a legitimate tensor source per #380 but
+    // wasn't being classified pre-fix. The 8 additional tensor variables
+    // are the argmax call sites and their downstream uses across the call
+    // graph. Parameter-type expectations (`y_pred`, `y_true`) unchanged.
     test(
         "neural_network.py",
         "accuracy",
         2,
-        6,
+        14,
         Map.of(2, Set.of(TENSOR_256_10_FLOAT32), 3, Set.of(TENSOR_256_UINT8, TENSOR_10000_UINT8)));
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -120,6 +120,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
@@ -129,6 +130,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -970,13 +972,21 @@ public class TensorGeneratorFactory {
       // Fallback for `read_data`-pattern XML classes (#437, #380): when the
       // dispatch chain above has no entry, check whether the call's
       // function-object came from a `PythonPropertyRead` whose member-name
-      // is the parent of a `read_data` trampoline. If so, classify as a
-      // generic ⊤-shape / UNKNOWN-dtype tensor source — restoring
-      // pre-branch-267 identification semantics for ops not yet ported to
-      // dedicated `TensorGenerator` subclasses. Specific dispatch entries
-      // are checked first; this only fires when nothing in the table matched.
-      String propertyName = getPropertyReadMemberName(source, builder);
-      if (propertyName != null && classHasReadDataMethod(propertyName, builder)) {
+      // matches the parent class of an `Ltensorflow/.../<name>/read_data`
+      // trampoline. If so, classify as a generic ⊤-shape / UNKNOWN-dtype
+      // tensor source — restoring pre-branch-267 identification semantics
+      // for ops not yet ported to dedicated `TensorGenerator` subclasses.
+      // Specific dispatch entries are checked first; this only fires when
+      // nothing in the table matched.
+      //
+      // The trampoline lookup is restricted to the `Ltensorflow/` namespace
+      // so that `np.argmax(...)` and similar non-TF property reads aren't
+      // misclassified even if a future numpy.xml ever introduces an
+      // `argmax` class. All candidate constant-string member-names from the
+      // points-to set are checked, not just the first, to avoid
+      // iteration-order-dependent behavior on multi-candidate sites.
+      for (String propertyName : getPropertyReadMemberNames(source, builder)) {
+        if (!getTensorflowReadDataPropertyNames(builder).contains(propertyName)) continue;
         final String capturedName = propertyName;
         final TypeReference capturedFunction = calledFunction;
         LOGGER.fine(
@@ -996,43 +1006,53 @@ public class TensorGeneratorFactory {
   }
 
   /**
-   * If the given source's call's function object came from a {@link PythonPropertyRead} whose
-   * member-ref is a constant string, return that string. Otherwise return {@code null}.
+   * Returns the set of constant-string member-names that the call's function-object could resolve
+   * to via a {@link PythonPropertyRead}. Empty if the call's function-object isn't a property read
+   * or no constant strings are in the member-ref points-to set.
    *
    * <p>Used by the `read_data`-pattern fallback to walk back from a call site to the property-read
-   * that resolved its function object. Tolerant of empty points-to sets and
-   * non-`PythonPropertyRead` defs (returns {@code null}).
+   * that resolved its function object. Returns all candidate names rather than just the first, so
+   * downstream predicate checks are not iteration-order-dependent on multi-candidate sites.
    */
-  private static String getPropertyReadMemberName(
+  private static Set<String> getPropertyReadMemberNames(
       PointsToSetVariable source, PropagationCallGraphBuilder builder) {
     PointerKey k = source.getPointerKey();
-    if (!(k instanceof LocalPointerKey)) return null;
+    if (!(k instanceof LocalPointerKey)) return Collections.emptySet();
     LocalPointerKey lpk = (LocalPointerKey) k;
     CGNode node = lpk.getNode();
     SSAInstruction def = node.getDU().getDef(lpk.getValueNumber());
-    if (!(def instanceof SSAAbstractInvokeInstruction)) return null;
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return Collections.emptySet();
     SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) def;
-    if (call.getNumberOfUses() == 0) return null;
+    if (call.getNumberOfUses() == 0) return Collections.emptySet();
     SSAInstruction funcDef = node.getDU().getDef(call.getUse(0));
-    if (!(funcDef instanceof PythonPropertyRead)) return null;
+    if (!(funcDef instanceof PythonPropertyRead)) return Collections.emptySet();
     PythonPropertyRead funcRead = (PythonPropertyRead) funcDef;
     PointerKey memberKey =
         builder
             .getPointerAnalysis()
             .getHeapModel()
             .getPointerKeyForLocal(node, funcRead.getMemberRef());
+    Set<String> names = HashSetFactory.make();
     for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(memberKey)) {
       if (!(ik instanceof ConstantKey)) continue;
       Object value = ((ConstantKey<?>) ik).getValue();
-      if (value instanceof String) return (String) value;
+      if (value instanceof String) names.add((String) value);
     }
-    return null;
+    return names;
   }
 
   /**
-   * Returns {@code true} iff the class hierarchy contains a synthetic trampoline class for an
-   * XML-registered {@code read_data} method whose parent class's simple name matches {@code
-   * propertyName}.
+   * Per-{@link IClassHierarchy} memoized cache of property names whose {@code read_data} trampoline
+   * classes exist in the {@code Ltensorflow/} namespace. Computed once per analysis builder via a
+   * single class-hierarchy scan and reused thereafter so the {@code read_data}-pattern fallback's
+   * predicate check is O(1) per call instead of O(|CHA|).
+   */
+  private static final java.util.WeakHashMap<IClassHierarchy, Set<String>>
+      TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE = new java.util.WeakHashMap<>();
+
+  /**
+   * Returns the set of property names whose {@code Ltensorflow/.../<name>/read_data} trampoline
+   * class exists in the given {@link PropagationCallGraphBuilder}'s class hierarchy.
    *
    * <p>XML-registered helper methods like {@code read_data} get transformed by {@link
    * com.ibm.wala.cast.python.client.PythonAnalysisEngine#addSummaryBypassLogic} into synthetic
@@ -1041,18 +1061,34 @@ public class TensorGeneratorFactory {
    * class with a {@code do} method. So a class-hierarchy scan for a {@code read_data} method on the
    * parent class via {@link IClass#getDeclaredMethods()} returns nothing — we have to look for the
    * trampoline class instead.
+   *
+   * <p>Restricted to the {@code Ltensorflow/} namespace so non-TF property reads (e.g. {@code
+   * np.argmax(...)}) aren't misclassified even if a future {@code numpy.xml} introduces a class
+   * with the same simple name. Memoized via {@link #TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE} to
+   * avoid repeating the O(|CHA|) scan on every fallback check.
    */
-  private static boolean classHasReadDataMethod(
-      String propertyName, PropagationCallGraphBuilder builder) {
-    String trampolineSuffix =
-        "/"
-            + propertyName
-            + "/"
-            + PythonTensorAnalysisEngine.TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME;
-    for (IClass cls : builder.getClassHierarchy()) {
-      if (cls.getName().toString().endsWith(trampolineSuffix)) return true;
+  private static Set<String> getTensorflowReadDataPropertyNames(
+      PropagationCallGraphBuilder builder) {
+    IClassHierarchy cha = builder.getClassHierarchy();
+    synchronized (TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE) {
+      Set<String> cached = TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE.get(cha);
+      if (cached != null) return cached;
     }
-    return false;
+    String suffix = "/" + PythonTensorAnalysisEngine.TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME;
+    Set<String> names = HashSetFactory.make();
+    for (IClass cls : cha) {
+      String typeName = cls.getName().toString();
+      if (!typeName.startsWith("Ltensorflow/")) continue;
+      if (!typeName.endsWith(suffix)) continue;
+      int suffixStart = typeName.length() - suffix.length();
+      int sep = typeName.lastIndexOf('/', suffixStart - 1);
+      if (sep < 0) continue;
+      names.add(typeName.substring(sep + 1, suffixStart));
+    }
+    synchronized (TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE) {
+      TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE.put(cha, names);
+    }
+    return names;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -33,6 +33,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_WITH_OPT
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_ZIP_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DENSE_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DIVIDE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
@@ -103,6 +104,8 @@ import static java.util.Map.entry;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.python.util.Util;
@@ -126,6 +129,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -106,6 +106,7 @@ import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.python.util.Util;
+import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConcreteTypeKey;
@@ -127,6 +128,7 @@ import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -961,8 +963,141 @@ public class TensorGeneratorFactory {
           }
         }
       }
+      // Fallback for `read_data`-pattern XML classes (#437, #380): when the
+      // dispatch chain above has no entry, check whether the call's
+      // function-object came from a `PythonPropertyRead` whose member-name
+      // is the parent of a `read_data` trampoline. If so, classify as a
+      // generic ⊤-shape / UNKNOWN-dtype tensor source — restoring
+      // pre-branch-267 identification semantics for ops not yet ported to
+      // dedicated `TensorGenerator` subclasses. Specific dispatch entries
+      // are checked first; this only fires when nothing in the table matched.
+      String propertyName = getPropertyReadMemberName(source, builder);
+      if (propertyName != null && classHasReadDataMethod(propertyName, builder)) {
+        final String capturedName = propertyName;
+        final TypeReference capturedFunction = calledFunction;
+        LOGGER.fine(
+            () ->
+                "TensorGeneratorFactory: dispatching `."
+                    + capturedName
+                    + "(...)` (calledFunction="
+                    + capturedFunction
+                    + ") via `read_data`-pattern trampoline-class lookup;"
+                    + " no dispatch-table entry — falling back to generic ⊤-shape /"
+                    + " UNKNOWN-dtype tensor source.");
+        return new ReadDataFallback(source);
+      }
       throw new IllegalArgumentException(
           "Unknown call: " + calledFunction + " for source: " + source + ".");
+    }
+  }
+
+  /**
+   * If the given source's call's function object came from a {@link PythonPropertyRead} whose
+   * member-ref is a constant string, return that string. Otherwise return {@code null}.
+   *
+   * <p>Used by the `read_data`-pattern fallback to walk back from a call site to the property-read
+   * that resolved its function object. Tolerant of empty points-to sets and
+   * non-`PythonPropertyRead` defs (returns {@code null}).
+   */
+  private static String getPropertyReadMemberName(
+      PointsToSetVariable source, PropagationCallGraphBuilder builder) {
+    PointerKey k = source.getPointerKey();
+    if (!(k instanceof LocalPointerKey)) return null;
+    LocalPointerKey lpk = (LocalPointerKey) k;
+    CGNode node = lpk.getNode();
+    SSAInstruction def = node.getDU().getDef(lpk.getValueNumber());
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return null;
+    SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) def;
+    if (call.getNumberOfUses() == 0) return null;
+    SSAInstruction funcDef = node.getDU().getDef(call.getUse(0));
+    if (!(funcDef instanceof PythonPropertyRead)) return null;
+    PythonPropertyRead funcRead = (PythonPropertyRead) funcDef;
+    PointerKey memberKey =
+        builder
+            .getPointerAnalysis()
+            .getHeapModel()
+            .getPointerKeyForLocal(node, funcRead.getMemberRef());
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(memberKey)) {
+      if (!(ik instanceof ConstantKey)) continue;
+      Object value = ((ConstantKey<?>) ik).getValue();
+      if (value instanceof String) return (String) value;
+    }
+    return null;
+  }
+
+  /**
+   * Returns {@code true} iff the class hierarchy contains a synthetic trampoline class for an
+   * XML-registered {@code read_data} method whose parent class's simple name matches {@code
+   * propertyName}.
+   *
+   * <p>XML-registered helper methods like {@code read_data} get transformed by {@link
+   * com.ibm.wala.cast.python.client.PythonAnalysisEngine#addSummaryBypassLogic} into synthetic
+   * trampoline classes nested under the parent (per the {@code /class/}-namespace trampoline
+   * pattern): {@code <class>.read_data} becomes a new {@code Ltensorflow/.../<class>/read_data}
+   * class with a {@code do} method. So a class-hierarchy scan for a {@code read_data} method on the
+   * parent class via {@link IClass#getDeclaredMethods()} returns nothing — we have to look for the
+   * trampoline class instead.
+   */
+  private static boolean classHasReadDataMethod(
+      String propertyName, PropagationCallGraphBuilder builder) {
+    String trampolineSuffix =
+        "/"
+            + propertyName
+            + "/"
+            + PythonTensorAnalysisEngine.TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME;
+    for (IClass cls : builder.getClassHierarchy()) {
+      if (cls.getName().toString().endsWith(trampolineSuffix)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Generic fallback {@link TensorGenerator} for XML-modeled tensor-producing APIs that follow the
+   * {@code read_data} pattern but don't have a dedicated subclass yet (per #380). Returns ⊤ shape
+   * and {@code UNKNOWN} dtype — the API is identified as a tensor source, but no precise type is
+   * claimed.
+   *
+   * <p>Distinct from {@link Constant}, which inspects the call's value parameter to infer
+   * shape/dtype: that inspection can return the input tensor's dimensions rather than the op's
+   * actual output dimensions, giving misleading precision for ops where {@code Constant}'s value
+   * model doesn't apply. Per-op subclasses with proper precision can replace this fallback as
+   * they're added; the fallback is just the safety net during the migration.
+   */
+  private static final class ReadDataFallback extends TensorGenerator {
+    ReadDataFallback(PointsToSetVariable source) {
+      super(source);
+    }
+
+    @Override
+    protected Set<List<com.ibm.wala.cast.python.ml.types.TensorType.Dimension<?>>> getDefaultShapes(
+        PropagationCallGraphBuilder builder) {
+      return null;
+    }
+
+    @Override
+    protected int getShapeParameterPosition() {
+      return -1;
+    }
+
+    @Override
+    protected String getShapeParameterName() {
+      return null;
+    }
+
+    @Override
+    protected Set<com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType> getDefaultDTypes(
+        PropagationCallGraphBuilder builder) {
+      return java.util.EnumSet.of(com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN);
+    }
+
+    @Override
+    protected int getDTypeParameterPosition() {
+      return -1;
+    }
+
+    @Override
+    protected String getDTypeParameterName() {
+      return null;
     }
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1069,8 +1069,7 @@ public class TensorGeneratorFactory {
     }
 
     @Override
-    protected Set<List<com.ibm.wala.cast.python.ml.types.TensorType.Dimension<?>>> getDefaultShapes(
-        PropagationCallGraphBuilder builder) {
+    protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
       return null;
     }
 
@@ -1085,9 +1084,8 @@ public class TensorGeneratorFactory {
     }
 
     @Override
-    protected Set<com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType> getDefaultDTypes(
-        PropagationCallGraphBuilder builder) {
-      return java.util.EnumSet.of(com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN);
+    protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+      return EnumSet.of(UNKNOWN);
     }
 
     @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -138,6 +138,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1047,8 +1048,8 @@ public class TensorGeneratorFactory {
    * single class-hierarchy scan and reused thereafter so the {@code read_data}-pattern fallback's
    * predicate check is O(1) per call instead of O(|CHA|).
    */
-  private static final java.util.WeakHashMap<IClassHierarchy, Set<String>>
-      TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE = new java.util.WeakHashMap<>();
+  private static final WeakHashMap<IClassHierarchy, Set<String>>
+      TENSORFLOW_READ_DATA_PROPERTY_NAMES_CACHE = new WeakHashMap<>();
 
   /**
    * Returns the set of property names whose {@code Ltensorflow/.../<name>/read_data} trampoline

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1102,6 +1102,11 @@ public class TensorGeneratorFactory {
    * actual output dimensions, giving misleading precision for ops where {@code Constant}'s value
    * model doesn't apply. Per-op subclasses with proper precision can replace this fallback as
    * they're added; the fallback is just the safety net during the migration.
+   *
+   * <p>TODO: remove this class (and its callers in {@link #getGeneratorBody}, plus the helper
+   * methods {@link #getPropertyReadMemberNames} and {@link #getTensorflowReadDataPropertyNames})
+   * once every op currently routed through here has a dedicated {@link TensorGenerator} subclass
+   * with proper precision. Tracked in #449.
    */
   private static final class ReadDataFallback extends TensorGenerator {
     ReadDataFallback(PointsToSetVariable source) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1106,8 +1106,9 @@ public class TensorGeneratorFactory {
    *
    * <p>TODO: remove this class (and its callers in {@link #getGeneratorBody}, plus the helper
    * methods {@link #getPropertyReadMemberNames} and {@link #getTensorflowReadDataPropertyNames})
-   * once every op currently routed through here has a dedicated {@link TensorGenerator} subclass
-   * with proper precision. Tracked in #449.
+   * once the {@code read_data} pattern is fully migrated out of {@code tensorflow.xml} — at that
+   * point the {@code Ltensorflow/.../<op>/read_data} trampoline classes this fallback keys off
+   * disappear from the class hierarchy and the predicate becomes a no-op anyway. Tracked in #380.
    */
   private static final class ReadDataFallback extends TensorGenerator {
     ReadDataFallback(PointsToSetVariable source) {


### PR DESCRIPTION
## Summary

When `dispatchByPropertyName` and the class-hierarchy dispatch chain both fail to identify a tensor source, but the call's function-object came from a `PythonPropertyRead` whose member-name matches the parent class of an `Ltensorflow/.../<name>/read_data` trampoline, classify the call as a generic ⊤-shape / `UNKNOWN`-dtype tensor source via a new `ReadDataFallback` inner class.

This restores pre-branch-267 identification semantics for ops not yet ported to dedicated `TensorGenerator` subclasses (`tf.rank`, `tf.linspace`, `tf.boolean_mask`, etc. — ~22 ops per #380). Per-op subclasses with proper precision can replace the fallback as they're added.

## Placement And Scoping

The fallback fires only AFTER the dispatch chain has had a chance to handle the call — specific generators (`Eye`, `Stack`, `Constant`, ...) already in the table dispatch normally. The trampoline lookup is restricted to the `Ltensorflow/` namespace so non-TF property reads (e.g. `np.argmax(...)`) aren't misclassified even if a future `numpy.xml` ever introduces a class with the same simple name. All candidate constant-string member-names from the property-read points-to set are checked (not just the first), so the trigger isn't iteration-order-dependent on multi-candidate sites. The per-`IClassHierarchy` trampoline-name set is memoized so the predicate is O(1) per call after the first build (instead of an O(|CHA|) scan every time).

## Validation

- **Hybridize impact**: 39 → 29 failures (10 #437-bucket tests recovered, 0 new Hybridize regressions). Recovered: `testRank`, `testStack`, `testTopK`, `testLinSpace`, `testEinSum`, `testBooleanMask`, `testExtractPatches`, `testExp`, `testExp2`, `testMeshGrid`.
- **Ariadne `com.ibm.wala.cast.python.ml.test`**: 622 tests, 0 failures, 0 errors. `testNeuralNetwork4`'s expected count was updated 6 → 14 because `tf.argmax` is a legitimate tensor source per #380 that was incorrectly being missed pre-fix; the test was asserting the buggy pre-fix count, and the new count is correct (the 8 additional tensor variables are the argmax call sites and their downstream uses across the call graph).

## Related

This is a workaround at the safety-net layer. The durable fix requires #448's design changes — specifically (1) explicit resolution-failure signaling in `getFunction()` and (2) bridging the two parallel dispatch registries. Those would let the fallback become more targeted than property-name + trampoline-class match.

Closes nothing yet, but unblocks 10 of #437's 33 tests on the consumer side.
