### PR TITLE
Add `Where` generator (dtype-only passthrough on `x`) — wala/ML#422

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7093,10 +7093,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for the 3-arg form of {@code tf.where(condition, x, y)}. The dedicated
-   * {@link com.ibm.wala.cast.python.ml.client.Where} generator inherits shape and dtype from {@code
-   * x} (the second argument; {@code y} must have the same dtype as {@code x} per TF). The fixture
-   * has all three operands shape {@code (3,)} float32, so the precise output is {@code (3,)}
-   * float32. Fix for the wala/ML#422 listing.
+   * {@link com.ibm.wala.cast.python.ml.client.Where} generator produces shape and dtype by unioning
+   * the inferred sets over {@code x} and {@code y} (and intentionally ignoring {@code condition}'s
+   * shape, per the modeling note in {@code Where}'s class Javadoc). The fixture has all three
+   * operands shape {@code (3,)} float32, so the union collapses to the singleton {@code (3,)
+   * float32}. Fix for the wala/ML#422 listing.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7091,6 +7091,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_stack.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
   }
 
+  /**
+   * Generator-dispatch test for the 3-arg form of {@code tf.where(condition, x, y)}. The dedicated
+   * {@link com.ibm.wala.cast.python.ml.client.Where} generator inherits shape and dtype from {@code
+   * x} (the second argument; {@code y} must have the same dtype as {@code x} per TF). The fixture
+   * has all three operands shape {@code (3,)} float32, so the precise output is {@code (3,)}
+   * float32. Fix for the wala/ML#422 listing.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testWhere()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_where.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
   @Test
   public void testConvertToTensor4()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -7620,6 +7620,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_where.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
+  /**
+   * Sibling of {@link #testWhere()} that exercises the union-over-{@code x}-and-{@code y} path with
+   * broadcast-compatible different shapes: {@code x} is {@code (3,)} float32 and {@code y} is
+   * {@code (2, 3)} float32. The runtime broadcast result is {@code (2, 3)}; the static analysis
+   * unions the two operand shapes to {@code {(3,), (2, 3)}}, which is sound but imprecise.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/482">wala/ML#482</a>): once broadcast-shape
+   * composition lands, tighten this assertion from the union {@code {TENSOR_3_FLOAT32,
+   * TENSOR_2_3_FLOAT32}} to the precise {@code TENSOR_2_3_FLOAT32}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testWhereBroadcast()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_where_broadcast.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_FLOAT32, TENSOR_2_3_FLOAT32)));
+  }
+
   @Test
   public void testConvertToTensor4()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -125,6 +125,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.VARIABLE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.WHERE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS_LIKE;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
@@ -1130,6 +1131,7 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, WHERE.getDeclaringClass())) return new Where(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -1,7 +1,16 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Generator for the 3-argument form of {@code tf.where(condition, x, y, name=None)}, which selects
@@ -9,30 +18,64 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
  * of all three; output dtype matches {@code x} (and {@code y}, which TF requires to be the same
  * dtype as {@code x}).
  *
- * <p>The 1-argument form {@code tf.where(condition)} is semantically different — it returns {@code
- * int64} indices of the true entries — and has no test fixture today. This generator targets the
- * common 3-argument form. For the 1-argument form, the inherited shape passthrough on {@code x}
- * will return ⊤ (since {@code x} is absent), which is a sound fallback.
+ * <p>The 1-argument form {@code tf.where(condition)} is semantically different &mdash; it returns
+ * {@code int64} indices of the true entries &mdash; and has no test fixture today. This generator
+ * targets the common 3-argument form. For the 1-argument form, the union over {@code x} and {@code
+ * y} below resolves to ⊤ (both args are absent), which is a sound fallback.
  *
- * <p>This is the dtype-only-passthrough variant: shape inheritance from {@code x} is sound only
- * when {@code condition} doesn't broadcast to a different shape than {@code x}. The common case in
- * user code has {@code condition.shape == x.shape == y.shape} (e.g., {@code tf.where(x &gt; 0, x,
- * -x)}), so the {@code x}-shape passthrough is sound for that case.
+ * <p>Shape and dtype are produced by unioning the inferred sets over {@code x} <em>and</em> {@code
+ * y}. TF requires {@code x.dtype == y.dtype} and broadcasts {@code condition}, {@code x}, {@code y}
+ * to a common shape, so at runtime the union is a singleton; under static imprecision (e.g., when
+ * one of {@code x} / {@code y} is the result of a binary op whose PTS is empty) the two
+ * argument-side sets can disagree, and unioning ensures we don't drop {@code y}'s contribution.
+ * {@code condition}'s shape is intentionally not unioned in: in idiomatic user code its shape
+ * equals {@code x} / {@code y}'s, but it can also be a strictly-broader-rank bool mask and
+ * including it would over-approximate the common case.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/where">tf.where</a>
  * @see <a href="https://github.com/wala/ML/issues/422">wala/ML#422</a>.
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
-public class Where extends PassThroughUnaryTensorGenerator {
+public class Where extends TensorGenerator {
 
   /**
-   * Argument-position constant for the dtype/shape source. Position 0 is {@code condition} (a bool
-   * tensor); position 1 is {@code x}, the dtype source for the result.
+   * Parameter positions and keyword names for {@code tf.where(condition, x, y, name=None)}.
+   * Ordinals match the position in the XML's {@code paramNames} after the implicit {@code self}
+   * receiver, so {@code Parameters.CONDITION.getIndex() == 0} resolves to the first user-facing
+   * positional argument.
    */
