### PR TITLE
Switch CodeQL `java-kotlin` to `build-mode: none` so `paths-ignore` filters submodules

### DIFF
--- a/.github/codeql/codeql-config-java-kotlin.yml
+++ b/.github/codeql/codeql-config-java-kotlin.yml
@@ -19,6 +19,14 @@
 # dozens of findings on Ariadne's own code in noise. **When adding or
 # removing a submodule, update this list to match `.gitmodules` — there is
 # no automatic discovery.**
+#
+# `paths-ignore` only filters source files when the Java extractor scans
+# sources directly — i.e., when `codeql.yml` sets `build-mode: none`. With
+# the old build-trace mode, `paths-ignore` translated to
+# `LGTM_INDEX_FILTERS` but the extractor still indexed everything compiled
+# by the Maven build (including submodule classes), so submodule alerts
+# persisted. The `build-mode: none` switch in `codeql.yml` is what makes
+# this filter effective. See wala/ML#476 for the diagnosis.
 
 name: "ponder-lab/ML CodeQL config (java-kotlin)"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,42 +32,27 @@ jobs:
         with:
           submodules: recursive
 
-      - if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "25"
-          cache: maven
-
+      # Use `build-mode: none` for `java-kotlin` (added in CodeQL 2.16.5,
+      # March 2024). With `none`, the Java extractor scans source files
+      # directly instead of tracing a Maven/Ant build — which means the
+      # `paths-ignore` directive in `codeql-config-java-kotlin.yml` actually
+      # filters submodule paths (`IDE/`, `jython3/`) from the analysis. With
+      # the previous build-trace mode, `paths-ignore` translated to
+      # `LGTM_INDEX_FILTERS` but the Java extractor traced everything that
+      # got compiled by the Maven build (including submodules), so submodule
+      # alerts persisted regardless. See wala/ML#476.
+      #
+      # `build-mode: none` removes the need for `actions/setup-java`, the
+      # `Install Jython3` ant build, the `Install IDE` Maven install, and the
+      # `Build with Maven` step — none of those are needed when CodeQL works
+      # straight from sources. Builds for the other CI gates (regular
+      # `mvn test`, etc.) still happen in `continuous-integration.yml` — this
+      # change only affects the CodeQL job.
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.language == 'java-kotlin' && 'none' || '' }}
           config-file: ./.github/codeql/codeql-config-${{ matrix.language }}.yml
-
-      # The Java build needs the Jython3 submodule installed as a local
-      # Maven artifact before the main project can resolve. Mirrors the
-      # `Install Jython3` step in continuous-integration.yml.
-      - if: matrix.language == 'java-kotlin'
-        name: Install Jython3
-        shell: bash
-        run: |
-          pushd jython3
-          ant
-          pushd dist
-          mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true -B
-          popd
-          popd
-
-      - if: matrix.language == 'java-kotlin'
-        name: Install IDE
-        run: |
-          pushd IDE/com.ibm.wala.cast.lsp
-          mvn install -B -q -DskipTests
-          popd
-
-      - if: matrix.language == 'java-kotlin'
-        name: Build with Maven
-        run: mvn install -B -DskipTests
 
       - uses: github/codeql-action/analyze@v4
         with:


### PR DESCRIPTION
## Summary

Fixes wala/ML#476 — submodule alerts persist despite `paths-ignore` config.

The current CodeQL `java-kotlin` job runs against a Maven+Ant build trace. Under that mode, `paths-ignore` (`IDE/**`, `jython3/**` in `codeql-config-java-kotlin.yml`) translates into `LGTM_INDEX_FILTERS` env vars that the Java extractor passes through but does not honor — the extractor indexes everything compiled by the trace, including submodule classes built by `Install Jython3`, `Install IDE`, and the project Maven build. Result: 4914 open alerts on submodule code (4894 on `jython3/`, 20 on `IDE/`) versus 85 on Ariadne's own code, drowning the actual signal at ~58:1.

This switches the `java-kotlin` analysis to `build-mode: none` (added in CodeQL 2.16.5, March 2024), which scans Java sources directly without tracing a build. In that mode `paths-ignore` filters source files BEFORE they enter the database, so submodule paths are excluded as documented.

## Why `build-mode: none` Is The Right Call

Confirmed against the official GitHub CodeQL guidance — from a CodeQL maintainer in [github/codeql#8689 (comment)](https://github.com/github/codeql/issues/8689#issuecomment-3032839302):

> The current product direction for compiled languages has focused on `build-mode: none` (see e.g. [for Java](https://github.blog/changelog/2024-03-26-codeql-can-scan-java-projects-without-a-build/), [for C#](https://github.blog/changelog/2024-06-20-codeql-can-scan-c-projects-without-requiring-working-builds-public-beta/), and [for C++](https://github.blog/changelog/2025-06-03-codeql-can-be-enabled-at-scale-on-c-c-repositories-in-public-preview-using-build-free-scanning/))…
> 
> If you switch to `build-mode: none`, then you should notice an improvement in extraction speed in any case. Additionally, since `build-mode: none` doesn't perform a normal build, e.g. submodules or other parts of your project that you do not wish to analyse do not need to be present.

Earlier comments in the same thread by other affected users ([1](https://github.com/github/codeql/issues/8689#issuecomment-2623412394), [2](https://github.com/github/codeql/issues/8689#issuecomment-2742908722), [3](https://github.com/github/codeql/issues/8689#issuecomment-3028616255)) confirm `paths-ignore` is a known-broken interaction with build-trace extraction; GitHub's stated direction is `build-mode: none` rather than fixing the trace-mode filter.

## Workflow Changes

Removes four steps that exist solely to feed the Java build trace:

- `actions/setup-java@v5` (no JDK needed when CodeQL works from sources).
- `Install Jython3` (`pushd jython3 && ant && mvn install:install-file ...`).
- `Install IDE` (`pushd IDE/com.ibm.wala.cast.lsp && mvn install`).
- `Build with Maven` (`mvn install -B -DskipTests`).

`continuous-integration.yml` still runs the regular Maven build for `mvn test` and friends — those gates are unaffected. Only the CodeQL job sheds the build steps.

## Trade-Off

`build-mode: none` produces a slightly lower-fidelity analysis than build-traced mode for queries that depend on compiled bytecode (e.g., precise type resolution on heavily-overloaded methods). For Ariadne's coverage profile (`security-extended` + `security-and-quality`), the noise reduction (4914 → 0 submodule alerts) far outweighs the marginal precision loss on the 85 real alerts. CI time should also drop noticeably (no Ant build, no Maven install of two modules).

## Test Plan

- [ ] PR's CodeQL run completes successfully on `java-kotlin` with `build-mode: none`.
- [ ] PR's CodeQL run produces zero new submodule-path alerts (visible in the PR's security tab post-run).
- [ ] CI time on the PR's CodeQL job is ≤ the master baseline (sanity check; expected to drop).

## Cleanup Once This Lands

Bulk-dismiss the existing 4914 open submodule alerts via `PATCH /repos/ponder-lab/ML/code-scanning/alerts/{n}` with `state=dismissed`, `dismissed_reason="won't fix"`, `create_request=true` (org-level "Delegated alert dismissal" is enabled, so dismissals are routed through the request workflow). Tracked in wala/ML#476.

## Related

- wala/ML#476 — diagnostic findings; this PR is the proposed fix.
- ponder-lab/ML#232 — the PR that landed the original `paths-ignore` config that this PR makes effective.
- [github/codeql#8689](https://github.com/github/codeql/issues/8689) — upstream tracking issue for `paths-ignore` + compiled-language extraction.