### PR TITLE
Add per-op generators for sequence_mask, embedding_lookup, gather_nd, boolean_mask, extract_patches (wala/ML#449 Tier 8)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4352,10 +4352,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Generator-dispatch test for {@code tf.sequence_mask}. Output dtype is fixed at {@code bool}
-   * (the TF default; the {@code dtype} arg override isn't surfaced through {@code tensorflow.xml}
-   * yet), shape is ⊤. See {@link com.ibm.wala.cast.python.ml.client.SequenceMask} (wala/ML#449 Tier
-   * 8).
+   * Generator-dispatch test for {@code tf.sequence_mask}. Output dtype is the TF-default {@code
+   * bool}; the optional {@code dtype} override is exposed in {@code tensorflow.xml}'s {@code
+   * paramNames} but is not yet honored by the {@link
+   * com.ibm.wala.cast.python.ml.client.SequenceMask} generator, which emits {@code bool}
+   * unconditionally. Shape is ⊤. (wala/ML#449 Tier 8.)
    */
   @Test
   public void testSequenceMask()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -332,6 +332,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
+  private static final TensorType TENSOR_FLOAT32_UNKNOWN_SHAPE = new TensorType(FLOAT_32, null);
+
+  private static final TensorType TENSOR_BOOL_UNKNOWN_SHAPE = new TensorType(BOOL, null);
+
   private static final TensorType TENSOR_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3)));
 
@@ -4347,6 +4351,63 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testArgmin()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.sequence_mask}. Output dtype is fixed at {@code bool}
+   * (the TF default; the {@code dtype} arg override isn't surfaced through {@code tensorflow.xml}
+   * yet), shape is ⊤. See {@link com.ibm.wala.cast.python.ml.client.SequenceMask} (wala/ML#449 Tier
+   * 8).
+   */
+  @Test
+  public void testSequenceMask()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_BOOL_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.nn.embedding_lookup}. Output dtype is inherited from the
+   * {@code params} input (here float32), shape is ⊤. See {@link
+   * com.ibm.wala.cast.python.ml.client.EmbeddingLookup} (wala/ML#449 Tier 8).
+   */
+  @Test
+  public void testEmbeddingLookup()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_embedding_lookup.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.gather_nd}. Output dtype is inherited from the {@code
+   * params} input (here float32), shape is ⊤. See {@link
+   * com.ibm.wala.cast.python.ml.client.GatherNd} (wala/ML#449 Tier 8).
+   */
+  @Test
+  public void testGatherNd()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_gather_nd.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.boolean_mask}. Output dtype is inherited from the {@code
+   * tensor} input (here float32), shape is ⊤. See {@link
+   * com.ibm.wala.cast.python.ml.client.BooleanMask} (wala/ML#449 Tier 8).
+   */
+  @Test
+  public void testBooleanMask()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_boolean_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.image.extract_patches}. Output dtype is inherited from
+   * the {@code images} input (here float32), shape is ⊤. See {@link
+   * com.ibm.wala.cast.python.ml.client.ExtractPatches} (wala/ML#449 Tier 8).
+   */
+  @Test
+  public void testExtractPatches()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -332,9 +332,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
-  private static final TensorType TENSOR_FLOAT32_UNKNOWN_SHAPE = new TensorType(FLOAT_32, null);
-
-  private static final TensorType TENSOR_BOOL_UNKNOWN_SHAPE = new TensorType(BOOL, null);
+  private static final TensorType TENSOR_UNKNOWN_SHAPE_BOOL = new TensorType(BOOL, null);
 
   private static final TensorType TENSOR_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3)));
