### PR TITLE
Gate binop → `ElementWiseOperation` dispatch on operand tensor-evidence

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2147,6 +2147,43 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_recursive_function.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
+  /**
+   * Regression test for wala/ML#451 (reproducer 1): a recursive Python function whose only call
+   * sites are {@code recursive_fn(5)} (a Python int literal) and {@code recursive_fn(n - 1)} (still
+   * a Python int) must not classify its parameter as a tensor. There is no {@code tf.constant}, no
+   * decorator, and no tensor anywhere in the program — the analysis should report zero tensor
+   * parameters and zero function-local tensor variables.
+   */
+  @Test
+  public void testRecursionIntOnly()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_recursion_int_only.py", "recursive_fn", 0, 0);
+  }
+
+  /**
+   * Regression test for wala/ML#451 (reproducer 2): a recursive function whose external call site
+   * passes a real tensor ({@code recursive_fn(tf.constant(5))}). The parameter {@code n} should be
+   * classified as a scalar int32 tensor (the {@code tf.constant} flows through the assignment graph
+   * from the caller), and {@code n - 1} inside the body is a tensor binop too — the binop
+   * operand-tensor gate in {@link TensorGeneratorFactory} dispatches {@code n - 1} to {@link
+   * ElementWiseOperation} because at least one operand ({@code n}) has tensor evidence in its PTS.
+   *
+   * <p>Tensor-variable count breakdown: {@code vn=2} (parameter) is seen across two analysis
+   * contexts (the top-level call and the recursive self-call), and {@code vn=10} ({@code n - 1}) is
+   * the binop result in the top-level context. The Set-based counting in the test helper preserves
+   * these as three distinct entries.
+   */
+  @Test
+  public void testRecursionTensorOnly()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_recursion_tensor_only.py",
+        "recursive_fn",
+        1,
+        3,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
   @Test
   public void testAdd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -3855,14 +3892,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * a bare integer as the shape argument (the parenthesised {@code (-1)} parses as {@code -1}, not
    * a 1-tuple).
    *
-   * <p>Branch also registers an extra spurious tensor variable at {@code vn=44} with type {@code
-   * {[] of int32}} corresponding to {@code gpu_batch_size = int(batch_size / num_gpus)} at line
-   * 222, a pure Python {@code int} used as a slice index (wala/ML#392). That false positive is a
-   * separate, genuine regression.
-   *
-   * <p>Expected tensor variable count: 5 (branch actual). TODO: restore to master baseline 4 once
-   * wala/ML#392 is resolved. See also wala/ML#361 (MNIST modeling) and wala/ML#393 (CIFAR-10
-   * modeling, closed by the commit that landed this test's partial pass).
+   * <p>Expected tensor variable count: 4. Previously 5 — branch carried a spurious classification
+   * at {@code vn=44} ({@code gpu_batch_size = int(batch_size / num_gpus)} at line 222) where {@code
+   * batch_size / num_gpus} is a binop on Python ints, dispatched to {@link ElementWiseOperation}
+   * and typed {@code [] of int32} via {@link TensorGenerator#getDTypesOfValue}'s Integer-constant →
+   * INT32 path. Now correctly rejected by {@link TensorGeneratorFactory}'s binop operand-tensor
+   * gate (wala/ML#451), restoring the master-baseline count of 4. See also wala/ML#361 (MNIST
+   * modeling) and wala/ML#393 (CIFAR-10 modeling, closed by the commit that landed this test's
+   * partial pass).
    */
   @Test
   public void testMultiGPUTraining()
@@ -3871,7 +3908,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "multigpu_training.py",
         "run_optimization",
         2,
-        5,
+        4,
         Map.of(2, Set.of(TENSOR_4096_32_32_3_FLOAT32), 3, Set.of(TENSOR_4096_UINT8)));
   }
 
