### PR TITLE
Localize `IllegalStateException` tolerance for unparseable shapes in `BroadcastTo`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4586,8 +4586,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for {@code tf.broadcast_to(x, tf.shape(y))} &mdash; the runtime-tensor
    * shape-arg pattern. {@link com.ibm.wala.cast.python.ml.client.TensorGenerator
-   * #getShapesFromShapeArgument} throws {@link IllegalStateException} for the unrecognized {@code
-   * Ltensorflow/math/shape} allocation type that {@code tf.shape(y)} now produces (post the
+   * #getShapesFromShapeArgument} throws {@link IllegalStateException} for the runtime {@code
+   * Ltensorflow/python/framework/ops/Tensor} that {@code tf.shape(y)} now allocates (post the
    * wala/ML#489 root-cause fix on this PR's `tensorflow.xml`); {@link
    * com.ibm.wala.cast.python.ml.client.BroadcastTo#getDefaultShapes}'s try/catch returns {@code
    * null} (lattice ⊤) instead of letting the exception abort the analysis. The result is shape ⊤
@@ -6996,14 +6996,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
    * {@code (2, 3)} of {@code float32}. Post this PR's wala/ML#489 root-cause fix (`tensorflow.xml`
-   * allocates a fresh `Ltensorflow/math/shape` instance for `tf.shape(...)` instead of aliasing
-   * through `pass_through`), the helper's else-branch fires cleanly for the unrecognized allocation
-   * type and throws {@link IllegalStateException}. {@link
+   * allocates a fresh `Ltensorflow/python/framework/ops/Tensor` for `tf.shape(...)` instead of
+   * aliasing through `pass_through`), the helper's else-branch fires cleanly for the unrecognized
+   * allocation type and throws {@link IllegalStateException}. {@link
    * com.ibm.wala.cast.python.ml.client.Reshape} doesn't localize the catch (unlike {@link
    * com.ibm.wala.cast.python.ml.client.BroadcastTo}), per this PR's keep-throw-everywhere-except-
    * BroadcastTo design, so the exception propagates up and aborts the analysis on this fixture.
    * That's the design choice: missing modeling on `Reshape`'s runtime-tensor shape path surfaces as
    * a loud signal rather than a silent ⊤.
+   *
+   * <p>The {@code expected} types map below ({@code Map.of(2, Set.of(TENSOR_2_3_FLOAT32))}) is
+   * unreachable while the {@code @Test(expected = IllegalStateException.class)} suppression is in
+   * place; it's staged for the eventual flip so that lifting the suppression brings the
+   * precise-shape assertion back without further edits to this method.
    *
    * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): when {@code Reshape}
    * gains a precise-shape composer (or a localized try/catch), tighten this test to assert {@link

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4587,7 +4587,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Regression guard for {@code tf.broadcast_to(x, tf.shape(y))} &mdash; the runtime-tensor
    * shape-arg pattern. {@link com.ibm.wala.cast.python.ml.client.TensorGenerator
    * #getShapesFromShapeArgument} throws {@link IllegalStateException} for the unrecognized {@code
-   * Ltensorflow/functions/shape} allocation type that {@code tf.shape(y)} now produces (post the
+   * Ltensorflow/math/shape} allocation type that {@code tf.shape(y)} now produces (post the
    * wala/ML#489 root-cause fix on this PR's `tensorflow.xml`); {@link
    * com.ibm.wala.cast.python.ml.client.BroadcastTo#getDefaultShapes}'s try/catch returns {@code
    * null} (lattice ⊤) instead of letting the exception abort the analysis. The result is shape ⊤
@@ -6995,28 +6995,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
-   * {@code (2, 3)} of {@code float32}. Post the wala/ML#489 root-cause fix on this PR's
-   * `tensorflow.xml`, the malformed compound-dim shape is gone; the analyzer now produces a union
-   * of the input's shape ({@code (6,)} since {@code x} is 1-D with 6 elements) and a scalar &mdash;
-   * not the precise {@code (2, 3)} answer, but no longer the malformed compound. The {@link
-   * com.ibm.wala.cast.python.ml.client.Reshape} generator doesn't have a try/catch around the
-   * helper (unlike {@link com.ibm.wala.cast.python.ml.client.BroadcastTo}), so when the helper
-   * throws on the {@code Ltensorflow/functions/shape} allocation, the exception propagates to
-   * {@link com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory}'s upstream catch and the
-   * result falls back to less-precise inference paths.
+   * {@code (2, 3)} of {@code float32}. Post this PR's wala/ML#489 root-cause fix (`tensorflow.xml`
+   * allocates a fresh `Ltensorflow/math/shape` instance for `tf.shape(...)` instead of aliasing
+   * through `pass_through`), the helper's else-branch fires cleanly for the unrecognized allocation
+   * type and throws {@link IllegalStateException}. {@link
+   * com.ibm.wala.cast.python.ml.client.Reshape} doesn't localize the catch (unlike {@link
+   * com.ibm.wala.cast.python.ml.client.BroadcastTo}), per this PR's keep-throw-everywhere-except-
+   * BroadcastTo design, so the exception propagates up and aborts the analysis on this fixture.
+   * That's the design choice: missing modeling on `Reshape`'s runtime-tensor shape path surfaces as
+   * a loud signal rather than a silent ⊤.
    *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): tighten to {@link
-   * #TENSOR_2_3_FLOAT32} once {@code Reshape} can compute the precise shape from a runtime shape
-   * arg (or once the helper's runtime-tensor handling lands a precise composer).
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): when {@code Reshape}
+   * gains a precise-shape composer (or a localized try/catch), tighten this test to assert {@link
+   * #TENSOR_2_3_FLOAT32} (or ⊤) and remove the {@code expected} suppression.
    */
-  @Test
+  @Test(expected = IllegalStateException.class)
   public void testReshapeRuntimeShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // Observed: union of the input x's shape (6,) and a scalar. Captured per the
-    // prefer-observed-assertion convention (CONTRIBUTING.md > Java Testing).
-    TensorType inputShape = new TensorType(FLOAT_32, asList(new NumericDim(6)));
-    TensorType scalar = new TensorType(FLOAT_32, asList());
-    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(inputShape, scalar)));
+    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4594,6 +4594,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * with dtype inherited from {@code x} (float32). Without the catch, analysis aborts and this test
    * fails &mdash; this is the direct regression guard for this PR's localized-tolerance fix.
    *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): the runtime answer is
+   * (2, 3) of float32. When the helper learns to recognize {@code tf.shape(y)} as a shape arg
+   * (rather than treating it as an unmodeled runtime tensor), tighten this assertion from {@link
+   * #TENSOR_UNKNOWN_SHAPE_FLOAT32} to {@code TENSOR_2_3_FLOAT32}.
+   *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
    * @throws CancelException if the analysis is cancelled.
@@ -7010,8 +7015,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * place; it's staged for the eventual flip so that lifting the suppression brings the
    * precise-shape assertion back without further edits to this method.
    *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): when {@code Reshape}
