### PR TITLE
Add `values`/`indices` named-field aliases to `tf.math.top_k`'s XML (prerequisite for wala/ML#480)

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1053,13 +1053,17 @@
         </method>
       </class>
       <class name="top_k" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k. Direct `<new>+<putfield>` per wala/ML#380 (was a `read_data` materialization chain). Returns a `(values, indices)` tuple — both fields point at fresh `Tensor` allocations. -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k. Direct `<new>+<putfield>` per wala/ML#380 (was a `read_data` materialization chain). Returns a `(values, indices)` NamedTuple — both fields point at fresh `Tensor` allocations. The `values`/`indices` named-field aliases
+          (in addition to the numeric `0`/`1` fields) handle the NamedTuple attribute-access pattern: `result.values` reads field `"values"` (a string property name) and the alias makes that resolve to the same `xx` alloc as field `0`. Without the alias, `result.values` reads an empty field-PTS and falls through
+          to ⊤, even though `values, indices = result` (numeric destructuring) worked fine. See wala/ML#480 for the full diagnosis. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input k sorted name">
           <new def="x" class="Ltuple" />
           <new def="xx" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="xx" />
           <new def="yy" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy" />
+          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="yy" />
           <return value="x" />
         </method>
       </class>


### PR DESCRIPTION
## Summary

Prerequisite step for [wala/ML#480](https://github.com/wala/ML/issues/480) fix path.

`tf.math.top_k` returns a NamedTuple; user code typically accesses results via `result.values` and `result.indices`. The CAst lowering of attribute access produces property reads with string member names — and PA field resolution is string-keyed, so reading field `"values"` on the tuple alloc finds nothing today (only `"0"` and `"1"` are populated).

This PR adds `<putfield field="values">` (aliased to the same `xx` alloc as field `"0"`) and `<putfield field="indices">` (aliased to `yy` / field `"1"`) so attribute-access PA-resolves correctly to the right underlying alloc.

```xml
<class name="top_k" allocatable="true">
  <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input k sorted name">
    <new def="x" class="Ltuple" />
    <new def="xx" class="Ltensorflow/python/framework/ops/Tensor" />
    <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
    <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="xx" />   <!-- NEW -->
    <new def="yy" class="Ltensorflow/python/framework/ops/Tensor" />
    <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy" />
    <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="yy" />  <!-- NEW -->
    <return value="x" />
  </method>
</class>
```

## What This Doesn't Do (Yet)

Per-element dtype differentiation. `xx` and `yy` are both `Ltensorflow/python/framework/ops/Tensor` with no per-allocation-site dtype info; `TopK.getDefaultDTypes` (in the in-flight ponder-lab/ML#252) returns the aggregate union for both. Per-element precision needs the `TupleElementProvider` member-name-map dispatch fix proposed in wala/ML#480 — landing that change requires this XML alias as a prerequisite (the dispatch wrap can only fire on a string-member property read once the underlying field resolution doesn't return empty PTS).

## Test Plan

- [x] Full ML test suite passes locally: `656 tests, 0 failures, 0 errors, 0 skipped`.
- [x] No observable type changes — the alias unblocks future precision improvements but doesn't directly change anything yet (semantically a no-op).
- [ ] CI confirms.

## Coordination With ponder-lab/ML#252

The two `testTopK*` tests on ponder-lab/ML#252 currently assert the observed aggregate union. They continue to pass after this PR's XML alias lands — the alias doesn't change the observable types yet. When wala/ML#480's dispatch fix follows, those tests will narrow to precise per-element dtypes.

## Related

- [wala/ML#480](https://github.com/wala/ML/issues/480) — full diagnosis of the per-element dispatch leak; this PR is the XML alias half (failure mode 1a).
- ponder-lab/ML#252 — adds `TopK` and `Meshgrid` generators with workaround union assertions.