@@ -4124,6 +4161,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testRange()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_range.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  /**
+   * Regression test for wala/ML#451 (reproducer 3): each element {@code i} from {@code for i in
+   * tf.range(...)} is a 0-D scalar int32 tensor. The receiving function {@code f}'s parameter must
+   * be tensor-classified — never primitive-co-classified downstream. Differs from {@link
+   * #testRange()} in being a stripped-down fixture that mirrors the issue body verbatim (no
+   * intermediate {@code start}/{@code limit}/{@code delta} variables, no Python {@code assert}s
+   * intervening between the {@code tf.range} call and the {@code for}-loop). Pre-fix, certain binop
+   * sources at iteration time could shadow the element's tensor classification with spurious
+   * primitive entries (the same {@link ElementWiseOperation} over-dispatch fixed by the binop
+   * operand-tensor gate); the cleaner fixture here exercises that path directly.
+   */
+  @Test
+  public void testRangeIterationElementType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_range_iter.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -972,21 +972,23 @@ public class TensorGeneratorFactory {
         || isType(calledFunction, SUBTRACT.getDeclaringClass())
         || isType(calledFunction, DIVIDE.getDeclaringClass())) {
       // For SSABinaryOp sources (`a - b` rather than `tf.subtract(a, b)`), gate
-      // ElementWiseOperation dispatch on at least one operand resolving to a
-      // TensorGenerator. Without this, every Python-int arithmetic expression
-      // (e.g. `n - 1` in a recursive function whose only call sites pass ints)
-      // gets classified as a tensor — `getDataflowSources` adds every binary-op
-      // result as a candidate source, and EWO's "always a tensor" assumption
-      // turns Integer constants in operand PTS into INT32 dtypes, which then
-      // back-propagate to parameters via the PA assignment graph at the
-      // recursive-call edge. The TF-API path (`tf.add(...)`, etc.) is
-      // unaffected: those are SSAAbstractInvoke, not SSABinaryOp, so the
+      // ElementWiseOperation dispatch on at least one operand showing tensor
+      // evidence — see {@link #operandHasTensorEvidence} for the three-axis
+      // definition (implicit PK / structural `tryGetGenerator` resolution /
+      // non-`ConstantKey` PTS content). Without this gate, every Python-int
+      // arithmetic expression (e.g. `n - 1` in a recursive function whose only
+      // call sites pass ints) gets classified as a tensor — `getDataflowSources`
+      // adds every binary-op result as a candidate source, and EWO's "always a
+      // tensor" assumption turns Integer constants in operand PTS into INT32
+      // dtypes, which then back-propagate to parameters via the PA assignment
+      // graph at the recursive-call edge. The TF-API path (`tf.add(...)`, etc.)
+      // is unaffected: those are SSAAbstractInvoke, not SSABinaryOp, so the
       // structural check below skips them. See wala/ML#451.
       if (isBinopWithoutTensorOperand(source, builder, visited)) {
         LOGGER.fine(
             () ->
-                "Rejecting ElementWiseOperation dispatch — no operand resolves"
-                    + " to a TensorGenerator. source="
+                "Rejecting ElementWiseOperation dispatch — no operand has tensor"
+                    + " evidence. source="
                     + source);
         throw new IllegalArgumentException("Binary op with no tensor operand: " + source + ".");
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -424,6 +424,103 @@ public class TensorGeneratorFactory {
   }
 
   /**
+   * Returns {@code true} iff {@code source}'s defining instruction is an {@link
+   * SSABinaryOpInstruction} and none of its operands have any tensor evidence.
+   *
+   * <p>Used by {@link #getGeneratorBody} to gate the {@code ElementWiseOperation} dispatch for
+   * binop-defined sources: the TF semantics of element-wise add/sub/mul/div only apply when at
+   * least one operand is itself a tensor. Without this gate, expressions like {@code n - 1} on
+   * Python ints (or comparisons / arithmetic at any non-tensor binop site that happens to also land
+   * in {@link #getDataflowSources}'s {@code SSABinaryOpInstruction} branch) get spuriously
+   * classified as scalar tensors via the operand-PTS Integer-constant → INT32-dtype path in {@link
+   * TensorGenerator#getDTypesOfValue}; under recursion, the spurious type back-propagates to the
+   * parameter via the PA assignment graph at the recursive-call edge.
+   *
+   * <p>Tensor evidence is checked along three axes (per operand):
+   *
+   * <ol>
+   *   <li><b>Implicit PK.</b> Summary-method returns whose PTS hasn't been materialised manifest as
+   *       implicit pointer keys. Treat as tensor-relevant — gating on these would over-reject
+   *       legitimate tensor binops chained through summary-returning ops.
+   *   <li><b>Structural ({@link #tryGetGenerator}).</b> If the operand's own dispatch resolves to a
+   *       generator (its def is a TF call, an EachElementGet over a tensor iterable, etc.), the
+   *       binop is tensor-relevant.
+   *   <li><b>PTS content.</b> If the operand's PTS contains any non-{@link ConstantKey} instance
+   *       key (i.e. anything beyond Python {@code int}/{@code float}/{@code bool}/{@code str}
+   *       literals), treat as tensor-relevant. This catches parameters whose PTS contains a tensor
+   *       allocation flowed in from the caller (e.g. {@code replica_fn(tf.constant(3.0))} makes
+   *       {@code input}'s PTS the {@code constant_op}'s {@link AllocationSiteInNode}); also keeps
+   *       list/tuple-wrapped tensor flows working without re-implementing the catalog walk here.
+   * </ol>
+   *
+   * <p>Returns {@code false} (i.e. <i>does</i> dispatch to {@code ElementWiseOperation}) for
+   * non-binop sources: those reach this gate via the {@code tf.add}/{@code tf.subtract}/etc. TF API
+   * path (whose calls have ADD/SUB/MUL/DIV declaring classes), and that path is the pre-existing
+   * positive-identification entry that should not be restricted by this fix.
+   *
+   * @param source The candidate {@link ElementWiseOperation} source.
+   * @param builder The propagation call graph builder, used to materialise operand {@link
+   *     PointsToSetVariable}s and recurse into their generator dispatch.
+   * @param visited The DFS recursion-stack set threaded through {@link #getGenerator}; passed
+   *     unchanged to {@link #tryGetGenerator} so operand-side recursion participates in the same
+   *     cycle guard as the parent dispatch.
+   * @return {@code true} iff {@code source} is binop-defined and no operand has tensor evidence.
+   */
+  private static boolean isBinopWithoutTensorOperand(
+      PointsToSetVariable source,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
+    if (!(source.getPointerKey() instanceof LocalPointerKey)) return false;
+    LocalPointerKey lpk = (LocalPointerKey) source.getPointerKey();
+    CGNode node = lpk.getNode();
+    SSAInstruction def = node.getDU().getDef(lpk.getValueNumber());
+    if (!(def instanceof SSABinaryOpInstruction)) return false;
+    for (int i = 0; i < def.getNumberOfUses(); i++) {
+      int operandVn = def.getUse(i);
+      if (operandHasTensorEvidence(operandVn, node, builder, visited)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns {@code true} iff the operand at {@code operandVn} in {@code node} shows any sign of
+   * being a tensor. Used by {@link #isBinopWithoutTensorOperand} to gate the binop → EWO dispatch.
+   * See that method's Javadoc for the three-axis tensor-evidence definition.
+   *
+   * @param operandVn The operand SSA value number.
+   * @param node The {@link CGNode} containing the binop.
+   * @param builder The propagation call graph builder.
+   * @param visited The DFS recursion-stack set threaded through {@link #getGenerator}.
+   * @return {@code true} if the operand has tensor evidence; {@code false} otherwise.
+   */
+  private static boolean operandHasTensorEvidence(
+      int operandVn,
+      CGNode node,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
+    // Python literal constant in the IR symbol table (e.g. `1` in `n - 1`,
+    // `2.0` in `input * 2.0`) — not a tensor on its own. The companion operand
+    // is what carries any tensor evidence. Check this BEFORE PTS-based
+    // tensor-evidence inference: literals can have implicit/empty PTS
+    // (depending on the substrate) that would otherwise be misread as
+    // "summary-method return — conservatively a tensor."
+    if (node.getIR().getSymbolTable().isConstant(operandVn)) return false;
+    PointerKey pk =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, operandVn);
+    // Implicit pointer keys flag values whose PTS hasn't been materialised by
+    // the propagation system — most commonly summary-method returns. Treat
+    // those as potential tensors so legitimate chained tensor binops (e.g.
+    // `tf.constant(...) - some_summary_op_result`) aren't over-rejected.
+    if (builder.getPropagationSystem().isImplicit(pk)) return true;
+    PointsToSetVariable operandSrc = getPointsToSetVariable(pk, builder);
+    if (operandSrc != null && tryGetGenerator(operandSrc, builder, visited) != null) return true;
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(pk)) {
+      if (!(ik instanceof ConstantKey)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Returns a {@link TensorGenerator} instance for the given source and call graph builder.
    *
    * <p>This method identifies the specific TensorFlow function or operation that produced the value
@@ -873,9 +970,28 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, MULTIPLY.getDeclaringClass())
         || isType(calledFunction, ADD.getDeclaringClass())
         || isType(calledFunction, SUBTRACT.getDeclaringClass())
-        || isType(calledFunction, DIVIDE.getDeclaringClass()))
+        || isType(calledFunction, DIVIDE.getDeclaringClass())) {
+      // For SSABinaryOp sources (`a - b` rather than `tf.subtract(a, b)`), gate
+      // ElementWiseOperation dispatch on at least one operand resolving to a
+      // TensorGenerator. Without this, every Python-int arithmetic expression
+      // (e.g. `n - 1` in a recursive function whose only call sites pass ints)
+      // gets classified as a tensor — `getDataflowSources` adds every binary-op
+      // result as a candidate source, and EWO's "always a tensor" assumption
+      // turns Integer constants in operand PTS into INT32 dtypes, which then
+      // back-propagate to parameters via the PA assignment graph at the
+      // recursive-call edge. The TF-API path (`tf.add(...)`, etc.) is
+      // unaffected: those are SSAAbstractInvoke, not SSABinaryOp, so the
+      // structural check below skips them. See wala/ML#451.
+      if (isBinopWithoutTensorOperand(source, builder, visited)) {
+        LOGGER.fine(
+            () ->
+                "Rejecting ElementWiseOperation dispatch — no operand resolves"
+                    + " to a TensorGenerator. source="
+                    + source);
+        throw new IllegalArgumentException("Binary op with no tensor operand: " + source + ".");
+      }
       return new ElementWiseOperation(source);
-    else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
+    } else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
     else if (isType(calledFunction, SPARSE_FROM_DENSE.getDeclaringClass()))
       return new SparseFromDense(source);
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);

--- a/com.ibm.wala.cast.python.test/data/tf2_test_range_iter.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_range_iter.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+r = tf.range(3, 18, 3)
+for i in r:
+    f(i)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_recursion_int_only.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_recursion_int_only.py
@@ -1,0 +1,7 @@
+def recursive_fn(n):
+    if n > 0:
+        return recursive_fn(n - 1)
+    return 1
+
+
+recursive_fn(5)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_recursion_tensor_only.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_recursion_tensor_only.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def recursive_fn(n):
+    if n > 0:
+        return recursive_fn(n - 1)
+    return 1
+
+
+# `recursive_fn` is intentionally undecorated: the decorated form would re-trace
+# the recursive call at runtime and AutoGraph would error on the
+# `tf.Tensor`-as-Python-bool conversion before any assertions could run.
+# The wala/ML#451 reproducer-2 regression doesn't depend on the decorator: the
+# call-site argument is a real tensor either way, and the static analysis
+# question (does `n - 1` get classified as a tensor only when `n` is a tensor?)
+# is unchanged. The base case `return 1` is also kept — without it, this would
+# duplicate `tf2_test_recursive_function.py`. Python execution stops at the
+# recursive base case because the final return is a Python int, not a tensor;
+# that's expected and parallels the issue body's fixture verbatim.
+recursive_fn(tf.constant(5))


### PR DESCRIPTION
## Summary

- Gate the `SSABinaryOp` → `ElementWiseOperation` dispatch in `TensorGeneratorFactory` on at least one operand showing tensor evidence (three-axis check: implicit PK / structural `tryGetGenerator` / non-`ConstantKey` PTS content).
- Add three regression tests (one per reproducer in wala/ML#451): `testRecursionIntOnly`, `testRecursionTensorOnly`, `testRangeIterationElementType`.
- Restore `testMultiGPUTraining`'s expected count from 5 → 4 — same fix resolves wala/ML#392's `gpu_batch_size = int(batch_size / num_gpus)` false-positive.

## Why

`getDataflowSources` adds every binary-op result as a candidate tensor source, and pre-fix `EWO`'s "always a tensor" assumption combined with `TensorGenerator.getDTypesOfValue`'s Integer-constant → INT32 path turned Python-int arithmetic like `n - 1` into spurious scalar int32 tensors. Under recursion the spurious type back-propagated to the parameter via the PA assignment graph at the recursive-call edge, so downstream consumers (e.g. Hybridize's `hasTensorParameter` / `hasPrimitiveParameter` predicates) saw both flags true for cases with no supporting tensor call site.

The gate restores the discrimination the pre-branch-267 `read_data` marker pattern provided. The TF-API path (`tf.add(...)`, `tf.subtract(...)`, etc.) is unaffected: those are `SSAAbstractInvoke`, not `SSABinaryOp`, so the structural check skips them.

## Test plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest=TestTensorflow2Model test` — 607 / 0 / 0 / 0
- [x] `mvn test` from root (full multi-module suite) — 622 / 0 / 0 / 3 skipped
- [x] Three new tests are red on master and green with the fix
- [ ] Once `0.42.0-SNAPSHOT` redeploys from CI, ponder-lab/Hybridize-Functions-Refactoring#427's 27 affected tests in the seven buckets (`testRecursion 2/4/5/6/7/8/9/10`, `testTFRange 2/3/4/5/8`, `testPythonSideEffects 44–49`, `testGPModel/2/3`, `testRetracing 2/5`, `testHasLikelyTensorParameter158`, `testLikelyHasNonTensorParameter3`) flip green automatically — no Hybridize-side changes needed

Closes wala/ML#451 and wala/ML#392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)