### PR TITLE
Inline `read_data` markers for Input/py_function/unstack/meshgrid/split/tensor_scatter_nd_update (wala/ML#380)

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1490,30 +1490,22 @@
         </method>
       </class>
       <class name="meshgrid" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
       <class name="split" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
@@ -1534,14 +1526,10 @@
         </method>
       </class>
       <class name="tensor_scatter_nd_update" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor indices updates name">
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update -->
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor indices updates name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
@@ -1619,15 +1607,11 @@
         </method>
       </class>
       <class name="py_function" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Call `func` per https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function#returns -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self func inp Tout name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="uniform" allocatable="true">
@@ -1693,13 +1677,10 @@
         </method>
       </class>
       <class name="Input" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). Mirrors `tensorflow/keras/layers/Input` below. -->
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="from_nested_row_lengths" allocatable="true">
@@ -1777,16 +1758,12 @@
         </method>
       </class>
       <class name="unstack" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value num axis name">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value num axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>


### PR DESCRIPTION
## Summary

Batch 4 of the wala/ML#380 inlining sweep. Three patterns this round:

**Simple `Tensor` allocation (same as batches 1-3):**
- `Input` — the `tensorflow/functions/Input` variant. The `tensorflow/keras/layers/Input` variant is already inlined; this brings the two into alignment.
- `py_function`

**List with one constant-materialized element:**
- `unstack`
- `meshgrid`
- `split`

For these three, the `<new Llist>` + `<new constant>` + `<call constant.do>` + `<putfield field=0>` body is moved directly from `read_data` into `do`. Net behavior is identical (a list whose first slot is a constant-materialized tensor), but with one fewer call hop.

**Single constant-materialized tensor:**
- `tensor_scatter_nd_update` — moves the `<new constant>` + `<call constant.do>` body into `do`.

## Test plan

- [x] `mvn clean install -DskipTests` (XML resource cache flushed)
- [x] `mvn test` — `TestTensorflow2Model` 638/0/0/0; sibling modules clean

After this, only `Model` and `read_data_sets` remain. Both are more involved (multiple `read_data` calls with field side-effects) and will be batch 5 — the final one.