-   * gains a precise-shape composer (or a localized try/catch), tighten this test to assert {@link
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): when the helper
+   * learns to recognize {@code tf.shape(y)} as a shape arg (or {@code Reshape} gains a localized
+   * try/catch mirroring {@code BroadcastTo}'s), tighten this test to assert {@link
    * #TENSOR_2_3_FLOAT32} (or ⊤) and remove the {@code expected} suppression.
    */
   @Test(expected = IllegalStateException.class)

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -31,6 +31,7 @@ import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.classLoader.IField;
@@ -4582,6 +4583,44 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testBroadcastTo()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_broadcast_to.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * Regression guard for {@code tf.broadcast_to(x, tf.shape(y))} &mdash; the runtime-tensor
+   * shape-arg pattern. The expectation when this PR was filed was that {@link
+   * com.ibm.wala.cast.python.ml.client.TensorGenerator#getShapesFromShapeArgument} throws {@link
+   * IllegalStateException} for runtime-tensor shape arguments, and that {@link
+   * com.ibm.wala.cast.python.ml.client.BroadcastTo#getDefaultShapes}'s try/catch returns {@code
+   * null} (lattice ⊤) instead of letting the exception abort the analysis.
+   *
+   * <p>Empirically, that's not what happens on this case: the helper successfully builds a
+   * malformed compound-dim shape (the same shape produced by {@code testReshapeRuntimeShape} for
+   * {@code tf.reshape(x, tf.shape(y))}), so the catch path doesn't fire. The observed output is a
+   * 2-dim compound where each dim is itself a Compound of three Constant-0 entries &mdash; a
+   * malformed shape, not ⊤. Same root cause as wala/ML#489.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): the malformed
+   * compound-dim shape is incorrect; tighten the JUnit assertion to {@link
+   * #TENSOR_UNKNOWN_SHAPE_FLOAT32} (or the precise (2, 3) post-fix shape) once the helper's
+   * runtime-tensor handling is fixed.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBroadcastToRuntimeShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // The observed (imprecise) shape for `tf.broadcast_to(x, tf.shape(y))` &mdash; a 2-dim
+    // Compound where each dim is itself a Compound of three NumericDim(0) entries. Encoded
+    // here per the prefer-observed-assertion convention (CONTRIBUTING.md > Java Testing).
+    List<Dimension<?>> observed =
+        asList(
+            new CompoundDim(asList(new NumericDim(0), new NumericDim(0), new NumericDim(0))),
+            new CompoundDim(asList(new NumericDim(0), new NumericDim(0), new NumericDim(0))));
+    TensorType observedType = new TensorType(FLOAT_32, observed);
+    test("tf2_test_broadcast_to_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(observedType)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -30,8 +30,6 @@ import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
-import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
-import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.classLoader.IField;
@@ -4587,22 +4585,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression guard for {@code tf.broadcast_to(x, tf.shape(y))} &mdash; the runtime-tensor
-   * shape-arg pattern. The expectation when this PR was filed was that {@link
-   * com.ibm.wala.cast.python.ml.client.TensorGenerator#getShapesFromShapeArgument} throws {@link
-   * IllegalStateException} for runtime-tensor shape arguments, and that {@link
+   * shape-arg pattern. {@link com.ibm.wala.cast.python.ml.client.TensorGenerator
+   * #getShapesFromShapeArgument} throws {@link IllegalStateException} for the unrecognized {@code
+   * Ltensorflow/functions/shape} allocation type that {@code tf.shape(y)} now produces (post the
+   * wala/ML#489 root-cause fix on this PR's `tensorflow.xml`); {@link
    * com.ibm.wala.cast.python.ml.client.BroadcastTo#getDefaultShapes}'s try/catch returns {@code
-   * null} (lattice ⊤) instead of letting the exception abort the analysis.
-   *
-   * <p>Empirically, that's not what happens on this case: the helper successfully builds a
-   * malformed compound-dim shape (the same shape produced by {@code testReshapeRuntimeShape} for
-   * {@code tf.reshape(x, tf.shape(y))}), so the catch path doesn't fire. The observed output is a
-   * 2-dim compound where each dim is itself a Compound of three Constant-0 entries &mdash; a
-   * malformed shape, not ⊤. Same root cause as wala/ML#489.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): the malformed
-   * compound-dim shape is incorrect; tighten the JUnit assertion to {@link
-   * #TENSOR_UNKNOWN_SHAPE_FLOAT32} (or the precise (2, 3) post-fix shape) once the helper's
-   * runtime-tensor handling is fixed.
+   * null} (lattice ⊤) instead of letting the exception abort the analysis. The result is shape ⊤
+   * with dtype inherited from {@code x} (float32). Without the catch, analysis aborts and this test
+   * fails &mdash; this is the direct regression guard for this PR's localized-tolerance fix.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -4612,15 +4602,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testBroadcastToRuntimeShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // The observed (imprecise) shape for `tf.broadcast_to(x, tf.shape(y))` &mdash; a 2-dim
-    // Compound where each dim is itself a Compound of three NumericDim(0) entries. Encoded
-    // here per the prefer-observed-assertion convention (CONTRIBUTING.md > Java Testing).
-    List<Dimension<?>> observed =
-        asList(
-            new CompoundDim(asList(new NumericDim(0), new NumericDim(0), new NumericDim(0))),
-            new CompoundDim(asList(new NumericDim(0), new NumericDim(0), new NumericDim(0))));
-    TensorType observedType = new TensorType(FLOAT_32, observed);
-    test("tf2_test_broadcast_to_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(observedType)));
+    test(
+        "tf2_test_broadcast_to_runtime_shape.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -7008,28 +6995,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
-   * {@code (2, 3)} of {@code float32}; the analyzer currently produces a malformed compound-dim
-   * shape (two compound dims, each containing three {@code Constant(0)} sub-dims) plus a spurious
-   * scalar shape — neither the precise answer nor a sound ⊤. The assertion encodes the
-   * observed-imprecise output per the prefer-observed-assertion convention; when the modeling
-   * lands, tighten the assertion to {@link #TENSOR_2_3_FLOAT32}.
+   * {@code (2, 3)} of {@code float32}. Post the wala/ML#489 root-cause fix on this PR's
+   * `tensorflow.xml`, the malformed compound-dim shape is gone; the analyzer now produces a union
+   * of the input's shape ({@code (6,)} since {@code x} is 1-D with 6 elements) and a scalar &mdash;
+   * not the precise {@code (2, 3)} answer, but no longer the malformed compound. The {@link
+   * com.ibm.wala.cast.python.ml.client.Reshape} generator doesn't have a try/catch around the
+   * helper (unlike {@link com.ibm.wala.cast.python.ml.client.BroadcastTo}), so when the helper
+   * throws on the {@code Ltensorflow/functions/shape} allocation, the exception propagates to
+   * {@link com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory}'s upstream catch and the
+   * result falls back to less-precise inference paths.
    *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): {@code tf.reshape}
-   * with a runtime-tensor shape arg should either compute the precise shape or return ⊤ soundly,
-   * not a malformed compound-dim derived from misinterpreting the receiver tensor's element values
-   * as dim sizes.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): tighten to {@link
+   * #TENSOR_2_3_FLOAT32} once {@code Reshape} can compute the precise shape from a runtime shape
+   * arg (or once the helper's runtime-tensor handling lands a precise composer).
    */
   @Test
   public void testReshapeRuntimeShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // Observed-imprecise: scalar shape + a compound-of-compounds derived from y's structure.
-    // The compounds each contain three Constant(0) dims (the values of y's rows). See #489.
-    List<TensorType.Dimension<?>> threeZeros =
-        asList(new NumericDim(0), new NumericDim(0), new NumericDim(0));
-    TensorType malformed =
-        new TensorType(FLOAT_32, asList(new CompoundDim(threeZeros), new CompoundDim(threeZeros)));
+    // Observed: union of the input x's shape (6,) and a scalar. Captured per the
+    // prefer-observed-assertion convention (CONTRIBUTING.md > Java Testing).
+    TensorType inputShape = new TensorType(FLOAT_32, asList(new NumericDim(6)));
     TensorType scalar = new TensorType(FLOAT_32, asList());
-    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(scalar, malformed)));
+    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(inputShape, scalar)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -30,6 +30,7 @@ import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.classLoader.IField;
@@ -6964,6 +6965,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testReshape5() throws ClassHierarchyException, CancelException, IOException {
     test("tf2_test_reshape5.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_28_28_1_FLOAT32)));
+  }
+
+  /**
+   * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
+   * {@code (2, 3)} of {@code float32}; the analyzer currently produces a malformed compound-dim
+   * shape (two compound dims, each containing three {@code Constant(0)} sub-dims) plus a spurious
+   * scalar shape — neither the precise answer nor a sound ⊤. The assertion encodes the
+   * observed-imprecise output per the prefer-observed-assertion convention; when the modeling
+   * lands, tighten the assertion to {@link #TENSOR_2_3_FLOAT32}.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/489">wala/ML#489</a>): {@code tf.reshape}
+   * with a runtime-tensor shape arg should either compute the precise shape or return ⊤ soundly,
+   * not a malformed compound-dim derived from misinterpreting the receiver tensor's element values
+   * as dim sizes.
+   */
+  @Test
+  public void testReshapeRuntimeShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // Observed-imprecise: scalar shape + a compound-of-compounds derived from y's structure.
+    // The compounds each contain three Constant(0) dims (the values of y's rows). See #489.
+    List<TensorType.Dimension<?>> threeZeros =
+        asList(new NumericDim(0), new NumericDim(0), new NumericDim(0));
+    TensorType malformed =
+        new TensorType(FLOAT_32, asList(new CompoundDim(threeZeros), new CompoundDim(threeZeros)));
+    TensorType scalar = new TensorType(FLOAT_32, asList());
+    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(scalar, malformed)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -444,8 +444,9 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/ones_like -->
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — allocates a fresh 1-D int32 tensor whose values are the runtime shape of `input`. Modeled as `<new>+<return>` (not pass_through) because the result is a tensor *describing* the input's shape, not the input itself; aliasing
-          it to the input causes `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape spec (wala/ML#489). With the dedicated allocation, the helper's else-branch fires for the unrecognized type and `BroadcastTo`'s try/catch returns ⊤ correctly. -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — at runtime allocates a fresh 1-D int32 tensor whose values are `input`'s shape. The model here is partial: `<new>+<return>` allocates a `Ltensorflow/python/framework/ops/Tensor` of unknown dtype and unknown rank/shape (no
+          dedicated generator yet wired to encode int32 dtype or the statically-1 rank). That's enough to fix wala/ML#489's specific symptom &mdash; the dedicated allocation breaks the prior `pass_through` aliasing that caused `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape
+          spec. Tightening the result to int32 dtype / rank-1 shape is tracked at wala/ML#473. -->
         <new def="shape" class="Ltensorflow/math/shape" />
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape" />
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape" />

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -460,7 +460,7 @@
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — allocates a fresh 1-D int32 tensor whose values are the runtime shape of `input`. Modeled as `<new>+<return>` (not pass_through) because the result is a tensor *describing* the input's shape, not the input itself; aliasing
           it to the input causes `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape spec (wala/ML#489). With the dedicated allocation, the helper's else-branch fires for the unrecognized type and `BroadcastTo`'s try/catch returns ⊤ correctly. -->
-        <new def="shape" class="Ltensorflow/functions/shape" />
+        <new def="shape" class="Ltensorflow/math/shape" />
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape" />
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -458,9 +458,11 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/ones_like -->
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape -->
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — allocates a fresh 1-D int32 tensor whose values are the runtime shape of `input`. Modeled as `<new>+<return>` (not pass_through) because the result is a tensor *describing* the input's shape, not the input itself; aliasing
+          it to the input causes `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape spec (wala/ML#489). With the dedicated allocation, the helper's else-branch fires for the unrecognized type and `BroadcastTo`'s try/catch returns ⊤ correctly. -->
+        <new def="shape" class="Ltensorflow/functions/shape" />
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape" />
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through" />
@@ -904,6 +906,14 @@
       </class>
     </package>
     <package name="tensorflow/math">
+      <class name="shape" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — returns a 1-D int32 tensor whose values are `input`'s runtime shape. Modeled as `<new>+<return>` (fresh allocation, not pass-through) so `getShapesFromShapeArgument` doesn't conflate the shape-tensor with `input`'s data
+          structure (wala/ML#489). The result is a tensor whose rank is statically 1 but whose dim depends on `input`'s rank, which static analysis can't compute in general — left at ⊤ (no per-op generator wired up here). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input out_type name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
       <class name="sigmoid" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sigmoid. Modeled as `<new>+<return>` (fresh allocation, not pass-through) to match add/matmul and reflect actual TF semantics: sigmoid returns a new tensor with the same shape/dtype as its input, not the input object itself.
           Shape/dtype inference lives in the `Sigmoid` generator. -->

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -87,6 +87,21 @@ public class BroadcastTo extends TensorGenerator {
     return shapes == null || shapes.isEmpty() ? null : shapes;
   }
 
+  /**
+   * Routes the shape query through {@link #getDefaultShapes} unconditionally rather than deferring
+   * to the parent's PTS-based dispatch (which would call {@link #getShapesFromShapeArgument}
+   * directly without the tolerate-runtime-tensor catch). The point of this generator is the
+   * localized catch on `tf.broadcast_to(x, tf.shape(y))`; letting the parent's dispatch bypass it
+   * would defeat the purpose.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The shapes per {@link #getDefaultShapes}.
+   */
+  @Override
+  public Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
+    return getDefaultShapes(builder);
+  }
+
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     int inputVn =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -72,18 +72,11 @@ public class BroadcastTo extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, Parameters.SHAPE.getIndex(), Parameters.SHAPE.getName());
     if (shapePts == null || shapePts.isEmpty()) return null;
-    Set<List<Dimension<?>>> shapes;
-    try {
-      // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it doesn't
-      // recognize (notably when `shape` is itself a runtime tensor — e.g.
-      // `tf.broadcast_to(x, tf.shape(y))`). The lattice-correct response there is ⊤ ("tensor of
-      // unknown shape"), not aborting the analysis with an exception. The deeper fix is to change
-      // the helper's contract to return `null` rather than throw — see wala/ML#471 — but that
-      // touches every caller, so localize the catch here for now.
-      shapes = this.getShapesFromShapeArgument(builder, shapePts);
-    } catch (IllegalStateException e) {
-      return null;
-    }
+    // After wala/ML#471, `getShapesFromShapeArgument` returns `null` rather
+    // than throwing for shape forms it doesn't recognize (notably when
+    // `shape` is itself a runtime tensor — e.g. `tf.broadcast_to(x, tf.shape(y))`).
+    // The `null` return already encodes the lattice-correct ⊤.
+    Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, shapePts);
     return shapes == null || shapes.isEmpty() ? null : shapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -72,11 +72,18 @@ public class BroadcastTo extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, Parameters.SHAPE.getIndex(), Parameters.SHAPE.getName());
     if (shapePts == null || shapePts.isEmpty()) return null;
-    // After wala/ML#471, `getShapesFromShapeArgument` returns `null` rather
-    // than throwing for shape forms it doesn't recognize (notably when
-    // `shape` is itself a runtime tensor — e.g. `tf.broadcast_to(x, tf.shape(y))`).
-    // The `null` return already encodes the lattice-correct ⊤.
-    Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, shapePts);
+    Set<List<Dimension<?>>> shapes;
+    try {
+      // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it doesn't
+      // recognize. For `BroadcastTo` specifically, a runtime-tensor shape argument is an
+      // expected input pattern (e.g., `tf.broadcast_to(x, tf.shape(y))`), so we tolerate the
+      // throw here and degrade to ⊤ ("tensor of unknown shape"). Other callers let the throw
+      // propagate as a loud signal that modeling work is missing — see wala/ML#471's design
+      // discussion on PR #245.
+      shapes = this.getShapesFromShapeArgument(builder, shapePts);
+    } catch (IllegalStateException e) {
+      return null;
+    }
     return shapes == null || shapes.isEmpty() ? null : shapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -147,11 +147,11 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                Set<List<Dimension<?>>> sub =
-                    this.getShapesFromShapeArgument(
-                        builder, builder.getPointerAnalysis().getPointsToSet(pk));
-                // Soundness: an unparseable component represents real shape uncertainty for
-                // this index — propagate ⊤ rather than returning the parseable subset.
+                OrdinalSet<InstanceKey> fieldPts = builder.getPointerAnalysis().getPointsToSet(pk);
+                // Soundness: empty field PTS would throw `IllegalArgumentException` from the
+                // helper; treat as ⊤ for this index instead. Same for an unparseable result.
+                if (fieldPts == null || fieldPts.isEmpty()) return null;
+                Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPts);
                 if (sub == null) return null;
                 ret.addAll(sub);
               }
@@ -191,11 +191,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                Set<List<Dimension<?>>> sub =
-                    this.getShapesFromShapeArgument(
-                        builder, builder.getPointerAnalysis().getPointsToSet(pk));
-                // Soundness: in the legacy `output_shapes` path too, an unparseable component
-                // shape for this index represents real shape uncertainty — propagate ⊤.
+                OrdinalSet<InstanceKey> fieldPts = builder.getPointerAnalysis().getPointsToSet(pk);
+                // Same empty-PTS guard as the structured-signature path above.
+                if (fieldPts == null || fieldPts.isEmpty()) return null;
+                Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPts);
                 if (sub == null) return null;
                 ret.addAll(sub);
               }
