### PR TITLE
Add `less`/`less_equal`/`greater`/`greater_equal` generators (wala/ML#427)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2237,6 +2237,63 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Counterpart of {@link #testEqual} for {@code tf.less}. Verifies the {@link ComparisonOperation}
+   * route emits {@code bool} dtype for the four ordering comparisons (wala/ML#427 residual).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLess()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_less.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
+  /**
+   * Counterpart of {@link #testLess} for {@code tf.less_equal}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLessEqual()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_less_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
+  /**
+   * Counterpart of {@link #testLess} for {@code tf.greater}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testGreater()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_greater.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
+  /**
+   * Counterpart of {@link #testLess} for {@code tf.greater_equal}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testGreaterEqual()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_greater_equal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
+  /**
    * Regression test for wala/ML#435: a recursive Python function whose return value flows back into
    * itself used to drive {@link
    * com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator(

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -267,6 +267,24 @@
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="x" value="not_equal" />
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math" value="not_equal" />
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math_ops" value="not_equal" />
+        <!-- The four ordering comparison ops (`tf.less`, `tf.less_equal`, `tf.greater`, `tf.greater_equal`) round out the comparison family started by `equal`/`not_equal`; same alias structure (top-level `tf.X`, `tf.math.X`, `tf.math_ops.X`). Each routes to `ComparisonOperation` and emits `bool` per
+          wala/ML#427. -->
+        <new def="less" class="Ltensorflow/math/less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math_ops" value="less" />
+        <new def="less_equal" class="Ltensorflow/math/less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="x" value="less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math" value="less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math_ops" value="less_equal" />
+        <new def="greater" class="Ltensorflow/math/greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="x" value="greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math" value="greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math_ops" value="greater" />
+        <new def="greater_equal" class="Ltensorflow/math/greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="x" value="greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math" value="greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math_ops" value="greater_equal" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/log -->
         <putfield class="LRoot" field="log" fieldType="LRoot" ref="math" value="pass_through" />
         <putfield class="LRoot" field="log" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
@@ -291,11 +309,7 @@
         <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="math" value="pass_through" />
         <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/less -->
-        <!-- TODO: Return a dtype of bool instead of the input. -->
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
+        <!-- `tf.less`'s legacy `pass_through` aliasing was removed: the modern `<class name="less">` block + `ComparisonOperation` dispatch (wala/ML#427) now handle bool dtype directly. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/cos -->
         <putfield class="LRoot" field="cos" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math" value="pass_through" />
@@ -1005,6 +1019,34 @@
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
           <return value="xx" />
+        </method>
+      </class>
+      <class name="less" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/less — elementwise `x < y`. Direct `<new>+<return>` per wala/ML#380's preference (no `read_data` materialization chain). Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="less_equal" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/less_equal — elementwise `x <= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="greater" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater — elementwise `x > y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="greater_equal" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater_equal — elementwise `x >= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="top_k" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -53,9 +53,13 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWID
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IDENTITY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.INPUT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG_SOFTMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MATMUL;
@@ -1076,6 +1080,14 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, EQUAL.getDeclaringClass()))
       return new ComparisonOperation(source);
     else if (isType(calledFunction, NOT_EQUAL.getDeclaringClass()))
+      return new ComparisonOperation(source);
+    else if (isType(calledFunction, LESS.getDeclaringClass()))
+      return new ComparisonOperation(source);
+    else if (isType(calledFunction, LESS_EQUAL.getDeclaringClass()))
+      return new ComparisonOperation(source);
+    else if (isType(calledFunction, GREATER.getDeclaringClass()))
+      return new ComparisonOperation(source);
+    else if (isType(calledFunction, GREATER_EQUAL.getDeclaringClass()))
       return new ComparisonOperation(source);
     else if (isType(calledFunction, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
         || isType(calledFunction, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -889,6 +889,42 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String NOT_EQUAL_SIGNATURE = "tf.not_equal()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/less. */
+  public static final MethodReference LESS =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/less")),
+          AstMethodReference.fnSelector);
+
+  private static final String LESS_SIGNATURE = "tf.less()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/less_equal. */
+  public static final MethodReference LESS_EQUAL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/less_equal")),
+          AstMethodReference.fnSelector);
+
+  private static final String LESS_EQUAL_SIGNATURE = "tf.less_equal()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/greater. */
+  public static final MethodReference GREATER =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/greater")),
+          AstMethodReference.fnSelector);
+
+  private static final String GREATER_SIGNATURE = "tf.greater()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/greater_equal. */
+  public static final MethodReference GREATER_EQUAL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/greater_equal")),
+          AstMethodReference.fnSelector);
+
+  private static final String GREATER_EQUAL_SIGNATURE = "tf.greater_equal()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/cast. */
   public static final MethodReference CAST =
       MethodReference.findOrCreate(
@@ -1216,6 +1252,10 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
+          Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),
+          Map.entry(LESS_EQUAL.getDeclaringClass(), LESS_EQUAL_SIGNATURE),
+          Map.entry(GREATER.getDeclaringClass(), GREATER_SIGNATURE),
+          Map.entry(GREATER_EQUAL.getDeclaringClass(), GREATER_EQUAL_SIGNATURE),
           Map.entry(CAST.getDeclaringClass(), CAST_SIGNATURE),
           Map.entry(
               SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass(),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_greater.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_greater.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.greater(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_greater_equal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_greater_equal.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.greater_equal(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_less.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_less.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.less(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_less_equal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_less_equal.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([[1.0, 1.0], [2.0, 2.0]])
+y = tf.constant([[1.0, 2.0], [2.0, 1.0]])
+
+z = tf.less_equal(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.dtype == tf.bool
+assert z.shape == (2, 2)
+
+f(z)


### PR DESCRIPTION
## Summary

Routes the four ordering comparison ops (`tf.less`, `tf.less_equal`, `tf.greater`, `tf.greater_equal`) through the same `ComparisonOperation` generator that already handles `tf.equal` / `tf.not_equal`, completing the comparison-op family per wala/ML#427's residual scope.

Pre-fix: each of the four ops had no dedicated XML class and a legacy `value="pass_through"` aliasing (only `tf.less` had this; the other three were entirely unmodeled). All four routed through `ElementWiseOperation`, which inherits the input dtype — wrong for comparison ops, which should always produce `bool`.

Post-fix: each op has a real `<class>` block, a `MethodReference` constant, and a dispatch entry routing to `ComparisonOperation`. Output dtype is correctly `bool`.

## Modeling Choices

- **Direct `<new>+<return>`** body, not the legacy `read_data` materialization chain — per wala/ML#380's preferred pattern for new modelings.
- **Removed legacy `value="pass_through"`** aliasing for `tf.less` (was at `tensorflow.xml:313-316`). The pass-through aliasing overrode the new top-level binding and routed the call into `ElementWiseOperation` even after I added the new dispatch — discovered by callees-list inspection during testLess debugging.
- **Top-level aliases** under `tf.X`, `tf.math.X`, and `tf.math_ops.X` for each op, mirroring the `equal`/`not_equal` pattern.

## Test Plan

- [x] `testLess`, `testLessEqual`, `testGreater`, `testGreaterEqual` — each asserts `TENSOR_2_2_BOOL` (broadcast shape `[2, 2]`, bool dtype).
- [x] Full suite green: `mvn test` 656/0/0/3.
- [x] All four Python fixtures run cleanly under `python3.10`, exit code 0.
- [x] Existing `testEqual`/`testNotEqual` still pass (no regression to the comparison-op precedent).

## Cross-Refs

- wala/ML#427 — parent (residual scope: 4 of 6 ops).
- wala/ML#380 — direct `<new>+<return>` preference (followed for the new ops).
- wala/ML#428 — umbrella; this advances the comparison-op subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)