### PR TITLE
Add `Argmax`/`Argmin` generators (wala/ML#449 Tier 6)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4249,12 +4249,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   // wala/ML#449 Tier 6: argmax/argmin produce int64 indices. Output shape is left at ⊤ for now;
   // see `Argmax.getDefaultShapes` for why precise shape inference regresses `testNeuralNetwork*`.
 
+  /**
+   * Verifies that {@code tf.math.argmax(x, axis=0)} routes through the dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.Argmax} generator and emits the precise {@code int64} dtype
+   * (the TF default for argmax indices). Output shape is left at ⊤ in this Tier 6 PR — see
+   * wala/ML#462 for why.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
   @Test
   public void testArgmax()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_argmax.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
   }
 
+  /**
+   * Counterpart of {@link #testArgmax()} for {@code tf.math.argmin}. Same semantics: dtype is fixed
+   * at {@code int64}, shape is left at ⊤. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
   @Test
   public void testArgmin()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -330,6 +330,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_INT64 =
       new TensorType(INT_64, asList(new NumericDim(2)));
 
+  private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
+
   private static final TensorType TENSOR_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3)));
 
@@ -4242,6 +4244,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testSize()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_size.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  // wala/ML#449 Tier 6: argmax/argmin produce int64 indices. Output shape is left at ⊤ for now;
+  // see `Argmax.getDefaultShapes` for why precise shape inference regresses `testNeuralNetwork*`.
+
+  @Test
+  public void testArgmax()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_argmax.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+  }
+
+  @Test
+  public void testArgmin()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -180,6 +180,12 @@
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="x" value="argmax" />
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math" value="argmax" />
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math_ops" value="argmax" />
+        <!-- Same aliasing for `tf.argmin` / `tf.math.argmin`. -->
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin -->
+        <new def="argmin" class="Ltensorflow/math/argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="x" value="argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math" value="argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math_ops" value="argmin" />
         <!-- Same aliasing for `tf.equal` / `tf.math.equal`. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/equal -->
         <new def="equal" class="Ltensorflow/math/equal" />
@@ -892,6 +898,16 @@
         </method>
       </class>
       <class name="argmax" allocatable="true">
+        <method name="read_data" descriptor="()LRoot;" numArgs="1">
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="x" />
+        </method>
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
+          <return value="xx" />
+        </method>
+      </class>
+      <class name="argmin" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -898,6 +898,8 @@
         </method>
       </class>
       <class name="argmax" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator emits `int64` (the TF default) for the output dtype; output shape is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for
+          `axis`) is retained in `paramNames`; the modern `output_type` parameter isn't surfaced here yet — wala/ML#463 covers the migration. -->
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
@@ -908,6 +910,7 @@
         </method>
       </class>
       <class name="argmin" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same `read_data` materialization chain, same `int64` output dtype via the dedicated `Argmin` generator). -->
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -32,10 +32,10 @@ public class Argmax extends ReduceMean {
     return null;
   }
 
-  @Override
-  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    return EnumSet.of(DType.INT64);
-  }
+  // `getDefaultDTypes` is intentionally not overridden: the parent's `getDTypes(builder)` (which
+  // dispatches to `getDefaultDTypes` when there is no dtype argument) is itself overridden here to
+  // return INT64 unconditionally, bypassing the dtype-arg path entirely. Overriding
+  // `getDefaultDTypes` would be dead code.
 
   @Override
   protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -1,0 +1,44 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.argmax}. Output dtype is fixed at {@link DType#INT64} (the TF
+ * default; the {@code output_type=tf.int32} alternative isn't currently surfaced through {@code
+ * tensorflow.xml}, so the generator emits {@code int64} unconditionally). Output shape is left at ⊤
+ * for now; computing the precise shape (input.shape with the {@code axis} dimension removed)
+ * regresses tests such as {@code testNeuralNetwork*}, where the per-context shape union for {@code
+ * y_true} (e.g. {@code [256]} train vs. {@code [10000]} test) cross-products through {@code
+ * ElementWiseOperation}'s strict broadcast check. Shape precision can be added once the EWO union
+ * behaviour is addressed (wala/ML#462). See wala/ML#449 (Tier 6).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/argmax">tf.math.argmax</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Argmax extends ReduceMean {
+
+  public Argmax(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.INT64);
+  }
+
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.INT64);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmin.java
@@ -1,0 +1,19 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.math.argmin}. Reuses {@link Argmax}'s axis-removal shape inference and
+ * fixed {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType#INT64} output dtype (the
+ * shape and dtype semantics are identical between the two ops; only the runtime value differs). See
+ * wala/ML#449 (Tier 6).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/argmin">tf.math.argmin</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Argmin extends Argmax {
+
+  public Argmin(PointsToSetVariable source) {
+    super(source);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmin.java
@@ -3,10 +3,10 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
- * Generator for {@code tf.math.argmin}. Reuses {@link Argmax}'s axis-removal shape inference and
- * fixed {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType#INT64} output dtype (the
- * shape and dtype semantics are identical between the two ops; only the runtime value differs). See
- * wala/ML#449 (Tier 6).
+ * Generator for {@code tf.math.argmin}. Inherits {@link Argmax}'s ⊤ shape (deferred to wala/ML#462)
+ * and fixed {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType#INT64} output dtype —
+ * the shape and dtype semantics are identical to {@code tf.math.argmax}; only the runtime value
+ * differs (smallest vs. largest index). See wala/ML#449 (Tier 6).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/argmin">tf.math.argmin</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -4,6 +4,8 @@ import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.RESHAPE_METHOD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMAX;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TRAIN;
@@ -1087,6 +1089,8 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, LOG_SOFTMAX.getDeclaringClass())) return new LogSoftmax(source);
     else if (isType(calledFunction, RANK.getDeclaringClass())) return new Rank(source);
     else if (isType(calledFunction, SIZE.getDeclaringClass())) return new Size(source);
+    else if (isType(calledFunction, ARGMAX.getDeclaringClass())) return new Argmax(source);
+    else if (isType(calledFunction, ARGMIN.getDeclaringClass())) return new Argmin(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -862,6 +862,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String ARGMAX_SIGNATURE = "tf.argmax()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/argmin. */
+  public static final MethodReference ARGMIN =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/argmin")),
+          AstMethodReference.fnSelector);
+
+  private static final String ARGMIN_SIGNATURE = "tf.argmin()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1195,6 +1204,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(CIFAR10_Y_TEST, CIFAR10_Y_TEST_SIGNATURE),
           Map.entry(PLACEHOLDER.getDeclaringClass(), PLACEHOLDER_SIGNATURE),
           Map.entry(ARGMAX.getDeclaringClass(), ARGMAX_SIGNATURE),
