### PR TITLE
Inline `read_data` markers for argmax/argmin/equal/not_equal (wala/ML#380)

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -946,37 +946,25 @@
       </class>
       <class name="argmax" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator emits `int64` (the TF default) for the output dtype; output shape is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for
-          `axis`) is retained in `paramNames`; the modern `output_type` parameter isn't surfaced here yet — wala/ML#463 covers the migration. -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+          `axis`) is retained in `paramNames`; the modern `output_type` parameter isn't surfaced here yet — wala/ML#463 covers the migration. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="argmin" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same `read_data` materialization chain, same `int64` output dtype via the dedicated `Argmin` generator). -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same direct `<new>+<return>` per wala/ML#380, same `int64` output dtype via the dedicated `Argmin` generator). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="equal" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/equal -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Return a Tensor whose dtype is bool (see wala/ML#427). -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="rsqrt" allocatable="true">
@@ -1044,14 +1032,10 @@
         </method>
       </class>
       <class name="not_equal" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/not_equal -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/not_equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="less" allocatable="true">


### PR DESCRIPTION
## Summary

Mechanical inlining of the `read_data` materialization chain into the `do` method for four ops, per wala/ML#380:

- `argmax`
- `argmin`
- `equal`
- `not_equal`

Each class previously had:

```xml
<method name="read_data" descriptor="()LRoot;" numArgs="1">
  <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
  <return value="x" />
</method>
<method name="do" ...>
  <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
  <return value="xx" />
</method>
```

and now has:

```xml
<method name="do" ...>
  <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
  <return value="res" />
</method>
```

## Why

This is the established pattern for new ops on the project (precedents: `less`/`less_equal`/`greater`/`greater_equal`, `rsqrt`, `log_softmax`, `exp`, sigmoid, softmax, etc. — see the alloc-class header comment in `tensorflow.xml`). The `read_data` indirection is a leftover from an older modeling style; inlining matches what new ops do and removes an unnecessary call hop.

Dispatch is unchanged: `TensorGeneratorFactory` keys off the called function (e.g., `tf.math.argmax`), not the `read_data` marker. `TensorTypeAnalysis` still seeds the result via the `do` method-name match.

## Test plan

- [x] `mvn clean install -DskipTests` (XML resource cache flushed)
- [x] `mvn test` — all fresh test reports show 0 failures, 0 errors (`TestTensorflow2Model` 638/0/0/0; sibling modules clean)

This is batch 1 of an ongoing sweep. There are 21 more `read_data + do` classes to inline.