### PR TITLE
Add dedicated `Concat` generator (wala/ML#449 Tier 5)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7056,21 +7056,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Tier-5 generator (wala/ML#449): {@code tf.concat(values, axis)}. Pre-fix the {@code concat} XML
-   * routed through a {@code read_data} marker that allocated a non-tensor wrapper class ({@code
-   * Ltensorflow/python/ops/array_ops/concat}), giving {@code [{? of unknown}]} via {@code
-   * ReadDataFallback}. Post-fix the XML mirrors {@code add_n}'s pattern: read field 0 of {@code
-   * values} (the input tensor list) and route through {@code convert_to_tensor}, propagating the
-   * first input's shape and dtype. Dtype propagation is sound (concat preserves dtype). Shape is
-   * approximated by inheriting from the first input — this is <em>unsound</em>, since runtime
-   * concat grows the {@code axis} dimension by the sum of the input dims; a future generator can
-   * read {@code axis} and the full {@code values} list to produce a precise (and sound) shape. The
-   * lock-in here pins the observable static-analysis output as the current approximation.
+   * Tier-5 generator (wala/ML#449): {@code tf.concat(values, axis)}. The dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.Concat} generator computes the precise output shape by
+   * walking every entry in the {@code values} list, summing each input's dim along the resolved
+   * {@code axis}, and inheriting the rest of the shape from the first input. The fixture
+   * concatenates two {@code (3,)} tensors along {@code axis=0}, so the precise output is {@code
+   * (6,)}; dtype is inherited from the first element ({@code int32}).
    */
   @Test
   public void testConcat()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_concat.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
+    test("tf2_test_concat.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_6_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -254,6 +254,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
 
+  private static final TensorType TENSOR_2_6_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(6)));
+
   private static final TensorType TENSOR_2_1_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(1)));
 