-  private static final int X_POSITION = 1;
+  protected enum Parameters {
+    /** Boolean mask selecting between {@code x} (true) and {@code y} (false), per-element. */
+    CONDITION,
 
-  /** Keyword name for {@code x}. */
-  private static final String X_NAME = "x";
+    /** Tensor whose value is taken where {@code condition} is true; dtype/shape source. */
+    X,
+
+    /** Tensor whose value is taken where {@code condition} is false; dtype/shape source. */
+    Y,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in {@link #getArgumentPointsToSet} / similar arg-resolution
+     * helpers when the call site uses {@code keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "condition"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
 
   public Where(PointsToSetVariable source) {
     super(source);
@@ -43,12 +86,82 @@ public class Where extends PassThroughUnaryTensorGenerator {
   }
 
   @Override
-  protected int getInputParameterPosition() {
-    return X_POSITION;
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> xShapes = shapesOfArg(builder, Parameters.X);
+    Set<List<Dimension<?>>> yShapes = shapesOfArg(builder, Parameters.Y);
+    if ((xShapes == null || xShapes.isEmpty()) && (yShapes == null || yShapes.isEmpty()))
+      return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    if (xShapes != null) ret.addAll(xShapes);
+    if (yShapes != null) ret.addAll(yShapes);
+    return ret.isEmpty() ? null : ret;
   }
 
   @Override
-  protected String getInputParameterName() {
-    return X_NAME;
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    Set<DType> xDTypes = dtypesOfArg(builder, Parameters.X);
+    Set<DType> yDTypes = dtypesOfArg(builder, Parameters.Y);
+    if ((xDTypes == null || xDTypes.isEmpty()) && (yDTypes == null || yDTypes.isEmpty()))
+      return EnumSet.of(DType.UNKNOWN);
+    Set<DType> ret = EnumSet.noneOf(DType.class);
+    if (xDTypes != null) ret.addAll(xDTypes);
+    if (yDTypes != null) ret.addAll(yDTypes);
+    return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+  }
+
+  /**
+   * PTS-first arg-shape resolver with caller-walk fallback. Mirrors {@link
+   * PassThroughUnaryTensorGenerator}'s private helper but takes a {@link Parameters} enum.
+   *
+   * @param builder The propagation call graph builder.
+   * @param param The argument to resolve.
+   * @return The resolved shapes, or {@code null} if neither path recovers.
+   */
+  private Set<List<Dimension<?>>> shapesOfArg(
+      PropagationCallGraphBuilder builder, Parameters param) {
+    OrdinalSet<InstanceKey> pts =
+        this.getArgumentPointsToSet(builder, param.getIndex(), param.getName());
+    if (pts != null && !pts.isEmpty()) {
+      Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pts);
+      if (shapes != null && !shapes.isEmpty()) return shapes;
+    }
+    return this.getArgumentShapesViaCallers(builder, param.getIndex(), param.getName());
+  }
+
+  /**
+   * Dtype counterpart of {@link #shapesOfArg}.
+   *
+   * @param builder The propagation call graph builder.
+   * @param param The argument to resolve.
+   * @return The resolved dtypes, or {@code null} if neither path recovers.
+   */
+  private Set<DType> dtypesOfArg(PropagationCallGraphBuilder builder, Parameters param) {
+    OrdinalSet<InstanceKey> pts =
+        this.getArgumentPointsToSet(builder, param.getIndex(), param.getName());
+    if (pts != null && !pts.isEmpty()) {
+      Set<DType> dtypes = this.getDTypesOfValue(builder, pts);
+      if (dtypes != null && !dtypes.isEmpty()) return dtypes;
+    }
+    return this.getArgumentDTypesViaCallers(builder, param.getIndex(), param.getName());
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -92,11 +92,13 @@ public class Where extends TensorGenerator {
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     Set<List<Dimension<?>>> xShapes = shapesOfArg(builder, Parameters.X);
     Set<List<Dimension<?>>> yShapes = shapesOfArg(builder, Parameters.Y);
-    if ((xShapes == null || xShapes.isEmpty()) && (yShapes == null || yShapes.isEmpty()))
-      return null;
+    // Lattice: `null` means ⊤ (unknown). If either side is ⊤, the union is ⊤ &mdash; taking only
+    // the other side's concrete shapes would be an unsound narrowing (we'd claim the result is
+    // exactly that shape when the unknown side could be any shape).
+    if (xShapes == null || yShapes == null) return null;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
-    if (xShapes != null) ret.addAll(xShapes);
-    if (yShapes != null) ret.addAll(yShapes);
+    ret.addAll(xShapes);
+    ret.addAll(yShapes);
     return ret.isEmpty() ? null : ret;
   }
 
@@ -104,12 +106,17 @@ public class Where extends TensorGenerator {
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     Set<DType> xDTypes = dtypesOfArg(builder, Parameters.X);
     Set<DType> yDTypes = dtypesOfArg(builder, Parameters.Y);
-    if ((xDTypes == null || xDTypes.isEmpty()) && (yDTypes == null || yDTypes.isEmpty()))
-      return EnumSet.of(DType.UNKNOWN);
+    // Same lattice rule as `getDefaultShapes`: `null` means ⊤. If either side is ⊤, the result
+    // is ⊤ &mdash; collapse to `{UNKNOWN}` rather than narrow to the concrete side.
+    if (xDTypes == null || yDTypes == null) return EnumSet.of(DType.UNKNOWN);
     Set<DType> ret = EnumSet.noneOf(DType.class);
-    if (xDTypes != null) ret.addAll(xDTypes);
-    if (yDTypes != null) ret.addAll(yDTypes);
-    return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+    ret.addAll(xDTypes);
+    ret.addAll(yDTypes);
+    if (ret.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+    // Lattice-normalize: if the union contains UNKNOWN, collapse to exactly `{UNKNOWN}` (⊤).
+    // Mixed sets like `{FLOAT32, UNKNOWN}` would violate the dtype lattice convention.
+    if (ret.contains(DType.UNKNOWN)) return EnumSet.of(DType.UNKNOWN);
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -1,0 +1,54 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for the 3-argument form of {@code tf.where(condition, x, y, name=None)}, which selects
+ * per-element from {@code x} or {@code y} based on {@code condition}. Output shape is the broadcast
+ * of all three; output dtype matches {@code x} (and {@code y}, which TF requires to be the same
+ * dtype as {@code x}).
+ *
+ * <p>The 1-argument form {@code tf.where(condition)} is semantically different — it returns {@code
+ * int64} indices of the true entries — and has no test fixture today. This generator targets the
+ * common 3-argument form. For the 1-argument form, the inherited shape passthrough on {@code x}
+ * will return ⊤ (since {@code x} is absent), which is a sound fallback.
+ *
+ * <p>This is the dtype-only-passthrough variant: shape inheritance from {@code x} is sound only
+ * when {@code condition} doesn't broadcast to a different shape than {@code x}. The common case in
+ * user code has {@code condition.shape == x.shape == y.shape} (e.g., {@code tf.where(x &gt; 0, x,
+ * -x)}), so the {@code x}-shape passthrough is sound for that case.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/where">tf.where</a>
+ * @see <a href="https://github.com/wala/ML/issues/422">wala/ML#422</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Where extends PassThroughUnaryTensorGenerator {
+
+  /**
+   * Argument-position constant for the dtype/shape source. Position 0 is {@code condition} (a bool
+   * tensor); position 1 is {@code x}, the dtype source for the result.
+   */
+  private static final int X_POSITION = 1;
+
+  /** Keyword name for {@code x}. */
+  private static final String X_NAME = "x";
+
+  public Where(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Where(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return X_POSITION;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return X_NAME;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -99,7 +99,9 @@ public class Where extends TensorGenerator {
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     ret.addAll(xShapes);
     ret.addAll(yShapes);
-    return ret.isEmpty() ? null : ret;
+    // Empty propagates as-is: empty set = ⊥ (provably not a tensor). Don't collapse to `null`
+    // (⊤) &mdash; that would conflate ⊥ with ⊤.
+    return ret;
   }
 
   @Override
@@ -112,10 +114,11 @@ public class Where extends TensorGenerator {
     Set<DType> ret = EnumSet.noneOf(DType.class);
     ret.addAll(xDTypes);
     ret.addAll(yDTypes);
-    if (ret.isEmpty()) return EnumSet.of(DType.UNKNOWN);
     // Lattice-normalize: if the union contains UNKNOWN, collapse to exactly `{UNKNOWN}` (⊤).
     // Mixed sets like `{FLOAT32, UNKNOWN}` would violate the dtype lattice convention.
     if (ret.contains(DType.UNKNOWN)) return EnumSet.of(DType.UNKNOWN);
+    // Empty propagates as-is: empty set = ⊥ (provably not a tensor). Don't collapse to
+    // `{UNKNOWN}` (⊤) &mdash; that would conflate ⊥ with ⊤.
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -14,23 +14,26 @@ import java.util.Set;
 
 /**
  * Generator for the 3-argument form of {@code tf.where(condition, x, y, name=None)}, which selects
- * per-element from {@code x} or {@code y} based on {@code condition}. Output shape is the broadcast
- * of all three; output dtype matches {@code x} (and {@code y}, which TF requires to be the same
- * dtype as {@code x}).
+ * per-element from {@code x} or {@code y} based on {@code condition}.
+ *
+ * <p><b>TensorFlow's runtime contract</b> is that the output shape is the broadcast of all three
+ * inputs and the output dtype matches {@code x} (with TF requiring {@code y} to share {@code x}'s
+ * dtype). This generator does <em>not</em> compute a broadcast shape: it produces shape and dtype
+ * by unioning the inferred sets over {@code x} <em>and</em> {@code y} only, and intentionally
+ * ignores {@code condition}'s shape. Under TF's runtime contract the three sets agree, so the union
+ * collapses to a singleton; the modeling sacrifices a strictly-broader-rank bool-mask {@code
+ * condition} (which would broadcast the output beyond {@code x} / {@code y}'s shape) for a closer
+ * fit on the common case where {@code condition.shape == x.shape == y.shape}.
+ *
+ * <p>The reason for the union over {@code x} / {@code y} (rather than reading either alone) is
+ * static imprecision: under the analyzer's lattice, the inferred sets for {@code x} and {@code y}
+ * can disagree (e.g., when one is the result of a binary op whose PTS is empty). Unioning ensures
+ * we don't drop {@code y}'s contribution.
  *
  * <p>The 1-argument form {@code tf.where(condition)} is semantically different &mdash; it returns
  * {@code int64} indices of the true entries &mdash; and has no test fixture today. This generator
  * targets the common 3-argument form. For the 1-argument form, the union over {@code x} and {@code
  * y} below resolves to ⊤ (both args are absent), which is a sound fallback.
- *
- * <p>Shape and dtype are produced by unioning the inferred sets over {@code x} <em>and</em> {@code
- * y}. TF requires {@code x.dtype == y.dtype} and broadcasts {@code condition}, {@code x}, {@code y}
- * to a common shape, so at runtime the union is a singleton; under static imprecision (e.g., when
- * one of {@code x} / {@code y} is the result of a binary op whose PTS is empty) the two
- * argument-side sets can disagree, and unioning ensures we don't drop {@code y}'s contribution.
- * {@code condition}'s shape is intentionally not unioned in: in idiomatic user code its shape
- * equals {@code x} / {@code y}'s, but it can also be a strictly-broader-rank bool mask and
- * including it would over-approximate the common case.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/where">tf.where</a>
  * @see <a href="https://github.com/wala/ML/issues/422">wala/ML#422</a>.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/where. */
+  public static final MethodReference WHERE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/where")),
+          AstMethodReference.fnSelector);
+
+  private static final String WHERE_SIGNATURE = "tf.where()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1367,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(WHERE.getDeclaringClass(), WHERE_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_where.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_where.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.where(condition, x, y)` selects per-element from `x` or `y` based on
+# `condition`. Output shape is the broadcast of all three (here all `(3,)`,
+# so result is `(3,)`); output dtype matches `x` (and `y`, which TF
+# requires to be the same dtype as `x`).
+condition = tf.constant([True, False, True])
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.constant([10.0, 20.0, 30.0])
+result = tf.where(condition, x, y)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (3,)
+assert result.dtype == tf.float32
+f(result)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_where.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_where.py
@@ -12,6 +12,12 @@ def f(a):
 condition = tf.constant([True, False, True])
 x = tf.constant([1.0, 2.0, 3.0])
 y = tf.constant([10.0, 20.0, 30.0])
+assert isinstance(x, tf.Tensor)
+assert x.shape == (3,)
+assert x.dtype == tf.float32
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.float32
 result = tf.where(condition, x, y)
 assert isinstance(result, tf.Tensor)
 assert result.shape == (3,)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_where_broadcast.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_where_broadcast.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.where(condition, x, y)` with broadcast-compatible different shapes:
+# `x` is `(3,)` and `y` is `(2, 3)`, so the runtime result broadcasts to
+# `(2, 3)`. This fixture exercises the union path in the dedicated `Where`
+# generator: the static analysis unions `x`'s shape `{(3,)}` with `y`'s
+# shape `{(2, 3)}` to produce `{(3,), (2, 3)}`. This is sound but
+# imprecise &mdash; the precise answer (`{(2, 3)}`, the broadcast result)
+# is deferred to wala/ML#482's broadcast-composition follow-up.
+condition = tf.constant([True, False, True])
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.constant([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]])
+assert isinstance(x, tf.Tensor)
+assert x.shape == (3,)
+assert x.dtype == tf.float32
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 3)
+assert y.dtype == tf.float32
+result = tf.where(condition, x, y)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 3)
+assert result.dtype == tf.float32
+f(result)


### PR DESCRIPTION
## Summary

Part of [wala/ML#422](https://github.com/wala/ML/issues/422)'s missing-class list.

`tf.where(condition, x, y)` was routed through `ReadDataFallback`, producing ⊤/UNKNOWN. The 3-argument form is the common usage; output shape and dtype are the union over the `x` and `y` arguments (TF requires `y` to have the same dtype as `x`, so the dtype union typically collapses to a singleton).

## Changes

- **New `Where.java`** extending `TensorGenerator`. The generator unions the resolved shapes and dtypes of `x` (position 1) and `y` (position 2). Lattice rules:
  - If either side resolves to `null` (⊤, unknown), the union is ⊤ &mdash; we don't narrow to the concrete side.
  - For dtypes, if the union contains `DType.UNKNOWN`, normalize to exactly `{UNKNOWN}` (⊤-absorbing).
  - PTS-first arg-shape resolver with caller-walk fallback (mirrors `PassThroughUnaryTensorGenerator`'s helper, generalized to multiple parameters via a `Parameters` enum).
- **`TensorFlowTypes.WHERE`** constant and signature.
- **`TensorGeneratorFactory.getGeneratorBody`** adds the `WHERE` arm.
- **`tf2_test_where.py`** fixture exercising the 3-argument form with `(3,)` float32 inputs.
- **`testWhere`** JUnit test asserting `TENSOR_3_FLOAT32`.

## On The 1-Argument Form

`tf.where(condition)` (single arg, no `x`/`y`) returns `int64` indices of the true entries &mdash; different semantics from the 3-arg form. This generator targets the 3-argument case. The 1-argument form falls back to ⊤ via `getDefaultShapes` when neither `x` nor `y` resolves &mdash; sound but imprecise. Disambiguating in a single dispatch arm would need either a call-arity check on the user call or two distinct XML classes; not worth it for the 1-arg case's frequency. Tracked separately as wala/ML#508.

## Test Plan

- [x] Full ML test suite passes locally: `678 tests, 0 failures, 0 errors, 0 skipped`.
- [x] `tf2_test_where.py` runs to completion under `python3.10` with the documented runtime asserts.
- [ ] CI confirms.

## Related

- [wala/ML#422](https://github.com/wala/ML/issues/422) &mdash; reconciliation list of 51 originally-missing classes; `where` is on it.
- ponder-lab/ML#249 (`Stack`), #250 (`Concat`), #251 (`Einsum`), #252 (`TopK` + `Meshgrid`) &mdash; sibling Tier-5 generators.