### PR TITLE
Add multi-Model regression tests for `Model` precision (wala/ML#380)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1741,19 +1741,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * share the same call site for {@code Model.do} (the one inside {@code make_model}). Under {@code
    * nCFAContextSelector(2)} the 2 most-recent call sites in the context for {@code
    * Model.read_data}'s inner allocation are {@code (read_data_call_in_Model.do,
-   * Model.do_call_in_make_model)} — the user-side {@code make_model} call site is *not* in those
-   * two frames, so both user models collapse to the same allocation context. f's parameter should
-   * end up with the union of both models' weight shapes (not just model1's), causing the test's
-   * 2-element assertion to fail.
+   * Model.do_call_in_make_model)} — the user-side {@code make_model} call site falls outside those
+   * two frames, so both user models collapse to the same allocation context and each sink ends up
+   * with the union of both models' weight shapes. The assertion below pins that observed
+   * (imprecise) union, which makes a precision improvement detectable as a regression: when the fix
+   * lands, the actual set will shrink to the per-Model 2-element subset and this test will start
+   * failing with a clear "expected union, got per-Model" diff — the cue to update the assertion to
+   * its precise form.
    *
-   * <p>This test is the regression target: any precision improvement that distinguishes multi-Model
-   * under reduced-k or under inlined-{@code read_data} should make this test pass. See the
-   * discussion under wala/ML#380.
-   *
-   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
-   * configurable-k work) lands a fix that distinguishes the per-Model contexts here.
+   * <p>TODO(wala/ML#380): When inlining of {@code Model.read_data} (or wala/ML#379's configurable-k
+   * work) distinguishes the per-Model contexts here, narrow the assertion to {@code
+   * Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)} for {@code f} and the matching pair for {@code
+   * g} in {@link #testModelAttributesMultiModelWrapped2()}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testModelAttributesMultiModelWrapped()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1761,16 +1762,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)));
+        Map.of(
+            2,
+            Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
   }
 
   /**
-   * Companion to {@link #testModelAttributesMultiModelWrapped()} — same fixture, second sink.
+   * Companion to {@link #testModelAttributesMultiModelWrapped()} — same fixture, second sink. The
+   * assertion pins the same observed union; both sinks see the union under 2-CFA.
    *
-   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
-   * configurable-k work) lands a fix.
+   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
+   * Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testModelAttributesMultiModelWrapped2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1778,39 +1782,52 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "g",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+        Map.of(
+            2,
+            Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
   }
 
   /**
    * Multi-Model precision regression on the {@code model(x)} call-output path: two distinct Models
    * constructed inside a {@code make_and_call(units, x)} helper that also performs the call. Each
    * user-side {@code make_and_call(...)} returns the model's output, with disjoint shapes (5 vs 7)
-   * per call. Sink {@code f} should see only model1's output shape; companion {@link
-   * #testModelCallMultiModelWrapped2()} pins {@code g} to model2's. Under 2-CFA the two user-side
-   * {@code make_and_call} call sites collapse into one context for {@code Model.__call__}, so each
-   * sink ends up with the union ({@code {(20, 5), (20, 7)}}) rather than the per-Model shape — same
-   * precision-loss mechanism as {@link #testModelAttributesMultiModelWrapped()}, but on the
-   * call-output path instead of the trainable-weights path.
+   * per call. Under 2-CFA the two user-side {@code make_and_call} call sites collapse into one
+   * context for {@code Model.__call__}'s output allocation, so each sink ends up with the union
+   * {@code {(20, 5), (20, 7)}} rather than the per-Model shape — same precision-loss mechanism as
+   * {@link #testModelAttributesMultiModelWrapped()}, but on the call-output path instead of the
+   * trainable-weights path. The assertion pins the observed union; a precision improvement will
+   * narrow it.
    *
-   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
-   * configurable-k work) lands a fix that distinguishes the per-Model contexts here.
+   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
+   * Set.of(TENSOR_20_5_FLOAT32)} for {@code f} and {@code Set.of(TENSOR_20_7_FLOAT32)} for {@code
+   * g} in {@link #testModelCallMultiModelWrapped2()}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testModelCallMultiModelWrapped()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_model_call_multi_wrapped.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_20_5_FLOAT32)));
+    test(
+        "tf2_test_model_call_multi_wrapped.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_20_5_FLOAT32, TENSOR_20_7_FLOAT32)));
   }
 
   /**
    * Companion to {@link #testModelCallMultiModelWrapped()} — same fixture, second sink.
    *
-   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
-   * configurable-k work) lands a fix.
+   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
+   * Set.of(TENSOR_20_7_FLOAT32)}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testModelCallMultiModelWrapped2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_model_call_multi_wrapped.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_20_7_FLOAT32)));
+    test(
+        "tf2_test_model_call_multi_wrapped.py",
+        "g",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_20_5_FLOAT32, TENSOR_20_7_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -362,6 +362,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_64_7_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(7)));
 
+  private static final TensorType TENSOR_20_5_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(5)));
+
+  private static final TensorType TENSOR_20_7_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(7)));
+
   private static final TensorType TENSOR_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5)));
 
@@ -1773,6 +1779,38 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+  }
+
+  /**
+   * Multi-Model precision regression on the {@code model(x)} call-output path: two distinct Models
+   * constructed inside a {@code make_and_call(units, x)} helper that also performs the call. Each
+   * user-side {@code make_and_call(...)} returns the model's output, with disjoint shapes (5 vs 7)
+   * per call. Sink {@code f} should see only model1's output shape; companion {@link
+   * #testModelCallMultiModelWrapped2()} pins {@code g} to model2's. Under 2-CFA the two user-side
+   * {@code make_and_call} call sites collapse into one context for {@code Model.__call__}, so each
+   * sink ends up with the union ({@code {(20, 5), (20, 7)}}) rather than the per-Model shape — same
+   * precision-loss mechanism as {@link #testModelAttributesMultiModelWrapped()}, but on the
+   * call-output path instead of the trainable-weights path.
+   *
+   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
+   * configurable-k work) lands a fix that distinguishes the per-Model contexts here.
+   */
+  @Test(expected = AssertionError.class)
+  public void testModelCallMultiModelWrapped()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_model_call_multi_wrapped.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_20_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testModelCallMultiModelWrapped()} — same fixture, second sink.
+   *
+   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
+   * configurable-k work) lands a fix.
+   */
+  @Test(expected = AssertionError.class)
+  public void testModelCallMultiModelWrapped2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_model_call_multi_wrapped.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_20_7_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -353,6 +353,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_64_5_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(5)));
 