@@ -7067,6 +7070,40 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testConcat()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_concat.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_6_INT32)));
+  }
+
+  /**
+   * Multi-rank {@code tf.concat([t1, t2], axis=1)} with {@code (2, 3)} inputs. Exercises the
+   * rank-aware path in {@link com.ibm.wala.cast.python.ml.client.Concat#computeConcatenatedShape}:
+   * non-axis dim preservation (the leading {@code 2} survives) and the axis-dim sum (the trailing
+   * {@code 3 + 3 = 6}).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testConcatMultirank()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_concat_multirank.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_6_INT32)));
+  }
+
+  /**
+   * {@code tf.concat([t1, t2], axis=-1)} with {@code (2, 3)} inputs. Exercises the negative-axis
+   * normalization in {@link com.ibm.wala.cast.python.ml.client.Concat#computeConcatenatedShape}:
+   * {@code axis = -1} resolves to {@code rank - 1 = 1} for rank-2 inputs, producing the same {@code
+   * (2, 6)} answer as the explicit {@code axis=1} fixture.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testConcatNegativeAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_concat_negaxis.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_6_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1313,13 +1313,11 @@
         </method>
       </class>
       <class name="concat" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat. Mirrors `add_n`'s pattern: read field 0 of the input list and route through `convert_to_tensor` so the dtype propagates from the first input element. Shape is approximated by inheriting from the first input — known unsoundness,
-          since runtime concat grows the `axis` dimension by the sum of the input dims. A future generator can read the full `values` list and `axis` to produce a precise (and sound) shape. See wala/ML#449 (Tier 5). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat. Direct `<new>+<return>` paired with the dedicated `Concat` generator (wala/ML#449 Tier 5): the generator computes the precise output shape by walking every entry in the `values` list, summing each input's dim along the resolved
+          `axis`, and inheriting the rest of the shape from the first input. Pre-fix the XML routed through `convert_to_tensor` which inherited the first input's shape verbatim — sound on dtype but unsound on shape (missed the per-input axis-dim sum). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
-          <getfield class="Llist" field="0" fieldType="LRoot" ref="values" def="x" />
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="Variable" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -1,0 +1,273 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.types.PythonTypes.Root;
+import static com.ibm.wala.cast.python.types.PythonTypes.list;
+import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
+import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
+import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code tf.concat(values, axis=0, name='concat')}. Computes the precise output shape
+ * by walking every entry in the {@code values} list, summing each input's dim along the resolved
+ * {@code axis}, and inheriting the rest of the shape from the first input. The output dtype is
+ * inherited from the first element of {@code values}.
+ *
+ * <p>Falls back to ⊤ shape when:
+ *
+ * <ul>
+ *   <li>The {@code values} argument's PTS doesn't resolve to a list/tuple.
+ *   <li>The {@code axis} argument is non-constant or evaluates to multiple values.
+ *   <li>Any input element's shape can't be resolved or has a non-numeric dim at the {@code axis}
+ *       position (e.g., a {@code SymbolicDim}).
+ * </ul>
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/concat">tf.concat</a>
+ * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Concat extends TensorGenerator {
+
+  @SuppressWarnings("unused")
+  private static final Logger LOGGER = getLogger(Concat.class.getName());
+
+  /**
+   * Parameter positions and keyword names for {@code tf.concat(values, axis=0, name='concat')}.
+   * Ordinals match the position in {@code tensorflow.xml}'s {@code paramNames} after the implicit
+   * {@code self} receiver, so {@code Parameters.VALUES.getIndex() == 0} resolves to the first
+   * user-facing positional argument.
+   */
+  protected enum Parameters {
+    /**
+     * The list of tensors to concatenate; all must have the same rank and matching non-axis dims.
+     */
+    VALUES,
+
+    /** The axis along which to concatenate. Default {@code 0}. */
+    AXIS,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "values"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public Concat(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Concat(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> valuesPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.VALUES.getIndex(), Parameters.VALUES.getName());
+    if (valuesPts == null || valuesPts.isEmpty()) return null;
+
+    Integer axis = resolveConstantAxis(builder);
+    if (axis == null) return null; // axis present but unresolved → ⊤.
+
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+
+    for (InstanceKey valIk : valuesPts) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
+      if (asin == null) continue;
+      TypeReference ref = asin.getConcreteType().getReference();
+      if (!(ref.equals(list) || ref.equals(tuple))) continue;
+
+      OrdinalSet<InstanceKey> catalog =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      if (catalog.size() == 0) continue;
+
+      List<Dimension<?>> outShape = computeConcatenatedShape(builder, asin, catalog, axis);
+      if (outShape != null) ret.add(outShape);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> valuesPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.VALUES.getIndex(), Parameters.VALUES.getName());
+    if (valuesPts == null || valuesPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    Set<DType> ret = EnumSet.noneOf(DType.class);
+
+    for (InstanceKey valIk : valuesPts) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
+      if (asin == null) continue;
+      TypeReference ref = asin.getConcreteType().getReference();
+      if (!(ref.equals(list) || ref.equals(tuple))) continue;
+
+      OrdinalSet<InstanceKey> catalog =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      OrdinalSet<InstanceKey> firstElemPts = getElementPts(builder, asin, catalog, 0);
+      if (firstElemPts == null) continue;
+      Set<DType> firstDTypes = this.getDTypesOfValue(builder, firstElemPts);
+      if (firstDTypes != null) ret.addAll(firstDTypes);
+    }
+    return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+  }
+
+  /**
+   * Computes the concatenated shape: takes the first input's shape verbatim except at the {@code
+   * axis} position, where the dim is replaced by the sum across all inputs. Returns {@code null} if
+   * any input's shape can't be resolved or has a non-{@link NumericDim} at the axis.
+   */
+  private List<Dimension<?>> computeConcatenatedShape(
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode listAsin,
+      OrdinalSet<InstanceKey> catalog,
+      int axis) {
+    // Get the first element's shape as the template.
+    OrdinalSet<InstanceKey> firstElemPts = getElementPts(builder, listAsin, catalog, 0);
+    if (firstElemPts == null) return null;
+    Set<List<Dimension<?>>> firstShapes = this.getShapesOfValue(builder, firstElemPts);
+    if (firstShapes == null || firstShapes.isEmpty()) return null;
+    // Pick any one; in practice we expect a single shape for the list.
+    List<Dimension<?>> firstShape = firstShapes.iterator().next();
+    int rank = firstShape.size();
+    int normalizedAxis = axis < 0 ? axis + rank : axis;
+    if (normalizedAxis < 0 || normalizedAxis >= rank) return null;
+
+    // Sum the axis dim across all elements.
+    long sum = 0;
+    for (InstanceKey catalogIK : catalog) {
+      if (!(catalogIK instanceof ConstantKey)) return null;
+      Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
+      if (fieldIndex == null) return null;
+      OrdinalSet<InstanceKey> elemPts = getElementPts(builder, listAsin, catalog, fieldIndex);
+      if (elemPts == null) return null;
+      Set<List<Dimension<?>>> elemShapes = this.getShapesOfValue(builder, elemPts);
+      if (elemShapes == null || elemShapes.isEmpty()) return null;
+      List<Dimension<?>> elemShape = elemShapes.iterator().next();
+      if (elemShape.size() != rank) return null; // rank mismatch — can't concat soundly
+      Dimension<?> axisDim = elemShape.get(normalizedAxis);
+      if (!(axisDim instanceof NumericDim)) return null; // non-numeric → can't sum
+      sum += ((NumericDim) axisDim).value();
+    }
+
+    List<Dimension<?>> outShape = new ArrayList<>(firstShape);
+    outShape.set(normalizedAxis, new NumericDim((int) sum));
+    return outShape;
+  }
+
+  /**
+   * Reads the {@code axis} argument's PTS and resolves it to a concrete integer if all keys are
+   * {@code ConstantKey<Number>}. Returns {@code 0} when {@code axis} isn't passed (TF default) and
+   * {@code null} when the argument is present but unresolvable (caller should emit ⊤).
+   */
+  private Integer resolveConstantAxis(PropagationCallGraphBuilder builder) {
+    boolean axisPresent =
+        this.isKeywordArgumentPresent(builder, Parameters.AXIS.getName())
+            || this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(n -> n > Parameters.AXIS.getIndex());
+    if (!axisPresent) return 0;
+    OrdinalSet<InstanceKey> axisPts =
+        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+    if (axisPts == null || axisPts.isEmpty()) return null;
+    Integer ret = null;
+    for (InstanceKey ik : axisPts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof Number)) return null;
+      int v = ((Number) val).intValue();
+      if (ret == null) ret = v;
+      else if (ret != v) return null;
+    }
+    return ret == null ? 0 : ret;
+  }
+
+  /**
+   * Resolves the points-to set of the element at {@code fieldIndex} on the given list/tuple alloc,
+   * or {@code null} if the field can't be resolved.
+   */
+  private OrdinalSet<InstanceKey> getElementPts(
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode listAsin,
+      OrdinalSet<InstanceKey> catalog,
+      int fieldIndex) {
+    for (InstanceKey catalogIK : catalog) {
+      if (!(catalogIK instanceof ConstantKey)) continue;
+      Integer idx = getFieldIndex((ConstantKey<?>) catalogIK);
+      if (idx == null || idx != fieldIndex) continue;
+      FieldReference subscript =
+          FieldReference.findOrCreate(
+              Root, findOrCreateAsciiAtom(Integer.toString(fieldIndex)), Root);
+      IField f = builder.getClassHierarchy().resolveField(subscript);
+      if (f == null) continue;
+      PointerKey pk = builder.getPointerKeyForInstanceField(listAsin, f);
+      return builder.getPointerAnalysis().getPointsToSet(pk);
+    }
+    return null;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -13,6 +13,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TRAIN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONCAT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONVERT_TO_TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET;
@@ -1130,6 +1131,7 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, CONCAT.getDeclaringClass())) return new Concat(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/concat. */
+  public static final MethodReference CONCAT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/concat")),
+          AstMethodReference.fnSelector);
+
+  private static final String CONCAT_SIGNATURE = "tf.concat()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1367,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(CONCAT.getDeclaringClass(), CONCAT_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_concat_multirank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_concat_multirank.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Multi-rank `tf.concat` with `axis=1` (positional non-default axis). Exercises the
+# rank-aware branches in `Concat.computeConcatenatedShape`: axis normalization for
+# multi-dim shapes, dim-preservation outside the concat axis, and the rank-equality
+# guard.
+t1 = tf.constant([[1, 2, 3], [4, 5, 6]])  # (2, 3)
+t2 = tf.constant([[7, 8, 9], [10, 11, 12]])  # (2, 3)
+result = tf.concat([t1, t2], axis=1)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 6)
+assert result.dtype == tf.int32
+f(result)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_concat_negaxis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_concat_negaxis.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.concat` with negative axis (`axis=-1`). Exercises the `axis < 0 ?
+# axis + rank : axis` normalization branch in `Concat.computeConcatenatedShape`.
+# For 2D inputs, `axis=-1` is the last axis (index 1).
+t1 = tf.constant([[1, 2, 3], [4, 5, 6]])  # (2, 3)
+t2 = tf.constant([[7, 8, 9], [10, 11, 12]])  # (2, 3)
+result = tf.concat([t1, t2], axis=-1)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 6)
+assert result.dtype == tf.int32
+f(result)


