### PR TITLE
Honor `output_type=tf.int32` in `Argmax` / `Argmin` generators

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4500,8 +4500,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Counterpart of {@link #testArgmax()} for {@code tf.math.argmin}. Same semantics: dtype is fixed
-   * at {@code int64}, shape is left at ⊤. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
+   * Counterpart of {@link #testArgmax()} for {@code tf.math.argmin}. Same semantics: dtype defaults
+   * to {@code int64} (overridable via {@code output_type}, see {@link #testArgminOutputType()}),
+   * shape is left at ⊤. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
    *
    * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): output shape is left
    * at ⊤; same {@code ElementWiseOperation} cartesian-pair driver as for {@link #testArgmax()}.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4513,7 +4513,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Verifies that {@code tf.math.argmax(x, axis=0, output_type=tf.int32)} honors the explicit
    * {@code output_type} override and emits an {@code int32}-dtype tensor instead of the {@code
    * int64} default. Exercises the dtype-arg dispatch path on {@link
-   * com.ibm.wala.cast.python.ml.client.Argmax} after the wala/ML#463 fix.
+   * com.ibm.wala.cast.python.ml.client.Argmax} after the wala/ML#463 fix. The fixture's sink {@code
+   * f(x, y)} has two parameters so that each tensor's inferred type can be checked independently.
+   *
+   * <p>Shape on {@code y} (parameter index {@code 3}) is currently ⊤: precise axis-aware shape
+   * composition would require reading {@code input.shape[:axis] + input.shape[axis+1:]}, which
+   * regresses {@code testNeuralNetwork*} via the {@code ElementWiseOperation} cartesian-pair issue
+   * tracked in wala/ML#462. Captured-imprecise per the prefer-observed-assertion convention;
+   * tighten to a precise {@code (3,) int32} once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -4524,7 +4531,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testArgmaxOutputType()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_argmax_output_type.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+        "tf2_test_argmax_output_type.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_2_3_FLOAT32),
+            3, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
   }
 
   /**
@@ -4541,7 +4554,55 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testArgminOutputType()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_argmin_output_type.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+        "tf2_test_argmin_output_type.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_2_3_FLOAT32),
+            3, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Companion to {@link #testArgmaxOutputType()} that exercises the *single-parameter sink, two
+   * call sites* shape: {@code def f(a): ...; f(x); f(y)}. Parameter {@code a} should union {@code
+   * x}'s and {@code y}'s tensor types across the two call sites &mdash; verifies that the {@code
+   * output_type=tf.int32} override on {@code y} survives the second sink call rather than being
+   * clobbered by the {@code int64} default.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgmaxOutputTypeDoubleSink()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmax_output_type_double_sink.py",
+        "f",
+        1,
+        2,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Counterpart of {@link #testArgmaxOutputTypeDoubleSink()} for {@code tf.math.argmin}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgminOutputTypeDoubleSink()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmin_output_type_double_sink.py",
+        "f",
+        1,
+        2,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
   }
 
   // wala/ML#449 Tier 7: linspace/broadcast_to. Shape derives from a shape-arg (`num`/`shape`),

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4543,7 +4543,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Counterpart of {@link #testArgmaxOutputType()} for {@code tf.math.argmin}. Same dispatch path
    * via the inherited {@link com.ibm.wala.cast.python.ml.client.Argmin} extends {@link
-   * com.ibm.wala.cast.python.ml.client.Argmax} relationship.
+   * com.ibm.wala.cast.python.ml.client.Argmax} relationship; same shape-imprecision driver too.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the inferred ⊤ shape
+   * on {@code y} (vn=3) is imprecise &mdash; precise axis-aware shape composition for {@code
+   * Argmin} is gated by the {@code ElementWiseOperation} cartesian-pair issue, same as for {@code
+   * Argmax}. Tighten to the precise post-fix shape once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -4570,6 +4575,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * output_type=tf.int32} override on {@code y} survives the second sink call rather than being
    * clobbered by the {@code int64} default.
    *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the {@code y}
+   * contribution to the union is currently ⊤-shape ({@code TENSOR_INT32_UNKNOWN_SHAPE}) for the
+   * same reason as {@link #testArgmaxOutputType()} &mdash; gated by the {@code
+   * ElementWiseOperation} cartesian-pair issue. Tighten {@code y}'s contribution to its precise
+   * post-fix shape (a {@code (3,) int32}) once #462 lands.
+   *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
    * @throws CancelException if the analysis is cancelled.
@@ -4587,7 +4598,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Counterpart of {@link #testArgmaxOutputTypeDoubleSink()} for {@code tf.math.argmin}.
+   * Counterpart of {@link #testArgmaxOutputTypeDoubleSink()} for {@code tf.math.argmin}; same
+   * shape-imprecision driver.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the {@code y}
+   * contribution to the union is currently ⊤-shape ({@code TENSOR_INT32_UNKNOWN_SHAPE}) for the
+   * same reason as {@link #testArgmaxOutputTypeDoubleSink()}. Tighten to the precise {@code (3,)
+   * int32} once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -340,6 +340,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
+  private static final TensorType TENSOR_INT32_UNKNOWN_SHAPE = new TensorType(INT_32, null);
+
   private static final TensorType TENSOR_UNKNOWN_SHAPE_BOOL = new TensorType(BOOL, null);
 
   private static final TensorType TENSOR_3_INT32 =
@@ -4505,6 +4507,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testArgmin()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Verifies that {@code tf.math.argmax(x, axis=0, output_type=tf.int32)} honors the explicit
+   * {@code output_type} override and emits an {@code int32}-dtype tensor instead of the {@code
+   * int64} default. Exercises the dtype-arg dispatch path on {@link
+   * com.ibm.wala.cast.python.ml.client.Argmax} after the wala/ML#463 fix.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgmaxOutputType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmax_output_type.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Counterpart of {@link #testArgmaxOutputType()} for {@code tf.math.argmin}. Same dispatch path
+   * via the inherited {@link com.ibm.wala.cast.python.ml.client.Argmin} extends {@link
+   * com.ibm.wala.cast.python.ml.client.Argmax} relationship.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgminOutputType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmin_output_type.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
   }
 
   // wala/ML#449 Tier 7: linspace/broadcast_to. Shape derives from a shape-arg (`num`/`shape`),

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4480,8 +4480,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Verifies that {@code tf.math.argmax(x, axis=0)} routes through the dedicated {@link
    * com.ibm.wala.cast.python.ml.client.Argmax} generator and emits the precise {@code int64} dtype
-   * (the TF default for argmax indices). Output shape is left at ⊤ in this Tier 6 PR — see
-   * wala/ML#462 for why.
+   * (the TF default for argmax indices).
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): output shape is left
+   * at ⊤. Precise axis-aware shape composition (reading {@code input.shape[:axis] +
+   * input.shape[axis+1:]}) regresses {@code testNeuralNetwork*} via the {@code
+   * ElementWiseOperation} cartesian-pair issue tracked at #462. Tighten to the precise post-fix
+   * shape once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -4497,6 +4502,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Counterpart of {@link #testArgmax()} for {@code tf.math.argmin}. Same semantics: dtype is fixed
    * at {@code int64}, shape is left at ⊤. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): output shape is left
+   * at ⊤; same {@code ElementWiseOperation} cartesian-pair driver as for {@link #testArgmax()}.
+   * Tighten to the precise post-fix shape once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -4516,11 +4525,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * com.ibm.wala.cast.python.ml.client.Argmax} after the wala/ML#463 fix. The fixture's sink {@code
    * f(x, y)} has two parameters so that each tensor's inferred type can be checked independently.
    *
-   * <p>Shape on {@code y} (parameter index {@code 3}) is currently ⊤: precise axis-aware shape
-   * composition would require reading {@code input.shape[:axis] + input.shape[axis+1:]}, which
-   * regresses {@code testNeuralNetwork*} via the {@code ElementWiseOperation} cartesian-pair issue
-   * tracked in wala/ML#462. Captured-imprecise per the prefer-observed-assertion convention;
-   * tighten to a precise {@code (3,) int32} once #462 lands.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the inferred ⊤ shape
+   * on {@code y} (vn=3) is imprecise &mdash; precise axis-aware shape composition (reading {@code
+   * input.shape[:axis] + input.shape[axis+1:]}) regresses {@code testNeuralNetwork*} via the {@code
+   * ElementWiseOperation} cartesian-pair issue tracked at #462. Captured-imprecise per the
+   * prefer-observed-assertion convention; tighten to a precise {@code (3,) int32} once #462 lands.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -943,16 +943,16 @@
         </method>
       </class>
       <class name="argmax" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator emits `int64` (the TF default) for the output dtype; output shape is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for
-          `axis`) is retained in `paramNames`; the modern `output_type` parameter isn't surfaced here yet — wala/ML#463 covers the migration. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator reads the `output_type` argument when explicitly passed (e.g. `output_type=tf.int32`) and falls back to the TF default of `int64` otherwise; output shape
+          is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for `axis`) is retained in `paramNames` for back-compat. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="argmin" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same direct `<new>+<return>` per wala/ML#380, same `int64` output dtype via the dedicated `Argmin` generator). -->
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same direct `<new>+<return>` per wala/ML#380, same `output_type`-overrideable output dtype via the dedicated `Argmin` generator). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -2,26 +2,76 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
 /**
- * Generator for {@code tf.math.argmax}. Output dtype is fixed at {@link DType#INT64} (the TF
- * default; the {@code output_type=tf.int32} alternative isn't currently surfaced through {@code
- * tensorflow.xml}, so the generator emits {@code int64} unconditionally). Output shape is left at ⊤
- * for now; computing the precise shape (input.shape with the {@code axis} dimension removed)
- * regresses tests such as {@code testNeuralNetwork*}, where the per-context shape union for {@code
- * y_true} (e.g. {@code [256]} train vs. {@code [10000]} test) cross-products through {@code
+ * Generator for {@code tf.math.argmax}. Output dtype defaults to {@link DType#INT64} (the TF
+ * default); when the call passes an explicit {@code output_type} argument (e.g. {@code
+ * output_type=tf.int32}), the inherited dtype-arg machinery in {@link TensorGenerator#getDTypes}
+ * resolves it via {@link #getDTypeParameterPosition} / {@link #getDTypeParameterName} and uses the
+ * resolved dtype instead of the default — fix for <a
+ * href="https://github.com/wala/ML/issues/463">wala/ML#463</a>. Output shape is left at ⊤ for now;
+ * computing the precise shape (input.shape with the {@code axis} dimension removed) regresses tests
+ * such as {@code testNeuralNetwork*}, where the per-context shape union for {@code y_true} (e.g.
+ * {@code [256]} train vs. {@code [10000]} test) cross-products through {@code
  * ElementWiseOperation}'s strict broadcast check. Shape precision can be added once the EWO union
- * behaviour is addressed (wala/ML#462). See wala/ML#449 (Tier 6).
+ * behaviour is addressed (<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>). See <a
+ * href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 6).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/argmax">tf.math.argmax</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class Argmax extends ReduceMean {
+
+  /**
+   * Parameter positions and keyword names for {@code tf.math.argmax(input, axis=None,
+   * output_type=tf.dtypes.int64, name=None)}. Ordinals match the position in {@code
+   * tensorflow.xml}'s {@code paramNames} after the implicit {@code self} receiver, so {@code
+   * Parameters.INPUT.getIndex() == 0} resolves to the first user-facing positional argument. The
+   * trailing {@code DIMENSION} entry preserves back-compat with the deprecated TF 1.x alias for
+   * {@code axis}.
+   */
+  protected enum Parameters {
+    /** The tensor to scan; the index of its max element along {@code axis} is returned. */
+    INPUT,
+
+    /** The axis along which to scan; defaults to {@code None}. */
+    AXIS,
+
+    /** Optional dtype override for the index output (defaults to {@code int64}). */
+    OUTPUT_TYPE,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME,
+
+    /** TF 1.x alias for {@code axis}; retained for back-compat. */
+    DIMENSION;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers when the call site uses {@code
+     * keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "output_type"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
 
   public Argmax(PointsToSetVariable source) {
     super(source);
@@ -32,13 +82,51 @@ public class Argmax extends ReduceMean {
     return null;
   }
 
-  // `getDefaultDTypes` is intentionally not overridden: the parent's `getDTypes(builder)` (which
-  // dispatches to `getDefaultDTypes` when there is no dtype argument) is itself overridden here to
-  // return INT64 unconditionally, bypassing the dtype-arg path entirely. Overriding
-  // `getDefaultDTypes` would be dead code.
+  /**
+   * The default output dtype when no {@code output_type} argument is passed. {@link
+   * TensorGenerator#getDTypes} dispatches here only when the dtype-arg path returns no resolved
+   * dtype, so this is the fallback. TF 2.9 default is {@code int64}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code EnumSet.of(DType.INT64)}.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.INT64);
+  }
 
   @Override
+  protected int getDTypeParameterPosition() {
+    return Parameters.OUTPUT_TYPE.getIndex();
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return Parameters.OUTPUT_TYPE.getName();
+  }
+
+  /**
+   * Bypasses {@link ReduceMean#getDTypes} (which inherits from the input tensor's dtype) by
+   * inlining the canonical {@link TensorGenerator#getDTypes} dispatch: read the {@code output_type}
+   * argument if present, otherwise fall back to {@link #getDefaultDTypes}. {@code argmax} produces
+   * an integer index regardless of input dtype, so the input-dtype path is never the right answer
+   * here.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The output dtype: the resolved {@code output_type} when explicitly passed, or {@code
+   *     int64} (the TF default) otherwise.
+   */
+  @Override
   protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
-    return EnumSet.of(DType.INT64);
+    int valNum =
+        this.getArgumentValueNumber(
+            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName(), true);
+    if (valNum <= 0) return this.getDefaultDTypes(builder);
+
+    OrdinalSet<InstanceKey> pointsToSet =
+        this.getArgumentPointsToSet(
+            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName());
+    if (pointsToSet == null || pointsToSet.isEmpty()) return this.getDefaultDTypes(builder);
+    return this.getDTypesFromDTypeArgument(builder, pointsToSet);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -8,14 +8,18 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.math.argmax}. Output dtype defaults to {@link DType#INT64} (the TF
  * default); when the call passes an explicit {@code output_type} argument (e.g. {@code
- * output_type=tf.int32}), the inherited dtype-arg machinery in {@link TensorGenerator#getDTypes}
- * resolves it via {@link #getDTypeParameterPosition} / {@link #getDTypeParameterName} and uses the
- * resolved dtype instead of the default — fix for <a
+ * output_type=tf.int32}), the canonical dtype-arg dispatch from {@link TensorGenerator#getDTypes}
+ * is inlined here (in this class's {@link #getDTypes} override; see its Javadoc) to bypass {@link
+ * ReduceMean#getDTypes}, which would otherwise inherit the input tensor's dtype &mdash; the wrong
+ * answer for argmax, which always returns an integer index. The override resolves the {@code
+ * output_type} argument via {@link #getDTypeParameterPosition} / {@link #getDTypeParameterName} and
+ * uses it instead of the default &mdash; fix for <a
  * href="https://github.com/wala/ML/issues/463">wala/ML#463</a>. Output shape is left at ⊤ for now;
  * computing the precise shape (input.shape with the {@code axis} dimension removed) regresses tests
  * such as {@code testNeuralNetwork*}, where the per-context shape union for {@code y_true} (e.g.
@@ -55,12 +59,14 @@ public class Argmax extends ReduceMean {
 
     /**
      * Lowercase keyword name used in argument-resolution helpers when the call site uses {@code
-     * keyword=value} syntax.
+     * keyword=value} syntax. Uses {@link Locale#ROOT} so the conversion is locale-stable (a
+     * Turkish-locale JVM lowercasing {@code DIMENSION} would otherwise produce {@code dımensıon}
+     * with dotless {@code ı}, breaking keyword lookup for {@code dimension}).
      *
      * @return The lowercased enum name (e.g. {@code "output_type"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
 
-def f(a):
+def f(x, y):
     pass
 
 
@@ -11,8 +11,11 @@ def f(a):
 # `tensorflow.xml`'s `paramNames` and routes through the inherited
 # dtype-arg machinery.
 x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+assert x.shape == (2, 3)
+assert x.dtype == tf.float32
 y = tf.math.argmax(x, axis=0, output_type=tf.int32)
 assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
 assert y.dtype == tf.int32
 
-f(y)
+f(x, y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Drives the `output_type=tf.int32` branch of `Argmax.getDTypes`. Default
+# argmax output dtype is `int64`; passing `output_type=tf.int32` should
+# override it to `int32`. The static analysis reads `output_type` from
+# `tensorflow.xml`'s `paramNames` and routes through the inherited
+# dtype-arg machinery.
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.argmax(x, axis=0, output_type=tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.dtype == tf.int32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type_double_sink.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type_double_sink.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Companion to `tf2_test_argmax_output_type.py` — exercises the
+# *single-parameter sink, two call sites* shape: parameter `a` should
+# union `x`'s and `y`'s tensor types across the two call sites. With
+# `output_type=tf.int32`, the union is `{(2, 3) float32, ? int32}`.
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+assert x.shape == (2, 3)
+assert x.dtype == tf.float32
+y = tf.math.argmax(x, axis=0, output_type=tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int32
+
+f(x)
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmin_output_type.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmin_output_type.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Counterpart of `tf2_test_argmax_output_type.py` for `tf.math.argmin`.
+# `Argmin` extends `Argmax`, so the same `output_type` machinery applies.
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+y = tf.math.argmin(x, axis=0, output_type=tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.dtype == tf.int32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmin_output_type_double_sink.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmin_output_type_double_sink.py
@@ -1,12 +1,11 @@
 import tensorflow as tf
 
 
-def f(x, y):
+def f(a):
     pass
 
 
-# Counterpart of `tf2_test_argmax_output_type.py` for `tf.math.argmin`.
-# `Argmin` extends `Argmax`, so the same `output_type` machinery applies.
+# Counterpart of `tf2_test_argmax_output_type_double_sink.py` for `tf.math.argmin`.
 x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 assert x.shape == (2, 3)
 assert x.dtype == tf.float32
@@ -15,4 +14,5 @@ assert isinstance(y, tf.Tensor)
 assert y.shape == (3,)
 assert y.dtype == tf.int32
 
-f(x, y)
+f(x)
+f(y)


### PR DESCRIPTION
## Summary

Fixes [wala/ML#463](https://github.com/wala/ML/issues/463).

`tf.math.argmax` / `tf.math.argmin` accept an `output_type` keyword that overrides the default `int64` index dtype with `int32` (the only other accepted value per the TF 2.9 docs). The XML modeling and the `Argmax` Java generator both ignored this argument: the XML didn't include `output_type` in `paramNames`, so the analyzer couldn't even resolve the keyword; and `Argmax.getDTypes` returned `INT64` unconditionally regardless.

## Changes

- **XML** (`tensorflow.xml`): `argmax` and `argmin` blocks now expose `output_type` in `paramNames` (`numArgs=6`, position matching the TF 2.x signature `(input, axis, output_type, name)` — trailing `dimension` retained as the TF 1.x alias for `axis`).
- **Java** (`Argmax.java`):
  - Adds a `Parameters` enum mirroring the new XML positions.
  - Overrides `getDTypeParameterPosition` / `getDTypeParameterName` to point at `output_type`.
  - Replaces the `getDTypes` override that returned `INT64` unconditionally with `getDefaultDTypes` returning `INT64`; a targeted `getDTypes` override inlines the canonical `TensorGenerator.getDTypes` dispatch (read dtype-arg if present; fall back to `getDefaultDTypes`) — bypassing `ReduceMean`'s inherit-from-input dtype path, which is wrong for argmax (the output is an integer index regardless of input dtype).
  - `Argmin` inherits the new behavior unchanged via class extension.
- **Tests**: two new fixtures + JUnit tests (`testArgmaxOutputType`, `testArgminOutputType`) asserting the `int32` override; new `TENSOR_INT32_UNKNOWN_SHAPE` constant.

## Test Plan

- [x] Full ML test suite passes locally: `658 tests, 0 failures, 0 errors, 0 skipped`.
- [x] Existing `testArgmax` / `testArgmin` continue to pass — the new XML position for `output_type` doesn't break the absent-`output_type` defaults path.
- [x] New `testArgmaxOutputType` / `testArgminOutputType` pass.
- [x] Both Python fixtures run to completion under `python3.10` with the documented `tf.int32` runtime assertion.
- [ ] CI confirms.

## Why The `getDTypes` Override Inlines The Base Logic

`Argmax extends ReduceMean extends TensorGenerator`. `ReduceMean.getDTypes` is overridden to return the input tensor's dtype — correct for `tf.reduce_mean`, wrong for argmax (which always returns an integer regardless of input). To use the canonical `TensorGenerator.getDTypes` dispatch (which checks the dtype arg, then falls back to `getDefaultDTypes`), Argmax has to bypass `ReduceMean`'s override; Java doesn't allow `super.super.method()`, so the canonical logic is inlined in `Argmax.getDTypes` (a four-line read-arg-or-fall-back-to-default body). If the `Argmax` / `ReduceMean` hierarchy is ever revisited (e.g. via a unified-dispatch refactor under wala/ML#469), this duplication can be eliminated.

## Related

- [wala/ML#463](https://github.com/wala/ML/issues/463) — this PR's tracking issue.
- [wala/ML#449](https://github.com/wala/ML/issues/449) — Tier roadmap (this is part of the Tier 6 cleanup).
- [wala/ML#462](https://github.com/wala/ML/issues/462) — output-shape precision is still deferred (separate issue, not addressed here).
- [wala/ML#472](https://github.com/wala/ML/issues/472) — design discussion on `PassThroughUnaryTensorGenerator`'s fixed-dtype subclasses; this commit's pattern (override `getDefaultDTypes` to return a constant + override `getDType*` getters to expose the override arg) lines up with what `SequenceMask` would do once `dtype` is wired through.