@@ -251,11 +250,11 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
             IField f = builder.getClassHierarchy().resolveField(subscript);
             if (f != null) {
               PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-              Set<List<Dimension<?>>> sub =
-                  this.getShapesFromShapeArgument(
-                      builder, builder.getPointerAnalysis().getPointsToSet(pk));
-              // Soundness: an unparseable component of a structured signature represents real
-              // element-shape uncertainty — propagate ⊤ rather than the parseable subset.
+              OrdinalSet<InstanceKey> fieldPts = builder.getPointerAnalysis().getPointsToSet(pk);
+              // Soundness: empty field PTS would throw `IllegalArgumentException` from the
+              // helper; treat as ⊤ instead. Same for an unparseable result.
+              if (fieldPts == null || fieldPts.isEmpty()) return null;
+              Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPts);
               if (sub == null) return null;
               ret.addAll(sub);
             }
@@ -283,8 +282,12 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
 
     if (outputShapesPts != null && !outputShapesPts.isEmpty()) {
       Set<List<Dimension<?>>> ret = this.getShapesFromShapeArgument(builder, outputShapesPts);
-      // If we found any shapes in the output_shapes, return them.
-      if (ret != null && !ret.isEmpty()) {
+      // Soundness: a `null` from the helper means the `output_shapes` argument was present but
+      // unparseable — falling through to the scalar default would be unsound (the runtime shape
+      // could be anything). Return ⊤ instead. Empty (helper recovered no shape values from a
+      // recognized structure) still falls through to the scalar default.
+      if (ret == null) return null;
+      if (!ret.isEmpty()) {
         return ret;
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -150,7 +150,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
                 Set<List<Dimension<?>>> sub =
                     this.getShapesFromShapeArgument(
                         builder, builder.getPointerAnalysis().getPointsToSet(pk));
-                if (sub != null) ret.addAll(sub);
+                // Soundness: an unparseable component represents real shape uncertainty for
+                // this index — propagate ⊤ rather than returning the parseable subset.
+                if (sub == null) return null;
+                ret.addAll(sub);
               }
             }
           }
@@ -248,14 +251,20 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
               Set<List<Dimension<?>>> sub =
                   this.getShapesFromShapeArgument(
                       builder, builder.getPointerAnalysis().getPointsToSet(pk));
-              if (sub != null) ret.addAll(sub);
+              // Soundness: an unparseable component of a structured signature represents real
+              // element-shape uncertainty — propagate ⊤ rather than the parseable subset.
+              if (sub == null) return null;
+              ret.addAll(sub);
             }
           }
         } else {
           // Case 1.2: Single spec object as signature.
           Set<List<Dimension<?>>> sub =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
-          if (sub != null) ret.addAll(sub);
+          // Soundness: a present-but-unparseable signature is shape-unknown, not "no signature";
+          // return ⊤ rather than falling through to later default-shape inference.
+          if (sub == null) return null;
+          ret.addAll(sub);
         }
       }
       // If we found any shapes in the output_signature, return them.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -147,9 +147,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                ret.addAll(
