### PR TITLE
Add Tier 3 reduction generators: reduce_max/prod/logsumexp/all (#449)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4063,6 +4063,33 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_reduce_mean.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
   }
 
+  // wala/ML#449 Tier 3: reductions. Each collapses dims along `axis` (default `None` = all dims)
+  // and preserves dtype from input (except `reduce_all` which is always BOOL).
+
+  @Test
+  public void testReduceMax()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_max.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceProd()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_prod.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceLogSumExp()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_logsumexp.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  @Test
+  public void testReduceAll()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_all.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_BOOL)));
+  }
+
   /**
    * Verifies that {@code tf.estimator.EstimatorSpec(...)} produces a fresh allocation with each
    * named parameter stored as a field on the result. The test reads {@code spec.loss} and asserts

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1023,19 +1023,18 @@
         </method>
       </class>
       <class name="reduce_all" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_all -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_all. Modeled as `<new>+<return>` so the factory dispatches to the dedicated `ReduceAll` generator (wala/ML#449 Tier 3); the `convert_to_tensor` chain preserved input's shape, but reductions collapse dims along `axis`.
+          Shape logic lives in `ReduceMean`'s axis/keepdims handling, which `ReduceAll` reuses by inheritance; dtype is always `BOOL`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/math/reduce_all" />
+          <return value="res" />
         </method>
       </class>
       <class name="reduce_prod" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_prod -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_prod. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/math/reduce_prod" />
+          <return value="res" />
         </method>
       </class>
       <class name="tanh" allocatable="true">
@@ -1055,19 +1054,18 @@
         </method>
       </class>
       <class name="reduce_max" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_max -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_max. Modeled as `<new>+<return>` for the same reason as `reduce_all`/`reduce_prod` — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="res" class="Ltensorflow/math/reduce_max" />
+          <return value="res" />
         </method>
       </class>
       <class name="reduce_logsumexp" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_logsumexp -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_logsumexp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (`reduce_logsumexp` requires float input at runtime; static analysis just preserves whatever the input
+          dtype was). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/math/reduce_logsumexp" />
+          <return value="res" />
         </method>
       </class>
       <class name="acos" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceAll.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceAll.java
@@ -1,0 +1,33 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.reduce_all}. Reuses {@link ReduceMean}'s axis-collapse / keepdims
+ * shape inference; output dtype is always {@link DType#BOOL} (the runtime API requires a bool input
+ * and returns bool). See wala/ML#449 (Tier 3).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/reduce_all">tf.math.reduce_all</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ReduceAll extends ReduceMean {
+
+  public ReduceAll(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.BOOL);
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.BOOL);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceLogSumExp.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceLogSumExp.java
@@ -1,0 +1,31 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.reduce_logsumexp}. Reuses {@link ReduceMean}'s axis-collapse /
+ * keepdims shape inference, but overrides {@link #getDTypes(PropagationCallGraphBuilder)} to
+ * inherit the input's dtype directly. {@code reduce_logsumexp} requires a float input at runtime,
+ * but static analysis just preserves whatever the input dtype was. See wala/ML#449 (Tier 3).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/reduce_logsumexp">tf.math.reduce_logsumexp</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ReduceLogSumExp extends ReduceMean {
+
+  public ReduceLogSumExp(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    int inputValNum =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+    return this.getDTypes(builder, inputValNum);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMax.java
@@ -1,0 +1,31 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.reduce_max}. Reuses {@link ReduceMean}'s axis-collapse / keepdims
+ * shape inference, but overrides {@link #getDTypes(PropagationCallGraphBuilder)} to inherit the
+ * input's dtype directly (no {@code int → float32} promotion that {@link ReduceMean} applies for
+ * its mean-specific runtime semantics). See wala/ML#449 (Tier 3).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/reduce_max">tf.math.reduce_max</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ReduceMax extends ReduceMean {
+
+  public ReduceMax(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    int inputValNum =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+    return this.getDTypes(builder, inputValNum);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceProd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceProd.java
@@ -1,0 +1,31 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.reduce_prod}. Reuses {@link ReduceMean}'s axis-collapse / keepdims
+ * shape inference, but overrides {@link #getDTypes(PropagationCallGraphBuilder)} to inherit the
+ * input's dtype directly (no {@code int → float32} promotion that {@link ReduceMean} applies). See
+ * wala/ML#449 (Tier 3).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/reduce_prod">tf.math.reduce_prod</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ReduceProd extends ReduceMean {
+
+  public ReduceProd(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    int inputValNum =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+    return this.getDTypes(builder, inputValNum);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -77,7 +77,11 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RAGGED_RANGE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANDOM_NORMAL_INIT_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANGE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.READ_DATA_SETS;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_ALL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_LOGSUMEXP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MEAN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_PROD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_SUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIGMOID;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SLICE_BUILTIN;
@@ -1052,6 +1056,11 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, CIFAR10_Y_TEST))
       return new Cifar10InputData(source, Cifar10InputData.Y_TEST_SHAPE);
     else if (isType(calledFunction, REDUCE_MEAN.getDeclaringClass())) return new ReduceMean(source);
+    else if (isType(calledFunction, REDUCE_MAX.getDeclaringClass())) return new ReduceMax(source);
+    else if (isType(calledFunction, REDUCE_PROD.getDeclaringClass())) return new ReduceProd(source);
+    else if (isType(calledFunction, REDUCE_LOGSUMEXP.getDeclaringClass()))
+      return new ReduceLogSumExp(source);
+    else if (isType(calledFunction, REDUCE_ALL.getDeclaringClass())) return new ReduceAll(source);
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);
     else if (isType(calledFunction, EQUAL.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -697,7 +697,7 @@ public class TensorFlowTypes extends PythonTypes {
               PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_max")),
           AstMethodReference.fnSelector);
 
-  private static final String REDUCE_MAX_SIGNATURE = "tf.math.reduce_max()";
+  private static final String REDUCE_MAX_SIGNATURE = "tf.reduce_max()";
 
   /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_prod. */
   public static final MethodReference REDUCE_PROD =
