### PR TITLE
Group dependabot bumps for build plugins and Python tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,59 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot configuration. See:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Approach: dependabot opens grouped PRs for build-only plugins and
+# Python tooling (where the patch/minor risk profile makes batch review
+# safe), and individual PRs for runtime libraries and the WALA pin
+# (where each bump can affect analysis behaviour and deserves its own
+# review thread).
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Maven build-only plugins. These don't ship into the analyzer's
+      # runtime classpath, so a patch/minor bump is unlikely to change
+      # analysis output. Group them into a single weekly PR.
+      maven-plugins:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "org.codehaus.mojo:*"
+          - "com.diffplug.spotless:*"
+          - "com.puppycrawl.tools:*"
+          - "org.jacoco:*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Runtime libraries (`com.google.guava:*`, `commons-cli:*`,
+    # `commons-csv:*`, `org.json:*`, `org.jetbrains:annotations`) and the
+    # WALA pin (`com.ibm.wala:*`, parameterized by `wala.version`) are
+    # *deliberately* not grouped — they ship into the analyzer and any
+    # bump can shift analysis behaviour or surface compatibility breaks
+    # in the points-to / call-graph layer. Keep them as individual PRs.
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-tooling:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions versions in `.github/workflows/*.yml`. Previously
+  # untracked. Security-relevant for action supply-chain; weekly
+  # checks, no grouping (each action is independent and the volume is
+  # low).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

Today's snapshot of `ponder-lab/ML` shows 6 simultaneously-open dependabot PRs, with recent history demonstrating heavy churn — several PRs close as superseded by newer bumps within days (`versions-maven-plugin`, `spotless`, `black` repeatedly). The weekly-individual-PR shape generates review noise without proportional value, while batch-merging risks bundling in a runtime-library bump that should have been reviewed individually.

This config groups bumps where grouping is safe and leaves them individual where it isn't.

## What

| Category | Examples | Treatment |
|---|---|---|
| Build-only plugins | `maven-*-plugin`, `org.codehaus.mojo:*`, `spotless`, `checkstyle`, `jacoco` | **Group** patch+minor (one PR/week) |
| Python tooling | `black`, pip deps | **Group** patch+minor |
| Runtime libraries | `guava`, `commons-cli`, `commons-csv`, `org.json`, `jetbrains:annotations` | **Individual** — ship into analyzer |
| WALA pin | `com.ibm.wala:*` via `wala.version` | **Individual** — analysis-layer foundation |
| GitHub Actions | (currently untracked) | **Add** ecosystem; individual; weekly |

## Why "Build-Only Plugins" Are Safe to Group

Maven plugins like `maven-shade-plugin`, `spotless-maven-plugin`, `jacoco-maven-plugin` execute during the build phase but don't ship into the resulting fat-jar's runtime classpath. A patch/minor bump can change build behaviour (formatting, packaging) but won't change analyzer behaviour for downstream consumers like Hybridize. Batch review is appropriate.

## Why Runtime Libraries Are Not Grouped

Libraries like `com.google.guava`, `commons-cli`, `commons-csv`, `org.json`, and `org.jetbrains:annotations` are referenced from the analyzer's runtime code and ship into the published artifact. Even patch bumps can introduce subtle behaviour shifts that affect analysis output for downstream consumers. Each gets its own PR thread.

The `wala.version` pin (`com.ibm.wala:*`) is treated the same way — it's the foundation of the analysis stack and a bump touches the entire points-to / call-graph layer.

## Why Major Bumps Still Land Individually

`update-types: [minor, patch]` excludes majors from the group. Majors always open as standalone PRs because they typically need per-PR review for API breaks (today's bumps would be a good test of this — a `wala.version 1.6.x → 1.7.x` major would not have been grouped under any config).

## New: GitHub Actions Ecosystem

Previously not tracked. Action versions in `.github/workflows/*.yml` are supply-chain-relevant (a compromised action can run arbitrary code in CI). Adding weekly checks; individual PRs since action volume is low.

## Net Effect

- A typical Maven-plugin week opens **1 grouped PR** instead of 5.
- Runtime-library bumps stay individual, preserving per-dep review.
- Picks up GitHub Actions bumps that were previously untracked.
- No change to the `tensorflow` ignore (Hybridize keeps theirs; Ariadne never had one and doesn't pin TF for tests).

## Test Plan

- [ ] CI green on this PR (config-only change)
- [ ] Next dependabot run (weekly schedule) opens grouped PRs as configured
- [ ] No regressions: existing manifests still resolve

## Cross-Refs

- ponder-lab/Hybridize-Functions-Refactoring#446 — companion PR doing the same on the Hybridize side, with the additional cleanup of removing two silently-broken `dependabot-auto-{approve,merge}` workflow files. Ariadne doesn't have those workflows, so this PR is config-only.