+                Set<List<Dimension<?>>> sub =
                     this.getShapesFromShapeArgument(
-                        builder, builder.getPointerAnalysis().getPointsToSet(pk)));
+                        builder, builder.getPointerAnalysis().getPointsToSet(pk));
+                if (sub != null) ret.addAll(sub);
               }
             }
           }
@@ -187,9 +188,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                ret.addAll(
+                Set<List<Dimension<?>>> sub =
                     this.getShapesFromShapeArgument(
-                        builder, builder.getPointerAnalysis().getPointsToSet(pk)));
+                        builder, builder.getPointerAnalysis().getPointsToSet(pk));
+                if (sub != null) ret.addAll(sub);
               }
             }
           }
@@ -243,14 +245,17 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
             IField f = builder.getClassHierarchy().resolveField(subscript);
             if (f != null) {
               PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-              ret.addAll(
+              Set<List<Dimension<?>>> sub =
                   this.getShapesFromShapeArgument(
-                      builder, builder.getPointerAnalysis().getPointsToSet(pk)));
+                      builder, builder.getPointerAnalysis().getPointsToSet(pk));
+              if (sub != null) ret.addAll(sub);
             }
           }
         } else {
           // Case 1.2: Single spec object as signature.
-          ret.addAll(this.getShapesFromShapeArgument(builder, Collections.singleton(ik)));
+          Set<List<Dimension<?>>> sub =
+              this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
+          if (sub != null) ret.addAll(sub);
         }
       }
       // If we found any shapes in the output_signature, return them.
@@ -267,7 +272,7 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
     if (outputShapesPts != null && !outputShapesPts.isEmpty()) {
       Set<List<Dimension<?>>> ret = this.getShapesFromShapeArgument(builder, outputShapesPts);
       // If we found any shapes in the output_shapes, return them.
-      if (!ret.isEmpty()) {
+      if (ret != null && !ret.isEmpty()) {
         return ret;
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -194,7 +194,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
                 Set<List<Dimension<?>>> sub =
                     this.getShapesFromShapeArgument(
                         builder, builder.getPointerAnalysis().getPointsToSet(pk));
-                if (sub != null) ret.addAll(sub);
+                // Soundness: in the legacy `output_shapes` path too, an unparseable component
+                // shape for this index represents real shape uncertainty — propagate ⊤.
+                if (sub == null) return null;
+                ret.addAll(sub);
               }
             }
           }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -397,7 +397,9 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
   @Override
   public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
     Set<List<Dimension<?>>> shapes = this.getShapesForIndex(builder, index);
+    if (shapes == null) return null;
     Set<DType> dTypes = this.getDTypesForIndex(builder, index);
