### PR TITLE
Filter `push:` Trigger off Queue Branches (Completes #217's Fix)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,15 @@
 name: Continuous integration
 on:
   push:
+    # GitHub Merge Queue creates branches under `refs/heads/gh-readonly-queue/...` and pushes
+    # the queue's test commit there. That push fires this workflow's `push:` trigger AS WELL
+    # AS the `merge_group:` trigger — two runs in the same concurrency group, where the second
+    # cancels the first. The cancelled run is reported as failed to the merge queue, which
+    # kicks the PR out (per the PR #217 fix's known incompleteness — Copilot caught this on
+    # the equivalent Hybridize PR #443). Filtering out queue branches from `push:` lets
+    # `merge_group:` be the sole trigger for queue-branch pushes.
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
 concurrency:


### PR DESCRIPTION
## Summary

PR #217 landed an incomplete fix for the merge-queue concurrency kick: it disabled `cancel-in-progress` for `merge_group` events but didn't address the related case where the queue branch's push event fires the `push:` trigger *concurrently* with the `merge_group:` trigger. Both events end up in the same concurrency group (same workflow + same ref), and the second's `cancel-in-progress` cancels the first. The cancelled run is reported as failed to the merge queue, which kicks the PR out.

Copilot caught this on the equivalent Hybridize PR (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/pull/443#discussion_r3182666842, now also addressed there). The same fix applies here.

## Fix

Add `branches-ignore: ['gh-readonly-queue/**']` to the `push:` trigger so queue-branch pushes route only through `merge_group:` — no duplicate run, no race.

## Test Plan

- [ ] Land via merge queue itself; verify the PR doesn't get kicked. (The queue is not currently broken on master because the partial fix from #217 is enough to handle most queue events; this PR is the belt-and-suspenders completion that closes the remaining race.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)