### PR TITLE
Make `createManualGenerator`'s silent skip audible (dedup-per-type WARNING)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -162,14 +162,14 @@ public abstract class TensorGenerator {
    * garbage-collected. Safe to call more than once.
    *
    * @param builder The builder whose cache entries should be cleared.
+   * @implNote {@code WARNED_UNREGISTERED_MANUAL_TYPES} is intentionally <em>not</em> cleared here.
+   *     The dedup is at JVM scope so each unregistered type warns exactly once total &mdash;
+   *     re-warning per test would still flood logs (~1500 firings on the current suite). The set is
+   *     small and the goal is "make each gap audible once," not "track gaps per analysis."
    */
   public static void clearCaches(PropagationCallGraphBuilder builder) {
     SHAPES_CACHE.remove(builder);
     DTYPES_CACHE.remove(builder);
-    // Note: WARNED_UNREGISTERED_MANUAL_TYPES is intentionally NOT cleared per builder. The
-    // dedup is at JVM scope so each unregistered type warns exactly once total — re-warning
-    // per test would still flood logs (~1500 firings on the current suite). The set is small
-    // and the goal is "make each gap audible once," not "track gaps per analysis."
   }
 
   /** The source of the tensor, represented by a points-to set variable. */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -162,7 +162,7 @@ public abstract class TensorGenerator {
    * garbage-collected. Safe to call more than once.
    *
    * @param builder The builder whose cache entries should be cleared.
-   * @implNote {@code WARNED_UNREGISTERED_MANUAL_TYPES} is intentionally <em>not</em> cleared here.
+   * @implNote {@link #WARNED_UNREGISTERED_MANUAL_TYPES} is intentionally <em>not</em> cleared here.
    *     The dedup is at JVM scope so each unregistered type warns exactly once total &mdash;
    *     re-warning per test would still flood logs (~1500 firings on the current suite). The set is
    *     small and the goal is "make each gap audible once," not "track gaps per analysis."

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +166,10 @@ public abstract class TensorGenerator {
   public static void clearCaches(PropagationCallGraphBuilder builder) {
     SHAPES_CACHE.remove(builder);
     DTYPES_CACHE.remove(builder);
+    // Note: WARNED_UNREGISTERED_MANUAL_TYPES is intentionally NOT cleared per builder. The
+    // dedup is at JVM scope so each unregistered type warns exactly once total — re-warning
+    // per test would still flood logs (~1500 firings on the current suite). The set is small
+    // and the goal is "make each gap audible once," not "track gaps per analysis."
   }
 
   /** The source of the tensor, represented by a points-to set variable. */
@@ -2872,6 +2877,45 @@ public abstract class TensorGenerator {
     } else if (type.equals(TensorFlowTypes.INPUT.getDeclaringClass())) {
       return new Input(node);
     }
+    // Unregistered type: the manual-walker dispatch table doesn't know about this op, so the
+    // caller will treat the null return as "no contribution" and silently lose precision on
+    // anything reached through this node. The factory-side dispatch
+    // (`TensorGeneratorFactory.getGeneratorBody`) may still cover this type — the two tables
+    // aren't yet unified (wala/ML#469); audit both when this fires for an op we expect to model.
+    // Logged at WARNING (deduplicated per type, see `WARNED_UNREGISTERED_MANUAL_TYPES`) per
+    // wala/ML#468 to make the silent-skip audible without flooding logs when the same op is hit
+    // many times within one analysis.
+    final TypeReference unregisteredType = type;
+    if (WARNED_UNREGISTERED_MANUAL_TYPES.add(unregisteredType.getName().toString())) {
+      LOGGER.warning(
+          () ->
+              "createManualGenerator: no manual generator registered for type "
+                  + unregisteredType.getName()
+                  + " (first occurrence; further calls for this type are silent). Treating as"
+                  + " no contribution; this is likely a wala/ML#468 / wala/ML#469 gap in the"
+                  + " manual-walker dispatch table. Add a case here if this op should be"
+                  + " modeled in manual-walker contexts.");
+    } else {
+      LOGGER.fine(
+          () ->
+              "createManualGenerator: no manual generator registered for type "
+                  + unregisteredType.getName()
+                  + " (already warned).");
+    }
     return null;
   }
+
+  /**
+   * De-duplication set for the wala/ML#468 unregistered-type WARNING in {@link
+   * #createManualGenerator(CGNode, PropagationCallGraphBuilder)}. Without dedup the WARNING fires
+   * per call site, which on the existing test suite produces ~1500 lines per analysis run —
+   * drowning the signal. Tracking already-warned type names keeps each new gap visible exactly once
+   * per JVM lifetime.
+   *
+   * <p>Intentionally JVM-scoped (not cleared by {@link #clearCaches}): the goal is to surface each
+   * gap once per JVM run, not once per analysis. Re-warning per test still floods logs because the
+   * same op gets hit by many tests.
+   */
+  private static final Set<String> WARNED_UNREGISTERED_MANUAL_TYPES =
+      Collections.synchronizedSet(new HashSet<>());
 }


### PR DESCRIPTION
## Summary

Fixes [wala/ML#468](https://github.com/wala/ML/issues/468) (the minimal layer; the structural unification is tracked separately at wala/ML#469).

`TensorGenerator.createManualGenerator(node, builder)` is a long if-else dispatch keyed by `node.getMethod().getDeclaringClass()`. When the type doesn't match any arm, it returns `null`. Callers treat `null` as "no contribution" and fall through silently, so any op reached through `Model.getWeightShapes`'s graph walk that isn't registered just disappears from the analysis. Pure silent precision loss with no log line or test failure.

This PR adds a WARNING-level log at the unregistered-type fall-through, deduplicated per type name via a JVM-scoped `Set<String>` so each unique gap warns exactly once. Naive WARNING per call site fires ~1500 times on the current test suite (drowning the signal); per-type dedup brings that to **33 unique gaps** — the actual count of ops the manual-walker doesn't model today. Each gap can be closed individually by adding the missing case to the dispatch table; the structural fix (unify factory + manual dispatch) is wala/ML#469.

## Why JVM-Scope Dedup, Not Per-Builder

`clearCaches` runs at the end of each analysis to release per-builder state. If the dedup set were cleared there, the same gap would re-warn for every test that hits it — re-flooding the logs. The dedup is intentionally JVM-scoped: each gap surfaces once per JVM lifetime, which is the right granularity for "make this gap audible." The set is small (≤ ~tens of type names) and bounded by the number of distinct ops in the codebase.

## Test Plan

- [x] Full ML test suite passes locally: `656 tests, 0 failures, 0 errors, 0 skipped`.
- [x] WARNING count: 1514 → 33 unique-per-type lines in a fresh suite run; each names a distinct unregistered TF/numpy/keras op.
- [ ] CI confirms.

## What The 33 Gaps Look Like

When you read the test logs after this lands, you'll see one WARNING per gap, e.g. (sample inferred from wala/ML#468's "concrete instances" list — actual log will show real types):

```
createManualGenerator: no manual generator registered for type Ltensorflow/functions/linspace
  (first occurrence; further calls for this type are silent). Treating as no contribution; this
  is likely a wala/ML#468 / wala/ML#469 gap in the manual-walker dispatch table. Add a case here
  if this op should be modeled in manual-walker contexts.
```

A separate audit/follow-up issue can list out the 33 gaps and prioritize which ones to close first — but that's out of scope here.

## Related

- [wala/ML#468](https://github.com/wala/ML/issues/468) — the tracking issue (minimal layer).
- [wala/ML#469](https://github.com/wala/ML/issues/469) — structural unification of factory + manual dispatch (eliminates this whole class of gap).
- [wala/ML#470](https://github.com/wala/ML/issues/470) — coverage meta-test that would catch the same gap at compile/test time.