### PR TITLE
Add `Gradient` generator (wala/ML#430)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1798,7 +1798,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tensorflow_gan_tutorial.py",
         "train_step",
         1,
-        5,
+        7,
         Map.of(2, Set.of(TENSOR_256_28_28_1_FLOAT32, TENSOR_96_28_28_1_FLOAT32)));
   }
 
@@ -1818,7 +1818,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tensorflow_gan_tutorial2.py",
         "train_step",
         1,
-        5,
+        7,
         Map.of(2, Set.of(TENSOR_256_28_28_1_FLOAT32, TENSOR_96_28_28_1_FLOAT32)));
   }
 
@@ -1974,7 +1974,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "neural_network.py",
         "run_optimization",
         2,
-        4,
+        5,
         Map.of(2, Set.of(TENSOR_256_784_FLOAT32), 3, Set.of(TENSOR_256_UINT8)));
   }
 
@@ -2089,7 +2089,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testAutoencoder3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("autoencoder.py", "run_optimization", 1, 3, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
+    test("autoencoder.py", "run_optimization", 1, 4, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
   }
 
   /**
@@ -4115,7 +4115,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "multigpu_training.py",
         "run_optimization",
         2,
-        4,
+        5,
         Map.of(2, Set.of(TENSOR_4096_32_32_3_FLOAT32), 3, Set.of(TENSOR_4096_UINT8)));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1784,9 +1784,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * = 234 full batches + 1 partial batch of 96; verified by Python assert statements in {@code
    * tensorflow_gan_tutorial.py}).
    *
-   * <p>Expected tensor variable count: 5 (matches master baseline and branch actual; no count
-   * regression or advance). The test fails only on types: value 2 ({@code images}) registers as
-   * {@code {? float32}} because the mnist data pipeline loses shape information through {@code
+   * <p>Expected tensor variable count: 7. After wala/ML#430's {@code Gradient} generator allocates
+   * a fresh tensor per {@code tape.gradient(...)} call instead of aliasing {@code sources}, each of
+   * the two gradient calls in {@code train_step} (one for the generator, one for the discriminator)
+   * registers an additional local tensor variable, lifting the count from the prior master baseline
+   * of 5 to 7. The test still fails only on types: value 2 ({@code images}) registers as {@code {?
+   * float32}} because the mnist data pipeline loses shape information through {@code
    * mnist.load_data()} and the subsequent ndarray operations (wala/ML#361). Types are aspirational;
    * hardcoding {@code mnist.load_data()} as an intrinsic (per the plan discussed on branch 267)
    * would unblock this test without needing the general annotation framework (wala/ML#370).
@@ -1808,8 +1811,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Python assert statements in {@code tensorflow_gan_tutorial.py} (not duplicated in {@code
    * tensorflow_gan_tutorial2.py} since the two files are structurally identical apart from the
    * decorator): shape in {@code {(256, 28, 28, 1), (96, 28, 28, 1)}}, dtype {@code float32}.
-   * Expected count 5 matches master baseline and branch actual; same mnist modeling gap
-   * (wala/ML#361) blocks type inference on value 2.
+   * Expected count 7 — same accounting as {@link #testGanTutorial()}: the two `tape.gradient(...)`
+   * calls each contribute one fresh tensor variable post-wala/ML#430 (5 → 7). Same mnist modeling
+   * gap (wala/ML#361) blocks type inference on value 2.
    */
   @Test
   public void testGanTutorial2()
@@ -1963,9 +1967,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * <p>Rule-based tensor variable count is 6 (2 parameters {@code x}, {@code y} + 4 intermediate
    * ops {@code pred}, {@code loss}, {@code trainable_variables}, {@code gradients}). With the fix
    * for wala/ML#358, {@code pred = neural_net(x, is_training=True)} is now tracked at {@code (256,
-   * 10) float32}, bringing the registered count to 4. {@code trainable_variables} and {@code
-   * gradients} are lists of tensors rather than single tensors and don't register as {@code
-   * TensorVariable}s; the remaining gap from 4 to 6 is tracked by wala/ML#391.
+   * 10) float32}, bringing the registered count to 4. After wala/ML#430's {@code Gradient}
+   * generator, {@code gradients} now registers as one fresh tensor variable (the generator
+   * allocates fresh per call rather than aliasing {@code sources}), lifting the count from 4 to 5.
+   * {@code trainable_variables} remains a list of tensors and still doesn't register; the residual
+   * gap from 5 to 6 is tracked by wala/ML#391.
    */
   @Test
   public void testNeuralNetwork3()
