### PR TITLE
Cover the `axis`-passed branch in `Linspace.getDefaultShapes` (wala/ML#449 Tier 7)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4543,8 +4543,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * for soundness. The assertion encodes the observed result with a TODO pointing at the precision
    * improvement that would narrow it.
    *
-   * <p>TODO(wala/ML#475): Once {@code Linspace.getDefaultShapes} computes the precise output shape
-   * from {@code start.shape[:axis] + (num,) + start.shape[axis:]}, narrow the assertion to {@code
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/475">wala/ML#475</a> is fixed and
+   * {@code Linspace.getDefaultShapes} computes the precise output shape from {@code
+   * start.shape[:axis] + (num,) + start.shape[axis:]}, narrow the assertion to {@code
    * Set.of(TENSOR_2_5_FLOAT32)} (a new constant).
    *
    * <p>Companion to {@link #testLinspace()} (covering the absent-axis branch).

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4536,10 +4536,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Drives the {@code axis}-passed branch in {@link
    * com.ibm.wala.cast.python.ml.client.Linspace#getDefaultShapes}. With {@code axis=1} and vector
    * {@code start}/{@code stop}, {@code tf.linspace} interpolates along axis 1, producing a
-   * higher-rank result whose precise shape combines {@code start}'s rank with {@code num} — the
-   * static analysis can't recover this, so the generator returns ⊤ (unknown shape). Dtype is still
-   * derived from {@code start} (float32). Companion to {@link #testLinspace()} (covering the
-   * absent-axis branch).
+   * higher-rank result whose runtime shape is {@code (2, 5)} with dtype {@code float32}.
+   *
+   * <p>The static analysis currently returns ⊤ (unknown shape) for any axis-passed call — combining
+   * {@code start}'s rank with {@code num} is not yet implemented; the generator trades precision
+   * for soundness. The assertion encodes the observed result with a TODO pointing at the precision
+   * improvement that would narrow it.
+   *
+   * <p>TODO(wala/ML#475): Once {@code Linspace.getDefaultShapes} computes the precise output shape
+   * from {@code start.shape[:axis] + (num,) + start.shape[axis:]}, narrow the assertion to {@code
+   * Set.of(TENSOR_2_5_FLOAT32)} (a new constant).
+   *
+   * <p>Companion to {@link #testLinspace()} (covering the absent-axis branch).
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4533,6 +4533,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Drives the {@code axis}-passed branch in {@link
+   * com.ibm.wala.cast.python.ml.client.Linspace#getDefaultShapes}. With {@code axis=1} and vector
+   * {@code start}/{@code stop}, {@code tf.linspace} interpolates along axis 1, producing a
+   * higher-rank result whose precise shape combines {@code start}'s rank with {@code num} — the
+   * static analysis can't recover this, so the generator returns ⊤ (unknown shape). Dtype is still
+   * derived from {@code start} (float32). Companion to {@link #testLinspace()} (covering the
+   * absent-axis branch).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLinspaceAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_linspace_axis.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Verifies that {@code tf.broadcast_to(x, [2, 3])} routes through the dedicated {@link
    * BroadcastTo} generator and emits shape {@code (2, 3)} (read from the {@code shape} argument's
    * literal list) with {@code float32} dtype (derived from the {@code input} tensor).

--- a/com.ibm.wala.cast.python.test/data/tf2_test_linspace_axis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_linspace_axis.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Drives the axis-passed branch in `Linspace.getDefaultShapes`. With axis=1 and
+# vector start/stop, `tf.linspace` interpolates along axis 1, producing a
+# higher-rank result whose precise shape (2, 5) requires combining `start`'s
+# rank with `num` — the static analysis can't recover this, so the generator
+# returns ⊤ (unknown shape).
+start = tf.constant([0.0, 10.0])
+stop = tf.constant([1.0, 20.0])
+y = tf.linspace(start, stop, 5, axis=1)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 5)
+assert y.dtype == tf.float32
+
+f(y)


### PR DESCRIPTION
## Summary

Codecov-driven coverage follow-up to ponder-lab/ML#233 (wala/ML#449 Tier 7).

After ponder-lab/ML#233 landed `Linspace`, Codecov flagged the `axis`-resolved positional/keyword branch in `Linspace.getDefaultShapes` as uncovered (https://github.com/ponder-lab/ML/pull/233#issuecomment-4381345173). This adds a fixture that calls `tf.linspace(start, stop, 5, axis=1)` with vector `start` / `stop`, exercising the keyword-axis-present path.

The runtime result is shape `(2, 5)` with float32 dtype; the static analysis correctly returns ⊤ shape with float32 dtype, because combining `start`'s rank with `num` is beyond what the generator's heuristic recovers. The assertion is `TENSOR_UNKNOWN_SHAPE_FLOAT32`.

## Why Stack On `449-tier7-linspace-fill-broadcast`

This PR is a pure coverage follow-up to ponder-lab/ML#233. Stacking it on PR ponder-lab/ML#233's branch keeps the coverage delta in the same review unit; the base will collapse to master once #233 merges.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest='TestTensorflow2Model#testLinspaceAxis' -Dsurefire.failIfNoSpecifiedTests=false test` passes locally.
- [x] `tf2_test_linspace_axis.py` runs to completion under `python3.10` (the `assert` statements pass).

## Related

- ponder-lab/ML#233 — the original Tier 7 PR.
- The Tier 7 codecov audit on https://github.com/ponder-lab/ML/pull/233#issuecomment-4381345173 — the coverage gap identified.
- wala/ML#473 — the broadcast-to-runtime-shape coverage fixture intended for this PR was dropped here and inlined into the bug as a reproducer; once that bug is fixed, that fixture lands as a separate PR.