### PR TITLE
Make Codecov reports informational; stop blocking the merge queue on patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary

Codecov is intended as an informational signal in this repo (it is not in the master ruleset's required-checks list: that list is `build` / `Analyze (actions)` / `Analyze (java-kotlin)`). However, the same ruleset's `merge_queue` rule uses `grouping_strategy: ALLGREEN`, which gates the queue on every status check, not just the required ones. So a `codecov/patch: FAILURE` blocks the merge queue even when codecov is otherwise informational. PR ponder-lab/ML#233 hit this on the post-master-merge build (https://github.com/ponder-lab/ML/pull/233 — required checks all green, queue blocked solely on `codecov/patch`).

This adds a minimal `.codecov.yml` that flags both `project` and `patch` status checks as `informational: true`, so codecov reports `SUCCESS` to GitHub regardless of the threshold. The codecov comment with the coverage breakdown still posts as before; only the GitHub status contribution is neutralized.

The behavior change matches the documented intent: codecov is informational. After this lands, the merge queue stops blocking on coverage and individual PRs (#233, #240, future PRs) can land based on the actual gates (build + CodeQL).

## Why Not A Ruleset Edit?

Two reasons to do this in-repo rather than via the ruleset:

1. **Documents intent in code.** A future contributor opening the repo can read `.codecov.yml` and see codecov is informational; a ruleset edit is invisible from the source tree.
2. **Scoped to codecov.** The ruleset's `ALLGREEN` policy is otherwise correct (it catches drift in non-required checks before they regress to required). Disabling it globally would be heavier than necessary; this change neutralizes only the codecov status while keeping `ALLGREEN` for everything else.

## Test Plan

- [ ] After merge, the codecov comment continues to post on PRs (verify by inspecting the next PR's comments).
- [ ] After merge, `codecov/patch` and `codecov/project` report `SUCCESS` (informational) regardless of threshold (verify by inspecting the next PR's status checks).
- [ ] Re-run / re-trigger CI on PR ponder-lab/ML#233 — `codecov/patch` should flip to `SUCCESS` and the merge queue should pick it up.