@@ -4362,7 +4360,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testSequenceMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_BOOL_UNKNOWN_SHAPE)));
+    test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_BOOL)));
   }
 
   /**
@@ -4374,7 +4372,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testEmbeddingLookup()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_embedding_lookup.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+        "tf2_test_embedding_lookup.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -4385,7 +4383,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testGatherNd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gather_nd.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+    test("tf2_test_gather_nd.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -4396,7 +4394,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testBooleanMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_boolean_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+    test("tf2_test_boolean_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -4407,7 +4405,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testExtractPatches()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_FLOAT32_UNKNOWN_SHAPE)));
+    test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
@@ -1,0 +1,43 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.boolean_mask}. Output dtype is inherited from the {@code tensor} input.
+ * Output shape is left at ⊤ for now: the precise shape depends on the runtime contents of the
+ * boolean {@code mask} (the result is a 1-D dense tensor whose length is the number of {@code True}
+ * entries in the mask), which static analysis cannot recover. See wala/ML#449 (Tier 8).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/boolean_mask">tf.boolean_mask</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class BooleanMask extends PassThroughUnaryTensorGenerator {
+
+  public BooleanMask(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public BooleanMask(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "tensor";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
@@ -9,9 +9,11 @@ import java.util.Set;
 
 /**
  * Generator for {@code tf.boolean_mask}. Output dtype is inherited from the {@code tensor} input.
- * Output shape is left at ⊤ for now: the precise shape depends on the runtime contents of the
- * boolean {@code mask} (the result is a 1-D dense tensor whose length is the number of {@code True}
- * entries in the mask), which static analysis cannot recover. See wala/ML#449 (Tier 8).
+ * Output shape is left at ⊤ for now: the masked dimension's length is the number of {@code True}
+ * entries in {@code mask}, a runtime quantity that static analysis cannot recover. The remaining
+ * dimensions follow {@code tensor.shape} (offset by {@code axis}), so the result rank is generally
+ * {@code tensor.rank - mask.rank + 1}, not always 1-D — but the dependence on the mask's runtime
+ * truthiness still leaves the masked dimension undetermined. See wala/ML#449 (Tier 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/boolean_mask">tf.boolean_mask</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
@@ -10,8 +10,10 @@ import java.util.Set;
 /**
  * Generator for {@code tf.nn.embedding_lookup}. Output dtype is inherited from the {@code params}
  * argument (the embedding table). Output shape is left at ⊤ for now: the precise shape is {@code
- * (*ids.shape, params.shape[-1])} which requires combining two inputs' shapes — wala/ML#449 (Tier
- * 8) covers refining this once a tier base for "shape derived from multiple inputs" is in place.
+ * ids.shape + params.shape[1:]} (each id selects a full row of the embedding table, then the result
+ * is reshaped around {@code ids.shape}), which requires combining two inputs' shapes — wala/ML#449
+ * (Tier 8) covers refining this once a tier base for "shape derived from multiple inputs" is in
+ * place.
  *
  * @see <a
  *     href="https://www.tensorflow.org/api_docs/python/tf/nn/embedding_lookup">tf.nn.embedding_lookup</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
@@ -1,0 +1,44 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.nn.embedding_lookup}. Output dtype is inherited from the {@code params}
+ * argument (the embedding table). Output shape is left at ⊤ for now: the precise shape is {@code
+ * (*ids.shape, params.shape[-1])} which requires combining two inputs' shapes — wala/ML#449 (Tier
+ * 8) covers refining this once a tier base for "shape derived from multiple inputs" is in place.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/nn/embedding_lookup">tf.nn.embedding_lookup</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class EmbeddingLookup extends PassThroughUnaryTensorGenerator {
+
+  public EmbeddingLookup(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public EmbeddingLookup(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "params";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
@@ -1,0 +1,44 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.image.extract_patches}. Output dtype is inherited from the {@code images}
+ * input. Output shape is left at ⊤ for now: the precise shape depends on the {@code sizes}, {@code
+ * strides}, {@code rates}, and {@code padding} arguments together with {@code images.shape}, which
+ * is non-trivial to compute and not yet supported by the tier framework. See wala/ML#449 (Tier 8).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/image/extract_patches">tf.image.extract_patches</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ExtractPatches extends PassThroughUnaryTensorGenerator {
+
+  public ExtractPatches(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public ExtractPatches(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "images";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
@@ -1,0 +1,43 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.gather_nd}. Output dtype is inherited from the {@code params} input.
+ * Output shape is left at ⊤ for now: the precise shape is {@code indices.shape[:-1] +
+ * params.shape[indices.shape[-1]:]} which requires combining two inputs' shapes — wala/ML#449 (Tier
+ * 8) covers refining this once a tier base for "shape derived from multiple inputs" is in place.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/gather_nd">tf.gather_nd</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class GatherNd extends PassThroughUnaryTensorGenerator {
+
+  public GatherNd(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public GatherNd(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "params";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -1,0 +1,52 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.sequence_mask}. Output dtype defaults to {@link DType#BOOL} per the
+ * TensorFlow API; the optional {@code dtype} argument that can override it is not yet surfaced
+ * through {@code tensorflow.xml}, so this generator emits {@code BOOL} unconditionally — same
+ * pattern as {@link Argmax}'s fixed {@code INT64}. Output shape is left at ⊤: the precise shape is
+ * {@code (*lengths.shape, maxlen)} which requires combining one input's shape with another input's
+ * runtime value. See wala/ML#449 (Tier 8).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/sequence_mask">tf.sequence_mask</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class SequenceMask extends PassThroughUnaryTensorGenerator {
+
+  public SequenceMask(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public SequenceMask(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "lengths";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.BOOL);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -11,11 +11,13 @@ import java.util.Set;
 
 /**
  * Generator for {@code tf.sequence_mask}. Output dtype defaults to {@link DType#BOOL} per the
- * TensorFlow API; the optional {@code dtype} argument that can override it is not yet surfaced
- * through {@code tensorflow.xml}, so this generator emits {@code BOOL} unconditionally — same
- * pattern as {@link Argmax}'s fixed {@code INT64}. Output shape is left at ⊤: the precise shape is
- * {@code (*lengths.shape, maxlen)} which requires combining one input's shape with another input's
- * runtime value. See wala/ML#449 (Tier 8).
+ * TensorFlow API; the optional {@code dtype} argument that can override it is exposed in {@code
+ * tensorflow.xml} (see {@code sequence_mask}'s {@code paramNames}, which include {@code dtype}) but
+ * is not yet honored by this generator, so it emits {@code BOOL} unconditionally — similar to
+ * {@link Argmax}'s {@code INT64} default (whose {@code output_type} override, by contrast, isn't
+ * yet surfaced in the XML at all). Output shape is left at ⊤: the precise shape is {@code
+ * (*lengths.shape, maxlen)} which requires combining one input's shape with another input's runtime
+ * value. See wala/ML#449 (Tier 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/sequence_mask">tf.sequence_mask</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -7,6 +7,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.BOOLEAN_MASK;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TEST;
@@ -36,8 +37,10 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_ZIP_TYPE
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DENSE_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DIVIDE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EMBEDDING_LOOKUP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EXP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EXTRACT_PATCHES;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FLATTEN;
@@ -52,6 +55,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_ROW_STARTS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWIDS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER_ND;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER_EQUAL;
@@ -95,6 +99,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MEAN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_PROD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_SUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RSQRT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SEQUENCE_MASK;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIGMOID;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIZE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SLICE_BUILTIN;
@@ -1104,6 +1109,15 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, SIZE.getDeclaringClass())) return new Size(source);
     else if (isType(calledFunction, ARGMAX.getDeclaringClass())) return new Argmax(source);
     else if (isType(calledFunction, ARGMIN.getDeclaringClass())) return new Argmin(source);
+    else if (isType(calledFunction, SEQUENCE_MASK.getDeclaringClass()))
+      return new SequenceMask(source);
+    else if (isType(calledFunction, EMBEDDING_LOOKUP.getDeclaringClass()))
+      return new EmbeddingLookup(source);
+    else if (isType(calledFunction, GATHER_ND.getDeclaringClass())) return new GatherNd(source);
+    else if (isType(calledFunction, BOOLEAN_MASK.getDeclaringClass()))
+      return new BooleanMask(source);
+    else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
+      return new ExtractPatches(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -871,6 +871,56 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String ARGMIN_SIGNATURE = "tf.argmin()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/sequence_mask. */
+  public static final MethodReference SEQUENCE_MASK =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/sequence_mask")),
+          AstMethodReference.fnSelector);
+
+  private static final String SEQUENCE_MASK_SIGNATURE = "tf.sequence_mask()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/nn/embedding_lookup. */
+  public static final MethodReference EMBEDDING_LOOKUP =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/embedding_lookup")),
+          AstMethodReference.fnSelector);
+
+  private static final String EMBEDDING_LOOKUP_SIGNATURE = "tf.nn.embedding_lookup()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/gather_nd. */
+  public static final MethodReference GATHER_ND =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/gather_nd")),
+          AstMethodReference.fnSelector);
+
+  private static final String GATHER_ND_SIGNATURE = "tf.gather_nd()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/boolean_mask. */
+  public static final MethodReference BOOLEAN_MASK =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/boolean_mask")),
+          AstMethodReference.fnSelector);
+
+  private static final String BOOLEAN_MASK_SIGNATURE = "tf.boolean_mask()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/image/extract_patches. */
+  public static final MethodReference EXTRACT_PATCHES =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/extract_patches")),
+          AstMethodReference.fnSelector);
+
+  private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1250,6 +1300,11 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(PLACEHOLDER.getDeclaringClass(), PLACEHOLDER_SIGNATURE),
           Map.entry(ARGMAX.getDeclaringClass(), ARGMAX_SIGNATURE),
           Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