+    if (dTypes == null) return null;
 
     Set<TensorType> ret = HashSetFactory.make();
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -45,7 +45,7 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     OrdinalSet<InstanceKey> targetSizePts = this.getArgumentPointsToSet(builder, 1, "target_size");
     if (targetSizePts != null && !targetSizePts.isEmpty()) {
       Set<List<Dimension<?>>> targetSizes = this.getShapesFromShapeArgument(builder, targetSizePts);
-      if (!targetSizes.isEmpty()) {
+      if (targetSizes != null && !targetSizes.isEmpty()) {
         targetSize = targetSizes.iterator().next();
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -45,7 +45,11 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     OrdinalSet<InstanceKey> targetSizePts = this.getArgumentPointsToSet(builder, 1, "target_size");
     if (targetSizePts != null && !targetSizePts.isEmpty()) {
       Set<List<Dimension<?>>> targetSizes = this.getShapesFromShapeArgument(builder, targetSizePts);
-      if (targetSizes != null && !targetSizes.isEmpty()) {
+      // Soundness: when `target_size` is present but unparseable, the runtime value could be
+      // anything — falling back to the (256, 256) default would falsely claim a fixed shape.
+      // Return ⊤ instead.
+      if (targetSizes == null) return null;
+      if (!targetSizes.isEmpty()) {
         targetSize = targetSizes.iterator().next();
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
@@ -97,7 +97,7 @@ public class NdarrayReshape extends TensorGenerator {
     if (shapePts == null || shapePts.isEmpty()) return getDefaultShapes(builder);
 
     Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
-    if (rawShapes.isEmpty()) return getDefaultShapes(builder);
+    if (rawShapes == null || rawShapes.isEmpty()) return getDefaultShapes(builder);
 
     Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
@@ -97,7 +97,12 @@ public class NdarrayReshape extends TensorGenerator {
     if (shapePts == null || shapePts.isEmpty()) return getDefaultShapes(builder);
 
     Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
-    if (rawShapes == null || rawShapes.isEmpty()) return getDefaultShapes(builder);
+    // Soundness: when the `shape` argument is present but unparseable (helper returns null),
+    // the output shape is ⊤ — falling back to receiver-shape inference would be unsound since
+    // `ndarray.reshape(...)` is determined by the argument. Empty result distinct: no signature
+    // recoverable, fall back to receiver shape.
+    if (rawShapes == null) return null;
+    if (rawShapes.isEmpty()) return getDefaultShapes(builder);
 
     Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -498,7 +498,12 @@ public class RaggedConstant extends Constant {
             builder, this.getInnerShapeParameterPosition(), getInnerShapeParameterName());
 
     if (pointsToSet != null && !pointsToSet.isEmpty()) {
-      return this.getShapesFromShapeArgument(builder, pointsToSet);
+      Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, pointsToSet);
+      // After wala/ML#471 the helper can return null when the shape arg is
+      // an unrecognized form. The caller treats empty as "no inner shape
+      // info; use defaults", which matches the lattice meaning of null
+      // here, so collapse null to emptySet at the boundary.
+      return shapes == null ? emptySet() : shapes;
     } else return emptySet();
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -384,10 +384,12 @@ public class RaggedConstant extends Constant {
               .filter(Objects::nonNull)
               .collect(toSet());
 
+      Set<List<Dimension<?>>> rawInnerShapeArguments = this.getPossibleInnerShapeArguments(builder);
+      // Soundness: a `null` from `getPossibleInnerShapeArguments` means `inner_shape` was
+      // present but unparseable — the overall ragged-constant shape must be ⊤ in that case.
+      if (rawInnerShapeArguments == null) return null;
       Set<List<Dimension<?>>> innerShapeArguments =
-          this.getPossibleInnerShapeArguments(builder).stream()
-              .filter(Objects::nonNull)
-              .collect(toSet());
+          rawInnerShapeArguments.stream().filter(Objects::nonNull).collect(toSet());
 
       if (rankArguments.isEmpty())
         // Default ragged rank.
@@ -498,12 +500,11 @@ public class RaggedConstant extends Constant {
             builder, this.getInnerShapeParameterPosition(), getInnerShapeParameterName());
 
     if (pointsToSet != null && !pointsToSet.isEmpty()) {
-      Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, pointsToSet);
-      // After wala/ML#471 the helper can return null when the shape arg is
-      // an unrecognized form. The caller treats empty as "no inner shape
-      // info; use defaults", which matches the lattice meaning of null
-      // here, so collapse null to emptySet at the boundary.
-      return shapes == null ? emptySet() : shapes;
+      // After wala/ML#471 the helper returns `null` when `inner_shape` is present but
+      // unparseable. Propagate that upward — the caller short-circuits to ⊤ for the overall
+      // ragged-constant shape. Empty (no PTS recovered, or `inner_shape` not provided at all) is
+      // distinct from `null` and means "use defaults".
+      return this.getShapesFromShapeArgument(builder, pointsToSet);
     } else return emptySet();
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -500,10 +500,13 @@ public class RaggedConstant extends Constant {
             builder, this.getInnerShapeParameterPosition(), getInnerShapeParameterName());
 
     if (pointsToSet != null && !pointsToSet.isEmpty()) {
-      // After wala/ML#471 the helper returns `null` when `inner_shape` is present but
-      // unparseable. Propagate that upward — the caller short-circuits to ⊤ for the overall
-      // ragged-constant shape. Empty (no PTS recovered, or `inner_shape` not provided at all) is
-      // distinct from `null` and means "use defaults".
+      // The helper still throws `IllegalStateException` for unparseable `inner_shape` forms
+      // (e.g., a runtime tensor). The keep-throw contract is intentional &mdash; per wala/ML#471
+      // the strict signal surfaces missing modeling rather than silently degrading. The
+      // exception propagates up to the analysis driver; only `BroadcastTo` localizes a catch
+      // (because runtime-tensor shape args are the legitimate use case there). Empty (no PTS
+      // recovered, or `inner_shape` not provided at all) returns the empty set, distinct from
+      // an unparseable form, and means "use defaults".
       return this.getShapesFromShapeArgument(builder, pointsToSet);
     } else return emptySet();
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -106,7 +106,9 @@ public class ReduceMean extends TensorGenerator {
           // Try to handle list/tuple of axes.
           Set<List<Dimension<?>>> axesLists =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
-          if (axesLists == null) continue;
+          // Soundness: if any axis form is unparseable, output shape is ⊤. Returning the
+          // recognized-axis subset would under-approximate.
+          if (axesLists == null) return null;
           for (List<Dimension<?>> axesList : axesLists) {
             Set<Integer> s = new HashSet<>();
             for (Dimension<?> d : axesList) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -103,9 +103,10 @@ public class ReduceMean extends TensorGenerator {
             axisValues.add(s);
           }
         } else {
-          // Try to handle list/tuple of axes
+          // Try to handle list/tuple of axes.
           Set<List<Dimension<?>>> axesLists =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
+          if (axesLists == null) continue;
           for (List<Dimension<?>> axesList : axesLists) {
             Set<Integer> s = new HashSet<>();
             for (Dimension<?> d : axesList) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -106,8 +106,11 @@ public class ReduceMean extends TensorGenerator {
           // Try to handle list/tuple of axes.
           Set<List<Dimension<?>>> axesLists =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
-          // Soundness: if any axis form is unparseable, output shape is ⊤. Returning the
-          // recognized-axis subset would under-approximate.
+          // Soundness: if any axis form is unparseable, the helper throws
+          // `IllegalStateException` and the exception propagates up to the analysis driver
+          // (which degrades to ⊤ for this generator). The null guard below is defensive in
+          // case wala/ML#471's resolution converts the helper's contract from throw to
+          // null-return; today it's dead code but cheap insurance.
           if (axesLists == null) return null;
           for (List<Dimension<?>> axesList : axesLists) {
             Set<Integer> s = new HashSet<>();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -106,11 +106,14 @@ public class ReduceMean extends TensorGenerator {
           // Try to handle list/tuple of axes.
           Set<List<Dimension<?>>> axesLists =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
-          // If any axis form is unparseable, the helper throws `IllegalStateException` and
-          // the exception propagates up; `PythonTensorAnalysisEngine.performAnalysis` does
-          // not catch generator exceptions today, so this aborts the run. The null guard
-          // below is defensive in case wala/ML#471's resolution converts the helper's
-          // contract from throw to null-return; today it's dead code but cheap insurance.
+          // The helper has two failure modes: throw `IllegalStateException` for unrecognized
+          // top-level allocation types (which propagates up — `performAnalysis` doesn't catch
+          // generator exceptions today, so the run aborts), or return `null` for recognized
+          // sub-parse failures during recursive descent (empty `tf.constant` value PTS, empty
+          // `TensorSpec`/`RaggedTensorSpec` shape PTS, recursive null). Either can fire here
+          // when the axis arg is e.g. `tf.constant([...])` whose value-field PTS is empty, so
+          // the null guard below is live, not defensive — translate `null` to ⊤ for this
+          // generator.
           if (axesLists == null) return null;
           for (List<Dimension<?>> axesList : axesLists) {
             Set<Integer> s = new HashSet<>();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -106,11 +106,11 @@ public class ReduceMean extends TensorGenerator {
           // Try to handle list/tuple of axes.
           Set<List<Dimension<?>>> axesLists =
               this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
-          // Soundness: if any axis form is unparseable, the helper throws
-          // `IllegalStateException` and the exception propagates up to the analysis driver
-          // (which degrades to ⊤ for this generator). The null guard below is defensive in
-          // case wala/ML#471's resolution converts the helper's contract from throw to
-          // null-return; today it's dead code but cheap insurance.
+          // If any axis form is unparseable, the helper throws `IllegalStateException` and
+          // the exception propagates up; `PythonTensorAnalysisEngine.performAnalysis` does
+          // not catch generator exceptions today, so this aborts the run. The null guard
+          // below is defensive in case wala/ML#471's resolution converts the helper's
+          // contract from throw to null-return; today it's dead code but cheap insurance.
           if (axesLists == null) return null;
           for (List<Dimension<?>> axesList : axesLists) {
             Set<Integer> s = new HashSet<>();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -67,7 +67,7 @@ public class Reshape extends TensorGenerator {
 
     if (shapePts != null && !shapePts.isEmpty()) {
       Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
-      if (!rawShapes.isEmpty()) {
+      if (rawShapes != null && !rawShapes.isEmpty()) {
         Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
 
         for (List<Dimension<?>> shape : rawShapes) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -67,7 +67,11 @@ public class Reshape extends TensorGenerator {
 
     if (shapePts != null && !shapePts.isEmpty()) {
       Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
-      if (rawShapes != null && !rawShapes.isEmpty()) {
+      // Soundness: when the `shape` argument is present but unparseable, the output shape is ⊤
+      // (the result is determined by `shape`, not the input tensor — falling back to input-shape
+      // inference would be unsound).
+      if (rawShapes == null) return null;
+      if (!rawShapes.isEmpty()) {
         Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
 
         for (List<Dimension<?>> shape : rawShapes) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -94,7 +94,11 @@ public class SparseAdd extends ElementWiseOperation {
           OrdinalSet<InstanceKey> fieldPointsTo = pointerAnalysis.getPointsToSet(pk);
           if (fieldPointsTo == null || fieldPointsTo.isEmpty()) continue;
           Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPointsTo);
-          if (sub != null) ret.addAll(sub);
+          // Soundness: if any dense_shape is unparseable, the overall shape is ⊤. Returning a
+          // partial set would under-approximate (the unparseable component represents a real
+          // possibility we can't ignore).
+          if (sub == null) return null;
+          ret.addAll(sub);
         }
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -92,7 +92,9 @@ public class SparseAdd extends ElementWiseOperation {
         if (field != null) {
           PointerKey pk = builder.getPointerKeyForInstanceField(ik, field);
           OrdinalSet<InstanceKey> fieldPointsTo = pointerAnalysis.getPointsToSet(pk);
-          ret.addAll(this.getShapesFromShapeArgument(builder, fieldPointsTo));
+          if (fieldPointsTo == null || fieldPointsTo.isEmpty()) continue;
+          Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPointsTo);
+          if (sub != null) ret.addAll(sub);
         }
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -92,10 +92,14 @@ public class SparseAdd extends ElementWiseOperation {
         if (field != null) {
           PointerKey pk = builder.getPointerKeyForInstanceField(ik, field);
           OrdinalSet<InstanceKey> fieldPointsTo = pointerAnalysis.getPointsToSet(pk);
-          if (fieldPointsTo == null || fieldPointsTo.isEmpty()) continue;
+          // Soundness: empty `dense_shape` PTS is "shape unknown" (the field exists but the
+          // analysis couldn't recover any concrete shape values), not "skip this SparseTensor".
+          // Skipping would conflate ⊤ with ⊥ and under-approximate the result for the whole
+          // sparse-tensor value.
+          if (fieldPointsTo == null || fieldPointsTo.isEmpty()) return null;
           Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPointsTo);
-          // Soundness: if any dense_shape is unparseable, the overall shape is ⊤. Returning a
-          // partial set would under-approximate (the unparseable component represents a real
+          // Same rationale: if any dense_shape is unparseable, the overall shape is ⊤. Returning
+          // a partial set would under-approximate (the unparseable component represents a real
           // possibility we can't ignore).
           if (sub == null) return null;
           ret.addAll(sub);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -238,44 +238,34 @@ public abstract class TensorGenerator {
   /**
    * Returns the possible shapes of the tensor returned by this generator.
    *
-   * <p>Throws {@link IllegalStateException} when the shape argument's PTS contains forms this
-   * method does not recognize as a static shape &mdash; runtime tensors (e.g. the result of {@code
-   * tf.shape(y)}), opaque builder objects, or anything that isn't a list / tuple / {@code
-   * tf.constant} / {@code TensorSpec} / {@code RaggedTensorSpec}. The strict throw is intentional:
-   * an unrecognized shape form means missing or incorrect modeling, and silencing it via a {@code
-   * null} return would suppress that diagnostic signal across the whole generator surface during
-   * development. The deeper fix (change the helper's contract to return {@code null} instead of
-   * throw) is tracked at <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>; for now
-   * the tolerance is localized to the one caller where runtime-tensor shape arguments are the
+   * <p>The strict-throw contract for unrecognized top-level forms is intentional: an unrecognized
+   * shape form means missing or incorrect modeling, and silencing it via a {@code null} return
+   * would suppress that diagnostic signal across the whole generator surface during development.
+   * The deeper fix (change the helper's contract to return {@code null} instead of throw) is
+   * tracked at <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>; for now the
+   * tolerance is localized to the one caller where runtime-tensor shape arguments are the
    * legitimate use case &mdash; {@link BroadcastTo#getDefaultShapes} wraps this helper in a {@code
-   * try / catch (IllegalStateException)} that returns {@code null} (lattice ⊤). Other callers stay
+   * try/catch (IllegalStateException)} that returns {@code null} (lattice ⊤). Other callers stay
    * strict; a missing case there surfaces as an analysis-aborting exception, which is the
    * load-bearing "modeling gap" signal.
    *
-   * <p>Throws {@link IllegalArgumentException} when the {@code pointsToSet} parameter itself is
-   * empty or {@code null} &mdash; that's a caller-contract violation (callers should check for
-   * empty PTS before invoking this helper), distinct from "shape was a runtime tensor".
-   *
-   * <p>Returns {@code null} (lattice ⊤) for sub-parse failures during recursive descent on the
-   * cases this PR converts: when a {@code tf.constant} value PTS is empty after the call-site walk,
-   * when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#TENSOR_SPEC} or {@link
-   * com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC} shape field has empty
-   * PTS, or when a recursive call on any of these returns {@code null}. This is distinct from the
-   * strict-throw contract for unrecognized top-level forms above: the throw signals "this kind of
-   * shape isn't modeled at all"; the {@code null} returns signal "this shape's structure is
-   * recognized but the leaves aren't statically resolvable" (a soundness ⊤ appropriate for the
-   * lattice).
-   *
-   * <p>Out of scope of this PR: the list/tuple branch with empty element PTS still returns an empty
-   * result set rather than {@code null}, which means callers can't distinguish "list with
-   * unresolved element" from "no shape recovered" at that path. Tracked at <a
-   * href="https://github.com/wala/ML/issues/504">wala/ML#504</a>.
-   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?
-   * @return A set of possible shapes; or {@code null} (⊤) when sub-parse fails as documented above.
-   *     Never {@code null} for unrecognized top-level forms &mdash; those throw {@link
-   *     IllegalStateException} instead.
+   * @return A set of possible shapes, or {@code null} (lattice ⊤) for sub-parse failures during
+   *     recursive descent: when a {@code tf.constant} value PTS is empty after the call-site walk,
+   *     when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#TENSOR_SPEC} or {@link
+   *     com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC} shape field has empty
+   *     PTS, or when a recursive call on any of these returns {@code null}. The {@code null}
+   *     returns signal "this shape's structure is recognized but the leaves aren't statically
+   *     resolvable" &mdash; distinct from the strict-throw contract for unrecognized top-level
+   *     forms, which signals "this kind of shape isn't modeled at all."
+   * @throws IllegalArgumentException when the {@code pointsToSet} parameter is itself empty or
+   *     {@code null}. That's a caller-contract violation (callers should check for empty PTS before
+   *     invoking this helper); distinct from "shape was a runtime tensor."
+   * @throws IllegalStateException when the shape argument's PTS contains forms this method does not
+   *     recognize as a static shape &mdash; runtime tensors (e.g. the result of {@code
+   *     tf.shape(y)}), opaque builder objects, or anything that isn't a list/tuple, {@code
+   *     tf.constant}, {@code TensorSpec}, or {@code RaggedTensorSpec}.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -238,23 +238,29 @@ public abstract class TensorGenerator {
   /**
    * Returns the possible shapes of the tensor returned by this generator.
    *
-   * <p>Returns {@code null} when the shape argument's PTS contains forms this method does not
-   * recognize as a static shape — runtime tensors (e.g. the result of {@code tf.shape(y)}), opaque
-   * builder objects, or anything that isn't a list / tuple / {@code tf.constant} / {@code
-   * TensorSpec} / {@code RaggedTensorSpec}. The {@code null} return is the lattice signal for ⊤
-   * ("tensor of unknown shape") matching the convention documented in this class's class-level
-   * Javadoc and {@code CONTRIBUTING.md}'s "Tensor Type Generators" section. Callers that aggregate
-   * sub-shapes should propagate {@code null} upward rather than treating it as an empty result. See
-   * <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>.
+   * <p>Throws {@link IllegalStateException} when the shape argument's PTS contains forms this
+   * method does not recognize as a static shape &mdash; runtime tensors (e.g. the result of {@code
+   * tf.shape(y)}), opaque builder objects, or anything that isn't a list / tuple / {@code
+   * tf.constant} / {@code TensorSpec} / {@code RaggedTensorSpec}. The strict throw is intentional:
+   * an unrecognized shape form means missing or incorrect modeling, and silencing it via a {@code
+   * null} return would suppress that diagnostic signal across the whole generator surface during
+   * development. The deeper fix (change the helper's contract to return {@code null} instead of
+   * throw) is tracked at <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>; for now
+   * the tolerance is localized to the one caller where runtime-tensor shape arguments are the
+   * legitimate use case &mdash; {@link BroadcastTo#getDefaultShapes} wraps this helper in a {@code
+   * try / catch (IllegalStateException)} that returns {@code null} (lattice ⊤). Other callers stay
+   * strict; a missing case there surfaces as an analysis-aborting exception, which is the
+   * load-bearing "modeling gap" signal.
    *
-   * <p>Still throws {@link IllegalArgumentException} when the {@code pointsToSet} parameter itself
-   * is empty or {@code null} — that's a caller-contract violation (callers should check for empty
-   * PTS before invoking this helper), distinct from "shape was a runtime tensor".
+   * <p>Throws {@link IllegalArgumentException} when the {@code pointsToSet} parameter itself is
+   * empty or {@code null} &mdash; that's a caller-contract violation (callers should check for
+   * empty PTS before invoking this helper), distinct from "shape was a runtime tensor".
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?
-   * @return A set of possible shapes of the tensor returned by this generator, or {@code null} when
-   *     no static shape can be recovered from {@code pointsToSet}.
+   * @return A set of possible shapes of the tensor returned by this generator. Never {@code null}
+   *     under normal operation; unrecognized forms throw {@link IllegalStateException} rather than
+   *     returning {@code null}.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -345,28 +345,20 @@ public abstract class TensorGenerator {
                 if (nestedShapes == null) return null;
                 for (List<Dimension<?>> nestedShape : nestedShapes)
                   tensorDimensions.add(new CompoundDim(nestedShape));
-              } else {
-                // WARNING (not FINE) so the missing-modeling signal stays loud — the legacy
-                // contract was to throw `IllegalStateException` here, which propagated all the
-                // way up and aborted the analysis. The new contract returns ⊤ so the analysis
-                // continues, but we still want operators to know that modeling work is needed.
-                LOGGER.warning(
-                    "Unrecognized instance-field allocation for shape arg: "
+              } else
+                throw new IllegalStateException(
+                    "Expected a constant key or nested structure for instance field: "
                         + pointerKeyForInstanceField
-                        + " -> "
+                        + ", but got: "
                         + instanceFieldIK
-                        + "; returning null (⊤). Modeling for this shape form is missing.");
-                return null;
-              }
-            } else {
-              LOGGER.warning(
-                  "Unrecognized instance-field key for shape arg: "
+                        + ".");
+            } else
+              throw new IllegalStateException(
+                  "Expected a constant key or nested structure for instance field: "
                       + pointerKeyForInstanceField
-                      + " -> "
+                      + ", but got: "
                       + instanceFieldIK
-                      + "; returning null (⊤). Modeling for this shape form is missing.");
-              return null;
-            }
+                      + ".");
           }
 
           LOGGER.info(
@@ -465,15 +457,9 @@ public abstract class TensorGenerator {
         Set<List<Dimension<?>>> specShapes = this.getShapesFromShapeArgument(builder, shapePts);
         if (specShapes == null) return null;
         ret.addAll(specShapes);
-      } else {
-        LOGGER.warning(
-            "Unrecognized shape-argument allocation: "
-                + reference
-                + " for source "
-                + this.getSource()
-                + "; returning null (⊤). Modeling for this shape form is missing.");
-        return null;
-      }
+      } else
+        throw new IllegalStateException(
+            "Expected a " + list + " or " + tuple + " for the shape, but got: " + reference + ".");
     }
 
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -262,10 +262,14 @@ public abstract class TensorGenerator {
    * @throws IllegalArgumentException when the {@code pointsToSet} parameter is itself empty or
    *     {@code null}. That's a caller-contract violation (callers should check for empty PTS before
    *     invoking this helper); distinct from "shape was a runtime tensor."
-   * @throws IllegalStateException when the shape argument's PTS contains forms this method does not
-   *     recognize as a static shape &mdash; runtime tensors (e.g. the result of {@code
-   *     tf.shape(y)}), opaque builder objects, or anything that isn't a list/tuple, {@code
-   *     tf.constant}, {@code TensorSpec}, or {@code RaggedTensorSpec}.
+   * @throws IllegalStateException when the shape argument's PTS contains an {@code
+   *     AllocationSiteInNode} of a type this method does not recognize as a static shape &mdash;
+   *     runtime tensors (e.g. the result of {@code tf.shape(y)}), opaque builder objects, or
+   *     anything that isn't a list/tuple, {@code tf.constant}, {@code TensorSpec}, or {@code
+   *     RaggedTensorSpec}. Non-allocation {@code InstanceKey}s in the PTS (e.g., {@code
+   *     ConstantKey} for a scalar Python int passed as the shape) are silently skipped rather than
+   *     throwing &mdash; if every key in the PTS is non-allocation, the method returns the empty
+   *     set rather than {@code null} or an exception.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -346,21 +346,25 @@ public abstract class TensorGenerator {
                 for (List<Dimension<?>> nestedShape : nestedShapes)
                   tensorDimensions.add(new CompoundDim(nestedShape));
               } else {
-                LOGGER.fine(
+                // WARNING (not FINE) so the missing-modeling signal stays loud — the legacy
+                // contract was to throw `IllegalStateException` here, which propagated all the
+                // way up and aborted the analysis. The new contract returns ⊤ so the analysis
+                // continues, but we still want operators to know that modeling work is needed.
+                LOGGER.warning(
                     "Unrecognized instance-field allocation for shape arg: "
                         + pointerKeyForInstanceField
                         + " -> "
                         + instanceFieldIK
-                        + "; returning null (⊤).");
+                        + "; returning null (⊤). Modeling for this shape form is missing.");
                 return null;
               }
             } else {
-              LOGGER.fine(
+              LOGGER.warning(
                   "Unrecognized instance-field key for shape arg: "
                       + pointerKeyForInstanceField
                       + " -> "
                       + instanceFieldIK
-                      + "; returning null (⊤).");
+                      + "; returning null (⊤). Modeling for this shape form is missing.");
               return null;
             }
           }
@@ -462,12 +466,12 @@ public abstract class TensorGenerator {
         if (specShapes == null) return null;
         ret.addAll(specShapes);
       } else {
-        LOGGER.fine(
+        LOGGER.warning(
             "Unrecognized shape-argument allocation: "
                 + reference
                 + " for source "
                 + this.getSource()
-                + "; returning null (⊤).");
+                + "; returning null (⊤). Modeling for this shape form is missing.");
         return null;
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -256,11 +256,21 @@ public abstract class TensorGenerator {
    * empty or {@code null} &mdash; that's a caller-contract violation (callers should check for
    * empty PTS before invoking this helper), distinct from "shape was a runtime tensor".
    *
+   * <p>Returns {@code null} (lattice ⊤) for sub-parse failures during recursive descent: when a
+   * recognized container's nested elements have empty PTS, when a {@code tf.constant} value PTS is
+   * empty after the call-site walk, when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes
+   * #TENSOR_SPEC} or {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC}
+   * shape field has empty PTS, or when a recursive call on any of these returns {@code null}. This
+   * is distinct from the strict-throw contract for unrecognized top-level forms above: the throw
+   * signals "this kind of shape isn't modeled at all"; the {@code null} returns signal "this
+   * shape's structure is recognized but the leaves aren't statically resolvable" (a soundness ⊤
+   * appropriate for the lattice).
+   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?
-   * @return A set of possible shapes of the tensor returned by this generator. Never {@code null}
-   *     under normal operation; unrecognized forms throw {@link IllegalStateException} rather than
-   *     returning {@code null}.
+   * @return A set of possible shapes; or {@code null} (⊤) when sub-parse fails as documented above.
+   *     Never {@code null} for unrecognized top-level forms &mdash; those throw {@link
+   *     IllegalStateException} instead.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -238,14 +238,27 @@ public abstract class TensorGenerator {
   /**
    * Returns the possible shapes of the tensor returned by this generator.
    *
+   * <p>Returns {@code null} when the shape argument's PTS contains forms this method does not
+   * recognize as a static shape — runtime tensors (e.g. the result of {@code tf.shape(y)}), opaque
+   * builder objects, or anything that isn't a list / tuple / {@code tf.constant} / {@code
+   * TensorSpec} / {@code RaggedTensorSpec}. The {@code null} return is the lattice signal for ⊤
+   * ("tensor of unknown shape") matching the convention documented in this class's class-level
+   * Javadoc and {@code CONTRIBUTING.md}'s "Tensor Type Generators" section. Callers that aggregate
+   * sub-shapes should propagate {@code null} upward rather than treating it as an empty result. See
+   * <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>.
+   *
+   * <p>Still throws {@link IllegalArgumentException} when the {@code pointsToSet} parameter itself
+   * is empty or {@code null} — that's a caller-contract violation (callers should check for empty
+   * PTS before invoking this helper), distinct from "shape was a runtime tensor".
+   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?
-   * @return A set of possible shapes of the tensor returned by this generator.
+   * @return A set of possible shapes of the tensor returned by this generator, or {@code null} when
+   *     no static shape can be recovered from {@code pointsToSet}.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
     if (pointsToSet == null || !pointsToSet.iterator().hasNext())
-      // TODO: The shape argument could be a tensor, in which case the points-to set would be empty.
       throw new IllegalArgumentException(
           "Empty points-to set for shape argument in source: " + this.getSource() + ".");
 
@@ -329,22 +342,27 @@ public abstract class TensorGenerator {
                     this.getShapesFromShapeArgument(
                         builder, Collections.singleton(instanceFieldIK));
 
+                if (nestedShapes == null) return null;
                 for (List<Dimension<?>> nestedShape : nestedShapes)
                   tensorDimensions.add(new CompoundDim(nestedShape));
-              } else
-                throw new IllegalStateException(
-                    "Expected a constant key or nested structure for instance field: "
+              } else {
+                LOGGER.fine(
+                    "Unrecognized instance-field allocation for shape arg: "
                         + pointerKeyForInstanceField
-                        + ", but got: "
+                        + " -> "
                         + instanceFieldIK
-                        + ".");
-            } else
-              throw new IllegalStateException(
-                  "Expected a constant key or nested structure for instance field: "
+                        + "; returning null (⊤).");
+                return null;
+              }
+            } else {
+              LOGGER.fine(
+                  "Unrecognized instance-field key for shape arg: "
                       + pointerKeyForInstanceField
-                      + ", but got: "
+                      + " -> "
                       + instanceFieldIK
-                      + ".");
+                      + "; returning null (⊤).");
+              return null;
+            }
           }
 
           LOGGER.info(
@@ -421,7 +439,10 @@ public abstract class TensorGenerator {
           PointerKey valuePK = builder.getPointerKeyForInstanceField(asin, valueField);
           valuePts = pointerAnalysis.getPointsToSet(valuePK);
         }
-        ret.addAll(this.getShapesFromShapeArgument(builder, valuePts));
+        if (valuePts == null || valuePts.isEmpty()) return null;
+        Set<List<Dimension<?>>> constantShapes = this.getShapesFromShapeArgument(builder, valuePts);
+        if (constantShapes == null) return null;
+        ret.addAll(constantShapes);
       } else if (reference.equals(TensorFlowTypes.TENSOR_SPEC)
           || reference.equals(TensorFlowTypes.RAGGED_TENSOR_SPEC)) {
         // We have a TensorSpec or RaggedTensorSpec. These objects carry shape and dtype
@@ -436,10 +457,19 @@ public abstract class TensorGenerator {
                         : TensorFlowTypes.RAGGED_SPEC_SHAPE);
         PointerKey shapePK = builder.getPointerKeyForInstanceField(instanceKey, shapeField);
         OrdinalSet<InstanceKey> shapePts = pointerAnalysis.getPointsToSet(shapePK);
-        ret.addAll(this.getShapesFromShapeArgument(builder, shapePts));
-      } else
-        throw new IllegalStateException(
-            "Expected a " + list + " or " + tuple + " for the shape, but got: " + reference + ".");
+        if (shapePts == null || shapePts.isEmpty()) return null;
+        Set<List<Dimension<?>>> specShapes = this.getShapesFromShapeArgument(builder, shapePts);
+        if (specShapes == null) return null;
+        ret.addAll(specShapes);
+      } else {
+        LOGGER.fine(
+            "Unrecognized shape-argument allocation: "
+                + reference
+                + " for source "
+                + this.getSource()
+                + "; returning null (⊤).");
+        return null;
+      }
     }
 
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -256,15 +256,20 @@ public abstract class TensorGenerator {
    * empty or {@code null} &mdash; that's a caller-contract violation (callers should check for
    * empty PTS before invoking this helper), distinct from "shape was a runtime tensor".
    *
-   * <p>Returns {@code null} (lattice ⊤) for sub-parse failures during recursive descent: when a
-   * recognized container's nested elements have empty PTS, when a {@code tf.constant} value PTS is
-   * empty after the call-site walk, when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes
-   * #TENSOR_SPEC} or {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC}
-   * shape field has empty PTS, or when a recursive call on any of these returns {@code null}. This
-   * is distinct from the strict-throw contract for unrecognized top-level forms above: the throw
-   * signals "this kind of shape isn't modeled at all"; the {@code null} returns signal "this
-   * shape's structure is recognized but the leaves aren't statically resolvable" (a soundness ⊤
-   * appropriate for the lattice).
+   * <p>Returns {@code null} (lattice ⊤) for sub-parse failures during recursive descent on the
+   * cases this PR converts: when a {@code tf.constant} value PTS is empty after the call-site walk,
+   * when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#TENSOR_SPEC} or {@link
+   * com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC} shape field has empty
+   * PTS, or when a recursive call on any of these returns {@code null}. This is distinct from the
+   * strict-throw contract for unrecognized top-level forms above: the throw signals "this kind of
+   * shape isn't modeled at all"; the {@code null} returns signal "this shape's structure is
+   * recognized but the leaves aren't statically resolvable" (a soundness ⊤ appropriate for the
+   * lattice).
+   *
+   * <p>Out of scope of this PR: the list/tuple branch with empty element PTS still returns an empty
+   * result set rather than {@code null}, which means callers can't distinguish "list with
+   * unresolved element" from "no shape recovered" at that path. Tracked at <a
+   * href="https://github.com/wala/ML/issues/504">wala/ML#504</a>.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?

--- a/com.ibm.wala.cast.python.test/data/tf2_test_broadcast_to_runtime_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_broadcast_to_runtime_shape.py
@@ -1,0 +1,23 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Regression guard for the `tf.broadcast_to(x, tf.shape(y))` shape-arg
+# pattern. At runtime, `z` has shape (2, 3) of float32. The analyzer's
+# `getShapesFromShapeArgument` helper doesn't recognize a runtime-tensor
+# `shape` arg (it expects a list/tuple/tf.constant/TensorSpec), so it
+# throws `IllegalStateException`. PR ponder-lab/ML#245 localizes the
+# tolerance to `BroadcastTo.getDefaultShapes` via a try/catch that
+# returns null (lattice ⊤, "tensor of unknown shape") rather than
+# aborting the analysis. This fixture fires that catch path; without
+# the catch, analysis aborts and the JUnit test fails.
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.constant([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+z = tf.broadcast_to(x, tf.shape(y))
+assert isinstance(z, tf.Tensor)
+assert z.shape == (2, 3)
+assert z.dtype == tf.float32
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
@@ -2,14 +2,15 @@
 #
 # At runtime, `z` has shape (2, 3) of float32. Post the wala/ML#489 root-cause fix on this
 # PR's `tensorflow.xml` (separating `tf.shape`'s allocation from `pass_through` aliasing),
-# the malformed compound-dim shape that previously surfaced here is gone. The analyzer now
-# produces a union of the input x's shape ((6,)) and a scalar — neither the precise (2, 3)
-# answer nor a sound ⊤, but no longer malformed. Reshape doesn't have a try/catch around the
-# helper (unlike BroadcastTo), so the exception propagates to upstream fallback paths.
+# `tf.shape(y)` allocates a fresh `Ltensorflow/python/framework/ops/Tensor` whose static
+# shape `getShapesFromShapeArgument` doesn't recognize. `Reshape` doesn't localize the
+# resulting `IllegalStateException` (unlike `BroadcastTo`), per this PR's keep-throw-
+# everywhere-except-BroadcastTo design, so the exception aborts the analysis on this fixture.
 #
-# The corresponding JUnit test asserts the currently-observed shape with a TODO referencing
-# #489; when Reshape gains a precise composer or a try/catch, the assertion will start
-# failing and the TODO is the cue to tighten it.
+# The corresponding JUnit test (`testReshapeRuntimeShape`) is annotated
+# `@Test(expected = IllegalStateException.class)` with a TODO referencing #489. When `Reshape`
+# gains a precise composer or a localized try/catch, the suppression lifts and the test
+# starts asserting the precise shape (or ⊤) instead.
 import tensorflow as tf
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
@@ -1,0 +1,21 @@
+# Regression guard for `tf.reshape(x, tf.shape(y))` shape inference (wala/ML#489).
+#
+# At runtime, `z` has shape (2, 3) of float32. The analyzer currently produces a malformed
+# compound-dim shape (`[Compound,[Constant,0, Constant,0, Constant,0], ...]`) instead of
+# either the precise (2, 3) answer or a sound ⊤ (null shape). The corresponding JUnit test
+# is suppressed with `@Test(expected = AssertionError.class)` and a TODO referencing #489;
+# when modeling lands, flip the suppression to plain `@Test`.
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+y = tf.constant([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])  # shape (2, 3)
+z = tf.reshape(x, tf.shape(y))  # runtime: shape (2, 3) of float32
+assert isinstance(z, tf.Tensor)
+assert z.shape == (2, 3)
+assert z.dtype == tf.float32
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
@@ -1,11 +1,15 @@
 # Regression guard for `tf.reshape(x, tf.shape(y))` shape inference (wala/ML#489).
 #
-# At runtime, `z` has shape (2, 3) of float32. The analyzer currently produces a malformed
-# compound-dim shape (`[Compound,[Constant,0, Constant,0, Constant,0], ...]`) instead of
-# either the precise (2, 3) answer or a sound ⊤ (null shape). The corresponding JUnit test
-# (`testReshapeRuntimeShape`) asserts the currently-observed malformed shape with a TODO
-# referencing #489; when the modeling lands, the assertion will start failing and the TODO
-# is the cue to tighten it to the precise post-fix shape.
+# At runtime, `z` has shape (2, 3) of float32. Post the wala/ML#489 root-cause fix on this
+# PR's `tensorflow.xml` (separating `tf.shape`'s allocation from `pass_through` aliasing),
+# the malformed compound-dim shape that previously surfaced here is gone. The analyzer now
+# produces a union of the input x's shape ((6,)) and a scalar — neither the precise (2, 3)
+# answer nor a sound ⊤, but no longer malformed. Reshape doesn't have a try/catch around the
+# helper (unlike BroadcastTo), so the exception propagates to upstream fallback paths.
+#
+# The corresponding JUnit test asserts the currently-observed shape with a TODO referencing
+# #489; when Reshape gains a precise composer or a try/catch, the assertion will start
+# failing and the TODO is the cue to tighten it.
 import tensorflow as tf
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_runtime_shape.py
@@ -3,8 +3,9 @@
 # At runtime, `z` has shape (2, 3) of float32. The analyzer currently produces a malformed
 # compound-dim shape (`[Compound,[Constant,0, Constant,0, Constant,0], ...]`) instead of
 # either the precise (2, 3) answer or a sound ⊤ (null shape). The corresponding JUnit test
-# is suppressed with `@Test(expected = AssertionError.class)` and a TODO referencing #489;
-# when modeling lands, flip the suppression to plain `@Test`.
+# (`testReshapeRuntimeShape`) asserts the currently-observed malformed shape with a TODO
+# referencing #489; when the modeling lands, the assertion will start failing and the TODO
+# is the cue to tighten it to the precise post-fix shape.
 import tensorflow as tf
 
 


### PR DESCRIPTION
Addresses (without closing) [wala/ML#471](https://github.com/wala/ML/issues/471).

## Summary

[`TensorGenerator.getShapesFromShapeArgument`](https://github.com/ponder-lab/ML/blob/master/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java) throws `IllegalStateException` when the shape-argument PTS contains forms it doesn't recognize (runtime tensors like `tf.shape(y)`, opaque builder objects, anything that's not list/tuple, `tf.constant`, `TensorSpec`, or `RaggedTensorSpec`). On `tf.broadcast_to(x, tf.shape(y))` and similar, the exception aborts the analysis on otherwise-valid programs.

This PR localizes the tolerance to the single caller (`BroadcastTo`) where the runtime-tensor `shape` arg is the legitimate use case, leaving the helper's strict throw intact for every other caller. `BroadcastTo.getDefaultShapes` wraps the helper call in a local `try/catch` that returns `null` (⊤ &mdash; "tensor of unknown shape") on `IllegalStateException`.

In addition, several helper-internal recursive descent paths (`tf.constant` value PTS, `TensorSpec` / `RaggedTensorSpec` shape PTS, recursive null returns) now return `null` rather than building partial shapes when sub-parse fails &mdash; a soundness fix that prevents the parent code from constructing malformed compound dimensions when a recursive call surfaces an unparseable element. The new contract is documented on the helper's `@return` tag.

Also folds in the wala/ML#489 root-cause fix: `tf.shape` now allocates a fresh `Ltensorflow/python/framework/ops/Tensor` rather than aliasing through `pass_through`, so the helper's else-branch fires cleanly for the unrecognized type instead of mis-parsing the input's data as a shape spec.

## Why Not Change the Helper's Contract Globally?

Initial design considered converting the helper to return `null` instead of throwing, so all eleven callers would benefit symmetrically. We're keeping the throw because the strict-mode signal is load-bearing: an `IllegalStateException` from this helper means "missing or incorrect modeling of a shape form," and silencing it with a global return-`null` would suppress the signal across the whole generator surface during development. The narrower fix &mdash; tolerate it only at the one call site where the runtime-tensor case is expected &mdash; preserves the strict signal everywhere else.

The deeper helper-contract refactor stays open as wala/ML#471; this PR is the minimal fix to unblock `tf.broadcast_to` with a runtime-tensor `shape`.

## Known Limitations Out Of Scope

- The list/tuple branch of `getShapesFromShapeArgument` still returns an empty result set rather than `null` when an element field's PTS is empty &mdash; documented contract says it should return `null` (⊤) but the code yields ⊥. Caller-visible distinction between "list with unresolved element" and "no shape recovered" is lost at that path. Tracked at wala/ML#504.
- Coverage on the new null-guard return paths in callers (`Reshape`, `NdarrayReshape`, `ReduceMean`, `FlowFromDirectoryGenerator`, `SparseAdd`, `DatasetFromGeneratorGenerator`) is 0&ndash;50% on the patch &mdash; the guards are correctness fixes that fire only when the helper returns `null` from its new sub-parse paths, which existing fixtures don't construct (PA-empty-PTS scenarios are awkward to build from user-level Python). Tracked at wala/ML#503; that issue captures the fixture work needed to close the gap.
- `tf.shape`'s result is allocated as an opaque `Ltensorflow/python/framework/ops/Tensor` of unknown dtype/rank. Tightening to int32 dtype + rank-1 shape on the result is part of the broader wala/ML#473 runtime-tensor-precision umbrella.

## Test Plan

- [x] Full ML test suite passes locally.
- [ ] CI confirms.