### PR TITLE
Drop dangling `read_data` call from `tensorflow/data/reduce.do()` (#456)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6406,6 +6406,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_convert_to_tensor.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
+  /**
+   * Lock-in test for wala/ML#456: {@code tf.data.Dataset.reduce(initial_state, reduce_func)}
+   * returns a tensor with the same shape/dtype as {@code initial_state}. Pre-fix the {@code
+   * tensorflow/data/reduce.do()} XML called {@code read_data} virtually on its receiver, but the
+   * {@code reduce} class didn't define {@code read_data} — the call was unresolved and {@code
+   * def="xx"} bound to nothing. Pre/post-fix this test produces the same observable type ({@code
+   * [{[] of int32}]}) for {@code f}'s parameter at {@code vn=2} because the initial-state's tensor
+   * type still propagates via PA assignment edges; the test serves as a regression lock so a future
+   * XML/PA refactor that breaks the propagation surfaces here instead of regressing silently. The
+   * XML cleanup itself is hygiene — it removes the unresolved virtual call and aligns the model
+   * with TF runtime semantics ({@code reduce(...)} returns {@code initial_state}'s shape/dtype).
+   */
+  @Test
+  public void testDatasetReduce()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset_reduce.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
   @Test
   public void testConvertToTensor2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2374,10 +2374,10 @@
         </method>
       </class>
       <class name="reduce" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#reduce -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#reduce. `Dataset.reduce(initial_state, reduce_func, name)` returns the *final state* — a tensor (or structure of tensors) with the same shape/dtype as `initial_state`, not a Dataset. Pre-fix this was modeled as `read_data(arg0)`
+          virtually on the receiver, but the `reduce` class doesn't define `read_data` — the call couldn't resolve and the result was ⊤. Pass `initial_state` through directly so its tensor type flows to the caller. See wala/ML#456. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self initial_state reduce_func name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <return value="initial_state" />
         </method>
       </class>
       <class name="enumerate" allocatable="true">

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_reduce.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_reduce.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+dataset = tf.data.Dataset.from_tensor_slices([1, 2, 3, 4, 5])
+result = dataset.reduce(tf.constant(0), lambda state, x: state + x)
+assert isinstance(result, tf.Tensor)
+assert result.shape == ()
+assert result.dtype == tf.int32
+
+f(result)


### PR DESCRIPTION
## Summary

Cleanup of `Ltensorflow/data/reduce.do()` per wala/ML#456. The previous body called `read_data` virtually on its receiver (`arg0`, a `Ltensorflow/data/reduce` instance), but the `reduce` class never defined `read_data` — the call was unresolved and `def="xx"` bound to nothing. `reduce` was the **only** Dataset endpoint still on this stale pattern (every other one — `batch`, `filter`, `take`, `map`, `concatenate`, `enumerate`, `repeat`, `prefetch`, `with_options` — migrated to the inline-allocation pattern alongside the `read_data` migration tracked at #380).

Per `tf.data.Dataset.reduce(initial_state, reduce_func, name)`'s runtime semantics — return the *final state*, a tensor with the same shape/dtype as `initial_state`, not a Dataset — pass `initial_state` through directly:

```xml
<method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self initial_state reduce_func name">
  <return value="initial_state" />
</method>
```

## Why ship it if there's no observable test failure?

The new `testDatasetReduce` regression test passes both pre- and post-fix because the initial-state's tensor type also propagates via PA assignment edges from the call site's argument. So this is hygiene: removes the unresolved virtual call and aligns the model with TF runtime semantics. The test acts as a regression lock so a future XML/PA refactor that breaks the propagation surfaces here instead of regressing silently.

## Test plan

- [x] `tf2_test_dataset_reduce.py` runs cleanly under `python3.10`.
- [x] `testDatasetReduce` passes both pre- and post-fix (verified by stashing/popping the XML change). Locks in `f`'s parameter type as `[{[] of int32}]` per the `tf.constant(0)` initial-state.
- [x] `mvn test` from root: 628 passed / 0 failures / 0 errors / 3 skipped.

Closes wala/ML#456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)