### PR TITLE
Inline `read_data` markers for sequence_mask/embedding_lookup/boolean_mask/gather_nd/extract_patches (wala/ML#380)

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1420,14 +1420,10 @@
         </method>
       </class>
       <class name="sequence_mask" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self lengths maxlen dtype name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="stop_gradient" allocatable="true">
@@ -1447,14 +1443,10 @@
         </method>
       </class>
       <class name="embedding_lookup" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params ids max_norm name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="one_hot" allocatable="true">
@@ -1659,14 +1651,10 @@
         </method>
       </class>
       <class name="gather_nd" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params indices batch_dims name">
-          <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd -->
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="truncated_normal" allocatable="true">
@@ -1745,14 +1733,10 @@
         </method>
       </class>
       <class name="boolean_mask" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor mask axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="linspace" allocatable="true">
@@ -1884,14 +1868,10 @@
     </package>
     <package name="tensorflow/functions/image">
       <class name="extract_patches" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self images sizes strides rates padding name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>


### PR DESCRIPTION
## Summary

Batch 3 of the wala/ML#380 inlining sweep. Same mechanical rewrite as #234 (batch 1) and #235 (batch 2):

- `sequence_mask`
- `embedding_lookup`
- `boolean_mask`
- `gather_nd`
- `extract_patches`

All five are simple single-output ops where `do` was just a thin wrapper around `read_data`. The `read_data` chain is replaced with a direct `<new>+<return>` of `Ltensorflow/python/framework/ops/Tensor`.

## Test plan

- [x] `mvn clean install -DskipTests` (XML resource cache flushed)
- [x] `mvn test` — `TestTensorflow2Model` 638/0/0/0; sibling modules clean

This is batch 3 of an ongoing sweep. ~10 more `read_data + do` classes remain (the harder ones — multi-output, special-cased, or class-hierarchy).