### PR DESCRIPTION
## Summary

Part of [wala/ML#449](https://github.com/wala/ML/issues/449) (Tier 5: stack/concat-style ops). Companion to ponder-lab/ML#249 (`Stack`).

Pre-fix the `tf.concat(values, axis=0)` modeling routed `values[0]` through `convert_to_tensor`, inheriting the first element's shape verbatim — sound on dtype but unsound on shape (missed the per-input axis-dim sum). A concat of two `(3,)` tensors along `axis=0` was reported as `(3,)` instead of `(6,)`.

## Changes

- **New `Concat.java`** extending `TensorGenerator`. `getDefaultShapes` walks every entry in the `values` list, sums each input's dim along the resolved `axis`, and inherits the rest of the shape from the first input. `getDefaultDTypes` inherits from the first element.
- **`tensorflow.xml`**: `concat` block migrated from `<getfield>+<call convert_to_tensor>+<return>` to direct `<new>+<return>`. Dispatch routes to `Concat`.
- **`TensorFlowTypes.CONCAT`** added.
- **`TensorGeneratorFactory.getGeneratorBody`** adds `CONCAT` arm.
- **`testConcat`** updated to assert `TENSOR_6_INT32` (was `TENSOR_3_INT32` per the previous unsound approximation).

## Falls Back To ⊤ When

- The `values` argument's PTS doesn't resolve to a list/tuple.
- The `axis` argument is non-constant.
- Any input element's shape can't be resolved.
- Any input has a non-numeric dim at the axis position (e.g. a `SymbolicDim`) — sum can't be computed.
- Inputs have mismatched ranks.

## Test Plan

- [x] Full ML test suite passes locally: `656 tests, 0 failures, 0 errors, 0 skipped`.
- [x] `tf2_test_concat.py`'s `assert result.shape == (6,)` already reflected the runtime-correct shape; only the JUnit assertion needed updating to match.
- [ ] CI confirms.

## Coordination With #249

This PR and ponder-lab/ML#249 (`Stack`) both touch `TensorFlowTypes.java` (adding adjacent constants) and `TensorGeneratorFactory.java` (adding adjacent dispatch arms). They edit different lines in each file so they should rebase cleanly against each other; whichever lands first, the second will need a trivial master-merge.

## Related

- ponder-lab/ML#249 — `Stack` generator (sibling Tier 5 op).
- [wala/ML#449](https://github.com/wala/ML/issues/449) Tier 5.
- [wala/ML#380](https://github.com/wala/ML/issues/380) — the `read_data` inlining work that this Tier follows.
- [wala/ML#437](https://github.com/wala/ML/issues/437) — original regression that put `concat` on the `ReadDataFallback` list.

## Out of Scope

- `tf.einsum`, `tf.math.top_k`, `tf.meshgrid` — also in #449's pending list. Each warrants its own focused PR (top_k and meshgrid produce tuple results; einsum requires equation-string parsing).