+          Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),
+          Map.entry(EMBEDDING_LOOKUP.getDeclaringClass(), EMBEDDING_LOOKUP_SIGNATURE),
+          Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
+          Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
+          Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_boolean_mask.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_boolean_mask.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+tensor = tf.constant([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+mask = tf.constant([True, False, True])
+y = tf.boolean_mask(tensor, mask)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 2)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_embedding_lookup.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_embedding_lookup.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+params = tf.constant([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+ids = tf.constant([0, 2])
+y = tf.nn.embedding_lookup(params, ids)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 2)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+images = tf.random.uniform((1, 10, 10, 3))
+y = tf.image.extract_patches(
+    images=images,
+    sizes=[1, 3, 3, 1],
+    strides=[1, 5, 5, 1],
+    rates=[1, 1, 1, 1],
+    padding="VALID",
+)
+assert isinstance(y, tf.Tensor)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_nd.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_nd.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+params = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+indices = tf.constant([[0, 0], [1, 1]])
+y = tf.gather_nd(params, indices)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2,)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+y = tf.sequence_mask([1, 3, 2], maxlen=5)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3, 5)
+assert y.dtype == tf.bool
+
+f(y)


### PR DESCRIPTION
## Summary

Closes the regression Copilot flagged on #236 — when those five ops' `read_data` markers are inlined, the generic `ReadDataFallback` dispatch no longer fires. This adds dedicated `TensorGenerator` subclasses so dispatch stays valid both pre- and post-#236.