@@ -706,7 +706,7 @@ public class TensorFlowTypes extends PythonTypes {
               PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_prod")),
           AstMethodReference.fnSelector);
 
-  private static final String REDUCE_PROD_SIGNATURE = "tf.math.reduce_prod()";
+  private static final String REDUCE_PROD_SIGNATURE = "tf.reduce_prod()";
 
   /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_logsumexp. */
   public static final MethodReference REDUCE_LOGSUMEXP =
@@ -716,7 +716,7 @@ public class TensorFlowTypes extends PythonTypes {
               TypeName.string2TypeName("Ltensorflow/math/reduce_logsumexp")),
           AstMethodReference.fnSelector);
 
-  private static final String REDUCE_LOGSUMEXP_SIGNATURE = "tf.math.reduce_logsumexp()";
+  private static final String REDUCE_LOGSUMEXP_SIGNATURE = "tf.reduce_logsumexp()";
 
   /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_all. */
   public static final MethodReference REDUCE_ALL =
@@ -725,7 +725,7 @@ public class TensorFlowTypes extends PythonTypes {
               PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_all")),
           AstMethodReference.fnSelector);
 
-  private static final String REDUCE_ALL_SIGNATURE = "tf.math.reduce_all()";
+  private static final String REDUCE_ALL_SIGNATURE = "tf.reduce_all()";
 
   public static final MethodReference MODEL =
       MethodReference.findOrCreate(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -690,6 +690,43 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String REDUCE_MEAN_SIGNATURE = "tf.reduce_mean()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_max. */
+  public static final MethodReference REDUCE_MAX =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_max")),
+          AstMethodReference.fnSelector);
+
+  private static final String REDUCE_MAX_SIGNATURE = "tf.math.reduce_max()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_prod. */
+  public static final MethodReference REDUCE_PROD =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_prod")),
+          AstMethodReference.fnSelector);
+
+  private static final String REDUCE_PROD_SIGNATURE = "tf.math.reduce_prod()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_logsumexp. */
+  public static final MethodReference REDUCE_LOGSUMEXP =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/math/reduce_logsumexp")),
+          AstMethodReference.fnSelector);
+
+  private static final String REDUCE_LOGSUMEXP_SIGNATURE = "tf.math.reduce_logsumexp()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_all. */
+  public static final MethodReference REDUCE_ALL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_all")),
+          AstMethodReference.fnSelector);
+
+  private static final String REDUCE_ALL_SIGNATURE = "tf.math.reduce_all()";
+
   public static final MethodReference MODEL =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
