### PR TITLE
Add `Linspace` + `BroadcastTo` generators (wala/ML#449 Tier 7)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -352,6 +352,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_5_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(5)));
 
+  private static final TensorType TENSOR_5_FLOAT64 =
+      new TensorType(FLOAT_64, asList(new NumericDim(5)));
+
   private static final TensorType TENSOR_64_5_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(5)));
 
@@ -4368,6 +4371,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testLinspace()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_linspace.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testLinspace()} that exercises the integer-promotion branch in {@link
+   * com.ibm.wala.cast.python.ml.client.Linspace#getDefaultDTypes}. {@code tf.linspace} with integer
+   * {@code start}/{@code stop} promotes the output to {@code float64} (verified on TF 2.9), not
+   * {@code float32}. The float-input case is covered by {@link #testLinspace()}.
+   */
+  @Test
+  public void testLinspaceInt()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_linspace_int.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT64)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -22,6 +22,8 @@ import com.ibm.wala.cast.lsp.AnalysisError;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
+import com.ibm.wala.cast.python.ml.client.BroadcastTo;
+import com.ibm.wala.cast.python.ml.client.Linspace;
 import com.ibm.wala.cast.python.ml.client.NonBroadcastableShapesException;
 import com.ibm.wala.cast.python.ml.client.NpArray;
 import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
@@ -4347,6 +4349,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testArgmin()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+  }
+
+  // wala/ML#449 Tier 7: linspace/broadcast_to. Shape derives from a shape-arg (`num`/`shape`),
+  // dtype derives from a value-arg (`start`/`input`).
+
+  /**
+   * Verifies that {@code tf.linspace(0.0, 10.0, 5)} routes through the dedicated {@link Linspace}
+   * generator and emits the precise rank-1 shape {@code (5,)} with {@code float32} dtype (derived
+   * from the float-typed {@code start} argument).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLinspace()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_linspace.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.broadcast_to(x, [2, 3])} routes through the dedicated {@link
+   * BroadcastTo} generator and emits shape {@code (2, 3)} (read from the {@code shape} argument's
+   * literal list) with {@code float32} dtype (derived from the {@code input} tensor).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBroadcastTo()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_broadcast_to.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4533,6 +4533,35 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Drives the {@code axis}-passed branch in {@link
+   * com.ibm.wala.cast.python.ml.client.Linspace#getDefaultShapes}. With {@code axis=1} and vector
+   * {@code start}/{@code stop}, {@code tf.linspace} interpolates along axis 1, producing a
+   * higher-rank result whose runtime shape is {@code (2, 5)} with dtype {@code float32}.
+   *
+   * <p>The static analysis currently returns ⊤ (unknown shape) for any axis-passed call — combining
+   * {@code start}'s rank with {@code num} is not yet implemented; the generator trades precision
+   * for soundness. The assertion encodes the observed result with a TODO pointing at the precision
+   * improvement that would narrow it.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/475">wala/ML#475</a> is fixed and
+   * {@code Linspace.getDefaultShapes} computes the precise output shape from {@code
+   * start.shape[:axis] + (num,) + start.shape[axis:]}, narrow the assertion to {@code
+   * Set.of(TENSOR_2_5_FLOAT32)} (a new constant).
+   *
+   * <p>Companion to {@link #testLinspace()} (covering the absent-axis branch).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLinspaceAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_linspace_axis.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Verifies that {@code tf.broadcast_to(x, [2, 3])} routes through the dedicated {@link
    * BroadcastTo} generator and emits shape {@code (2, 3)} (read from the {@code shape} argument's
    * literal list) with {@code float32} dtype (derived from the {@code input} tensor).

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -551,9 +551,11 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/solve -->
         <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through" />
         <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/broadcast_to -->
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
+        <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — fresh allocation routed to the dedicated `BroadcastTo` generator (wala/ML#449 Tier 7). Pre-fix used `value="pass_through"` aliasing, which routed the result through `PassThrough`'s identity semantics rather than computing the actual
+          broadcast shape from the `shape` argument. -->
+        <new def="broadcast_to" class="Ltensorflow/functions/broadcast_to" />
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to" />
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="broadcast_to" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile -->
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
@@ -1419,6 +1421,13 @@
           <return value="x" />
         </method>
       </class>
+      <class name="broadcast_to" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — direct `<new>+<return>` per wala/ML#380's preferred pattern. Routes to `BroadcastTo` for shape-from-`shape` and dtype-from-`input` (wala/ML#449 Tier 7). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input shape name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
       <class name="sequence_mask" allocatable="true">
         <method name="read_data" descriptor="()LRoot;">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
@@ -1756,14 +1765,10 @@
         </method>
       </class>
       <class name="linspace" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linspace -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/api_docs/python/tf/linspace — direct `<new>+<return>` per wala/ML#380's preferred pattern (was `read_data`). Routes to `Linspace` for shape-from-`num` and dtype-from-`start` (wala/ML#449 Tier 7). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start stop num name axis">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="stack" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -1,0 +1,80 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.broadcast_to(input, shape, name=None)}. Output shape is the {@code shape}
+ * argument's value (a 1-D int tensor / Python list of dims); output dtype follows {@code input}.
+ * Same shape-from-shape-arg pattern as {@link Fill} but reads dtype from the {@code input} tensor
+ * rather than a scalar value arg.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/broadcast_to">tf.broadcast_to</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class BroadcastTo extends TensorGenerator {
+
+  protected enum Parameters {
+    INPUT,
+    SHAPE,
+    NAME;
+
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public BroadcastTo(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> shapePts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.SHAPE.getIndex(), Parameters.SHAPE.getName());
+    if (shapePts == null || shapePts.isEmpty()) return null;
+    Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, shapePts);
+    return shapes == null || shapes.isEmpty() ? null : shapes;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    int inputVn =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName(), false);
+    Set<DType> dtypes = this.getDTypes(builder, inputVn);
+    return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return Parameters.SHAPE.getIndex();
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return Parameters.SHAPE.getName();
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -72,7 +72,18 @@ public class BroadcastTo extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, Parameters.SHAPE.getIndex(), Parameters.SHAPE.getName());
     if (shapePts == null || shapePts.isEmpty()) return null;
-    Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, shapePts);
+    Set<List<Dimension<?>>> shapes;
+    try {
+      // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it doesn't
+      // recognize (notably when `shape` is itself a runtime tensor — e.g.
+      // `tf.broadcast_to(x, tf.shape(y))`). The lattice-correct response there is ⊤ ("tensor of
+      // unknown shape"), not aborting the analysis with an exception. The deeper fix is to change
+      // the helper's contract to return `null` rather than throw — see TODO(<followup>) — but
+      // that touches every caller, so localize the catch here for now.
+      shapes = this.getShapesFromShapeArgument(builder, shapePts);
+    } catch (IllegalStateException e) {
+      return null;
+    }
     return shapes == null || shapes.isEmpty() ? null : shapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -59,6 +60,10 @@ public class BroadcastTo extends TensorGenerator {
 
   public BroadcastTo(PointsToSetVariable source) {
     super(source);
+  }
+
+  public BroadcastTo(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -21,15 +21,37 @@ import java.util.Set;
  */
 public class BroadcastTo extends TensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.broadcast_to(input, shape, name=None)}.
