### PR TITLE
Add dedicated `Stack` generator (wala/ML#449 Tier 5)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7074,21 +7074,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Tier-5 generator (wala/ML#449): {@code tf.stack(values, axis)}. Pre-fix the {@code stack} XML
-   * routed through a {@code read_data} marker that allocated a non-tensor wrapper class ({@code
-   * Ltensorflow/python/functions/stack}), giving {@code [{? of unknown}]} via {@code
-   * ReadDataFallback}. Post-fix the XML mirrors {@code add_n} / {@code concat}'s pattern — read
-   * field 0 of {@code values} and route through {@code convert_to_tensor}. Dtype propagation is
-   * sound (stack preserves dtype). Shape is approximated by inheriting from the first input — this
-   * is <em>unsound</em>, since runtime stack adds a new axis (rank+1); a future generator can
-   * compose the input shape with the {@code values} list length to produce a precise (and sound)
-   * shape. The lock-in here pins the observable static-analysis output as the current
-   * approximation.
+   * Tier-5 generator (wala/ML#449): {@code tf.stack(values, axis)}. The dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.Stack} generator computes the precise output shape by
+   * reading the {@code values} list's PTS-derived length {@code N} and inserting it at the resolved
+   * {@code axis} position into the first element's shape: {@code values[0].shape[:axis] + (N,) +
+   * values[0].shape[axis:]}. The fixture stacks two {@code (3,)} tensors with {@code axis=0}, so
+   * the precise output is {@code (2, 3)}; dtype is inherited from the first element ({@code
+   * int32}).
    */
   @Test
   public void testStack()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_stack.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
+    test("tf2_test_stack.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1697,13 +1697,11 @@
         </method>
       </class>
       <class name="stack" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack. Mirrors `add_n` / `concat`'s pattern: read field 0 of the input list and route through `convert_to_tensor` so dtype propagates from the first input element. Shape is approximated by inheriting from the first input — known
-          unsoundness, since runtime stack adds a new axis (rank+1). A future generator can compose the input shape with the `values` list length to produce a precise (and sound) shape. See wala/ML#449 (Tier 5). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack. Direct `<new>+<return>` paired with the dedicated `Stack` generator (wala/ML#449 Tier 5): the generator computes the precise output shape `t.shape[:axis] + (len(values),) + t.shape[axis:]` from the `values` list's PTS-derived
+          length and the first element's shape, and inherits the dtype from the first element. Pre-fix the XML routed through `convert_to_tensor` which inherited the first element's shape verbatim — sound on dtype but unsound on shape (missed the new axis). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
-          <getfield class="Llist" field="0" fieldType="LRoot" ref="values" def="x" />
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="unstack" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
@@ -1,0 +1,249 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.types.PythonTypes.Root;
+import static com.ibm.wala.cast.python.types.PythonTypes.list;
+import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
+import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
+import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code tf.stack(values, axis=0, name='stack')}. Computes the precise output shape
+ * by combining the {@code values} list's PTS-derived length {@code N} with the first element's
+ * shape: {@code values[0].shape[:axis] + (N,) + values[0].shape[axis:]}. The output dtype is
+ * inherited from the first element of {@code values}.
+ *
+ * <p>Currently handles {@code axis=0} (default) and constant {@code axis} values that resolve to
+ * {@code 0} or a positive index in range. For non-zero {@code axis}, the implementation reads the
+ * constant axis value if available; non-constant axis falls back to ⊤ shape.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/stack">tf.stack</a>
+ * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Stack extends TensorGenerator {
+
+  @SuppressWarnings("unused")
+  private static final Logger LOGGER = getLogger(Stack.class.getName());
+
+  /**
+   * Parameter positions and keyword names for {@code tf.stack(values, axis=0, name='stack')}.
+   * Ordinals match the position in {@code tensorflow.xml}'s {@code paramNames} after the implicit
+   * {@code self} receiver, so {@code Parameters.VALUES.getIndex() == 0} resolves to the first
+   * user-facing positional argument.
+   */
+  protected enum Parameters {
+    /** The list of tensors to stack. */
+    VALUES,
+
+    /** The axis along which to insert the new dimension. Default {@code 0}. */
+    AXIS,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "values"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public Stack(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Stack(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> valuesPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.VALUES.getIndex(), Parameters.VALUES.getName());
+    if (valuesPts == null || valuesPts.isEmpty()) return null;
+
+    Integer axis = resolveConstantAxis(builder);
+    if (axis == null) return null; // axis present but unresolved → ⊤.
+
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+
+    for (InstanceKey valIk : valuesPts) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
+      if (asin == null) continue;
+      TypeReference ref = asin.getConcreteType().getReference();
+      if (!(ref.equals(list) || ref.equals(tuple))) continue;
+
+      OrdinalSet<InstanceKey> catalog =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      int n = catalog.size();
+      if (n == 0) continue;
+
+      // Read first element's shape via field "0" of the values list.
+      Set<List<Dimension<?>>> firstShapes = getShapesOfFirstElement(builder, asin, catalog);
+      if (firstShapes == null) continue;
+
+      for (List<Dimension<?>> firstShape : firstShapes) {
+        // Negative-axis normalization: TF allows axis ∈ [-(R+1), R+1] where R = rank of first
+        // element. After normalization the axis is the insertion index in [0, R].
+        int rank = firstShape.size();
+        int normalizedAxis = axis < 0 ? axis + rank + 1 : axis;
+        if (normalizedAxis < 0 || normalizedAxis > rank) continue; // invalid → skip
+        List<Dimension<?>> outShape = new ArrayList<>(rank + 1);
+        outShape.addAll(firstShape.subList(0, normalizedAxis));
+        outShape.add(new NumericDim(n));
+        outShape.addAll(firstShape.subList(normalizedAxis, rank));
+        ret.add(outShape);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> valuesPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.VALUES.getIndex(), Parameters.VALUES.getName());
+    if (valuesPts == null || valuesPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    Set<DType> ret = EnumSet.noneOf(DType.class);
+
+    for (InstanceKey valIk : valuesPts) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
+      if (asin == null) continue;
+      TypeReference ref = asin.getConcreteType().getReference();
+      if (!(ref.equals(list) || ref.equals(tuple))) continue;
+
+      OrdinalSet<InstanceKey> catalog =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      OrdinalSet<InstanceKey> firstElemPts = getFirstElementPts(builder, asin, catalog);
+      if (firstElemPts == null) continue;
+      Set<DType> firstDTypes = this.getDTypesOfValue(builder, firstElemPts);
+      if (firstDTypes != null) ret.addAll(firstDTypes);
+    }
+    return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+  }
+
+  /**
+   * Reads the {@code axis} argument's PTS and resolves it to a concrete integer if all keys are
+   * {@code ConstantKey<Number>}. Returns {@code 0} when {@code axis} isn't passed (TF default) and
+   * {@code null} when the argument is present but unresolvable (caller should emit ⊤).
+   */
+  private Integer resolveConstantAxis(PropagationCallGraphBuilder builder) {
+    boolean axisPresent =
+        this.isKeywordArgumentPresent(builder, Parameters.AXIS.getName())
+            || this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(n -> n > Parameters.AXIS.getIndex());
+    if (!axisPresent) return 0;
+    OrdinalSet<InstanceKey> axisPts =
+        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+    if (axisPts == null || axisPts.isEmpty()) return null;
+    Integer ret = null;
+    for (InstanceKey ik : axisPts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof Number)) return null;
+      int v = ((Number) val).intValue();
+      if (ret == null) ret = v;
+      else if (ret != v) return null; // ambiguous axis → ⊤
+    }
+    return ret == null ? 0 : ret;
+  }
+
+  /**
+   * Reads field {@code "0"} of the {@code values} list/tuple and returns the shapes of that
+   * element, or {@code null} if the field can't be resolved.
+   */
+  private Set<List<Dimension<?>>> getShapesOfFirstElement(
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode listAsin,
+      OrdinalSet<InstanceKey> catalog) {
+    OrdinalSet<InstanceKey> firstElemPts = getFirstElementPts(builder, listAsin, catalog);
+    if (firstElemPts == null) return null;
+    return this.getShapesOfValue(builder, firstElemPts);
+  }
+
+  /**
+   * Resolves the points-to set of field {@code "0"} on the given list/tuple alloc, or {@code null}
+   * if the field can't be resolved.
+   */
+  private OrdinalSet<InstanceKey> getFirstElementPts(
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode listAsin,
+      OrdinalSet<InstanceKey> catalog) {
+    for (InstanceKey catalogIK : catalog) {
+      if (!(catalogIK instanceof ConstantKey)) continue;
+      Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
+      if (fieldIndex == null || fieldIndex != 0) continue;
+      FieldReference subscript =
+          FieldReference.findOrCreate(Root, findOrCreateAsciiAtom("0"), Root);
+      IField f = builder.getClassHierarchy().resolveField(subscript);
+      if (f == null) continue;
+      PointerKey pk = builder.getPointerKeyForInstanceField(listAsin, f);
+      return builder.getPointerAnalysis().getPointsToSet(pk);
+    }
+    return null;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -112,6 +112,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_FROM_DENSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.STACK;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.STOP_GRADIENT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SUBTRACT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR;
@@ -1130,6 +1131,7 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, STACK.getDeclaringClass())) return new Stack(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/stack. */
+  public static final MethodReference STACK =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/stack")),
+          AstMethodReference.fnSelector);
+
+  private static final String STACK_SIGNATURE = "tf.stack()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1367,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(STACK.getDeclaringClass(), STACK_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),