+  private static final TensorType TENSOR_7_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(7)));
+
+  private static final TensorType TENSOR_32_7_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(32), new NumericDim(7)));
+
   private static final TensorType TENSOR_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5)));
 
@@ -1683,6 +1689,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Multi-Model precision regression: two distinct {@code tf.keras.models.Model(...)} calls in one
+   * fixture, two sink functions, disjoint shapes per model. Validates that under the current
+   * modeling each sink's parameter sees only its own model's weight shapes (not the union across
+   * both models). See wala/ML#380's discussion of `Model.read_data` materialization. Companion to
+   * {@link #testModelAttributesMultiModel2()} (same fixture, second sink). Disjoint dim choices
+   * (64/5 vs 32/7) make a precision regression mechanically detectable: a "shapes unioned across
+   * models" failure mode produces the 4-element set, not a 2-element subset.
+   */
+  @Test
+  public void testModelAttributesMultiModel()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_attributes_multi.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testModelAttributesMultiModel()} — pins the second sink's parameter to the
+   * second model's weight shapes only.
+   */
+  @Test
+  public void testModelAttributesMultiModel2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_attributes_multi.py",
+        "g",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_32_7_FLOAT32, TENSOR_7_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -359,6 +359,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_32_7_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(32), new NumericDim(7)));
 
+  private static final TensorType TENSOR_64_7_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(7)));
+
   private static final TensorType TENSOR_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5)));
 
