### PR TITLE
Stop `tf.constant` from leaking primitive into Hybridize's primitive-classifier

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -30,17 +30,25 @@ import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
+import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.Context;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConcreteTypeKey;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceFieldPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.debug.UnimplementedError;
+import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -2202,6 +2210,109 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         3,
         Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  /**
+   * Regression test for wala/ML#451 (reopen): asserts the underlying PA state that Hybridize's
+   * {@code Function.inferPrimitiveParameters} consumes &mdash; specifically, that no primitive
+   * {@link ConstantKey} is reachable through the parameter's points-to set when traversed
+   * transitively through instance fields. The traversal here mirrors the recursion in {@code
+   * Function.containsPrimitive(InstanceKey, ...)}: a {@code ConstantKey} with a non-null value
+   * (excluding bools) is "primitive"; an {@link AllocationSiteInNode} or {@link ConcreteTypeKey} is
+   * recursively examined through its declared instance fields.
+   *
+   * <p>The fixture is the same as {@link #testRecursionTensorOnly()} ({@code recursive_fn(tf
+   * .constant(5))}). Pre-fix, this assertion failed because {@code tensorflow.xml}'s {@code
+   * tf.constant.do} method bound the user's {@code value} argument to the alloc's {@code value}
+   * field via {@code <putfield>}, so the field-traversal walk found the user's {@code
+   * ConstantKey<Integer:5>} and classified the parameter as primitive even though the alloc IS a
+   * tensor producer. The XML now omits that binding (the {@link
+   * com.ibm.wala.cast.python.ml.client.Constant} generator reads dtype/shape directly from the
+   * call's value-arg PTS rather than from the alloc's field), and a CG-walk fallback in {@code
+   * TensorGenerator.getShapesFromShapeArgument} keeps shape inference working for cases like {@code
+   * tf.constant([2, 3])} as a shape argument.
+   */
+  @Test
+  public void testRecursionTensorOnlyHasNoPrimitiveInPTS()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine =
+        makeEngine(emptyList(), new String[] {"tf2_test_recursion_tensor_only.py"});
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    addPytestEntrypoints(builder);
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+    engine.performAnalysis(builder);
+
+    String functionSignature = "script tf2_test_recursion_tensor_only.py.recursive_fn.do()LRoot;";
+    boolean checkedAtLeastOneContext = false;
+
+    for (CGNode node : CG) {
+      if (!node.getMethod().getSignature().equals(functionSignature)) continue;
+      // Parameter `n` is at vn=2 (vn=1 is `self`/function object).
+      PointerKey paramPK =
+          builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, 2);
+      OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(paramPK);
+      if (pts == null || pts.isEmpty()) continue;
+      checkedAtLeastOneContext = true;
+      for (InstanceKey ik : pts) {
+        Set<InstanceKey> seen = new HashSet<>();
+        assertTrue(
+            "Parameter `n` of recursive_fn(tf.constant(5)) should not have any primitive"
+                + " ConstantKey reachable through PA field traversal in context "
+                + node.getContext()
+                + " (instance="
+                + ik
+                + "). This is the underlying state that Hybridize's"
+                + " Function.containsPrimitive consumes (wala/ML#451 reopen).",
+            !containsPrimitiveByFieldWalk(ik, builder.getPointerAnalysis(), seen));
+      }
+    }
+    assertTrue(
+        "Expected to check at least one CGNode/context for recursive_fn with non-empty PTS"
+            + " for vn=2; if this assertion fails, the test setup may not have produced any"
+            + " analyzable parameter.",
+        checkedAtLeastOneContext);
+  }
+
+  /**
+   * Mirrors the recursion in Hybridize's {@code Function.containsPrimitive(InstanceKey, boolean,
+   * PointerAnalysis, Set, IProgressMonitor)}: returns {@code true} iff a non-boolean primitive
+   * {@link ConstantKey} value is reachable from {@code ik} through transitive instance field PTS
+   * lookup. Used by the {@link #testRecursionTensorOnlyHasNoPrimitiveInPTS} regression test to
+   * assert the underlying PA state Hybridize consumes.
+   *
+   * @param ik The {@link InstanceKey} to inspect.
+   * @param pa The {@link PointerAnalysis} for instance-field PTS lookups.
+   * @param seen The cycle-guard set of already-visited instance keys.
+   * @return {@code true} iff a primitive ConstantKey is reachable.
+   */
+  private static boolean containsPrimitiveByFieldWalk(
+      InstanceKey ik, PointerAnalysis<InstanceKey> pa, Set<InstanceKey> seen) {
+    if (!seen.add(ik)) return false;
+    if (ik instanceof ConstantKey<?>) {
+      Object v = ((ConstantKey<?>) ik).getValue();
+      if (v == null) return false;
+      // Match Hybridize's "ignore booleans" mode: bool literals don't count as primitive
+      // for the purpose of `getHasPrimitiveParameter`.
+      if (v.equals(Boolean.TRUE) || v.equals(Boolean.FALSE)) return false;
+      return true;
+    }
+    if (!(ik instanceof AllocationSiteInNode || ik instanceof ConcreteTypeKey)) return false;
+    InstanceKey toProcess = ik;
+    if (ik instanceof AllocationSiteInNode) {
+      // Already a concrete alloc; use as-is.
+    }
+    for (IField field : toProcess.getConcreteType().getAllInstanceFields()) {
+      InstanceFieldPointerKey fk =
+          (InstanceFieldPointerKey)
+              pa.getHeapModel().getPointerKeyForInstanceField(toProcess, field);
+      OrdinalSet<InstanceKey> fieldPTS = pa.getPointsToSet(fk);
+      if (fieldPTS == null) continue;
+      for (InstanceKey k : fieldPTS) {
+        if (containsPrimitiveByFieldWalk(k, pa, seen)) return true;
+      }
+    }
+    return false;
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1285,7 +1285,9 @@
       <class name="constant" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value dtype shape name">
           <new def="res" class="Ltensorflow/python/framework/constant_op/constant" />
-          <putfield class="Ltensorflow/python/framework/constant_op/constant" field="value" fieldType="LRoot" ref="res" value="value" />
+          <!-- The `value` putfield was removed (wala/ML#451 reopen): binding the user-supplied value to the alloc's `value` field caused Hybridize's `Function.containsPrimitive` to traverse fields of the alloc and find a `ConstantKey<Integer>`/`ConstantKey<Float>` for `tf.constant(N)`-style calls, classifying
+            parameters that receive the result (e.g. `recursive_fn(tf.constant(5))`'s `n`) as having primitive parameters. The Ariadne-side `Constant` generator reads dtype/shape directly from the call's `value` argument PTS via `getArgumentPointsToSet`, so dtype/shape inference is unaffected. The Java-side `TensorGenerator.getShapesFromShapeArgument`'s
+            `CONSTANT_OP_CONSTANT` branch falls back to walking back to the allocating call's value arg when the field is empty. -->
           <putfield class="Ltensorflow/python/framework/constant_op/constant" field="dtype" fieldType="LRoot" ref="res" value="dtype" />
           <return value="res" />
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -290,9 +290,18 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
     for (InstanceKey ik : pts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
       if (asin != null && asin.getConcreteType().getReference().equals(CONSTANT_OP_CONSTANT)) {
+        // Try the alloc's `value` field PTS first, then fall back to the
+        // allocating call's value-arg PTS. The XML stopped binding the value
+        // to the field (wala/ML#451 reopen) to keep Hybridize's
+        // `Function.containsPrimitive` from finding primitives through the
+        // alloc's instance-field chain; the fallback is the structural
+        // CG-walk equivalent that recovers the same PTS.
         IField f = builder.getClassHierarchy().resolveField(CONSTANT_VALUE);
         PointerKey pk = builder.getPointerKeyForInstanceField(ik, f);
         OrdinalSet<InstanceKey> valuePts = builder.getPointerAnalysis().getPointsToSet(pk);
+        if (valuePts == null || valuePts.isEmpty()) {
+          valuePts = getConstantCallValueArgPTS(asin, builder);
+        }
         result.addAll(getEffectiveInstances(builder, valuePts));
       } else {
         result.add(ik);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -394,18 +394,18 @@ public abstract class TensorGenerator {
         // find a primitive `ConstantKey` for `tf.constant(N)`-style calls,
         // classifying receiving parameters as primitive). Fall back to
         // walking back from the alloc's `do` CGNode to its calling sites and
-        // unioning each call's value-arg PTS.
-        OrdinalSet<InstanceKey> valuePts =
-            (instanceKey instanceof AllocationSiteInNode)
-                ? getConstantCallValueArgPTS((AllocationSiteInNode) instanceKey, builder)
-                : null;
+        // unioning each call's value-arg PTS. Use the already-unwrapped
+        // {@code asin} from the loop header so wrapping {@link InstanceKey}s
+        // (e.g. {@link com.ibm.wala.cast.ipa.callgraph.ScopeMappingInstanceKey})
+        // route through the CG-walk just like raw {@link AllocationSiteInNode}s.
+        OrdinalSet<InstanceKey> valuePts = getConstantCallValueArgPTS(asin, builder);
         if (valuePts == null || valuePts.isEmpty()) {
           // Defensive fallback in case the `value` field happens to be bound
           // in some other path (e.g. a future XML model that re-introduces
           // it for a sibling endpoint).
           IField valueField =
               builder.getClassHierarchy().resolveField(TensorFlowTypes.CONSTANT_VALUE);
-          PointerKey valuePK = builder.getPointerKeyForInstanceField(instanceKey, valueField);
+          PointerKey valuePK = builder.getPointerKeyForInstanceField(asin, valueField);
           valuePts = pointerAnalysis.getPointsToSet(valuePK);
         }
         ret.addAll(this.getShapesFromShapeArgument(builder, valuePts));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -45,6 +45,7 @@ import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -386,11 +387,27 @@ public abstract class TensorGenerator {
             ret.add(asList(dimensions));
           }
       } else if (reference.equals(CONSTANT_OP_CONSTANT)) {
-        // We have a constant tensor. We recurse into its value field.
-        IField valueField =
-            builder.getClassHierarchy().resolveField(TensorFlowTypes.CONSTANT_VALUE);
-        PointerKey valuePK = builder.getPointerKeyForInstanceField(instanceKey, valueField);
-        OrdinalSet<InstanceKey> valuePts = pointerAnalysis.getPointsToSet(valuePK);
+        // We have a constant tensor. We need the user-supplied value PTS to
+        // recurse into. The XML no longer binds it to the alloc's `value`
+        // field (wala/ML#451 reopen — that binding caused Hybridize's
+        // `Function.containsPrimitive` to traverse the alloc's fields and
+        // find a primitive `ConstantKey` for `tf.constant(N)`-style calls,
+        // classifying receiving parameters as primitive). Fall back to
+        // walking back from the alloc's `do` CGNode to its calling sites and
+        // unioning each call's value-arg PTS.
+        OrdinalSet<InstanceKey> valuePts =
+            (instanceKey instanceof AllocationSiteInNode)
+                ? getConstantCallValueArgPTS((AllocationSiteInNode) instanceKey, builder)
+                : null;
+        if (valuePts == null || valuePts.isEmpty()) {
+          // Defensive fallback in case the `value` field happens to be bound
+          // in some other path (e.g. a future XML model that re-introduces
+          // it for a sibling endpoint).
+          IField valueField =
+              builder.getClassHierarchy().resolveField(TensorFlowTypes.CONSTANT_VALUE);
+          PointerKey valuePK = builder.getPointerKeyForInstanceField(instanceKey, valueField);
+          valuePts = pointerAnalysis.getPointsToSet(valuePK);
+        }
         ret.addAll(this.getShapesFromShapeArgument(builder, valuePts));
       } else if (reference.equals(TensorFlowTypes.TENSOR_SPEC)
           || reference.equals(TensorFlowTypes.RAGGED_TENSOR_SPEC)) {
@@ -422,6 +439,62 @@ public abstract class TensorGenerator {
     else if (constantKeyValue instanceof String) return Integer.parseInt((String) constantKeyValue);
 
     return null;
+  }
+
+  /**
+   * Returns the union of {@code value}-argument points-to sets across every caller call site that
+   * resolved to the {@code do} {@link CGNode} of the given {@code tf.constant} allocation. Used by
+   * {@link #getShapesFromShapeArgument} as a fallback when the alloc's {@code value} field PTS is
+   * empty &mdash; which it now always is, since {@code tensorflow.xml} stopped binding the user's
+   * value to that field to keep Hybridize's {@code Function.containsPrimitive} from finding a
+   * primitive {@link ConstantKey} through the alloc's instance-field chain (wala/ML#451 reopen).
+   *
+   * <p>The walk is structural: {@code asin.getNode()} is the synthetic {@code constant_op.constant
+   * .do} CGNode where the {@code <new>} fired; its CG predecessors are the user-side CGNodes that
+   * called {@code tf.constant(...)}. For each such predecessor, every {@link CallSiteReference}
+   * resolving to {@code asin.getNode()} contributes the value argument's PTS via {@code
+   * call.getUse(1)} (use 0 is the function-object self).
+   *
+   * @param constAlloc The {@link AllocationSiteInNode} of a {@code Ltensorflow/python/framework/
+   *     constant_op/constant} allocation.
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @return The union of value-arg points-to sets across all matching caller sites; an empty {@link
+   *     OrdinalSet} if the alloc's CGNode has no callers (defensive — shouldn't happen in practice
+   *     for a reachable alloc).
+   */
+  protected OrdinalSet<InstanceKey> getConstantCallValueArgPTS(
+      AllocationSiteInNode constAlloc, PropagationCallGraphBuilder builder) {
+    CGNode allocNode = constAlloc.getNode();
+    CallGraph cg = builder.getCallGraph();
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    Set<InstanceKey> all = HashSetFactory.make();
+    for (Iterator<CGNode> it = cg.getPredNodes(allocNode); it.hasNext(); ) {
+      CGNode caller = it.next();
+      com.ibm.wala.ssa.IR callerIR = caller.getIR();
+      if (callerIR == null) continue;
+      for (SSAInstruction inst : callerIR.getInstructions()) {
+        if (!(inst instanceof SSAAbstractInvokeInstruction call)) continue;
+        // Check whether this call site resolves to allocNode. Iterating
+        // `getPossibleSites(caller, allocNode)` and matching by `CallSiteReference`
+        // sometimes returns empty under Python's CG modeling (the trampoline
+        // target selector dispatches dynamically); the structural per-instruction
+        // walk via `getPossibleTargets` is the reliable check.
+        boolean targets = false;
+        for (CGNode target : cg.getPossibleTargets(caller, call.getCallSite())) {
+          if (target.equals(allocNode)) {
+            targets = true;
+            break;
+          }
+        }
+        if (!targets) continue;
+        // use(0) is the function-object (self); use(1) is the user's `value` argument.
+        if (call.getNumberOfUses() < 2) continue;
+        int valueVn = call.getUse(1);
+        PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(caller, valueVn);
+        for (InstanceKey ik : pa.getPointsToSet(pk)) all.add(ik);
+      }
+    }
+    return OrdinalSet.toOrdinalSet(all, pa.getInstanceKeyMapping());
   }
 
   /**


### PR DESCRIPTION
## Summary

- Drop the `<putfield value>` binding on `tf.constant.do` in `tensorflow.xml`. The user's value argument is no longer reachable through the alloc's instance-field chain — so Hybridize's `Function.containsPrimitive(InstanceKey, ...)` walk no longer finds a primitive `ConstantKey` on a `tf.constant(N)`-style alloc.
- Replace the `value`-field reads in two Ariadne-side paths (`TensorGenerator.getShapesFromShapeArgument`'s `CONSTANT_OP_CONSTANT` branch + `RaggedFromNestedValueRowIds.getEffectiveInstances`) with a CG-walk fallback (`getConstantCallValueArgPTS`) that recovers the same PTS via the allocating call's `use(1)`.
- New regression test `testRecursionTensorOnlyHasNoPrimitiveInPTS` mirrors `Function.containsPrimitive`'s recursion in the test layer and asserts the underlying PA state Hybridize consumes — addressing the test-coverage gap the maintainer identified in #198's wake.

## Why

Per the maintainer's reopen comment on wala/ML#451: `#198`'s gate fixed the *tensor-side* over-classification (Python-int-only recursion) but didn't address the *primitive-side*. Hybridize's `inferPrimitiveParameters` reads the parameter's PA points-to set and recursively walks `concreteType.getAllInstanceFields()` looking for any reachable primitive `ConstantKey`. For `tf.constant(5)` the alloc's `value` field PTS contained the user's `ConstantKey<Integer:5>`; the walk found it, returned `true`, and classified the receiving parameter as primitive — even though the alloc IS a tensor.

The Ariadne-side `Constant` generator already reads dtype/shape from the call's value-arg PTS directly via `getArgumentPointsToSet`, so the field-binding on the alloc was redundant for that path. The two remaining consumers (shape-from-list-constant in `getShapesFromShapeArgument` and rowids-list-extraction in `RaggedFromNestedValueRowIds.getEffectiveInstances`) both now fall back to walking the alloc's `do` CGNode predecessors → each matching call's `use(1)` PTS.

## Test plan

- [x] `mvn test` from root — 627 / 0 / 0 / 3 skipped
- [x] New test `testRecursionTensorOnlyHasNoPrimitiveInPTS` red on master, green with the fix
- [x] No regression in any of the 8 tests that previously broke when I tried just-removing the putfield (`testAdd84-87`, `testEye6`, `testRaggedNestedValueRowids*`) — those exercise the `value`-field-traversal paths that now use the CG-walk fallback
- [ ] Once `0.42.0-SNAPSHOT` redeploys, `ponder-lab/Hybridize-Functions-Refactoring#427`'s `testRecursion 2/4/5/6` bucket should flip green. Other still-failing buckets (`testTFRange`, `testPythonSideEffects 44–49`, `testGPModel/2/3`, `testRetracing 2/5`, `testHasLikelyTensorParameter158`, `testLikelyHasNonTensorParameter3`) likely need parallel fixes for primitive-leak via *different* XML field patterns; this PR resolves the `tf.constant` source specifically and isolates the rest as separate per-source fixes.

Addresses wala/ML#451 (reopen) for the `tf.constant`-source bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)