### PR TITLE
Demote `LOGGER.info` diagnostics to `LOGGER.fine` (wala/ML#415)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -77,7 +77,7 @@ public class Input extends Ones {
       // Fallback to default.
       return this.getDefaultDTypes(builder);
 
-    LOGGER.info("Found possible dtypes: " + pointsToSet + " for source: " + this.getSource() + ".");
+    LOGGER.fine("Found possible dtypes: " + pointsToSet + " for source: " + this.getSource() + ".");
     return this.getDTypesFromDTypeArgument(builder, pointsToSet);
   }
 
@@ -96,10 +96,10 @@ public class Input extends Ones {
               builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
       if (shapePts == null || shapePts.isEmpty()) {
-        LOGGER.info("No shapes found for source: " + this.getSource() + "; using default shapes.");
+        LOGGER.fine("No shapes found for source: " + this.getSource() + "; using default shapes.");
         shapes = this.getDefaultShapes(builder);
       } else {
-        LOGGER.info(
+        LOGGER.fine(
             "Found possible shape points-to set: "
                 + shapePts
                 + " for source: "
@@ -108,7 +108,7 @@ public class Input extends Ones {
         shapes = this.getShapesFromShapeArgument(builder, shapePts);
       }
     } else {
-      LOGGER.info("No shapes found for source: " + this.getSource() + "; using default shapes.");
+      LOGGER.fine("No shapes found for source: " + this.getSource() + "; using default shapes.");
       shapes = this.getDefaultShapes(builder);
     }
 
@@ -124,7 +124,7 @@ public class Input extends Ones {
               builder, this.getBatchSizeParameterPosition(), this.getBatchSizeParameterName());
 
       if (batchSizePts == null || batchSizePts.isEmpty()) {
-        LOGGER.info(
+        LOGGER.fine(
             "Empty points-to set for batch_size argument in source: "
                 + this.getSource()
                 + "; assuming unknown.");
@@ -135,7 +135,7 @@ public class Input extends Ones {
 
     if (batchSizes.isEmpty()) batchSizes.add(null);
     else
-      LOGGER.info(
+      LOGGER.fine(
           "Found possible batch sizes: " + batchSizes + " for source: " + this.getSource() + ".");
 
     // If the base shape is ⊤ (unknown), the prepended batch dim doesn't recover enough info to
@@ -156,7 +156,7 @@ public class Input extends Ones {
         newShapes.add(newShape);
       }
 
-    LOGGER.info("Generated shapes: " + newShapes + " for source: " + source + ".");
+    LOGGER.fine("Generated shapes: " + newShapes + " for source: " + source + ".");
     return newShapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Ones.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Ones.java
@@ -50,7 +50,7 @@ public class Ones extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    LOGGER.info(
+    LOGGER.fine(
         "No dtype specified for source: " + source + ". Using default dtype of: " + FLOAT32 + " .");
 
     // Use the default dtype of float32.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -212,7 +212,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         } else if (inst instanceof SSABinaryOpInstruction) {
           // Binary operations (e.g. +, *) on tensors are also sources.
           sources.add(src);
-          LOGGER.info("Added dataflow source from binary op: " + src + ".");
+          LOGGER.fine("Added dataflow source from binary op: " + src + ".");
         } else if (inst instanceof EachElementGetInstruction) {
           // We are potentially pulling a tensor out of a tensor iterable.
           EachElementGetInstruction eachElementGetInstruction = (EachElementGetInstruction) inst;
@@ -220,12 +220,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           // Don't add the source if the container has elements in it. In that case, we want to add
           // the individual elements themselves as sources instead.
           if (definitionIsNonScalar(eachElementGetInstruction, du))
-            LOGGER.info(
+            LOGGER.fine(
                 "Definition of instruction: "
                     + eachElementGetInstruction
                     + " is non-scalar. Skipping...");
           else {
-            LOGGER.info(
+            LOGGER.fine(
                 "Definition of instruction: "
                     + eachElementGetInstruction
                     + " is scalar. Processing...");
@@ -314,12 +314,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           TensorGenerator generator = getGenerator(src, builder);
           LOGGER.fine(() -> "Found tensor generator: " + generator + " for source: " + src + ".");
           sources.add(src);
-          LOGGER.info("Added dataflow source from tensor generator: " + src + ".");
+          LOGGER.fine("Added dataflow source from tensor generator: " + src + ".");
           ret = true;
         } catch (IllegalArgumentException e) {
           // not a tensor source.
           LOGGER.log(Level.FINE, "Not a tensor source: " + methodName, e);
-          e.printStackTrace();
         }
       } else if (instruction.getNumberOfUses() > 1) {
         // Get the invoked function from the PA.
@@ -466,7 +465,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // First try intraprocedural analysis.
         if (definesTensorIterable(def, node, callGraph, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.info("Added dataflow source from tensor iterable: " + src + ".");
+          LOGGER.fine("Added dataflow source from tensor iterable: " + src + ".");
           return true;
         } else {
           // Use interprocedural analysis using the PA.
@@ -508,7 +507,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       PointsToSetVariable src,
       Set<PointsToSetVariable> sources,
       PointerAnalysis<InstanceKey> pointerAnalysis) {
-    LOGGER.info(
+    LOGGER.fine(
         () ->
             "Using interprocedural analysis to find potential tensor definition for use: "
                 + use
@@ -529,7 +528,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                 || reference.getName().toString().startsWith(DATA_PACKAGE_PREFIX))
             && isDatasetTensorElement(src, use, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.info("Added dataflow source from tensor dataset: " + src + ".");
+          LOGGER.fine("Added dataflow source from tensor dataset: " + src + ".");
           return true;
         }
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -83,7 +83,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
 
   @Override
   protected Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.info("Calculating shapes for RaggedFromNestedRowLengths.");
+    LOGGER.fine("Calculating shapes for RaggedFromNestedRowLengths.");
     // 1. Determine `nrows` and number of ragged dimensions from `nested_row_lengths`.
     // The number of rows is len(nested_row_lengths[0]).
     OrdinalSet<InstanceKey> nestedRowLengthsPts = this.getNestedStructurePointsToSet(builder);
@@ -93,7 +93,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
     Set<Integer> possibleK = HashSetFactory.make(); // Number of ragged dimensions.
 
     if (nestedRowLengthsPts != null && !nestedRowLengthsPts.isEmpty()) {
-      LOGGER.info(
+      LOGGER.fine(
           "Found " + nestedRowLengthsPts.size() + " points-to set(s) for nested_row_lengths.");
       for (InstanceKey ik : nestedRowLengthsPts) {
         if (ik instanceof AllocationSiteInNode) {
@@ -106,7 +106,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
                     ((AstPointerKeyFactory) builder.getPointerKeyFactory())
                         .getPointerKeyForObjectCatalog(asin));
             int k = objectCatalogPointsToSet.size();
-            LOGGER.info("Found nested_row_lengths list/tuple with length (K): " + k);
+            LOGGER.fine("Found nested_row_lengths list/tuple with length (K): " + k);
             possibleK.add(k);
 
             // Get the first element of nested_row_lengths to determine nrows.
@@ -125,7 +125,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
                   for (List<Dimension<?>> shape : shapesOfFirstElem) {
                     if (!shape.isEmpty()) {
                       Dimension<?> dim = shape.get(0);
-                      LOGGER.info("Found row dimension from first element: " + dim);
+                      LOGGER.fine("Found row dimension from first element: " + dim);
                       possibleRowDims.add(computeRowDim(dim));
                       foundRowDim = true;
                     }
@@ -158,11 +158,11 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
     Set<List<Dimension<?>>> valuesShapes = emptySet();
     if (valuesPts != null && !valuesPts.isEmpty()) {
       valuesShapes = this.getShapesOfValue(builder, valuesPts);
-      LOGGER.info("Found value shapes: " + valuesShapes);
+      LOGGER.fine("Found value shapes: " + valuesShapes);
     } else {
       valuesShapes = new java.util.HashSet<>();
       valuesShapes.add(emptyList());
-      LOGGER.info("No value shapes found, assuming empty list.");
+      LOGGER.fine("No value shapes found, assuming empty list.");
     }
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
@@ -195,7 +195,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
       throw new IllegalStateException("Could not calculate shapes for RaggedFromNestedRowLengths");
     }
 
-    LOGGER.info("Final calculated shapes: " + ret);
+    LOGGER.fine("Final calculated shapes: " + ret);
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -90,7 +90,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
 
   @Override
   protected Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.info("Calculating shapes for RaggedFromNestedValueRowIds.");
+    LOGGER.fine("Calculating shapes for RaggedFromNestedValueRowIds.");
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     // 1. Determine `nrows`.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -86,7 +86,7 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.info(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -86,7 +86,7 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.info(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -91,7 +91,7 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.info(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =
@@ -103,7 +103,7 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     }
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
-    LOGGER.info(
+    LOGGER.fine(
         () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -93,7 +93,7 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.info(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts = this.getValuesPointsToSet(builder);
@@ -103,7 +103,7 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     }
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
-    LOGGER.info(
+    LOGGER.fine(
         () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -144,7 +144,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
       }
     }
 
-    LOGGER.info(() -> "Possible value rowids for " + this.getSource() + ": " + ret + ".");
+    LOGGER.fine(() -> "Possible value rowids for " + this.getSource() + ": " + ret + ".");
     return ret;
   }
 
@@ -183,10 +183,10 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
         nrowsArgs = singleton(max + 1);
       }
       final Set<Long> finalNrowsArgs = nrowsArgs;
-      LOGGER.info(() -> "Inferred nrows for " + this.getSource() + ": " + finalNrowsArgs + ".");
+      LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalNrowsArgs + ".");
     } else {
       final Set<Long> finalNrowsArgs = nrowsArgs;
-      LOGGER.info(
+      LOGGER.fine(
           () -> "Found nrows arguments for " + this.getSource() + ": " + finalNrowsArgs + ".");
     }
 
@@ -216,7 +216,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
     }
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
-    LOGGER.info(
+    LOGGER.fine(
         () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -41,7 +41,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
     OrdinalSet<InstanceKey> valuesPts = getValuesPointsToSet(builder);
     if (valuesPts != null && !valuesPts.isEmpty()) {
       Set<DType> ret = this.getDTypesOfValue(builder, valuesPts);
-      LOGGER.info(() -> "Inferred dtypes from values for " + this.getSource() + ": " + ret + ".");
+      LOGGER.fine(() -> "Inferred dtypes from values for " + this.getSource() + ": " + ret + ".");
       return ret;
     }
     return EnumSet.of(DType.UNKNOWN);
@@ -58,7 +58,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
         shape.add(null); // Ragged dimension
         ret.add(shape);
       }
-      LOGGER.info(
+      LOGGER.fine(
           () -> "Determined default ragged shapes for " + this.getSource() + ": " + ret + ".");
       return ret;
     }
@@ -77,7 +77,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       }
     }
 
-    LOGGER.info(() -> "Determined final ragged shapes for " + this.getSource() + ": " + ret + ".");
+    LOGGER.fine(() -> "Determined final ragged shapes for " + this.getSource() + ": " + ret + ".");
     return ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -230,7 +230,7 @@ public abstract class TensorGenerator {
           ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
     }
 
-    LOGGER.info("Generator " + this.getClass().getSimpleName() + " produced types: " + ret);
+    LOGGER.fine("Generator " + this.getClass().getSimpleName() + " produced types: " + ret);
 
     return ret;
   }
@@ -347,7 +347,7 @@ public abstract class TensorGenerator {
                       + ".");
           }
 
-          LOGGER.info(
+          LOGGER.fine(
               "Found possible shape dimensions: "
                   + tensorDimensions
                   + " for field: "
@@ -1304,7 +1304,7 @@ public abstract class TensorGenerator {
         Object value = constantKey.getValue();
 
         if (value == null) {
-          LOGGER.info(
+          LOGGER.fine(
               "DType argument is None for source: "
                   + this.getSource()
                   + "; using default dtypes."
@@ -1345,7 +1345,7 @@ public abstract class TensorGenerator {
                   for (InstanceKey ik : pts)
                     if (ik.equals(instanceKey)) {
                       ret.add(dtype);
-                      LOGGER.info(
+                      LOGGER.fine(
                           "Found dtype: "
                               + dtype
                               + " for source: "
@@ -1452,7 +1452,7 @@ public abstract class TensorGenerator {
         }
 
         ret.add(dtype);
-        LOGGER.info(
+        LOGGER.fine(
             "Found dtype: "
                 + dtype
                 + " for source: "
@@ -1666,7 +1666,7 @@ public abstract class TensorGenerator {
         Object value = constantKey.getValue();
         if (value instanceof Float || value instanceof Double) {
           ret.add(FLOAT32);
-          LOGGER.info(
+          LOGGER.fine(
               "Inferred dtype: "
                   + FLOAT32
                   + " for source: "
@@ -1676,7 +1676,7 @@ public abstract class TensorGenerator {
                   + ".");
         } else if (value instanceof Integer || value instanceof Long) {
           ret.add(INT32);
-          LOGGER.info(
+          LOGGER.fine(
               "Inferred dtype: "
                   + INT32
                   + " for source: "
@@ -1686,7 +1686,7 @@ public abstract class TensorGenerator {
                   + ".");
         } else if (value instanceof String) {
           ret.add(STRING);
-          LOGGER.info(
+          LOGGER.fine(
               "Inferred dtype: "
                   + STRING
                   + " for source: "
@@ -1696,7 +1696,7 @@ public abstract class TensorGenerator {
                   + ".");
         } else if (value instanceof Boolean) {
           ret.add(BOOL);
-          LOGGER.info(
+          LOGGER.fine(
               "Inferred dtype: "
                   + BOOL
                   + " for source: "
@@ -1712,7 +1712,7 @@ public abstract class TensorGenerator {
           // (#447): missing types should fall through to ⊤ in the lattice
           // rather than terminate the analysis.
           ret.add(UNKNOWN);
-          LOGGER.info(
+          LOGGER.fine(
               "Unrecognized constant type for source: "
                   + this.getSource()
                   + " value: "

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -348,7 +348,7 @@ public class TensorGeneratorFactory {
       }
     }
 
-    LOGGER.info("findCreator fallback returning original source: " + source);
+    LOGGER.fine("findCreator fallback returning original source: " + source);
     return source;
   }
 
@@ -939,13 +939,13 @@ public class TensorGeneratorFactory {
     }
 
     TypeReference calledFunction = getFunction(source, builder);
-    LOGGER.info("Getting tensor generator for call to: " + calledFunction + ".");
+    LOGGER.fine("Getting tensor generator for call to: " + calledFunction + ".");
 
     // sanitize the type name by removing the artificial suffix that is added for synthetic
     // classes to facilitate trampoline generation.
     calledFunction = sanitize(calledFunction);
 
-    LOGGER.info("Getting tensor generator for sanitized call to: " + calledFunction + ".");
+    LOGGER.fine("Getting tensor generator for sanitized call to: " + calledFunction + ".");
 
     if (isType(calledFunction, ONES.getDeclaringClass())) return new Ones(source);
     else if (isType(calledFunction, CONSTANT.getDeclaringClass())) return new Constant(source);


### PR DESCRIPTION
## Summary

Fixes [wala/ML#415](https://github.com/wala/ML/issues/415).

The project's diagnostic-logging convention (per `CLAUDE.md` and the saved-memory record): **keep per-node analysis flow at `FINE`/`FINER`, never at `INFO`**. With `logging.properties`'s root level defaulting to `FINE`, `INFO` calls dominate the local-run console.

This PR demotes 49 `LOGGER.info(...)` sites in `com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/` to `LOGGER.fine(...)`, plus drops one redundant bare `e.printStackTrace()` in `PythonTensorAnalysisEngine`'s "not a tensor source" catch (the same line already calls `LOGGER.log(Level.FINE, ..., e)` which preserves the stack trace at the right level).

## Files Touched

| File | INFO → FINE | Notes |
|---|---|---|
| `PythonTensorAnalysisEngine.java` | 7 | + dropped bare `printStackTrace` at the IAE catch |
| `TensorGenerator.java` | 10 | |
| `TensorGeneratorFactory.java` | 3 | |
| `Input.java` | 7 | |
| `Ones.java` | 1 | |
| `RaggedFromValueRowIds.java` | 4 | |
| `RaggedFromNestedRowLengths.java` | 7 | |
| `RaggedTensorFromValues.java` | 3 | |
| `RaggedFromNestedValueRowIds.java` | 1 | |
| `RaggedFromRowSplits.java` | 2 | |
| `RaggedFromRowStarts.java` | 2 | |
| `RaggedFromRowLengths.java` | 1 | |
| `RaggedFromRowLimits.java` | 1 | |

## Test Plan

- [x] Full ML test suite passes locally: `656 tests, 0 failures, 0 errors, 0 skipped`.
- [ ] CI confirms.

## Out Of Scope

- The issue's mention of "a handful of per-constant-value details inside loops may warrant `FINER`" — left as an opportunistic refinement for a future contributor; this PR uses `FINE` uniformly per the issue's "convention for the sweep" guidance ("Most of these describe routine per-node analysis flow — `FINE` is appropriate"). Demoting select sites further to `FINER` doesn't need to gate this PR.
- Other modules (`com.ibm.wala.cast.python` front-end, etc.) — this PR is scoped to the ML generator package, which is where the issue's enumerated sites live.

## Related

- [wala/ML#415](https://github.com/wala/ML/issues/415) — tracking issue.