@@ -2079,12 +2085,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code (256, 784)} dtype {@code float32} (verified by Python assert statements in {@code
    * autoencoder.py}).
    *
-   * <p>Expected tensor variable count: 3 (master baseline). Rule-based would be 6 (1 parameter + 5
-   * intermediate ops {@code encoder(x)} result, {@code decoder(...) = reconstructed_image}, {@code
-   * mean_square(...) = loss}, {@code trainable_variables}, {@code gradients}), dropping to 4 if
-   * list-of-tensors values don't register, but branch currently registers 1 &mdash; a regression
-   * from master. Keeping expected at the master baseline lets the failing count check serve as the
-   * regression signal; no separate issue is needed because the test itself tracks the discrepancy.
+   * <p>Expected tensor variable count: 4. Rule-based would be 6 (1 parameter + 5 intermediate ops
+   * {@code encoder(x)} result, {@code decoder(...) = reconstructed_image}, {@code mean_square(...)
+   * = loss}, {@code trainable_variables}, {@code gradients}), dropping to 4 if list-of-tensors
+   * values don't register. After wala/ML#430's {@code Gradient} generator, {@code gradients} now
+   * registers as one fresh tensor variable; combined with the previously-registered tensors the
+   * count reaches 4 — matching the rule-based-minus-{@code trainable_variables} ceiling. (Pre-#430
+   * the count was 1, so the master baseline of 3 had been deliberately preserved as a regression
+   * canary; that role is now superseded by reaching the rule-based ceiling.)
    */
   @Test
   public void testAutoencoder3()
@@ -4099,14 +4107,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * a bare integer as the shape argument (the parenthesised {@code (-1)} parses as {@code -1}, not
    * a 1-tuple).
    *
-   * <p>Expected tensor variable count: 4. Previously 5 — branch carried a spurious classification
-   * at {@code vn=44} ({@code gpu_batch_size = int(batch_size / num_gpus)} at line 222) where {@code
-   * batch_size / num_gpus} is a binop on Python ints, dispatched to {@link ElementWiseOperation}
-   * and typed {@code [] of int32} via {@link TensorGenerator#getDTypesOfValue}'s Integer-constant →
-   * INT32 path. Now correctly rejected by {@link TensorGeneratorFactory}'s binop operand-tensor
-   * gate (wala/ML#451), restoring the master-baseline count of 4. See also wala/ML#361 (MNIST
-   * modeling) and wala/ML#393 (CIFAR-10 modeling, closed by the commit that landed this test's
-   * partial pass).
+   * <p>Expected tensor variable count: 5. The historical trajectory is: pre-wala/ML#451 the count
+   * was 5 because of a spurious classification at {@code vn=44} ({@code gpu_batch_size =
+   * int(batch_size / num_gpus)} at line 222) where {@code batch_size / num_gpus} is a binop on
+   * Python ints, dispatched to {@link ElementWiseOperation} and typed {@code [] of int32} via
+   * {@link TensorGenerator#getDTypesOfValue}'s Integer-constant → INT32 path. wala/ML#451's binop
+   * operand-tensor gate rejected that classification, dropping the count to the master baseline of
+   * 4. wala/ML#430's {@code Gradient} generator then added one fresh tensor per {@code
+   * tape.gradient(...)} call (one such call here), bringing the count back to 5 — but now backed by
+   * the legitimate registration of the gradient result rather than the spurious binop pickup. See
+   * also wala/ML#361 (MNIST modeling) and wala/ML#393 (CIFAR-10 modeling, closed by the commit that
+   * landed this test's partial pass).
    */
   @Test
   public void testMultiGPUTraining()

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1990,9 +1990,10 @@
         </method>
       </class>
       <class name="gradient" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient — fresh allocation (not pass-through of `sources`). The dedicated `Gradient` generator inherits shape and dtype from the `sources` argument. See wala/ML#430. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self target sources output_gradients unconnected_gradients">