@@ -1073,6 +1110,10 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SUBTRACT.getDeclaringClass(), SUBTRACT_SIGNATURE),
           Map.entry(DIVIDE.getDeclaringClass(), DIVIDE_SIGNATURE),
           Map.entry(REDUCE_MEAN.getDeclaringClass(), REDUCE_MEAN_SIGNATURE),
+          Map.entry(REDUCE_MAX.getDeclaringClass(), REDUCE_MAX_SIGNATURE),
+          Map.entry(REDUCE_PROD.getDeclaringClass(), REDUCE_PROD_SIGNATURE),
+          Map.entry(REDUCE_LOGSUMEXP.getDeclaringClass(), REDUCE_LOGSUMEXP_SIGNATURE),
+          Map.entry(REDUCE_ALL.getDeclaringClass(), REDUCE_ALL_SIGNATURE),
           Map.entry(MODEL.getDeclaringClass(), MODEL_SIGNATURE),
           Map.entry(MODEL_CALL.getDeclaringClass(), MODEL_CALL_SIGNATURE),
           Map.entry(TENSOR.getDeclaringClass(), TENSOR_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_all.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_all.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[True, False], [True, True]])
+y = tf.math.reduce_all(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == ()
+assert y.dtype == tf.bool
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_logsumexp.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_logsumexp.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.reduce_logsumexp(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == ()
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_max.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_max.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.reduce_max(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == ()
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_prod.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_prod.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.reduce_prod(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == ()
+assert y.dtype == tf.float32
+
+f(y)


### PR DESCRIPTION
## Summary

Tier 3 of #449's per-op generator triage: four reductions that pre-fix preserved input shape (their XML routed through `convert_to_tensor` chain, which doesn't collapse axes). All four now correctly emit reduced shapes via `ReduceMean`'s axis-collapse + keepdims logic, with op-specific dtype handling.

Each generator subclasses `ReduceMean` (~10–15 LOC each) to reuse the shape-rewriting machinery and overrides `getDTypes` for op-specific dtype:

| Op | Dtype rule |
|---|---|
| `tf.math.reduce_max` | inherit input (no `int → float32` promotion) |
| `tf.math.reduce_prod` | inherit input (same) |
| `tf.math.reduce_logsumexp` | inherit input (runtime requires float; static analysis just preserves) |
| `tf.math.reduce_all` | hardcoded `BOOL` (runtime API is bool-in/bool-out) |

## Empirical baseline

All four red on master with the new test fixtures (returning unreduced input shape `[2, 3]` of float32, or `[2, 2]` of bool for `reduce_all`). Post-fix all four green with `[] of <dtype>` (scalar from default `axis=None`).

## Read-data migration progress

Per #380 / "transition away from `read_data`" direction: this PR doesn't add to that count directly because these four ops were already on the `convert_to_tensor` chain (not `read_data`). But the migration shape is the same: drop the indirection, allocate `Ltensorflow/math/<op>` directly, dispatch to dedicated generator. Total Tier-1+2+3 generators added so far: 9 (plus the `PassThroughUnaryTensorGenerator` base from Tier 2).

## Other changes

- `numArgs` corrected from 3 → 5 on `reduce_all`/`reduce_prod` (was inconsistent with `reduce_max`'s already-correct 5; matches paramNames length).

## Test plan

- [x] All four new fixtures (`tf2_test_reduce_max.py`, `tf2_test_reduce_prod.py`, `tf2_test_reduce_logsumexp.py`, `tf2_test_reduce_all.py`) run cleanly under `python3.10`.
- [x] All four test methods (`testReduceMax`, `testReduceProd`, `testReduceLogSumExp`, `testReduceAll`) red on master, green with this PR.
- [x] `mvn test` from root: 631 / 0 / 0 / 3 skipped.

## Side note (out of scope, flagging for future cleanup)

Noticed that `ReduceSum extends ReduceMean` — it inherits `ReduceMean`'s `int → float32` promotion, but `tf.reduce_sum`'s runtime semantics preserve dtype. Same kind of override the new Tier-3 generators do. Not fixing in this PR to keep the scope tight, but worth a small follow-up.

Progress on #449: 9 dedicated generators (Tier 1: 2 + Tier 2: 3 + Tier 3: 4) + the `PassThroughUnaryTensorGenerator` base. Tier 4 (fixed-output `tf.rank`/`tf.size`) is a quick two-op next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)