### PR TITLE
Inline `read_data` markers for reduce_sum/tensordot/trace/einsum/top_k/where (wala/ML#380)

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -934,14 +934,10 @@
         </method>
       </class>
       <class name="reduce_sum" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_sum -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_sum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="argmax" allocatable="true">
@@ -1002,36 +998,24 @@
         </method>
       </class>
       <class name="tensordot" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self a b axes name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="trace" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="einsum" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self equation *inputs **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="add_n" allocatable="true">
@@ -1083,16 +1067,12 @@
         </method>
       </class>
       <class name="top_k" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k. Direct `<new>+<putfield>` per wala/ML#380 (was a `read_data` materialization chain). Returns a `(values, indices)` tuple — both fields point at fresh `Tensor` allocations. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input k sorted name">
           <new def="x" class="Ltuple" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
+          <new def="xx" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="yy" />
+          <new def="yy" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy" />
           <return value="x" />
         </method>
@@ -1479,14 +1459,10 @@
         </method>
       </class>
       <class name="where" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self condition x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="meshgrid" allocatable="true">


### PR DESCRIPTION
## Summary

Batch 2 of the wala/ML#380 inlining sweep. Same mechanical rewrite as #234 (batch 1) applied to:

- `reduce_sum`
- `tensordot`
- `trace`
- `einsum`
- `top_k`
- `where`

`top_k` is the only nontrivial case: its `do` returns a `(values, indices)` tuple. The two `read_data` calls are replaced with two direct `<new>` allocations of `Ltensorflow/python/framework/ops/Tensor`, each `<putfield>`-ed into a tuple field. Net behavior is identical (two fresh tensor allocations under the tuple), but with the indirection through `read_data` removed.

## Why

See #234 — same rationale, same pattern. Independent of #234 (disjoint set of ops), so this PR can land in either order.

## Test plan

- [x] `mvn clean install -DskipTests` (XML resource cache flushed)
- [x] `mvn test` — `TestTensorflow2Model` 638/0/0/0; sibling modules clean

This is batch 2 of an ongoing sweep. ~15 more `read_data + do` classes remain.