### PR TITLE
Disable CodeQL `actions/unpinned-tag` rule for this repo

### DIFF
--- a/.github/codeql/codeql-config-actions.yml
+++ b/.github/codeql/codeql-config-actions.yml
@@ -1,13 +1,18 @@
-# CodeQL configuration.
+# CodeQL configuration for the `actions` language analysis.
+#
+# The matrix workflow runs CodeQL once per language and selects the config
+# file by interpolating `${{ matrix.language }}`. This file is for `actions`;
+# `codeql-config-java-kotlin.yml` is the sibling for `java-kotlin`.
 #
 # 1. Drops the `security-and-quality` query suite (kept only `security-extended`).
 #    Running both suites on the `actions` language produced 17,317 results — well
 #    over CodeQL's 5000-result-per-analysis storage limit, with the overflow
 #    silently dropped. `security-and-quality` adds code-quality lint queries on
 #    top of `security-extended`'s already-broad security set; the marginal
-#    signal for our codebase is mostly noise on YAML workflows. Keeping just
-#    `security-extended` brings the result count under the cap while preserving
-#    every security-relevant query.
+#    signal on YAML workflows is mostly noise. Keeping just `security-extended`
+#    brings the result count under the cap while preserving every
+#    security-relevant query. (The `java-kotlin` config still runs both suites
+#    — only `actions` hit the cap, so only `actions` needs the trim.)
 #
 # 2. Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
 #    tag references on non-GitHub-owned actions, asking for a SHA pin). For this
@@ -16,7 +21,7 @@
 #    trade-off — see the discussion on ponder-lab/ML#225 (codecov-action 5 → 6).
 #    Re-enable by removing the `actions/unpinned-tag` exclusion below.
 
-name: "ponder-lab/ML CodeQL config"
+name: "ponder-lab/ML CodeQL config (actions)"
 
 queries:
   - uses: security-extended

--- a/.github/codeql/codeql-config-java-kotlin.yml
+++ b/.github/codeql/codeql-config-java-kotlin.yml
@@ -1,0 +1,18 @@
+# CodeQL configuration for the `java-kotlin` language analysis.
+#
+# The matrix workflow runs CodeQL once per language and selects the config
+# file by interpolating `${{ matrix.language }}`. This file is for
+# `java-kotlin`; `codeql-config-actions.yml` is the sibling for `actions`.
+#
+# Runs both `security-extended` and `security-and-quality` query suites —
+# the same coverage that was in place before the per-language config split.
+# `java-kotlin` doesn't hit CodeQL's 5000-result-per-analysis cap (only
+# `actions` did, with 17,317 results), so this file keeps the broader
+# coverage. The `actions/unpinned-tag` rule isn't applicable to Java code,
+# so no rule exclusion is needed here either.
+
+name: "ponder-lab/ML CodeQL config (java-kotlin)"
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+# CodeQL configuration for the `actions` analysis.
+#
+# Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
+# tag references on non-GitHub-owned actions, asking for a SHA pin). For this
+# repo the rule fires as a build-reproducibility concern more than a
+# supply-chain-attack concern, and version-tag pinning is an acceptable
+# trade-off — see the discussion on ponder-lab/ML#225 (codecov-action 5 → 6).
+# Re-enable by removing the `actions/unpinned-tag` exclusion below.
+
+name: "ponder-lab/ML CodeQL config"
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: actions/unpinned-tag

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,17 +1,25 @@
-# CodeQL configuration for the `actions` analysis.
+# CodeQL configuration.
 #
-# Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
-# tag references on non-GitHub-owned actions, asking for a SHA pin). For this
-# repo the rule fires as a build-reproducibility concern more than a
-# supply-chain-attack concern, and version-tag pinning is an acceptable
-# trade-off — see the discussion on ponder-lab/ML#225 (codecov-action 5 → 6).
-# Re-enable by removing the `actions/unpinned-tag` exclusion below.
+# 1. Drops the `security-and-quality` query suite (kept only `security-extended`).
+#    Running both suites on the `actions` language produced 17,317 results — well
+#    over CodeQL's 5000-result-per-analysis storage limit, with the overflow
+#    silently dropped. `security-and-quality` adds code-quality lint queries on
+#    top of `security-extended`'s already-broad security set; the marginal
+#    signal for our codebase is mostly noise on YAML workflows. Keeping just
+#    `security-extended` brings the result count under the cap while preserving
+#    every security-relevant query.
+#
+# 2. Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
+#    tag references on non-GitHub-owned actions, asking for a SHA pin). For this
+#    repo the rule fires as a build-reproducibility concern more than a
+#    supply-chain-attack concern, and version-tag pinning is an acceptable
+#    trade-off — see the discussion on ponder-lab/ML#225 (codecov-action 5 → 6).
+#    Re-enable by removing the `actions/unpinned-tag` exclusion below.
 
 name: "ponder-lab/ML CodeQL config"
 
 queries:
   - uses: security-extended
-  - uses: security-and-quality
 
 query-filters:
   - exclude:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          config-file: ./.github/codeql/codeql-config.yml
+          config-file: ./.github/codeql/codeql-config-${{ matrix.language }}.yml
 
       # The Java build needs the Jython3 submodule installed as a local
       # Maven artifact before the main project can resolve. Mirrors the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       # The Java build needs the Jython3 submodule installed as a local
       # Maven artifact before the main project can resolve. Mirrors the


### PR DESCRIPTION
## Summary

Splits CodeQL config per matrix language so we can apply different rules per language. Two coordinated changes:

### 1. Disable `actions/unpinned-tag` rule (`actions` config only)

The rule flags third-party action references like `uses: codecov/codecov-action@v6` and asks for a SHA pin. For this repo the rule fires as a build-reproducibility concern more than a supply-chain-attack one — version-tag pinning is the accepted trade-off, per the discussion on https://github.com/ponder-lab/ML/pull/225 (codecov-action 5 → 6).

### 2. Drop `security-and-quality` query suite (`actions` config only)

Running both `security-extended` and `security-and-quality` on the `actions` language produced 17,317 results — over CodeQL's 5000-result-per-analysis storage limit, with overflow silently dropped (visible as the "Only 5000 were stored" status warning). Keeping just `security-extended` retains every security-relevant query while staying under the cap.

`java-kotlin` doesn't hit the cap, so its config keeps the original `security-extended` + `security-and-quality` set — quality-lint coverage on Java code is preserved.

## What This Does

- Adds `.github/codeql/codeql-config-actions.yml` — `security-extended` only, with the `actions/unpinned-tag` rule excluded.
- Adds `.github/codeql/codeql-config-java-kotlin.yml` — both suites, no rule exclusions.
- Updates the workflow's `init` step to interpolate the language: `config-file: ./.github/codeql/codeql-config-${{ matrix.language }}.yml`.

## Reverting

Restore single-config behaviour by reverting the workflow line and consolidating either of the two configs back into a generic `codeql-config.yml`. The two configs are independent — re-enabling `security-and-quality` for `actions` (or removing the `actions/unpinned-tag` exclusion) is a single-file edit.

## Test Plan

- [x] CodeQL workflow YAML is syntactically valid.
- [x] Per-language config selection verified by inspecting the workflow's `config-file:` interpolation.
- [ ] Verify on the next CodeQL run that `actions` analysis stays under 5000 results and `java-kotlin` still receives `security-and-quality` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
