### PR TITLE
Don't cancel `merge_group` CI runs (kicks PRs from the queue)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,8 +4,14 @@ on:
   pull_request:
   merge_group:
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') }} # Cancel if not a tag push.
+  # Group includes the workflow name so merge_group runs from different workflows don't collide.
+  # Cancel-in-progress is allowed for `pull_request` (new push to PR supersedes prior runs) and
+  # for non-tag `push` events (commits to a branch supersede prior runs); explicitly NOT for
+  # `merge_group` events, because GitHub Merge Queue spawns concurrent runs on the queue branch
+  # and cancellation marks the cancelled run as failed, kicking the PR out of the queue.
+  # Tags also run to completion so the deploy gate isn't accidentally cancelled.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
## Summary

`Continuous integration`'s `concurrency.cancel-in-progress` evaluates TRUE for `merge_group` events. GitHub Merge Queue spawns concurrent runs on the queue branch (`gh-readonly-queue/master/pr-N-...`) and the cancellation marks the cancelled run as `cancelled` to the queue, which the queue interprets as a failed required check and kicks the PR out.

Observed on https://github.com/ponder-lab/ML/pull/216 at 2026-05-04T15:20:17Z, ~30 seconds after add-to-queue:

```
15:19:28  added_to_merge_queue
15:19:46  4 runs fire on gh-readonly-queue branch:
            - Continuous integration (in_progress)
            - Continuous integration (CANCELLED)  ← duplicate cancelled by concurrency
            - CodeQL (in_progress)
            - Automatic Dependency Submission (success)
15:20:17  removed_from_merge_queue by github-merge-queue[bot]
```

## Fix

Limit `cancel-in-progress` to `pull_request` and non-tag `push` events. `merge_group` runs to completion regardless. Add `github.workflow` to the concurrency group so two distinct workflows targeting the same ref don't collide.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
```

## Why This Matters Now

The `auto-update-prs` workflow had a similar gotcha (GITHUB_TOKEN-driven `pulls.updateBranch` doesn't trigger downstream workflows) which we reverted. Both are flavors of "concurrency/automation rules need explicit `merge_group` awareness." This fix unblocks https://github.com/ponder-lab/ML/pull/216 (and any future PR going through the merge queue).

## Test Plan

- [ ] Land this PR via direct push or another route (the merge queue itself is currently broken for PRs that depend on this fix — chicken-and-egg).
- [ ] Re-add https://github.com/ponder-lab/ML/pull/216 to the merge queue; verify it lands cleanly.

Direct push approach acceptable since this is a workflow-config-only change with no semantic impact, parallel to the previous CI workflow patches (`37e959ed`, `291893d6`, `b9411b58`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)