+   * Ordinals match the position in the XML's {@code paramNames} after the implicit {@code self}
+   * receiver, so {@code Parameters.INPUT.getIndex() == 0} resolves to the first user-facing
+   * positional argument.
+   */
   protected enum Parameters {
+    /** The tensor whose dtype is inherited by the output. */
     INPUT,
+
+    /** The target shape (1-D integer tensor or list-of-ints) the input is broadcast to. */
     SHAPE,
+
+    /** Optional debug name for the op; not consumed by this generator. */
     NAME;
 
+    /**
+     * Lowercase keyword name used in {@link #getArgumentPointsToSet} / similar arg-resolution
+     * helpers when the call site uses {@code keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "input"}).
+     */
     public String getName() {
       return name().toLowerCase();
     }
 
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
     public int getIndex() {
       return ordinal();
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -78,8 +78,8 @@ public class BroadcastTo extends TensorGenerator {
       // recognize (notably when `shape` is itself a runtime tensor — e.g.
       // `tf.broadcast_to(x, tf.shape(y))`). The lattice-correct response there is ⊤ ("tensor of
       // unknown shape"), not aborting the analysis with an exception. The deeper fix is to change
-      // the helper's contract to return `null` rather than throw — see TODO(<followup>) — but
-      // that touches every caller, so localize the catch here for now.
+      // the helper's contract to return `null` rather than throw — see wala/ML#471 — but that
+      // touches every caller, so localize the catch here for now.
       shapes = this.getShapesFromShapeArgument(builder, shapePts);
     } catch (IllegalStateException e) {
       return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
@@ -75,6 +76,10 @@ public class Linspace extends TensorGenerator {
 
   public Linspace(PointsToSetVariable source) {
     super(source);
+  }
+
+  public Linspace(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -87,13 +87,22 @@ public class Linspace extends TensorGenerator {
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     // The `(num,)` shape is only sound when `axis == 0` (the default rank-1 case). For non-default
     // axes the result rank depends on `start`/`stop` being tensors and on broadcasting we don't
-    // track here, so emit ⊤ rather than risk an unsound concrete shape. Resolve `axis` against its
-    // PTS: only proceed with the rank-1 shape when *every* `axis` instance key is a `ConstantKey`
-    // with value `0`. If `axis` isn't passed at all (default), `getArgumentPointsToSet` returns
-    // null/empty — that's also the rank-1 case and is allowed to proceed.
-    OrdinalSet<InstanceKey> axisPts =
-        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
-    if (axisPts != null && !axisPts.isEmpty()) {
+    // track here, so emit ⊤ rather than risk an unsound concrete shape. Distinguish three cases:
+    //
+    // 1. `axis` not passed (omitted; defaults to 0) — safe to proceed with `(num,)`.
+    // 2. `axis` passed but PA can't resolve any instances — *unsound* to assume 0; return ⊤.
+    // 3. `axis` passed and resolved — proceed only when every instance key is a ConstantKey of 0.
+    //
+    // `getArgumentValueNumber(..., optional=true)` returns -1 when the kwarg is absent, which lets
+    // us tell case (1) apart from case (2) — the empty-PTS check alone conflates them.
+    int axisVn =
+        this.getArgumentValueNumber(
+            builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName(), true);
+    if (axisVn != -1) {
+      OrdinalSet<InstanceKey> axisPts =
+          this.getArgumentPointsToSet(
+              builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+      if (axisPts == null || axisPts.isEmpty()) return null; // case (2)
       for (InstanceKey ik : axisPts) {
         if (!(ik instanceof ConstantKey)) return null;
         Object val = ((ConstantKey<?>) ik).getValue();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -85,6 +85,22 @@ public class Linspace extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // The `(num,)` shape is only sound when `axis == 0` (the default rank-1 case). For non-default
+    // axes the result rank depends on `start`/`stop` being tensors and on broadcasting we don't
+    // track here, so emit ⊤ rather than risk an unsound concrete shape. Resolve `axis` against its
+    // PTS: only proceed with the rank-1 shape when *every* `axis` instance key is a `ConstantKey`
+    // with value `0`. If `axis` isn't passed at all (default), `getArgumentPointsToSet` returns
+    // null/empty — that's also the rank-1 case and is allowed to proceed.
+    OrdinalSet<InstanceKey> axisPts =
+        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+    if (axisPts != null && !axisPts.isEmpty()) {
+      for (InstanceKey ik : axisPts) {
+        if (!(ik instanceof ConstantKey)) return null;
+        Object val = ((ConstantKey<?>) ik).getValue();
+        if (!(val instanceof Number) || ((Number) val).intValue() != 0) return null;
+      }
+    }
+
     OrdinalSet<InstanceKey> numPts =
         this.getArgumentPointsToSet(builder, Parameters.NUM.getIndex(), Parameters.NUM.getName());
     if (numPts == null || numPts.isEmpty()) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -1,0 +1,105 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.linspace(start, stop, num, name=None, axis=0)}. Output is a 1-D tensor of
+ * length {@code num}; output dtype follows {@code start} (with int → float32 promotion per TF
+ * semantics: integer start/stop produce a float32 result). The {@code axis} parameter is honored
+ * only at its default value of 0 (the rank-1 case); non-default axes return ⊤ shape since they
+ * require start/stop to be tensors and the result-shape derivation depends on broadcasting that
+ * isn't tracked here.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linspace">tf.linspace</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Linspace extends TensorGenerator {
+
+  protected enum Parameters {
+    START,
+    STOP,
+    NUM,
+    NAME,
+    AXIS;
+
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public Linspace(PointsToSetVariable source) {
+    super(source);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> numPts =
+        this.getArgumentPointsToSet(builder, Parameters.NUM.getIndex(), Parameters.NUM.getName());
+    if (numPts == null || numPts.isEmpty()) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (InstanceKey ik : numPts) {
+      if (ik instanceof ConstantKey) {
+        Object val = ((ConstantKey<?>) ik).getValue();
+        if (val instanceof Number) {
+          List<Dimension<?>> shape = new ArrayList<>(1);
+          shape.add(new NumericDim(((Number) val).intValue()));
+          ret.add(shape);
+        }
+      }
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    int startVn =
+        this.getArgumentValueNumber(
+            builder, Parameters.START.getIndex(), Parameters.START.getName(), false);
+    Set<DType> startDTypes = this.getDTypes(builder, startVn);
+    if (startDTypes == null || startDTypes.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+    Set<DType> ret = new HashSet<>();
+    for (DType dt : startDTypes) {
+      // tf.linspace promotes integer start/stop to float32.
+      if (dt == DType.INT32 || dt == DType.INT64) ret.add(DType.FLOAT32);
+      else ret.add(dt);
+    }
+    return ret;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -87,22 +87,27 @@ public class Linspace extends TensorGenerator {
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     // The `(num,)` shape is only sound when `axis == 0` (the default rank-1 case). For non-default
     // axes the result rank depends on `start`/`stop` being tensors and on broadcasting we don't
-    // track here, so emit ⊤ rather than risk an unsound concrete shape. Distinguish three cases:
+    // track here, so emit ⊤ rather than risk an unsound concrete shape. Detect "axis present"
+    // explicitly via `isKeywordArgumentPresent` (for the kwarg form) plus a positional-count check
+    // (for `tf.linspace(start, stop, num, name, axis)` positional usage). When axis is absent we
+    // proceed with the rank-1 shape; when present we require every PTS instance key to be a
+    // `ConstantKey` of value `0`.
     //
-    // 1. `axis` not passed (omitted; defaults to 0) — safe to proceed with `(num,)`.
-    // 2. `axis` passed but PA can't resolve any instances — *unsound* to assume 0; return ⊤.
-    // 3. `axis` passed and resolved — proceed only when every instance key is a ConstantKey of 0.
-    //
-    // `getArgumentValueNumber(..., optional=true)` returns -1 when the kwarg is absent, which lets
-    // us tell case (1) apart from case (2) — the empty-PTS check alone conflates them.
-    int axisVn =
-        this.getArgumentValueNumber(
-            builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName(), true);
-    if (axisVn != -1) {
+    // The earlier `getArgumentValueNumber(..., optional=true) != -1` approach was unsound here:
+    // when the source is a `ReturnValueKey` of the inlined `linspace.do` (what `findCreator`
+    // typically walks to post-wala/ML#380), `getInvokeInstruction()` returns null and
+    // `getArgumentValueNumber` falls through to a manual-node fallback that returns the synthetic
+    // method's parameter VN unconditionally, mis-classifying every absent-axis user call as
+    // "passed".
+    boolean axisPresent =
+        this.isKeywordArgumentPresent(builder, Parameters.AXIS.getName())
+            || this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(n -> n > Parameters.AXIS.getIndex());
+    if (axisPresent) {
       OrdinalSet<InstanceKey> axisPts =
           this.getArgumentPointsToSet(
               builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
-      if (axisPts == null || axisPts.isEmpty()) return null; // case (2)
+      if (axisPts == null || axisPts.isEmpty()) return null; // present but unresolved → ⊤
       for (InstanceKey ik : axisPts) {
         if (!(ik instanceof ConstantKey)) return null;
         Object val = ((ConstantKey<?>) ik).getValue();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -28,17 +28,46 @@ import java.util.Set;
  */
 public class Linspace extends TensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.linspace(start, stop, num, name=None,
+   * axis=0)}. Ordinals match the position in the XML's {@code paramNames} after the implicit {@code
+   * self} receiver, so {@code Parameters.START.getIndex() == 0} resolves to the first user-facing
+   * positional argument.
+   */
   protected enum Parameters {
+    /** The starting value of the sequence. The output dtype follows {@code start}'s dtype. */
     START,
+
+    /** The end value of the sequence (inclusive). */
     STOP,
+
+    /** Number of values in the sequence; determines the output's leading dimension. */
     NUM,
+
+    /** Optional debug name for the op; not consumed by this generator. */
     NAME,
+
+    /**
+     * Axis along which the sequence is generated. Honored only at its default value of 0; non-zero
+     * axes require {@code start}/{@code stop} to be tensors and produce ⊤ shape.
+     */
     AXIS;
 
+    /**
+     * Lowercase keyword name used in {@link #getArgumentPointsToSet} / similar arg-resolution
+     * helpers when the call site uses {@code keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "start"}).
+     */
     public String getName() {
       return name().toLowerCase();
     }
 
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
     public int getIndex() {
       return ordinal();
     }
@@ -64,6 +93,11 @@ public class Linspace extends TensorGenerator {
         }
       }
     }
+    // Lattice convention: a `null` return signals ⊤ ("tensor of unknown shape"), while an empty
+    // set signals ⊥ ("not a tensor"). When `num`'s PTS contains only non-numeric or non-Constant
+    // keys we recovered no concrete shape, but we still know the call returns a tensor — so emit
+    // ⊤ rather than ⊥. See `TensorGenerator`'s class-level Javadoc and CONTRIBUTING.md's "Tensor
+    // Type Generators" section.
     return ret.isEmpty() ? null : ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -18,11 +18,12 @@ import java.util.Set;
 
 /**
  * Generator for {@code tf.linspace(start, stop, num, name=None, axis=0)}. Output is a 1-D tensor of
- * length {@code num}; output dtype follows {@code start} (with int → float32 promotion per TF
- * semantics: integer start/stop produce a float32 result). The {@code axis} parameter is honored
- * only at its default value of 0 (the rank-1 case); non-default axes return ⊤ shape since they
- * require start/stop to be tensors and the result-shape derivation depends on broadcasting that
- * isn't tracked here.
+ * length {@code num}; output dtype follows {@code start} (with int → float64 promotion per TF
+ * semantics — verified empirically on TF 2.9: {@code tf.linspace(tf.constant(0, dtype=tf.int32),
+ * tf.constant(10, dtype=tf.int32), 5).dtype} is {@code float64}, not {@code float32}). The {@code
+ * axis} parameter is honored only at its default value of 0 (the rank-1 case); non-default axes
+ * return ⊤ shape since they require start/stop to be tensors and the result-shape derivation
+ * depends on broadcasting that isn't tracked here.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linspace">tf.linspace</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -115,8 +116,8 @@ public class Linspace extends TensorGenerator {
     if (startDTypes == null || startDTypes.isEmpty()) return EnumSet.of(DType.UNKNOWN);
     Set<DType> ret = new HashSet<>();
     for (DType dt : startDTypes) {
-      // tf.linspace promotes integer start/stop to float32.
-      if (dt == DType.INT32 || dt == DType.INT64) ret.add(DType.FLOAT32);
+      // tf.linspace promotes integer start/stop to float64 (verified on TF 2.9).
+      if (dt == DType.INT32 || dt == DType.INT64) ret.add(DType.FLOAT64);
       else ret.add(dt);
     }
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -7,6 +7,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.BROADCAST_TO;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TEST;
@@ -60,6 +61,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IMAGE_DATA_GENER
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.INPUT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS_EQUAL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LINSPACE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG_SOFTMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MATMUL;
@@ -953,6 +955,9 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, ARRAY_OPS_RESHAPE)
         || calledFunction.getName().equals(TF_RESHAPE)) return new Reshape(source);
     else if (isType(calledFunction, FILL.getDeclaringClass())) return new Fill(source);
+    else if (isType(calledFunction, LINSPACE.getDeclaringClass())) return new Linspace(source);
+    else if (isType(calledFunction, BROADCAST_TO.getDeclaringClass()))
+      return new BroadcastTo(source);
     else if (isType(calledFunction, CONVERT_TO_TENSOR.getDeclaringClass()))
       return new ConvertToTensor(source);
     else if (isType(calledFunction, ONE_HOT.getDeclaringClass())) return new OneHot(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -444,6 +444,25 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String FILL_SIGNATURE = "tf.fill()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/linspace. */
+  public static final MethodReference LINSPACE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/linspace")),
+          AstMethodReference.fnSelector);
+
+  private static final String LINSPACE_SIGNATURE = "tf.linspace()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/broadcast_to. */
+  public static final MethodReference BROADCAST_TO =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/broadcast_to")),
+          AstMethodReference.fnSelector);
+
+  private static final String BROADCAST_TO_SIGNATURE = "tf.broadcast_to()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/convert_to_tensor. */
   public static final MethodReference CONVERT_TO_TENSOR =
       MethodReference.findOrCreate(
@@ -1198,6 +1217,8 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(TRUNCATED_NORMAL.getDeclaringClass(), TRUNCATED_NORMAL_SIGNATURE),
           Map.entry(ZEROS_LIKE.getDeclaringClass(), ZEROS_LIKE_SIGNATURE),
           Map.entry(FILL.getDeclaringClass(), FILL_SIGNATURE),
+          Map.entry(LINSPACE.getDeclaringClass(), LINSPACE_SIGNATURE),
+          Map.entry(BROADCAST_TO.getDeclaringClass(), BROADCAST_TO_SIGNATURE),
           Map.entry(CONVERT_TO_TENSOR.getDeclaringClass(), CONVERT_TO_TENSOR_SIGNATURE),
           Map.entry(EYE.getDeclaringClass(), EYE_SIGNATURE),
           Map.entry(SPARSE_TENSOR.getDeclaringClass(), SPARSE_TENSOR_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_broadcast_to.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_broadcast_to.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.broadcast_to(x, [2, 3])
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 3)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_linspace.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_linspace.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+y = tf.linspace(0.0, 10.0, 5)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (5,)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_linspace_axis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_linspace_axis.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Drives the axis-passed branch in `Linspace.getDefaultShapes`. With axis=1 and
+# vector start/stop, `tf.linspace` interpolates along axis 1, producing a
+# higher-rank result whose precise shape (2, 5) requires combining `start`'s
+# rank with `num` — the static analysis can't recover this, so the generator
+# returns ⊤ (unknown shape).
+start = tf.constant([0.0, 10.0])
+stop = tf.constant([1.0, 20.0])
+y = tf.linspace(start, stop, 5, axis=1)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 5)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_linspace_int.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_linspace_int.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.linspace` with integer start/stop promotes to float64 (TF 2.9). The
+# float-input variant is covered by `tf2_test_linspace.py`; this fixture
+# exercises the int-promotion branch in `Linspace.getDefaultDTypes`.
+y = tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(10, dtype=tf.int32), 5)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (5,)
+assert y.dtype == tf.float64
+
+f(y)


### PR DESCRIPTION
## Summary

Two new Tier 7 op generators routed through the existing dispatch substrate:

- **`Linspace`** (`tf.linspace(start, stop, num, name=None, axis=0)`): output shape derives from the `num` argument's `ConstantKey` (rank-1 of length `num`); output dtype follows `start` with TF's int → float64 promotion (verified empirically on TF 2.9 — `tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(10, dtype=tf.int32), 5).dtype` is `float64`).
- **`BroadcastTo`** (`tf.broadcast_to(input, shape, name=None)`): output shape derives from the `shape` argument via `getShapesFromShapeArgument`; output dtype follows `input`. Same shape-from-arg + dtype-from-input pattern as `Reshape`.

## What Changed Pre-Fix

- `tf.linspace` routed through `ReadDataFallback` → ⊤ shape / `UNKNOWN` dtype.
- `tf.broadcast_to` was aliased via `value="pass_through"` (legacy workaround), routing through `PassThrough`'s identity semantics rather than computing actual broadcast shape.

## XML Modeling

Per wala/ML#380's preferred direct `<new>+<return>` pattern (no `read_data` chain):

- `<class name="linspace">`: drop `read_data` → direct allocation in `do`.
- `<class name="broadcast_to">`: added (was missing entirely); top-level `tf.broadcast_to` binding replaces the `value="pass_through"` aliasing with `<new def="broadcast_to" class="Ltensorflow/functions/broadcast_to" />`.

## Out of Scope

`Fill` was already wired up (`tf.fill` dispatches to `Fill` generator at `TensorGeneratorFactory:955`), so this PR doesn't touch it. The original Tier 7 plan included `tf.fill` — turns out it landed in earlier work; only `linspace` and `broadcast_to` remained.

## Test Plan

- [x] `testLinspace` and `testBroadcastTo` pass — assert precise shape `(5,)` / `(2, 3)` and dtype `float32`.
- [x] Full suite green: `mvn test` 658/0/0/3.
- [x] Both Python fixtures run cleanly under `python3.10`.

## Cross-Refs

- wala/ML#449 — parent (per-op generators replacing `ReadDataFallback`).
- wala/ML#380 — direct `<new>+<return>` preference (followed for new modeling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)