### PR TITLE
Add `TextLineDatasetGenerator` for iteration element classification

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -945,6 +945,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_dataset29.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
   }
 
+  /**
+   * Regression test for wala/ML#452: iterating a {@code tf.data.TextLineDataset} via {@code for
+   * element in dataset:} should classify each element as a 0-D string tensor. The receiving
+   * function {@code func}'s parameter at {@code vn=2} must therefore have type {@code
+   * SCALAR_TENSOR_OF_STRING}. Pre-fix, the analyzer's {@code TextLineDataset} model didn't preserve
+   * the per-element tensor type through the iteration substrate, leaving {@code func} with no
+   * tensor classification at all (downstream {@code Function.getHasTensorParameter()} reported
+   * false).
+   */
+  @Test
+  public void testTextLineDatasetIterationElementType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_textlinedataset_iter.py",
+        "func",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
   @Test
   public void testDataset30()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -100,7 +100,8 @@
         <new def="Dataset" class="Ltensorflow/data/Dataset" />
         <putfield class="LRoot" field="Dataset" fieldType="LRoot" ref="data" value="Dataset" />
         <!--https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TextLineDataset -->
-        <new def="TextLineDataset" class="Ltensorflow/data/Dataset" /> <!-- FIXME: Should *extend* `Dataset` -->
+        <!-- Distinct class type so the factory can dispatch to `TextLineDatasetGenerator` and seed iteration elements as 0-D string tensors (wala/ML#452). -->
+        <new def="TextLineDataset" class="Ltensorflow/data/TextLineDataset" />
         <putfield class="LRoot" field="TextLineDataset" fieldType="LRoot" ref="data" value="TextLineDataset" />
         <!--https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset -->
         <new def="TFRecordDataset" class="Ltensorflow/data/Dataset" /> <!-- FIXME: Should *extend* `Dataset` -->
@@ -2042,6 +2043,22 @@
         <method name="next" descriptor="()LRoot;" numArgs="1" paramNames="self">
           <getfield class="LRoot" field="dataset" fieldType="LRoot" ref="self" def="ds" />
           <return value="ds" />
+        </method>
+      </class>
+      <!-- Distinct type for `tf.data.TextLineDataset` so the factory dispatches to `TextLineDatasetGenerator` (intrinsic 0-D string element type). Mirrors `Dataset`'s iteration substrate (`__iter__` / `read_dataset` markers, `do` body) so iteration still materializes through `Ltensorflow/data/iterator`.
+        See wala/ML#452. -->
+      <class name="TextLineDataset" allocatable="true">
+        <method name="read_dataset" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <return value="self" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self filenames compression_type">
+          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x" />
+          <return value="x" />
+        </method>
+        <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="it" class="Ltensorflow/data/iterator" />
+          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self" />
+          <return value="it" />
         </method>
       </class>
       <class name="shuffle" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2045,14 +2045,38 @@
           <return value="ds" />
         </method>
       </class>
-      <!-- Distinct type for `tf.data.TextLineDataset` so the factory dispatches to `TextLineDatasetGenerator` (intrinsic 0-D string element type). Mirrors `Dataset`'s iteration substrate (`__iter__` / `read_dataset` markers, `do` body) so iteration still materializes through `Ltensorflow/data/iterator`.
+      <!-- Distinct type for `tf.data.TextLineDataset` so the factory dispatches to `TextLineDatasetGenerator` (intrinsic 0-D string element type). `do` allocates a fresh `TextLineDataset` per call site (parallel to the per-endpoint allocation pattern in `shuffle`/`batch`/etc.) so 1-CFA context preserves
+        call-site distinctness rather than aliasing every `tf.data.TextLineDataset(...)` to the same singleton from the import-time field allocation. The chain-method fields are bound on the new instance just like the other dataset endpoints, so `tf.data.TextLineDataset(...).shuffle(...).batch(...)` chains resolve.
         See wala/ML#452. -->
       <class name="TextLineDataset" allocatable="true">
         <method name="read_dataset" descriptor="()LRoot;" numArgs="1" paramNames="self">
           <return value="self" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self filenames compression_type">
-          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x" />
+          <new def="x" class="Ltensorflow/data/TextLineDataset" />
+          <!-- NOTE: This block of dataset field initializations is duplicated intentionally. See shuffle/do() for rationale. -->
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
+          <new def="rd_batch" class="Ltensorflow/data/batch" />
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
+          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
+          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
+          <new def="rd_take" class="Ltensorflow/data/take" />
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
+          <new def="rd_map" class="Ltensorflow/data/map" />
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
+          <new def="rd_filter" class="Ltensorflow/data/filter" />
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
+          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
           <return value="x" />
         </method>
         <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2680,6 +2680,8 @@ public abstract class TensorGenerator {
       return new DatasetZipGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_RANGE_TYPE)) {
       return new DatasetRangeGenerator(node);
+    } else if (type.equals(TensorFlowTypes.TEXT_LINE_DATASET_TYPE)) {
+      return new TextLineDatasetGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_RANDOM_TYPE)) {
       return new DatasetRandomGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_BATCH_TYPE)) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -90,6 +90,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_SOFTMAX_C
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SUBTRACT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TEXT_LINE_DATASET_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_OP;
@@ -890,6 +891,8 @@ public class TensorGeneratorFactory {
       return new DatasetFromTensorsGenerator(source);
     else if (isType(calledFunction, DATASET_BATCH_TYPE)) return new DatasetBatchGenerator(source);
     else if (isType(calledFunction, DATASET_RANGE_TYPE)) return new DatasetRangeGenerator(source);
+    else if (isType(calledFunction, TEXT_LINE_DATASET_TYPE))
+      return new TextLineDatasetGenerator(source);
     else if (isType(calledFunction, DATASET_RANDOM_TYPE)) return new DatasetRandomGenerator(source);
     else if (isType(calledFunction, DATASET_FROM_GENERATOR_TYPE))
       return new DatasetFromGeneratorGenerator(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TextLineDatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TextLineDatasetGenerator.java
@@ -1,0 +1,49 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator for tensors produced by iterating a {@code tf.data.TextLineDataset}. Each iteration
+ * element is a 0-D scalar string tensor (one line of text per element). See <a
+ * href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TextLineDataset">tf.data.TextLineDataset</a>.
+ *
+ * <p>Modeled as a distinct {@link DatasetGenerator} subclass with hardcoded element shape ({@code
+ * []}, scalar) and dtype ({@link DType#STRING}). The base {@link DatasetGenerator}'s
+ * receiver-walking shape/dtype inference can't recover these for {@code TextLineDataset} because
+ * the XML model previously aliased it with {@code Ltensorflow/data/Dataset} and there's no upstream
+ * tensor-allocation chain to peel — the per-line element type is intrinsic to the API. Same shape
+ * as {@link DatasetRangeGenerator}, which does the same trick for {@code tf.data.Dataset.range}
+ * (scalars of int64). See wala/ML#452.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TextLineDatasetGenerator extends DatasetGenerator {
+
+  public TextLineDatasetGenerator(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public TextLineDatasetGenerator(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    ret.add(Collections.emptyList());
+    return ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return Set.of(DType.STRING);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -305,6 +305,12 @@ public class TensorFlowTypes extends PythonTypes {
 
   public static final String DATASET_RANGE_SIGNATURE = "tf.data.Dataset.range()";
 
+  public static final TypeReference TEXT_LINE_DATASET_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/data/TextLineDataset"));
+
+  public static final String TEXT_LINE_DATASET_SIGNATURE = "tf.data.TextLineDataset()";
+
   public static final TypeReference DATASET_FROM_TENSOR_SLICES_TYPE =
       TypeReference.findOrCreate(
           pythonLoader, TypeName.findOrCreate("Ltensorflow/data/Dataset/from_tensor_slices"));
@@ -1020,6 +1026,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(DATASET_FILTER_TYPE, DATASET_FILTER_SIGNATURE),
           Map.entry(DATASET_FROM_TENSOR_SLICES_TYPE, DATASET_FROM_TENSOR_SLICES_SIGNATURE),
           Map.entry(DATASET_RANGE_TYPE, DATASET_RANGE_SIGNATURE),
+          Map.entry(TEXT_LINE_DATASET_TYPE, TEXT_LINE_DATASET_SIGNATURE),
           Map.entry(IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE, FLOW_FROM_DIRECTORY_SIGNATURE),
           Map.entry(DATASET_FROM_GENERATOR_TYPE, DATASET_FROM_GENERATOR_SIGNATURE),
           Map.entry(DATASET_FROM_TENSORS_TYPE, DATASET_FROM_TENSORS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_textlinedataset_iter.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_textlinedataset_iter.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def func(a):
+    assert isinstance(a, tf.Tensor)
+
+
+# Each element from `tf.data.TextLineDataset` iteration is a 0-D string tensor
+# at runtime. The static analysis must classify `func`'s parameter as a tensor
+# (wala/ML#452 reproducer).
+dataset = tf.data.TextLineDataset(["/tmp/text_lines0.txt", "/tmp/text_lines1.txt"])
+for element in dataset:
+    func(element)


### PR DESCRIPTION
## Summary

- Give `tf.data.TextLineDataset` its own class type (`Ltensorflow/data/TextLineDataset`) in `tensorflow.xml`, with a mirrored iteration substrate (`__iter__` / `read_dataset` / `do`).
- New `TextLineDatasetGenerator` (sibling to `DatasetRangeGenerator`) — hardcoded element shape `[]` and dtype `STRING`.
- Factory dispatches `Ltensorflow/data/TextLineDataset` → `TextLineDatasetGenerator`.
- Reproducer: `testTextLineDatasetIterationElementType` in `TestTensorflow2Model`.

## Why

`TextLineDataset` was modeled as just an `Ltensorflow/data/Dataset` allocation with a FIXME ("Should *extend* `Dataset`"). Calling `tf.data.TextLineDataset(["..."])` dispatched to plain `DatasetGenerator`, whose receiver-walking shape/dtype inference produced empty type sets: the receiver chain didn't terminate at any tensor producer, and there's no upstream allocation to peel — the per-line element type is intrinsic to the API. Iteration via `for element in dataset:` therefore left `element` un-classified, and downstream `Function.getHasTensorParameter()` reported `false` (wala/ML#452).

The fix mirrors how `DatasetRangeGenerator` handles `tf.data.Dataset.range` (also intrinsic — scalars of int64): a per-API generator with hardcoded element shape and dtype, dispatched via a distinct XML class type.

## Test plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest=TestTensorflow2Model test` — 605 / 0 / 0 / 0
- [x] `mvn test` from root — 623 / 0 / 0 / 3 skipped
- [x] New test `testTextLineDatasetIterationElementType` red on master, green with the fix
- [ ] Once `0.42.0-SNAPSHOT` redeploys from CI, `ponder-lab/Hybridize-Functions-Refactoring#427`'s `testDataset14` flips green automatically — no Hybridize-side changes needed

Closes wala/ML#452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)