### PR TITLE
Bundle `jnr-constants` in the published fat-jar

### DIFF
--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -57,15 +57,16 @@
     </dependency>
     <!-- `jython3` references `jnr/constants/Constant` (and other `jnr/...`)
       from its `org.python.modules.posix.PosixModule`. The `0.0.1-SNAPSHOT`
-      `jython3.jar` published to consumers is a slim jar (no transitive POM
-      deps because it's `install:install-file`-installed without
-      `generatePom=false`'s implications), so neither the Maven dependency
-      graph nor the shaded fat-jar pulls `jnr-constants` in unless we
-      declare it here. Declaring it makes `maven-shade-plugin` include
-      `jnr/constants/*` in the published fat-jar that downstream consumers
-      (e.g. `ponder-lab/Hybridize-Functions-Refactoring`) load through
-      Tycho — without it, code paths that reach `PosixModule` (e.g. the
-      TensorFlow GAN tutorial fixture) fail at runtime with
+      `jython3.jar` is registered via `mvn install:install-file
+      -DgeneratePom=true` (see `CONTRIBUTING.md` and the CI workflow),
+      which synthesizes a minimal POM that declares zero dependencies. So
+      neither the Maven dependency graph nor the shaded fat-jar pulls
+      `jnr-constants` in unless we declare it here. Declaring it makes
+      `maven-shade-plugin` include `jnr/constants/*` in the published
+      fat-jar that downstream consumers (e.g.
+      `ponder-lab/Hybridize-Functions-Refactoring`) load through Tycho —
+      without it, code paths that reach `PosixModule` (e.g. the TensorFlow
+      GAN tutorial fixture) fail at runtime with
       `NoClassDefFoundError: jnr/constants/Constant`. See wala/ML#453. -->
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -55,6 +55,22 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
+    <!-- `jython3` references `jnr/constants/Constant` (and other `jnr/...`)
+      from its `org.python.modules.posix.PosixModule`. The `0.0.1-SNAPSHOT`
+      `jython3.jar` published to consumers is a slim jar (no transitive POM
+      deps because it's `install:install-file`-installed without
+      `generatePom=false`'s implications), so neither the Maven dependency
+      graph nor the shaded fat-jar pulls `jnr-constants` in unless we
+      declare it here. Declaring it makes `maven-shade-plugin` include
+      `jnr/constants/*` in the published fat-jar that downstream consumers
+      (e.g. `ponder-lab/Hybridize-Functions-Refactoring`) load through
+      Tycho — without it, code paths that reach `PosixModule` (e.g. the
+      TensorFlow GAN tutorial fixture) fail at runtime with
+      `NoClassDefFoundError: jnr/constants/Constant`. See wala/ML#453. -->
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-constants</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
## Summary

- Declare `jnr-constants` as a direct dependency of `com.ibm.wala.cast.python.ml` so `maven-shade-plugin` always bundles `jnr/constants/**` (~1k classes) in the published fat-jar.
- No analyzer change. No test addition (the reproducer is downstream — see below).

## Why

`org.python.modules.posix.PosixModule` (in `jython3`) references `jnr/constants/Constant` and other `jnr/...` types for errno / file-stat constants. Both locally and in CI, `jython3` is registered to Maven via `install:install-file` from the Ant-built `jython-dev.jar`, which generates a POM with **no declared dependencies** — Maven sees `jython3` as a leaf with zero transitives, so neither downstream `<dependency>jython3</dependency>` declarations nor `maven-shade-plugin` ever pull `jnr-constants` into the published fat-jar.

Consequence: any consumer that reaches `PosixModule` at runtime (e.g. `ponder-lab/Hybridize-Functions-Refactoring`'s `testTensorFlowGanTutorial` under Tycho 5) fails with `NoClassDefFoundError: jnr/constants/Constant`. The test modules' pre-existing direct `jnr-constants` deps in `com.ibm.wala.cast.python.test/pom.xml` and `com.ibm.wala.cast.python.jython3.test/pom.xml` worked around this for Ariadne's own test runs but didn't help the consumer-facing fat-jar — because the production module never declared it.

## Test plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml clean package`: verify rebuilt fat-jar contains `jnr/constants/Constant.class` and 1054 other `jnr/constants/*` classes
- [x] `mvn test` from root — 625 / 0 / 0 / 3 skipped
- [ ] Once `0.42.0-SNAPSHOT` redeploys from CI, `ponder-lab/Hybridize-Functions-Refactoring#427`'s `testTensorFlowGanTutorial` flips green

A clean Ariadne-side reproducer would need a custom analysis driver that loads `PosixModule` from a slim classpath (i.e. simulating the consumer's runtime), which is out of scope for the packaging-level fix here. The failure is downstream-visible only.

Closes wala/ML#453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)