| Op | Generator | Output dtype | Output shape |
| --- | --- | --- | --- |
| `tf.sequence_mask` | `SequenceMask` | `BOOL` (fixed; mirrors `Argmax`'s int64) | ⊤ |
| `tf.nn.embedding_lookup` | `EmbeddingLookup` | from `params` | ⊤ |
| `tf.gather_nd` | `GatherNd` | from `params` | ⊤ |
| `tf.boolean_mask` | `BooleanMask` | from `tensor` | ⊤ |
| `tf.image.extract_patches` | `ExtractPatches` | from `images` | ⊤ |

All five extend `PassThroughUnaryTensorGenerator` for the dtype-from-input behavior and override `getDefaultShapes` → `null` (⊤). Precise shape inference for these is non-trivial (combining multiple inputs' shapes, runtime mask contents, or padding/stride arithmetic) and is tracked via wala/ML#449's tier roadmap.

The `dtype` / `output_type` keyword overrides for these ops are not yet surfaced through `tensorflow.xml`; refining the generators to honor them is a clean follow-up — same caveat as `Argmax`.

## Test plan

- [x] `python3.10 tf2_test_<op>.py` runs each fixture without assertion failures.
- [x] `mvn test` clean: `TestTensorflow2Model` 643/0/0/0; sibling modules clean.

This PR is independent of #236 (works pre- and post-inlining); they can land in either order.