### PR TITLE
Document the prefer-observed-assertion test convention in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,22 @@ When the PA assignment graph propagates a tensor type into a destination that se
 - Ensure that all new and existing JUnit test cases pass successfully before committing changes.
 - Use descriptive names for JUnit test methods that clearly indicate the purpose of the test.
 - If you change any of the summary files (e.g., `tensorflow.xml`), ensure that you add or update JUnit test cases to cover the changes made. Also, you must run `mvn clean` to ensure that the changes are correctly reflected in the build for summary (XML) files.
-- When suppressing a known-failing test with `@Test(expected = AssertionError.class)`, always add a `TODO:` line to the test's Javadoc naming the issue that needs to land before the annotation can be removed. For example:
+- When a test would fail because of a known precision/correctness gap, **prefer encoding the *observed* (current, imprecise) behavior in the assertion itself** with a `TODO(<issue>):` comment that names the precise post-fix form. When the fix lands, the actual result changes and the test starts failing with a clear "expected observed-form, got precise-form" diff — that's the cue to update the assertion. For example:
+
+	```java
+	/**
+	 * ...test description, including why the result is currently imprecise...
+	 *
+	 * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to
+	 * {@code Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)}.
+	 */
+	@Test
+	public void testModelAttributesMultiModelWrapped() {
+	test(..., Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+	}
+	```
+
+	The fallback is `@Test(expected = AssertionError.class)`, which inverts the pass/fail signal — when the fix lands the test silently passes through an unrelated assertion (or fails because no `AssertionError` was thrown). Use it only when the precise post-fix shape is not yet known or not yet expressible in `TensorType`. When you do use it, always add a `TODO:` line to the test's Javadoc naming the blocking issue. For example:
 
 	```java
 	/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,11 +94,11 @@ Within a single shape, use `new SymbolicDim("?")` for a known-rank-but-unknown-s
 
 Never return a bare empty set to mean "unknown dtype" — that collides with the "not a tensor" signal.
 
-### Tensor types — `getTensorTypes`
+### Tensor Types — `getTensorTypes`
 
 Shapes and dtypes are orthogonal. When the shape is unknown but the dtype is known, `getTensorTypes` emits `TensorType` instances with `null` dims so dtype information is preserved. `TensorType` is null-dims-safe; any code that consumes `TensorType`s must handle `getDims() == null`.
 
-### Checklist when adding a new generator
+### Checklist When Adding a New Generator
 
 - [ ] Audit every final-fallback return in `getDefaultShapes` and `getDefaultDTypes` against the tables above.
 - [ ] Prefer `null` over `Collections.emptySet()` when the intended meaning is "we know it's a tensor, we just can't figure out the shape."
@@ -115,7 +115,7 @@ When adding or modifying an API summary in `tensorflow.xml` / `numpy.xml`:
 - **Allocatable classes** — `<new class="L..."/>` requires the target class to be declared `<class name="..." allocatable="true">` somewhere in the XML, otherwise `HeapModel.getInstanceKeyForAllocation` returns `null` and the iKey never reaches the caller (see wala/WALA#1889 history). When a new `<new>` target class is added, audit existing ones in the same area for the declaration.
 - **`numArgs` / `paramNames` consistency** — every `<method numArgs="N" paramNames="...">` must have exactly `N` whitespace-separated names in `paramNames`. Mismatches silently break parameter resolution; audit when changing signatures.
 
-## Pinning shapes / blocking PA leaks
+## Pinning Shapes / Blocking PA Leaks
 
 When the PA assignment graph propagates a tensor type into a destination that semantically isn't a tensor, use one of these `TensorTypeAnalysis` mechanisms (both threaded through `PythonTensorAnalysisEngine.performAnalysis`):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ When the PA assignment graph propagates a tensor type into a destination that se
 	 */
 	@Test
 	public void testModelAttributesMultiModelWrapped() {
-	test(..., Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+		test(..., Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
 	}
 	```
 


### PR DESCRIPTION
## Summary

Adds a "Java Testing" sub-section in `CONTRIBUTING.md` documenting the project preference for capturing known precision/correctness gaps:

- **Default:** encode the *observed* (current, imprecise) result in the assertion + a `TODO(<issue>):` comment naming the precise post-fix form. When the fix lands, the actual result narrows and the test fails with a clear "expected observed-form, got precise-form" diff — that's the cue to update the assertion.
- **Fallback:** `@Test(expected = AssertionError.class)` — for cases where the precise post-fix shape isn't yet expressible. Existing requirement for a `TODO:` line in the Javadoc is preserved.

## Why split from ponder-lab/ML#238?

This was originally one of the commits in ponder-lab/ML#238 (regression tests for `Model` precision). Splitting it out per review:

- The doc edit is project-policy guidance, not a test addition. Different review concerns (editorial vs. analyzer-correctness).
- A future maintainer running `git blame` on the convention shouldn't land in a "regression tests for `Model`" PR.
- Atomic revert: if either piece needed reverting in isolation, splitting keeps them decoupled.

The example block in the doc references the wrapped multi-Model tests in #238; that's just an illustration. The convention itself stands independently.

## Test plan

- [x] Existing `mvn test` is unaffected — this is a documentation-only change.