-          <return value="sources" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -41,6 +42,18 @@ public class Gradient extends TensorGenerator {
 
   public Gradient(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs a {@code Gradient} anchored to a manual node. Used by {@link
+   * TensorGenerator#createManualGenerator} so that the synthetic-{@code do()} fallback path can
+   * recover shape/dtype for gradient-produced tensors without a caller-side {@link
+   * PointsToSetVariable}.
+   *
+   * @param node The {@link CGNode} for the {@code gradient.do()} synthetic method.
+   */
+  public Gradient(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
@@ -1,0 +1,97 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.GradientTape.gradient}. Returns a fresh tensor whose shape and dtype
+ * match the {@code sources} argument — the gradient of a function w.r.t. a tensor has the same
+ * shape and dtype as that tensor. The output is a distinct allocation from {@code sources} (no
+ * input alias). Per-source list/tensor structure is not modeled here; the common single-source case
+ * recovers the right shape and dtype, which is what downstream tests in the suite assert. See
+ * wala/ML#430.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/GradientTape#gradient">tf.GradientTape.gradient</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Gradient extends TensorGenerator {
+
+  private enum Parameters {
+    TARGET,
+    SOURCES,
+    OUTPUT_GRADIENTS,
+    UNCONNECTED_GRADIENTS;
+
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public Gradient(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return shapesOfArg(builder, Parameters.SOURCES.getIndex(), Parameters.SOURCES.getName());
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    Set<DType> dtypes =
+        dtypesOfArg(builder, Parameters.SOURCES.getIndex(), Parameters.SOURCES.getName());
+    return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+  }
+
+  private Set<List<Dimension<?>>> shapesOfArg(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
+    if (pts != null && !pts.isEmpty()) {
+      Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pts);
+      if (shapes != null && !shapes.isEmpty()) return shapes;
+    }
+    return this.getArgumentShapesViaCallers(builder, paramPos, paramName);
+  }
+
+  private Set<DType> dtypesOfArg(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
+    if (pts != null && !pts.isEmpty()) {
+      Set<DType> dtypes = this.getDTypesOfValue(builder, pts);
+      if (dtypes != null && !dtypes.isEmpty()) return dtypes;
+    }
+    return this.getArgumentDTypesViaCallers(builder, paramPos, paramName);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -50,6 +50,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_ROW_STARTS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWIDS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IDENTITY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.INPUT;
@@ -1090,6 +1091,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);
+    else if (isType(calledFunction, GRADIENT.getDeclaringClass())) return new Gradient(source);
     else if (isType(calledFunction, SOFTMAX.getDeclaringClass())) return new Softmax(source);
     else if (isType(calledFunction, DENSE_CALL.getDeclaringClass())) return new DenseCall(source);
     else if (isType(calledFunction, MODEL_CALL.getDeclaringClass())) return new ModelCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1012,6 +1012,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String STOP_GRADIENT_SIGNATURE = "tf.stop_gradient()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/GradientTape#gradient. */
+  public static final MethodReference GRADIENT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/gradient")),
+          AstMethodReference.fnSelector);
+
+  private static final String GRADIENT_SIGNATURE = "tf.GradientTape.gradient()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/nn/softmax. */
   public static final MethodReference SOFTMAX =
       MethodReference.findOrCreate(
@@ -1215,6 +1224,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SIZE.getDeclaringClass(), SIZE_SIGNATURE),
           Map.entry(IDENTITY.getDeclaringClass(), IDENTITY_SIGNATURE),
           Map.entry(STOP_GRADIENT.getDeclaringClass(), STOP_GRADIENT_SIGNATURE),
+          Map.entry(GRADIENT.getDeclaringClass(), GRADIENT_SIGNATURE),
           Map.entry(SOFTMAX.getDeclaringClass(), SOFTMAX_SIGNATURE),
           Map.entry(DENSE_CALL.getDeclaringClass(), DENSE_CALL_SIGNATURE),
           Map.entry(FLATTEN.getDeclaringClass(), FLATTEN_SIGNATURE),


### PR DESCRIPTION
## Summary

Routes `tf.GradientTape.gradient` through a dedicated `TensorGenerator` subclass instead of the input-aliasing shortcut. The previous XML modeling returned `sources` directly, silently aliasing the gradient result to the variables it was computed against. The new `Gradient` generator allocates a fresh tensor and inherits shape/dtype from the `sources` argument — same shape and dtype as the source (mathematically true for gradients), but a distinct allocation site.

## Why a Java Generator (and Not Just `<new>` in XML)

Earlier today I tried the minimal XML-only fix (`<new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>` + `<return value="res"/>`) for all three sibling cases (`gradient`, `parse_single_example`, `shuffle_batch`) suggested in the issue body. The full suite went red: `testGradient`/`testGradient2` couldn't recover the source's `[2, None] of float32` tensor type because a naked `<new>` doesn't carry shape/dtype info forward; `testEx1CG`'s reshape chain through `parse_single_example`/`shuffle_batch` broke for the same reason.

Documented the finding in https://github.com/wala/ML/issues/430#issuecomment-4373165321. Conclusion: the issue's "minimal `<new>` is strictly better than the alias" premise was too optimistic — the alias was load-bearing for shape/dtype propagation, and the proper fix needs a Java generator that allocates fresh AND inherits shape/dtype from the source argument (same pattern as `Identity`/`StopGradient`).

This PR implements the proper fix for **`gradient` only**. The two siblings are deferred (see "Deferred" below).

## Per-Source Structure

The TF API can return either a single tensor or a list of tensors depending on whether `sources` is a single tensor or a sequence. This generator models the single-tensor case correctly (shape/dtype inherited). For multi-source calls, the result still has a single fresh allocation rather than a list — adequate for the suite's assertions, can be refined later.

## Test Count Updates

Five tests had hard-coded `expectedNumberOfFunctionTensorVariables` that previously silently included the alias. Each `tape.gradient(...)` call now contributes one additional fresh tensor variable:

| Test | Before | After | Gradient Calls |
|---|---|---|---|
| `testNeuralNetwork3` | 4 | 5 | 1 |
| `testAutoencoder3` | 3 | 4 | 1 |
| `testGanTutorial` | 5 | 7 | 2 |
| `testGanTutorial2` | 5 | 7 | 2 |
| `testMultiGPUTraining` | 4 | 5 | 1 |

Each delta matches the number of `tape.gradient(...)` calls in the corresponding Python file.

## Test Plan

- [x] `testGradient`/`testGradient2` pass with their existing `TENSOR_2_NONE_FLOAT32` expectation (the gradient of a `[2, None] float32` ragged source is itself `[2, None] float32`). The prior aliasing-bug test passes via the new shape/dtype inheritance, no fixture changes.
- [x] Full suite green: `mvn test` 650/0/0/3.
- [x] Five test count expectations updated to reflect the +1-per-gradient-call reality.

## Deferred

- **`tf.io.parse_single_example`** — dict-shaped result; needs structurally different modeling (per-key tensor materialization). Will follow up.
- **`tf.compat.v1.train.shuffle_batch`** — adding a `ShuffleBatch` generator with the same shape-inheritance pattern regresses `testEx1CG`'s reshape→conv3d chain in a way that needs deeper investigation. Will follow up.

Both are still tracked in wala/ML#430.

## Cross-Refs

- wala/ML#430 — parent.
- wala/ML#429 — sibling (`EstimatorSpec`); same fix shape, already landed.
- ponder-lab/ML#220 — concurrent Tier 6 PR (argmax/argmin); independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)