+          Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(CAST.getDeclaringClass(), CAST_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.argmax(x, axis=0)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int64
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmin.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.argmin(x, axis=0)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int64
+
+f(y)


### PR DESCRIPTION
## Summary

Routes `tf.math.argmax`/`tf.math.argmin` through dedicated `TensorGenerator` subclasses instead of `ReadDataFallback`. Output dtype is fixed at `int64` (the TF default).

## Scope

**Output shape is intentionally left at ⊤ for now.** Computing the precise shape (input.shape with the `axis` dimension removed) regresses `testNeuralNetwork*`, where the per-context shape union for `y_true` (e.g. `[256]` train vs. `[10000]` test) cross-products through `ElementWiseOperation`'s strict broadcast check. Shape precision can be added once the EWO union-cartesian behaviour is addressed (wala/ML#462).

The dtype precision (`int64`) is the real Tier 6 win — observable in `testArgmax`/`testArgmin`, no regression on the rest of the suite.

## Files

- `tensorflow.xml`: adds `argmin` class mirroring `argmax`; new bindings under top-level `tf`, `tf.math`, and `tf.math_ops` aliases.
- `TensorFlowTypes.java`: `ARGMIN` `MethodReference` + signature mapping (paired with the existing `ARGMAX` entry).
- `TensorGeneratorFactory.java`: dispatch for `ARGMAX`/`ARGMIN`.
- `Argmax.java`: new generator; overrides `getDefaultDTypes`/`getDTypes` to `{INT64}`; `getDefaultShapes` returns `null` (with the deferred-shape-precision rationale in the Javadoc).
- `Argmin.java`: trivial `extends Argmax` (same shape/dtype semantics, only runtime value differs).
- `tf2_test_argmax.py`/`tf2_test_argmin.py`: Python test fixtures.
- `TestTensorflow2Model.java`: `testArgmax`/`testArgmin` + `TENSOR_INT64_UNKNOWN_SHAPE` constant.

## Test Plan

- [x] `testArgmax` and `testArgmin` pass — dtype precision win observable.
- [x] Full suite green: `mvn test` 652/0/0/3.
- [x] No regression on `testNeuralNetwork*` (the regression that motivated the deferred shape inference).
- [x] Both Python fixtures run cleanly under TF 2.x.

## Cross-Refs

- wala/ML#449 — parent (per-op generators replacing `ReadDataFallback`).
- wala/ML#462 — follow-up: EWO cartesian-pair throw blocks per-context shape precision.
- wala/ML#380 — related: `read_data` marker inlining (argmax/argmin still use markers; orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)