### PR TITLE
Add `TopK` and `Meshgrid` generators with `TupleElementProvider` (wala/ML#449 Tier 5)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -340,6 +340,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
+  private static final TensorType TENSOR_INT32_UNKNOWN_SHAPE = new TensorType(INT_32, null);
+
   private static final TensorType TENSOR_UNKNOWN_SHAPE_BOOL = new TensorType(BOOL, null);
 
   private static final TensorType TENSOR_3_INT32 =
@@ -7089,6 +7091,90 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testStack()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_stack.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
+  }
+
+  /**
+   * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
+   * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
+   * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype
+   * precision ({@code values} inherits input dtype; {@code indices} is fixed at {@code int32}), but
+   * the wrap-on-property-read dispatch in {@link
+   * com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory} doesn't fire for NamedTuple-style
+   * attribute access ({@code result.values} / {@code result.indices}). Until <a
+   * href="https://github.com/wala/ML/issues/480">wala/ML#480</a> is fixed, both destructured
+   * elements receive the aggregate union of per-element types.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/480">wala/ML#480</a> lands, narrow the
+   * assertion to {@code Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)} (precise {@code values} dtype).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTopKValues()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_top_k.py",
+        "f_values",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Counterpart of {@link #testTopKValues()} for the {@code indices} element of {@code
+   * tf.math.top_k}'s tuple result. Same wala/ML#480-driven imprecision: the assertion captures the
+   * observed aggregate union with a TODO to narrow once the per-index dispatch is fixed.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/480">wala/ML#480</a> lands, narrow the
+   * assertion to {@code Set.of(TENSOR_INT32_UNKNOWN_SHAPE)} (precise {@code indices} dtype).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTopKIndices()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_top_k.py",
+        "f_indices",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Tier-5 generator (wala/ML#449): {@code tf.meshgrid(*xi)}. Returns N tensors (one per input)
+   * sharing the broadcast of input shapes and the first input's dtype. The dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.Meshgrid} generator implements {@link
+   * com.ibm.wala.cast.python.ml.client.TupleElementProvider}, but the XML only allocates one tuple
+   * slot (field 0); the second meshgrid output ({@code Y} in the fixture) doesn't have a backing
+   * alloc, so it falls through to ⊤/UNKNOWN and the aggregate union leaks the {@code
+   * float32}/{@code unknown} pair. See <a href="https://github.com/wala/ML/issues/480">
+   * wala/ML#480</a>.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/480">wala/ML#480</a> lands (or the
+   * meshgrid XML is updated to allocate per-input tuple slots), narrow the assertion to {@code
+   * Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testMeshgrid()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_meshgrid.py",
+        "f",
+        1,
+        2,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7177,6 +7177,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
   }
 
+  /**
+   * Companion to {@link #testMeshgrid}: 2-parameter sink {@code f(X, Y)} so the analyzer's
+   * per-parameter typing on `tf.meshgrid`'s tuple result can be observed at distinct value numbers.
+   * The two parameters split the leak asymmetrically:
+   *
+   * <ul>
+   *   <li>vn=2 ({@code X}) shows the full {@code float32}/⊤-dtype union &mdash; the meshgrid XML
+   *       only allocates field-0 of the tuple, so when {@code X} aliases that slot through PA
+   *       propagation it picks up both the precise float32 alloc and the ⊤ tuple-slot leak.
+   *   <li>vn=3 ({@code Y}) collapses to just the precise {@code float32} &mdash; the second
+   *       meshgrid output's allocation site doesn't reach this parameter through the PA graph, so
+   *       the ⊤ leak doesn't surface.
+   * </ul>
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/480">wala/ML#480</a> lands, narrow
+   * vn=2's assertion to {@code Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)} (vn=3 is already there).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testMeshgridXY()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_meshgrid_xy.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE),
+            3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
   @Test
   public void testConvertToTensor4()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
@@ -1,0 +1,134 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.meshgrid(*xi, indexing='xy')}. Returns an N-tuple of tensors (where
+ * {@code N == len(xi)}); all output tensors share the broadcast of all input shapes and the first
+ * input's dtype.
+ *
+ * <p>Implements {@link TupleElementProvider} so that destructuring (e.g. {@code X, Y =
+ * tf.meshgrid(x, y)}) resolves to the right per-element shape and dtype regardless of how many
+ * indices the user accesses. The XML allocates only a 1-element list (post-wala/ML#380 inlining);
+ * the {@link TupleElementProvider} wrap in {@link TensorGeneratorFactory#getGenerator} answers any
+ * index with the per-element type, even when the XML-side tuple is undersized.
+ *
+ * <p>Output shape is currently ⊤ — computing the precise broadcast shape requires reading every
+ * input's shape (PA-resolvable for many cases; bounded by {@code len(xi)}). A follow-up can compose
+ * the per-input shapes. For now the precise per-element dtype (first input's) is the load-bearing
+ * fix vs. the previous {@code ReadDataFallback} routing.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/meshgrid">tf.meshgrid</a>
+ * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Meshgrid extends TensorGenerator implements TupleElementProvider {
+
+  /**
+   * Argument-position constant for the dtype source. Position 0 is the first {@code *args} tensor;
+   * meshgrid uses pure varargs (no leading non-tensor argument).
+   */
+  private static final int FIRST_INPUT_POSITION = 0;
+
+  /** Keyword name for the first input (the {@code *args} varargs). */
+  private static final String FIRST_INPUT_NAME = "args";
+
+  public Meshgrid(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Meshgrid(CGNode node) {
+    super(node);
+  }
+
+  /** Always yields a tuple — meshgrid's signature guarantees a tuple-of-tensors return. */
+  @Override
+  public boolean yieldsTuple(PropagationCallGraphBuilder builder) {
+    return true;
+  }
+
+  @Override
+  public Set<List<Dimension<?>>> getShapesForIndex(PropagationCallGraphBuilder builder, int index) {
+    // All outputs share the broadcast of input shapes; emit ⊤ until the broadcast composer
+    // lands.
+    return null;
+  }
+
+  @Override
+  public Set<DType> getDTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    OrdinalSet<InstanceKey> inputPts =
+        this.getArgumentPointsToSet(builder, FIRST_INPUT_POSITION, FIRST_INPUT_NAME);
+    if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+    Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
+    return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+  }
+
+  @Override
+  public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    Set<DType> dtypes = this.getDTypesForIndex(builder, index);
+    Set<List<Dimension<?>>> shapes = this.getShapesForIndex(builder, index);
+    Set<TensorType> ret = HashSetFactory.make();
+    if (shapes == null) {
+      for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
+    } else {
+      for (List<Dimension<?>> shape : shapes)
+        for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), shape));
+    }
+    return ret;
+  }
+
+  /**
+   * Aggregate {@code getTensorTypes} returns the per-element type (all elements share the same type
+   * for meshgrid). Matches the {@link DatasetFromTensorsGenerator} convention of unioning per-index
+   * types — for meshgrid the "union" collapses to a single type since every element has the same
+   * shape and dtype.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The element tensor type (all N outputs share this).
+   */
+  @Override
+  public Set<TensorType> getTensorTypes(PropagationCallGraphBuilder builder) {
+    return this.getTensorTypesForIndex(builder, 0);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null; // ⊤ at every level until broadcast composer lands.
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return this.getDTypesForIndex(builder, 0);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
@@ -76,15 +76,11 @@ public class Meshgrid extends TensorGenerator implements TupleElementProvider {
 
   @Override
   public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    // Shapes are uniformly ⊤ until the broadcast composer lands; emit one TensorType per
+    // dtype with null dims. When shapes become precise, this method needs to fan out per shape.
     Set<DType> dtypes = this.getDTypesForIndex(builder, index);
-    Set<List<Dimension<?>>> shapes = this.getShapesForIndex(builder, index);
     Set<TensorType> ret = HashSetFactory.make();
-    if (shapes == null) {
-      for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
-    } else {
-      for (List<Dimension<?>> shape : shapes)
-        for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), shape));
-    }
+    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
@@ -36,13 +36,37 @@ import java.util.Set;
 public class Meshgrid extends TensorGenerator implements TupleElementProvider {
 
   /**
-   * Argument-position constant for the dtype source. Position 0 is the first {@code *args} tensor;
-   * meshgrid uses pure varargs (no leading non-tensor argument).
+   * Parameter positions and keyword names for {@code tf.meshgrid(*xi, indexing='xy')}. Meshgrid
+   * uses pure varargs &mdash; the first user-facing positional argument is the first tensor in the
+   * {@code *args} varpack &mdash; so {@code Parameters.ARGS.getIndex() == 0} resolves to that first
+   * tensor. {@code INDEXING} captures the optional keyword argument that selects between Cartesian
+   * (`'xy'`) and matrix (`'ij'`) ordering; the analyzer does not consume it.
    */
-  private static final int FIRST_INPUT_POSITION = 0;
+  protected enum Parameters {
+    /** First input tensor in the {@code *args} varargs; the dtype source. */
+    ARGS,
 
-  /** Keyword name for the first input (the {@code *args} varargs). */
-  private static final String FIRST_INPUT_NAME = "args";
+    /** Keyword controlling Cartesian (`'xy'`) vs matrix (`'ij'`) ordering; not consumed. */
+    INDEXING;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "args"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
 
   public Meshgrid(PointsToSetVariable source) {
     super(source);
@@ -68,7 +92,7 @@ public class Meshgrid extends TensorGenerator implements TupleElementProvider {
   @Override
   public Set<DType> getDTypesForIndex(PropagationCallGraphBuilder builder, int index) {
     OrdinalSet<InstanceKey> inputPts =
-        this.getArgumentPointsToSet(builder, FIRST_INPUT_POSITION, FIRST_INPUT_NAME);
+        this.getArgumentPointsToSet(builder, Parameters.ARGS.getIndex(), Parameters.ARGS.getName());
     if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
     Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
     return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -70,6 +70,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG_SOFTMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MATMUL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MAX_POOL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MESHGRID;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MNIST_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MNIST_X_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MNIST_Y_TEST;
@@ -119,6 +120,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORDOT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR_SCATTER_ND_UPDATE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TEXT_LINE_DATASET_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TOP_K;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRACE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_OP;
@@ -1130,6 +1132,8 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, TOP_K.getDeclaringClass())) return new TopK(source);
+    else if (isType(calledFunction, MESHGRID.getDeclaringClass())) return new Meshgrid(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -1,0 +1,187 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.math.top_k(input, k=1, sorted=True, name=None)}. Returns a 2-tuple {@code
+ * (values, indices)}; both elements have shape {@code input.shape[:-1] + (k,)}. {@code values} has
+ * the input's dtype; {@code indices} is fixed at {@code int32}.
+ *
+ * <p>Implements {@link TupleElementProvider} so that destructuring or indexed accesses (e.g. {@code
+ * values, indices = tf.math.top_k(x, k)} or {@code result.indices}) resolve to the right
+ * per-element shape and dtype rather than collapsing both to the aggregate union. This is the first
+ * non-Dataset use of the {@link TupleElementProvider} pattern; the established Dataset-side
+ * precedent is {@link DatasetFromTensorsGenerator}.
+ *
+ * <p>Output shape precision is currently ⊤ — computing the precise {@code input.shape[:-1] + (k,)}
+ * requires reading the input's shape (PA-resolvable for many cases) and the {@code k} argument
+ * (PA-constant in the common case). A follow-up can wire that in. For now the per-element dtype
+ * precision (FLOAT32 for values, INT32 for indices) is the load-bearing fix vs. the previous {@code
+ * ReadDataFallback} routing, which produced {@code ⊤}/{@code unknown} for both.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/top_k">tf.math.top_k</a>
+ * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TopK extends TensorGenerator implements TupleElementProvider {
+
+  /** Tuple-element index for the {@code values} output. */
+  private static final int VALUES_INDEX = 0;
+
+  /** Tuple-element index for the {@code indices} output (always {@code int32}). */
+  private static final int INDICES_INDEX = 1;
+
+  /**
+   * Parameter positions and keyword names for {@code tf.math.top_k(input, k=1, sorted=True,
+   * name=None)}. Ordinals match the position in {@code tensorflow.xml}'s {@code paramNames} after
+   * the implicit {@code self} receiver.
+   */
+  protected enum Parameters {
+    /** The input tensor; the dtype source for {@code values}. */
+    INPUT,
+
+    /** The number of top entries to return; default {@code 1}. */
+    K,
+
+    /** Whether the resulting top-k entries should be returned in sorted order. */
+    SORTED,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name.
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public TopK(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public TopK(CGNode node) {
+    super(node);
+  }
+
+  /** Always yields a tuple — the call signature guarantees a {@code (values, indices)} return. */
+  @Override
+  public boolean yieldsTuple(PropagationCallGraphBuilder builder) {
+    return true;
+  }
+
+  @Override
+  public Set<List<Dimension<?>>> getShapesForIndex(PropagationCallGraphBuilder builder, int index) {
+    // Both values and indices share shape input.shape[:-1] + (k,). Currently emit ⊤ until an
+    // input-shape + k composer is added.
+    return null;
+  }
+
+  @Override
+  public Set<DType> getDTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    if (index == INDICES_INDEX) return EnumSet.of(DType.INT32);
+    if (index == VALUES_INDEX) {
+      OrdinalSet<InstanceKey> inputPts =
+          this.getArgumentPointsToSet(
+              builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName());
+      if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+      Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
+      return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+    }
+    return EnumSet.of(DType.UNKNOWN);
+  }
+
+  @Override
+  public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    Set<DType> dtypes = this.getDTypesForIndex(builder, index);
+    Set<List<Dimension<?>>> shapes = this.getShapesForIndex(builder, index);
+    Set<TensorType> ret = HashSetFactory.make();
+    if (shapes == null) {
+      // ⊤ shape — emit one TensorType per dtype with null dims.
+      for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
+    } else {
+      for (List<Dimension<?>> shape : shapes)
+        for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), shape));
+    }
+    return ret;
+  }
+
+  /**
+   * Aggregate {@code getTensorTypes} returns the UNION of per-index types, mirroring the
+   * established {@link DatasetFromTensorsGenerator} convention. Concretely: {@code (values_type,
+   * indices_type)} — values inherits input dtype with ⊤ shape; indices is {@code int32} with ⊤
+   * shape.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return Union of per-index tensor types.
+   */
+  @Override
+  public Set<TensorType> getTensorTypes(PropagationCallGraphBuilder builder) {
+    Set<TensorType> ret = HashSetFactory.make();
+    ret.addAll(this.getTensorTypesForIndex(builder, VALUES_INDEX));
+    ret.addAll(this.getTensorTypesForIndex(builder, INDICES_INDEX));
+    return ret;
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // ⊤ at the aggregate level — per-index access returns the precise shape (also currently ⊤
+    // pending the input-shape + k composer; both axes line up for now).
+    return null;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    // Aggregate dtype: union of values' (input dtype) and indices' (int32). The
+    // TupleElementProvider
+    // wrap on indexed access returns the precise per-index dtype; this aggregate is only consumed
+    // when the caller doesn't index into the tuple.
+    Set<DType> ret = EnumSet.noneOf(DType.class);
+    ret.addAll(this.getDTypesForIndex(builder, VALUES_INDEX));
+    ret.addAll(this.getDTypesForIndex(builder, INDICES_INDEX));
+    return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -103,29 +103,24 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
   @Override
   public Set<DType> getDTypesForIndex(PropagationCallGraphBuilder builder, int index) {
     if (index == INDICES_INDEX) return EnumSet.of(DType.INT32);
-    if (index == VALUES_INDEX) {
-      OrdinalSet<InstanceKey> inputPts =
-          this.getArgumentPointsToSet(
-              builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName());
-      if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
-      Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
-      return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
-    }
-    return EnumSet.of(DType.UNKNOWN);
+    if (index != VALUES_INDEX)
+      throw new IllegalArgumentException(
+          "TopK has only 2 outputs (values, indices); got index " + index + ".");
+    OrdinalSet<InstanceKey> inputPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName());
+    if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+    Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
+    return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
   }
 
   @Override
   public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
+    // Shapes are uniformly ⊤ until the input-shape + k composer lands; emit one TensorType per
+    // dtype with null dims. When shapes become precise, this method needs to fan out per shape.
     Set<DType> dtypes = this.getDTypesForIndex(builder, index);
-    Set<List<Dimension<?>>> shapes = this.getShapesForIndex(builder, index);
     Set<TensorType> ret = HashSetFactory.make();
-    if (shapes == null) {
-      // ⊤ shape — emit one TensorType per dtype with null dims.
-      for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
-    } else {
-      for (List<Dimension<?>> shape : shapes)
-        for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), shape));
-    }
+    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,24 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/top_k. */
+  public static final MethodReference TOP_K =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/top_k")),
+          AstMethodReference.fnSelector);
+
+  private static final String TOP_K_SIGNATURE = "tf.math.top_k()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/meshgrid. */
+  public static final MethodReference MESHGRID =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/meshgrid")),
+          AstMethodReference.fnSelector);
+
+  private static final String MESHGRID_SIGNATURE = "tf.meshgrid()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1376,8 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(TOP_K.getDeclaringClass(), TOP_K_SIGNATURE),
+          Map.entry(MESHGRID.getDeclaringClass(), MESHGRID_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.meshgrid(*xi)` returns N tensors (one per input). All output
+# tensors share the broadcast of input shapes and the first input's
+# dtype. The fixture exercises destructuring access into the tuple
+# result so the `TupleElementProvider` wrap fires on each element.
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.constant([10.0, 20.0])
+X, Y = tf.meshgrid(x, y)
+assert isinstance(X, tf.Tensor)
+assert isinstance(Y, tf.Tensor)
+assert X.dtype == tf.float32
+assert Y.dtype == tf.float32
+f(X)
+f(Y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid.py
@@ -14,6 +14,8 @@ y = tf.constant([10.0, 20.0])
 X, Y = tf.meshgrid(x, y)
 assert isinstance(X, tf.Tensor)
 assert isinstance(Y, tf.Tensor)
+assert X.shape == (2, 3)
+assert Y.shape == (2, 3)
 assert X.dtype == tf.float32
 assert Y.dtype == tf.float32
 f(X)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid_xy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid_xy.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a, b):
+    pass
+
+
+# Companion to `tf2_test_meshgrid.py` that exercises a 2-parameter sink
+# `f(X, Y)` so the analyzer's per-parameter typing on `tf.meshgrid`'s
+# tuple result can be observed at distinct value numbers.
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.constant([10.0, 20.0])
+X, Y = tf.meshgrid(x, y)
+assert isinstance(X, tf.Tensor)
+assert isinstance(Y, tf.Tensor)
+assert X.dtype == tf.float32
+assert Y.dtype == tf.float32
+f(X, Y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid_xy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_meshgrid_xy.py
@@ -13,6 +13,8 @@ y = tf.constant([10.0, 20.0])
 X, Y = tf.meshgrid(x, y)
 assert isinstance(X, tf.Tensor)
 assert isinstance(Y, tf.Tensor)
+assert X.shape == (2, 3)
+assert Y.shape == (2, 3)
 assert X.dtype == tf.float32
 assert Y.dtype == tf.float32
 f(X, Y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
@@ -1,0 +1,23 @@
+import tensorflow as tf
+
+
+def f_values(a):
+    pass
+
+
+def f_indices(a):
+    pass
+
+
+# `tf.math.top_k(input, k)` returns a `(values, indices)` named tuple.
+# `values` shares the input dtype (float32 here); `indices` is int32.
+# Shape is `input.shape[:-1] + (k,)` for both — currently emitted as ⊤.
+x = tf.constant([1.0, 3.0, 2.0, 5.0, 4.0])
+result = tf.math.top_k(x, k=2)
+values, indices = result.values, result.indices
+assert isinstance(values, tf.Tensor)
+assert isinstance(indices, tf.Tensor)
+assert values.dtype == tf.float32
+assert indices.dtype == tf.int32
+f_values(values)
+f_indices(indices)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
@@ -17,6 +17,8 @@ result = tf.math.top_k(x, k=2)
 values, indices = result.values, result.indices
 assert isinstance(values, tf.Tensor)
 assert isinstance(indices, tf.Tensor)
+assert values.shape == (2,)
+assert indices.shape == (2,)
 assert values.dtype == tf.float32
 assert indices.dtype == tf.int32
 f_values(values)


### PR DESCRIPTION
## Summary

Part of [wala/ML#449](https://github.com/wala/ML/issues/449) (Tier 5: tuple-result ops).

`tf.math.top_k(input, k)` and `tf.meshgrid(*xi)` were both routed through `ReadDataFallback`. Both produce tuple-of-tensors results, so the proper modeling needs `TupleElementProvider` — the established pattern from the Dataset-side generators (`DatasetFromTensorsGenerator` etc.). This is the **first non-Dataset use of `TupleElementProvider`** in the codebase.

## Changes

- **New `TopK.java`** extends `TensorGenerator` + implements `TupleElementProvider`. Per-index dtype precision: `values` (index 0) inherits the input's dtype; `indices` (index 1) is fixed at `int32`. Output shape ⊤ for both (composing `input.shape[:-1] + (k,)` is a deferred follow-up).
- **New `Meshgrid.java`** extends `TensorGenerator` + implements `TupleElementProvider`. All output elements share the broadcast of input shapes and the first input's dtype. Output shape ⊤ (broadcast composer is a deferred follow-up).
- **`TensorFlowTypes.TOP_K`** and **`TensorFlowTypes.MESHGRID`** constants + signatures.
- **`TensorGeneratorFactory.getGeneratorBody`** adds the two arms.
- **New fixtures** `tf2_test_top_k.py` (with destructured `values, indices`) and `tf2_test_meshgrid.py` (with destructured `X, Y`).
- **New JUnit tests** `testTopKValues`, `testTopKIndices`, `testMeshgrid`.
- **New constant** `TENSOR_INT32_UNKNOWN_SHAPE` (for the `indices` assertion).

## Known Limitation: wala/ML#480

The per-index dispatch wrap in [`TensorGeneratorFactory.getGenerator`](https://github.com/ponder-lab/ML/blob/master/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java#L887) fires for `propertyIndex != null`, which derives from numeric subscripts. Two issues surface for the new generators:

1. **NamedTuple attribute access** (`result.values` / `result.indices`) doesn't produce a numeric `propertyIndex`; the wrap is skipped.
2. **Meshgrid's XML** only allocates one tuple slot (post-wala/ML#380 inlining); destructuring `X, Y = ...` produces a `Y` access with no backing alloc, falling through to ⊤/UNKNOWN.

Both ops currently report the aggregate union of per-element types at every destructured element rather than the precise per-element type. The new tests assert the observed union per the prefer-observed-assertion convention with TODOs pointing at [wala/ML#480](https://github.com/wala/ML/issues/480) — when that lands, both narrow to precise per-element dtypes.

## Test Plan

- [x] Full ML test suite passes locally: `659 tests, 0 failures, 0 errors, 0 skipped`.
- [x] `tf2_test_top_k.py` and `tf2_test_meshgrid.py` Python fixtures run to completion under `python3.10` with the documented runtime asserts.
- [ ] CI confirms.

## Related

- [wala/ML#449](https://github.com/wala/ML/issues/449) Tier 5 — tracking issue.
- [wala/ML#480](https://github.com/wala/ML/issues/480) — per-index dispatch leak (filed as part of this work; blocks precise per-element assertions).
- ponder-lab/ML#249, #250, #251 — sibling Tier 5 generators (`Stack`, `Concat`, `Einsum`).