### PR TITLE
Refactor `tf.constant` recognition to use containing-method (wala/ML#459 PR 1/2)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -3,7 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import static com.ibm.wala.cast.python.ml.client.RaggedFromNestedValueRowIds.Parameters.FLAT_VALUES;
 import static com.ibm.wala.cast.python.ml.client.RaggedFromNestedValueRowIds.Parameters.NESTED_NROWS;
 import static com.ibm.wala.cast.python.ml.client.RaggedFromNestedValueRowIds.Parameters.NESTED_VALUE_ROWIDS;
-import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT_OP_CONSTANT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT_VALUE;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.list;
@@ -289,7 +289,22 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
     Set<InstanceKey> result = HashSetFactory.make();
     for (InstanceKey ik : pts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin != null && asin.getConcreteType().getReference().equals(CONSTANT_OP_CONSTANT)) {
+      if (asin != null
+          && asin.getNode()
+              .getMethod()
+              .getDeclaringClass()
+              .getReference()
+              .equals(CONSTANT.getDeclaringClass())) {
+        // Detect a `tf.constant(...)` result by checking the *containing method*
+        // of the allocation (the `tensorflow/functions/constant.do()` CGNode), not
+        // the alloc's concrete type. The latter is
+        // `Ltensorflow/python/framework/constant_op/constant`,
+        // a function-name duplicate that we want to be able to migrate to canonical
+        // `Ltensorflow/python/framework/ops/Tensor` later (wala/ML#459 PR 2). Reading
+        // the containing method's declaring class instead decouples this recognition
+        // from the alloc-class convention; the two are functionally equivalent today
+        // because the only place that allocates `CONSTANT_OP_CONSTANT` is inside `constant.do()`.
+        //
         // Try the alloc's `value` field PTS first, then fall back to the
         // allocating call's value-arg PTS. The XML stopped binding the value
         // to the field (wala/ML#451 reopen) to keep Hybridize's

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2,7 +2,6 @@ package com.ibm.wala.cast.python.ml.client;
 
 import static com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine.TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
-import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT_OP_CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_CHOOSE_FROM_DATASETS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_SAMPLE_FROM_DATASETS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
@@ -386,18 +385,32 @@ public abstract class TensorGenerator {
 
             ret.add(asList(dimensions));
           }
-      } else if (reference.equals(CONSTANT_OP_CONSTANT)) {
-        // We have a constant tensor. We need the user-supplied value PTS to
-        // recurse into. The XML no longer binds it to the alloc's `value`
-        // field (wala/ML#451 reopen — that binding caused Hybridize's
-        // `Function.containsPrimitive` to traverse the alloc's fields and
-        // find a primitive `ConstantKey` for `tf.constant(N)`-style calls,
-        // classifying receiving parameters as primitive). Fall back to
-        // walking back from the alloc's `do` CGNode to its calling sites and
-        // unioning each call's value-arg PTS. Use the already-unwrapped
-        // {@code asin} from the loop header so wrapping {@link InstanceKey}s
-        // (e.g. {@link com.ibm.wala.cast.ipa.callgraph.ScopeMappingInstanceKey})
-        // route through the CG-walk just like raw {@link AllocationSiteInNode}s.
+      } else if (asin.getNode()
+          .getMethod()
+          .getDeclaringClass()
+          .getReference()
+          .equals(CONSTANT.getDeclaringClass())) {
+        // We have a `tf.constant(...)` result. Detect this by checking the
+        // *containing method* of the allocation (the `tensorflow/functions/constant.do()`
+        // CGNode), not the alloc's concrete type — the latter is the function-name
+        // duplicate `Ltensorflow/python/framework/constant_op/constant`, which is a
+        // load-bearing function-type signal we want to be able to migrate to canonical
+        // `Ltensorflow/python/framework/ops/Tensor` later (wala/ML#459 PR 2). Reading
+        // the containing method's declaring class instead decouples this recognition
+        // from the alloc-class convention; the two are functionally equivalent today
+        // because the only place that allocates `CONSTANT_OP_CONSTANT` is inside
+        // `constant.do()`.
+        //
+        // We need the user-supplied value PTS to recurse into. The XML no longer
+        // binds it to the alloc's `value` field (wala/ML#451 reopen — that binding
+        // caused Hybridize's `Function.containsPrimitive` to traverse the alloc's
+        // fields and find a primitive `ConstantKey` for `tf.constant(N)`-style calls,
+        // classifying receiving parameters as primitive). Fall back to walking back
+        // from the alloc's `do` CGNode to its calling sites and unioning each call's
+        // value-arg PTS. Use the already-unwrapped {@code asin} from the loop header so
+        // wrapping {@link InstanceKey}s (e.g. {@link
+        // com.ibm.wala.cast.ipa.callgraph.ScopeMappingInstanceKey}) route through the
+        // CG-walk just like raw {@link AllocationSiteInNode}s.
         OrdinalSet<InstanceKey> valuePts = getConstantCallValueArgPTS(asin, builder);
         if (valuePts == null || valuePts.isEmpty()) {
           // Defensive fallback in case the `value` field happens to be bound
@@ -1359,9 +1372,21 @@ public abstract class TensorGenerator {
 
       if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
         throw new IllegalStateException("Unknown dtype: " + instanceKey + ".");
-      } else if (typeReference.equals(TensorFlowTypes.CONSTANT_OP_CONSTANT)) {
-        // We have a constant tensor. We extract its 'dtype' field and recurse to
-        // resolve the actual DType value.
+      } else if (instanceKey instanceof AllocationSiteInNode
+          && ((AllocationSiteInNode) instanceKey)
+              .getNode()
+              .getMethod()
+              .getDeclaringClass()
+              .getReference()
+              .equals(CONSTANT.getDeclaringClass())) {
+        // We have a `tf.constant(...)` result. Detect this by checking the
+        // *containing method* of the allocation (the `tensorflow/functions/constant.do()`
+        // CGNode), not the alloc's concrete type. The latter is the function-name
+        // duplicate `Ltensorflow/python/framework/constant_op/constant`, which we want
+        // to be able to migrate to canonical `Ltensorflow/python/framework/ops/Tensor`
+        // later (wala/ML#459 PR 2). Reading the containing method's declaring class
+        // instead decouples this recognition from the alloc-class convention.
+        // Extract the alloc's `dtype` field and recurse to resolve the actual DType.
         IField valueField =
             builder.getClassHierarchy().resolveField(TensorFlowTypes.CONSTANT_DTYPE);
         PointerKey valuePK = builder.getPointerKeyForInstanceField(instanceKey, valueField);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1372,9 +1372,8 @@ public abstract class TensorGenerator {
 
       if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
         throw new IllegalStateException("Unknown dtype: " + instanceKey + ".");
-      } else if (instanceKey instanceof AllocationSiteInNode
-          && ((AllocationSiteInNode) instanceKey)
-              .getNode()
+      } else if (asin != null
+          && asin.getNode()
               .getMethod()
               .getDeclaringClass()
               .getReference()
@@ -1386,6 +1385,13 @@ public abstract class TensorGenerator {
         // to be able to migrate to canonical `Ltensorflow/python/framework/ops/Tensor`
         // later (wala/ML#459 PR 2). Reading the containing method's declaring class
         // instead decouples this recognition from the alloc-class convention.
+        //
+        // Use the already-unwrapped {@code asin} from the loop header (line 1299) so
+        // wrapping {@link InstanceKey}s (e.g. {@link
+        // com.ibm.wala.cast.ipa.callgraph.ScopeMappingInstanceKey}) route through this
+        // branch correctly — the prior {@code instanceof AllocationSiteInNode} check
+        // would have skipped wrapped keys (Copilot review on PR #216).
+        //
         // Extract the alloc's `dtype` field and recurse to resolve the actual DType.
         IField valueField =
             builder.getClassHierarchy().resolveField(TensorFlowTypes.CONSTANT_DTYPE);


### PR DESCRIPTION
PR 1 of 2 for wala/ML#459's two-PR plan. **Functionally a no-op** on current master; sets up PR 2 (canonical `Tensor` alloc migration) to land cleanly.

## Summary

Three call sites in `com.ibm.wala.cast.python.ml.client/` recognize `tf.constant(...)` results by checking the alloc's concrete type against `CONSTANT_OP_CONSTANT` (= `Ltensorflow/python/framework/constant_op/constant`):

1. `TensorGenerator.getShapesFromShapeArgument` — shape recovery for `tf.constant([2,3])` shape args (the `testEye6` break point in the canonical-migration prototype).
2. `TensorGenerator.getDTypesFromDTypeArgument` — sibling read for dtype recovery.
3. `RaggedFromNestedValueRowIds.getEffectiveInstances` — value-arg PTS recovery in ragged-tensor inference.

Each replaces the alloc-class check with a containing-method check:

```java
// Before:
reference.equals(CONSTANT_OP_CONSTANT)

// After:
asin.getNode().getMethod().getDeclaringClass().getReference()
    .equals(CONSTANT.getDeclaringClass())
```

The signal source moves from "what concrete class did `<new>` allocate" to "what method (i.e., what TF function) is this allocation inside" — semantically the more accurate signal. Functionally equivalent today because the only place `CONSTANT_OP_CONSTANT` is allocated is inside `tensorflow/functions/constant.do()`.

## Why

wala/ML#459's design discussion identified that function-typed alloc classes (named after their function, like `Ltensorflow/python/framework/constant_op/constant`) are a duplication of identity that the dispatch system doesn't actually need — dispatch reads call-site-def, not alloc type. But three reader sites in shape/dtype recovery paths read these alloc-class strings as a signal, coupling those paths to the per-op alloc convention.

This PR decouples the recognition. After it lands, **PR 2 can migrate function-typed allocs to canonical `Ltensorflow/python/framework/ops/Tensor`** without breaking these readers.

## Audit

`grep -r "getConcreteType().getReference()" com.ibm.wala.cast.python.ml/source` found 82 reads. Classification:

| Category | Count |
|---|---|
| Object types (`tuple`, `list`, `SparseTensor`, `TensorSpec`, `RaggedTensorSpec`, `DType`, `Dataset`, `NEWAXIS`, `FEATURE`, etc.) | ~78 |
| Function types (`CONSTANT_OP_CONSTANT`) — refactored by this PR | 3 |
| Function-object PTS reads (`NEXT.getDeclaringClass()`) — different pattern, not affected | 1 |

The function-typed-as-tensor-result-signal smell is exactly the 3 sites this PR refactors.

## Test plan

- [x] `mvn test -pl com.ibm.wala.cast.python.ml.test`: 650/0/0/3 passing (no regressions).
- [x] Refactor is a behavioral no-op on current master (per-op convention still works as before).
- [ ] (PR 2) Migrate function-typed alloc classes to canonical Tensor; verify `testEye6` and the other 7 tests that broke in the prototype migration pass cleanly.

## Two-PR Plan

Per closed wala/ML#459:
1. **This PR**: refactor `tf.constant` reader sites to use containing-method-based detection.
2. **Follow-up PR**: migrate ~70 function-typed `<new>` alloc classes to canonical `Ltensorflow/python/framework/ops/Tensor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)