### PR DESCRIPTION
## Summary

Part of [wala/ML#449](https://github.com/wala/ML/issues/449) (Tier 5: stack/concat-style ops).

Pre-fix the `tf.stack(values, axis=0)` modeling routed `values[0]` through `convert_to_tensor`, which inherited the first element's shape verbatim — sound on dtype but unsound on shape (missed the new axis introduced by stack). A stack of two `(3,)` tensors was reported as `(3,)` instead of `(2, 3)`.

## Changes

- **New `Stack.java`** extending `TensorGenerator`. `getDefaultShapes` reads the `values` list's PTS-derived length `N`, resolves a constant `axis` (default `0`), reads the first element's shape via field `"0"` of the list/tuple alloc, and emits `firstShape[:axis] + (N,) + firstShape[axis:]`. Negative-axis normalization handles the `axis ∈ [-(R+1), R+1]` TF range. `getDefaultDTypes` inherits from the first element.
- **`tensorflow.xml`**: `stack` block migrated from `<getfield>+<call convert_to_tensor>+<return>` to direct `<new>+<return>`. The dispatch routes to `Stack`.
- **`TensorFlowTypes.STACK`** added.
- **`TensorGeneratorFactory.getGeneratorBody`** adds `STACK` arm.
- **`testStack`** updated to assert the precise `TENSOR_2_3_INT32` (was `TENSOR_3_INT32` per the previous unsound approximation).

## Falls Back To ⊤ When

- The `values` argument's PTS doesn't resolve to a list/tuple.
- The `axis` argument is non-constant or evaluates to multiple values.
- The first-element field `"0"` can't be resolved.

## Test Plan

- [x] Full ML test suite passes locally: `656 tests, 0 failures, 0 errors, 0 skipped`.
- [x] `tf2_test_stack.py`'s `assert result.shape == (2, 3)` already reflected the runtime-correct shape; only the JUnit assertion needed updating to match.
- [ ] CI confirms.

## Related

- [wala/ML#449](https://github.com/wala/ML/issues/449) Tier 5 — tracking issue.
- [wala/ML#380](https://github.com/wala/ML/issues/380) — the `read_data` inlining work that this Tier follows.
- [wala/ML#437](https://github.com/wala/ML/issues/437) — original regression that put `stack` on the `ReadDataFallback` list.

## Out of Scope

- `tf.einsum`, `tf.math.top_k`, `tf.meshgrid` — also in #449's pending list. Each warrants its own focused PR (top_k and meshgrid produce tuple results; einsum requires equation-string parsing).