@@ -1724,6 +1727,52 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_32_7_FLOAT32, TENSOR_7_FLOAT32)));
+  }
+
+  /**
+   * Multi-Model precision regression with one extra call-chain frame: both Models are constructed
+   * inside a {@code make_model(units)} helper, so both user-side calls of {@code make_model(...)}
+   * share the same call site for {@code Model.do} (the one inside {@code make_model}). Under {@code
+   * nCFAContextSelector(2)} the 2 most-recent call sites in the context for {@code
+   * Model.read_data}'s inner allocation are {@code (read_data_call_in_Model.do,
+   * Model.do_call_in_make_model)} — the user-side {@code make_model} call site is *not* in those
+   * two frames, so both user models collapse to the same allocation context. f's parameter should
+   * end up with the union of both models' weight shapes (not just model1's), causing the test's
+   * 2-element assertion to fail.
+   *
+   * <p>This test is the regression target: any precision improvement that distinguishes multi-Model
+   * under reduced-k or under inlined-{@code read_data} should make this test pass. See the
+   * discussion under wala/ML#380.
+   *
+   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
+   * configurable-k work) lands a fix that distinguishes the per-Model contexts here.
+   */
+  @Test(expected = AssertionError.class)
+  public void testModelAttributesMultiModelWrapped()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_attributes_multi_wrapped.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testModelAttributesMultiModelWrapped()} — same fixture, second sink.
+   *
+   * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#380 (or wala/ML#379's
+   * configurable-k work) lands a fix.
+   */
+  @Test(expected = AssertionError.class)
+  public void testModelAttributesMultiModelWrapped2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_attributes_multi_wrapped.py",
+        "g",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_attributes_multi.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_attributes_multi.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+a1 = tf.keras.layers.Input(shape=(64,))
+b1 = tf.keras.layers.Dense(5)(a1)
+model1 = tf.keras.models.Model(a1, b1)
+
+a2 = tf.keras.layers.Input(shape=(32,))
+b2 = tf.keras.layers.Dense(7)(a2)
+model2 = tf.keras.models.Model(a2, b2)
+
+for i in model1.trainable_weights:
+    assert i.dtype == tf.float32
+    assert i.shape in [(64, 5), (5,)]
+    f(i)
+
+for j in model2.trainable_weights:
+    assert j.dtype == tf.float32
+    assert j.shape in [(32, 7), (7,)]
+    g(j)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_attributes_multi_wrapped.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_attributes_multi_wrapped.py
@@ -1,0 +1,29 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def make_model(units):
+    inputs_layer = tf.keras.layers.Input(shape=(64,))
+    outputs_layer = tf.keras.layers.Dense(units)(inputs_layer)
+    return tf.keras.models.Model(inputs_layer, outputs_layer)
+
+
+model1 = make_model(5)
+model2 = make_model(7)
+
+for i in model1.trainable_weights:
+    assert i.dtype == tf.float32
+    assert i.shape in [(64, 5), (5,)]
+    f(i)
+
+for j in model2.trainable_weights:
+    assert j.dtype == tf.float32
+    assert j.shape in [(64, 7), (7,)]
+    g(j)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call_multi_wrapped.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call_multi_wrapped.py
@@ -1,0 +1,31 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def make_and_call(units, x):
+    inputs_layer = tf.keras.layers.Input(shape=(64,))
+    outputs_layer = tf.keras.layers.Dense(units)(inputs_layer)
+    model = tf.keras.models.Model(inputs_layer, outputs_layer)
+    return model(x)
+
+
+x1 = tf.random.uniform([20, 64])
+y1 = make_and_call(5, x1)
+
+x2 = tf.random.uniform([20, 64])
+y2 = make_and_call(7, x2)
+
+assert y1.shape == (20, 5)
+assert y2.shape == (20, 7)
+assert y1.dtype == tf.float32
+assert y2.dtype == tf.float32
+
+f(y1)
+g(y2)


### PR DESCRIPTION
## Summary

Adds three pairs of multi-Model regression tests for wala/ML#380, exercising the precision concern raised in PR review discussion.

| Commit | Tests | Behavior on master |
| --- | --- | --- |
| `ca9956b7` | `testModelAttributesMultiModel{,2}` | **Pass with the per-Model shape assertion.** Two `Model(...)` directly in user code, disjoint shapes per model. Validates that `read_data` + 2-CFA distinguishes per-Model alloc sites for the `trainable_weights` path. |
| `c5ee6468`, `9dc90421` | `testModelAttributesMultiModelWrapped{,2}` | **Pass with the *observed* union assertion** (per the prefer-observed-assertion convention — see ponder-lab/ML#241 for the `CONTRIBUTING.md` doc on the convention itself). One additional call-chain frame: both Models constructed inside a `make_model(units)` helper. Under 2-CFA the user-side call sites collapse into one context for `Model.read_data`'s alloc, so each sink ends up with the union of both models' weights. The Javadoc carries a `TODO(wala/ML#380)` naming the precise per-Model `Set.of(...)` form to narrow to once the fix lands. |
| `c01fe01b`, `9dc90421` | `testModelCallMultiModelWrapped{,2}` | **Pass with the observed union assertion**, same convention. Same wrapper structure but on the `model(x)` call-output path instead of `trainable_weights`. Under 2-CFA, both `Model.__call__` allocations share a context, so each sink ends up with the union `{(20, 5), (20, 7)}`. |

The "observed-union" assertion choice is intentional: with the union pinned in the assertion, the wrapped tests **pass on master**; when a precision improvement lands and the actual result narrows to the per-Model subset, the tests start failing with a clear "expected union, got per-Model" diff — that's the cue to update the assertion to its precise form. The convention itself (and its `@Test(expected = AssertionError.class)` fallback) is documented in ponder-lab/ML#241 as a separate, doc-only PR.

## Why this matters

These tests are the regression target for any future fix that distinguishes multi-Model under reduced effective k:
- An inlining of `Model.read_data` that preserves per-Model precision should narrow the wrapped-attributes assertions.
- A configurable-`k` mechanism (per wala/ML#379) that lets the analysis use deeper context for synthetic methods should narrow all four `Wrapped` assertions.
- The two non-wrapped tests already pass at the precise form — they're a baseline that any change must not regress.

## Test plan

- [x] `python3.10` runs each fixture without assertion failures.
- [x] `mvn test` clean: `TestTensorflow2Model` 644/0/0/0; sibling modules clean.
- [x] All four wrapped tests pass on master with the observed-union assertion (verified locally and in this PR's CI).

## Split history

The CONTRIBUTING.md edit documenting the prefer-observed-assertion convention has been moved to ponder-lab/ML#241 to keep this PR scoped to test additions only. See that PR for review of the convention text itself.