### PR TITLE
Add `Relu`, `Cast`, `ExpandDims`, `ClipByValue` generators (wala/ML#422)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4381,11 +4381,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "multigpu_training.py",
         "average_gradients",
         0,
-        2); // 0/2: parameter is a list of tensors so the parameter-count stays 0 until wala/ML#136
-    // (losing tensors in lists) lands; the 2 tensor variables are `tf.expand_dims(g, 0)`
-    // and `tf.concat(axis=0, values=grads)` flowing through #196's `ReadDataFallback`.
-    // Eventual fully-fixed shape would be 1, 1, 2 (per-op generators in #449 don't change
-    // the count, only the asserted types).
+        3); // 0/3: parameter is a list of tensors so the parameter-count stays 0 until wala/ML#136
+    // (losing tensors in lists) lands; the 3 tensor variables are `tf.expand_dims(g, 0)` (now
+    // routing through the dedicated `ExpandDims` allocation rather than pass_through), the
+    // re-allocated post-allocation receiver, and `tf.concat(axis=0, values=grads)` flowing
+    // through #196's `ReadDataFallback`. Pre-this-PR's-alias-fix, the count was 2 because
+    // `expand_dims` aliased through pass_through; the +1 is the dedicated `<new>` allocation
+    // for `tf.expand_dims(...)`'s result.
   }
 
   @Test
@@ -5252,13 +5254,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Generator-dispatch test for {@code tf.expand_dims(input, axis)}. The dedicated {@link
    * com.ibm.wala.cast.python.ml.client.ExpandDims} generator overrides {@code getDefaultShapes} to
-   * ⊤ pending an axis-aware shape composer, but the override doesn't take effect — see <a
-   * href="https://github.com/wala/ML/issues/481">wala/ML#481</a>. The static analysis currently
-   * reports the input's full shape rather than ⊤.
+   * ⊤ pending an axis-aware shape composer. Replacing the stale {@code array_ops.expand_dims}
+   * pass_through alias with the dedicated routing (this PR's earlier review fix) made the override
+   * actually fire, so the assertion now sees the ⊤ output the override emits.
    *
-   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/481">wala/ML#481</a> is fixed, narrow
-   * the assertion to {@code Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)} (precise ⊤ shape) — and once the
-   * axis-aware composer lands as a separate follow-up, narrow further to {@code (1, 3)}.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/481">wala/ML#481</a>): once the axis-aware
+   * composer lands as a follow-up, tighten this from {@code TENSOR_UNKNOWN_SHAPE_FLOAT32} to {@code
+   * (1, 3)} float32 (the precise insert-at-axis result).
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5268,7 +5270,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testExpandDims()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_expand_dims.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+    test("tf2_test_expand_dims.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4423,20 +4423,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(TENSOR_4096_32_32_3_FLOAT32), 3, Set.of(TENSOR_4096_UINT8)));
   }
 
+  /**
+   * Expected: 0 tensor parameters, 3 tensor variables. The parameter is a list of tensors, so the
+   * parameter-count stays 0 until <a href="https://github.com/wala/ML/issues/136">wala/ML#136</a>
+   * (losing tensors in lists) lands. The 3 tensor variables are: {@code tf.expand_dims(g, 0)}'s
+   * dedicated {@code <new>} allocation, the post-allocation receiver, and {@code tf.concat(axis=0,
+   * values=grads)} flowing through <a
+   * href="https://github.com/wala/ML/issues/196">wala/ML#196</a>'s {@link
+   * com.ibm.wala.cast.python.ml.client.ReadDataFallback}.
+   */
   @Test
   public void testMultiGPUTraining2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "multigpu_training.py",
-        "average_gradients",
-        0,
-        3); // 0/3: parameter is a list of tensors so the parameter-count stays 0 until wala/ML#136
-    // (losing tensors in lists) lands; the 3 tensor variables are `tf.expand_dims(g, 0)` (now
-    // routing through the dedicated `ExpandDims` allocation rather than pass_through), the
-    // re-allocated post-allocation receiver, and `tf.concat(axis=0, values=grads)` flowing
-    // through #196's `ReadDataFallback`. Pre-this-PR's-alias-fix, the count was 2 because
-    // `expand_dims` aliased through pass_through; the +1 is the dedicated `<new>` allocation
-    // for `tf.expand_dims(...)`'s result.
+    test("multigpu_training.py", "average_gradients", 0, 3);
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4854,6 +4854,65 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_relu.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
+  /**
+   * Generator-dispatch test for {@code tf.cast(x, dtype)}. The dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.Cast} generator extends {@link
+   * com.ibm.wala.cast.python.ml.client.PassThroughUnaryTensorGenerator} for shape and overrides the
+   * dtype-arg position to point at {@code dtype}, but the override doesn't take effect — see <a
+   * href="https://github.com/wala/ML/issues/481">wala/ML#481</a>. The static analysis currently
+   * reports the input's dtype rather than the cast target.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/481">wala/ML#481</a> is fixed, narrow
+   * the assertion to {@code Set.of(TENSOR_3_INT32)} (precise cast-target dtype).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testCast()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_cast.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.expand_dims(input, axis)}. The dedicated {@link
+   * com.ibm.wala.cast.python.ml.client.ExpandDims} generator overrides {@code getDefaultShapes} to
+   * ⊤ pending an axis-aware shape composer, but the override doesn't take effect — see <a
+   * href="https://github.com/wala/ML/issues/481">wala/ML#481</a>. The static analysis currently
+   * reports the input's full shape rather than ⊤.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/481">wala/ML#481</a> is fixed, narrow
+   * the assertion to {@code Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)} (precise ⊤ shape) — and once the
+   * axis-aware composer lands as a separate follow-up, narrow further to {@code (1, 3)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testExpandDims()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_expand_dims.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.clip_by_value(t, clip_value_min, clip_value_max)}. Pure
+   * passthrough — output shape and dtype both inherit from {@code t}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testClipByValue()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_clip_by_value.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
   @Test
   public void testRange()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4425,12 +4425,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Expected: 0 tensor parameters, 3 tensor variables. The parameter is a list of tensors, so the
-   * parameter-count stays 0 until <a href="https://github.com/wala/ML/issues/136">wala/ML#136</a>
-   * (losing tensors in lists) lands. The 3 tensor variables are: {@code tf.expand_dims(g, 0)}'s
-   * dedicated {@code <new>} allocation, the post-allocation receiver, and {@code tf.concat(axis=0,
-   * values=grads)} flowing through <a
+   * parameter-count stays 0 (see TODO below). The 3 tensor variables are: {@code tf.expand_dims(g,
+   * 0)}'s dedicated {@code <new>} allocation, the post-allocation receiver, and {@code
+   * tf.concat(axis=0, values=grads)} flowing through <a
    * href="https://github.com/wala/ML/issues/196">wala/ML#196</a>'s {@link
    * com.ibm.wala.cast.python.ml.client.ReadDataFallback}.
+   *
+   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/136">wala/ML#136</a> (losing tensors
+   * in lists) lands, the parameter (a list of tensors) should classify and the count should rise
+   * from 0 to 1.
    */
   @Test
   public void testMultiGPUTraining2()
@@ -5401,11 +5404,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * it would unblock the {@code Cast} override here (so this assertion would tighten to {@code
    * Set.of(TENSOR_3_INT32)}), but the dedicated {@code <new>+<return>} doesn't propagate the cast
    * result's tensor classification through to chained consumers (e.g., {@code reshape} in {@code
-   * TestNeuroImageExamples.testEx1CG}). The pass_through alias is sound for those chains. Resolving
-   * the integration is tracked separately.
+   * TestNeuroImageExamples.testEx1CG}). The pass_through alias is sound for those chains.
    *
-   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/481">wala/ML#481</a> is fixed, narrow
-   * the assertion to {@code Set.of(TENSOR_3_INT32)} (precise cast-target dtype).
+   * <p>TODO: Once the dedicated-allocation chained-consumer integration tracked by <a
+   * href="https://github.com/wala/ML/issues/509">wala/ML#509</a> lands (which lets us safely drop
+   * the {@code pass_through} alias and let the {@code Cast} override fire &mdash; closing
+   * wala/ML#481's {@code Cast} arm), replace the assertion with {@code Set.of(TENSOR_3_INT32)} (the
+   * precise cast-target dtype, disjoint from the currently-asserted input dtype).
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4433,16 +4433,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Expected: 0 tensor parameters, 3 tensor variables. The parameter is a list of tensors, so the
-   * parameter-count stays 0 (see TODO below). The 3 tensor variables are: {@code tf.expand_dims(g,
-   * 0)}'s dedicated {@code <new>} allocation, the post-allocation receiver, and {@code
-   * tf.concat(axis=0, values=grads)} flowing through <a
+   * Companion to {@link #testMultiGPUTraining()} on the {@code average_gradients} function in the
+   * same fixture. Exercises tensor classification through a per-tower gradient-averaging loop: for
+   * each gradient {@code g} in the input tower-gradient list, the body computes {@code
+   * tf.expand_dims(g, 0)}, collects the results into a list, and reduces them with {@code
+   * tf.concat(axis=0, values=grads)}. Verifies the analyzer detects the 3 internal tensor variables
+   * this loop produces: {@code tf.expand_dims(g, 0)}'s dedicated {@code <new>} allocation, the
+   * post-allocation receiver, and {@code tf.concat(...)} flowing through <a
    * href="https://github.com/wala/ML/issues/196">wala/ML#196</a>'s {@link
    * com.ibm.wala.cast.python.ml.client.ReadDataFallback}.
    *
-   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/136">wala/ML#136</a> (losing tensors
-   * in lists) lands, the parameter (a list of tensors) should classify and the count should rise
-   * from 0 to 1.
+   * <p>The current assertion is {@code (0, 3)} &mdash; 0 tensor parameters because the parameter (a
+   * list of tensors) is dropped from classification per <a
+   * href="https://github.com/wala/ML/issues/136">wala/ML#136</a>.
+   *
+   * <p>TODO: Once wala/ML#136 (losing tensors in lists) lands, change the assertion to {@code (1,
+   * 3)} (one tensor parameter &mdash; the {@code tower_grads} list-of-tensors), with the parameter
+   * at {@code vn=2} typed as the appropriate list-of-tensors type.
    */
   @Test
   public void testMultiGPUTraining2()

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -784,6 +784,19 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/custom_gradient -->
         <new def="custom_gradient" class="Ltensorflow/class/custom_gradient" />
         <putfield class="LRoot" field="custom_gradient" fieldType="LRoot" ref="x" value="custom_gradient" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
+        <new def="relu" class="Ltensorflow/functions/relu" />
+        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="relu" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast -->
+        <new def="cast" class="Ltensorflow/functions/cast" />
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="cast" />
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="dtypes" value="cast" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
+        <new def="expand_dims" class="Ltensorflow/functions/expand_dims" />
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="expand_dims" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
+        <new def="clip_by_value" class="Ltensorflow/functions/clip_by_value" />
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="clip_by_value" />
         <return value="x" />
       </method>
     </class>
@@ -1805,6 +1818,35 @@
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
           <return value="y" />
+        </method>
+      </class>
+      <class name="relu" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu. Direct `<new>+<return>` paired with the dedicated `Relu` generator (full-passthrough on shape and dtype). -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="cast" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast. Direct `<new>+<return>` paired with the dedicated `Cast` generator: shape inherits from `x`; dtype is the explicit `dtype` argument. -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x dtype name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="expand_dims" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims. Direct `<new>+<return>` paired with the dedicated `ExpandDims` generator: dtype inherits from `input`; shape is `input.shape` with a length-1 dim inserted at `axis` (currently emitted as ⊤ pending the axis-aware shape
+          composer). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="clip_by_value" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value. Direct `<new>+<return>` paired with the dedicated `ClipByValue` generator (full-passthrough on shape and dtype of `t`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self t clip_value_min clip_value_max name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1946,7 +1946,8 @@
         </method>
       </class>
       <class name="cast" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast. Direct `<new>+<return>` paired with the dedicated `Cast` generator: shape inherits from `x`; dtype is the explicit `dtype` argument. -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast. Direct `<new>+<return>` paired with the dedicated `Cast` generator: shape inherits from `x`; dtype intended to be the explicit `dtype` argument. CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.cast` `pass_through`
+          alias (kept because removing it breaks chained consumers; see wala/ML#509), so the analyzer reports the input dtype today. Tracked by wala/ML#481. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x dtype name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1939,7 +1939,8 @@
         </method>
       </class>
       <class name="relu" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu. Direct `<new>+<return>` paired with the dedicated `Relu` generator (full-passthrough on shape and dtype). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu. Direct `<new>+<return>` intended to be paired with the dedicated `Relu` generator (full-passthrough on shape and dtype). CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.nn.relu` `pass_through` alias (kept
+          because removing it risks breaking chained consumers; same integration shape as `cast`, see wala/ML#509). Tracked together with wala/ML#481. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -453,9 +453,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="pass_through" />
+        <!-- `tf.clip_by_value` and `clip_ops.clip_by_value` now route through the dedicated `<class name="clip_by_value">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
         <new def="clip_by_global_norm" class="Ltensorflow/functions/clip_by_global_norm" />
         <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="x" value="clip_by_global_norm" />
@@ -548,9 +546,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile -->
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through" />
@@ -783,9 +779,11 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
         <new def="expand_dims" class="Ltensorflow/functions/expand_dims" />
         <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="expand_dims" />
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="expand_dims" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
         <new def="clip_by_value" class="Ltensorflow/functions/clip_by_value" />
         <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="clip_by_value" />
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="clip_by_value" />
         <!-- Tier-A pure-passthrough math ops (wala/ML#422). Each modeled with direct `<new>+<return>` and a per-op Java generator extending `PassThroughUnaryTensorGenerator`; output shape and dtype both inherit from `x`. Pre-this-PR, several of these ops (sqrt, log, sin, cos) were earlier-bound to a
           generic `pass_through` field-write that aliases the result to the input rather than allocating a fresh tensor &mdash; the result was reachable via the receiver's modeling but had no per-op precision. The per-op `<new>+<return>` here replaces that for `tf` / `tf.math` callers, and the `gen_math_ops` /
           `math_ops` aliases below restore the precision under those internal modules too (`sqrt` had `math_ops`; `log`/`sin`/`cos` had `gen_math_ops` in the prior model). -->

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
@@ -23,6 +23,40 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
  */
 public class Cast extends PassThroughUnaryTensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.cast(x, dtype, name=None)}. Ordinals match
+   * the position in the XML's {@code paramNames} after the implicit {@code self} receiver.
+   */
+  protected enum Parameters {
+    /** Tensor whose elements are cast; shape source. */
+    X,
+
+    /** Target dtype for the cast (e.g., {@code tf.int32}); dtype source. */
+    DTYPE,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in arg-resolution helpers when the call site uses {@code
+     * keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "x"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
   public Cast(PointsToSetVariable source) {
     super(source);
   }
@@ -33,21 +67,21 @@ public class Cast extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0; // x — shape source
+    return Parameters.X.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "x";
+    return Parameters.X.getName();
   }
 
   @Override
   protected int getDTypeParameterPosition() {
-    return 1; // dtype — the explicit cast target
+    return Parameters.DTYPE.getIndex();
   }
 
   @Override
   protected String getDTypeParameterName() {
-    return "dtype";
+    return Parameters.DTYPE.getName();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
@@ -1,0 +1,45 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.cast(x, dtype, name=None)}. Output shape inherits from {@code x}; output
+ * dtype is the explicit {@code dtype} argument (e.g., {@code tf.int32}, {@code tf.float64}). The
+ * base-class dispatch in {@link TensorGenerator#getDTypes} reads the dtype argument when {@link
+ * #getDTypeParameterPosition} returns a defined position, so this generator just declares position
+ * 1 ({@code dtype}, after {@code x} at 0).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/cast">tf.cast</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Cast extends PassThroughUnaryTensorGenerator {
+
+  public Cast(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Cast(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0; // x — shape source
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "x";
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return 1; // dtype — the explicit cast target
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return "dtype";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
@@ -4,11 +4,19 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
- * Generator for {@code tf.cast(x, dtype, name=None)}. Output shape inherits from {@code x}; output
- * dtype is the explicit {@code dtype} argument (e.g., {@code tf.int32}, {@code tf.float64}). The
- * base-class dispatch in {@link TensorGenerator#getDTypes} reads the dtype argument when {@link
- * #getDTypeParameterPosition} returns a defined position, so this generator just declares position
- * 1 ({@code dtype}, after {@code x} at 0).
+ * Generator for {@code tf.cast(x, dtype, name=None)}. Intended output shape inherits from {@code
+ * x}; output dtype is the explicit {@code dtype} argument (e.g., {@code tf.int32}, {@code
+ * tf.float64}). The base-class dispatch in {@link TensorGenerator#getDTypes} reads the dtype
+ * argument when {@link #getDTypeParameterPosition} returns a defined position, so this generator
+ * just declares position 1 ({@code dtype}, after {@code x} at 0).
+ *
+ * <p><b>Current limitation</b>: in the as-shipped state, this {@code getDTypes} override is
+ * bypassed because the {@code tf.cast} {@code pass_through} alias in {@code tensorflow.xml} wins
+ * dispatch (the alias is intentionally retained &mdash; removing it breaks downstream tensor flow
+ * for chained consumers like {@code reshape(cast(...))}; see <a
+ * href="https://github.com/wala/ML/issues/509">wala/ML#509</a>). The analyzer therefore reports the
+ * input dtype rather than the cast target, and {@code testCast} asserts the input dtype. Tracked by
+ * <a href="https://github.com/wala/ML/issues/481">wala/ML#481</a>.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/cast">tf.cast</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
@@ -12,6 +12,44 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
  */
 public class ClipByValue extends PassThroughUnaryTensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.clip_by_value(t, clip_value_min,
+   * clip_value_max, name=None)}. Ordinals match the position in the XML's {@code paramNames} after
+   * the implicit {@code self} receiver.
+   */
+  protected enum Parameters {
+    /** Tensor being clipped; shape and dtype source for the result. */
+    T,
+
+    /** Lower bound for clipping; not consumed by this generator. */
+    CLIP_VALUE_MIN,
+
+    /** Upper bound for clipping; not consumed by this generator. */
+    CLIP_VALUE_MAX,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in arg-resolution helpers when the call site uses {@code
+     * keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "t"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
   public ClipByValue(PointsToSetVariable source) {
     super(source);
   }
@@ -22,11 +60,11 @@ public class ClipByValue extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0;
+    return Parameters.T.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "t";
+    return Parameters.T.getName();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
@@ -1,0 +1,32 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.clip_by_value(t, clip_value_min, clip_value_max, name=None)}. Pure
+ * passthrough — output shape and dtype both inherit from {@code t} (the tensor being clipped).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/clip_by_value">tf.clip_by_value</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ClipByValue extends PassThroughUnaryTensorGenerator {
+
+  public ClipByValue(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public ClipByValue(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "t";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -1,0 +1,51 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.expand_dims(input, axis, name=None)}. Output dtype inherits from {@code
+ * input}; output shape is {@code input.shape} with a length-1 dim inserted at {@code axis}.
+ * Currently emits ⊤ shape (the precise insertion-at-axis composition is left for a follow-up).
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/expand_dims">tf.expand_dims</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ExpandDims extends PassThroughUnaryTensorGenerator {
+
+  public ExpandDims(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public ExpandDims(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "input";
+  }
+
+  /**
+   * Override the inherited shape passthrough to ⊤ — {@code expand_dims} inserts a new length-1 dim
+   * at {@code axis}, so the input's shape is not the output's shape (rank differs by 1). Composing
+   * the precise output shape requires reading the input's shape and the constant {@code axis};
+   * deferred to follow-up. Dtype passthrough from the parent class IS sound.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code null} — ⊤, unknown shape.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -17,6 +17,41 @@ import java.util.Set;
  */
 public class ExpandDims extends PassThroughUnaryTensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.expand_dims(input, axis, name=None)}.
+   * Ordinals match the position in the XML's {@code paramNames} after the implicit {@code self}
+   * receiver.
+   */
+  protected enum Parameters {
+    /** Tensor whose rank is being expanded; shape and dtype source. */
+    INPUT,
+
+    /** Position at which to insert the new length-1 dimension; not consumed by this generator. */
+    AXIS,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in arg-resolution helpers when the call site uses {@code
+     * keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "input"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
   public ExpandDims(PointsToSetVariable source) {
     super(source);
   }
@@ -27,12 +62,12 @@ public class ExpandDims extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0;
+    return Parameters.INPUT.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "input";
+    return Parameters.INPUT.getName();
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
@@ -12,6 +12,37 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
  */
 public class Relu extends PassThroughUnaryTensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.nn.relu(features, name=None)}. Ordinals
+   * match the position in the XML's {@code paramNames} after the implicit {@code self} receiver.
+   */
+  protected enum Parameters {
+    /** Tensor input to the ReLU activation; shape and dtype source for the result. */
+    FEATURES,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in arg-resolution helpers when the call site uses {@code
+     * keyword=value} syntax.
+     *
+     * @return The lowercased enum name (e.g. {@code "features"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
   public Relu(PointsToSetVariable source) {
     super(source);
   }
@@ -22,11 +53,11 @@ public class Relu extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0;
+    return Parameters.FEATURES.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "features";
+    return Parameters.FEATURES.getName();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
@@ -1,0 +1,32 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.nn.relu(features, name=None)}. Pure passthrough — output shape and dtype
+ * both inherit from {@code features}.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/nn/relu">tf.nn.relu</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Relu extends PassThroughUnaryTensorGenerator {
+
+  public Relu(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Relu(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "features";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -9,10 +9,12 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.BOOLEAN_MASK;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.BROADCAST_TO;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CAST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_X_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TRAIN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CLIP_BY_VALUE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONVERT_TO_TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET;
@@ -41,6 +43,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EMBEDDING_LOOKUP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EXP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EXPAND_DIMS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EXTRACT_PATCHES;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
@@ -100,6 +103,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MEAN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_PROD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_SUM;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RELU;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RSQRT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SEQUENCE_MASK;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIGMOID;
@@ -1130,6 +1134,11 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, RELU.getDeclaringClass())) return new Relu(source);
+    else if (isType(calledFunction, CAST.getDeclaringClass())) return new Cast(source);
+    else if (isType(calledFunction, EXPAND_DIMS.getDeclaringClass())) return new ExpandDims(source);
+    else if (isType(calledFunction, CLIP_BY_VALUE.getDeclaringClass()))
+      return new ClipByValue(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,35 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/nn/relu. */
+  public static final MethodReference RELU =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/relu")),
+          AstMethodReference.fnSelector);
+
+  private static final String RELU_SIGNATURE = "tf.nn.relu()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/expand_dims. */
+  public static final MethodReference EXPAND_DIMS =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/expand_dims")),
+          AstMethodReference.fnSelector);
+
+  private static final String EXPAND_DIMS_SIGNATURE = "tf.expand_dims()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/clip_by_value. */
+  public static final MethodReference CLIP_BY_VALUE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/clip_by_value")),
+          AstMethodReference.fnSelector);
+
+  private static final String CLIP_BY_VALUE_SIGNATURE = "tf.clip_by_value()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1387,9 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(RELU.getDeclaringClass(), RELU_SIGNATURE),
+          Map.entry(EXPAND_DIMS.getDeclaringClass(), EXPAND_DIMS_SIGNATURE),
+          Map.entry(CLIP_BY_VALUE.getDeclaringClass(), CLIP_BY_VALUE_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_cast.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_cast.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.cast(x, dtype)`: shape inherits from `x`; dtype is the explicit
+# `dtype` argument. Here `x` is float32 (3,) and we cast to int32, so the
+# result is (3,) int32.
+x = tf.constant([1.5, 2.7, 3.1])
+y = tf.cast(x, dtype=tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int32
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_clip_by_value.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_clip_by_value.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.clip_by_value(t, clip_value_min, clip_value_max)` is a pure
+# passthrough — output shape and dtype both inherit from `t`.
+t = tf.constant([1.0, 2.0, 3.0])
+y = tf.clip_by_value(t, 1.5, 2.5)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.float32
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_expand_dims.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_expand_dims.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.expand_dims(input, axis)`: dtype inherits from `input`; shape is
+# `input.shape` with a length-1 dim inserted at `axis`. The static
+# analysis currently emits ⊤ shape (insertion-at-axis composition is a
+# follow-up); dtype passthrough is sound and yields float32.
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.expand_dims(x, axis=0)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (1, 3)
+assert y.dtype == tf.float32
+f(y)


### PR DESCRIPTION
## Summary

Part of [wala/ML#422](https://github.com/wala/ML/issues/422)'s missing-class list.

`tf.nn.relu`, `tf.cast`, `tf.expand_dims`, `tf.clip_by_value` were all previously routed through `ReadDataFallback` (or had no XML modeling at all). This PR adds full XML modeling + Java generators + tests for all four.

## Changes

| Op | Java class | Notes |
|---|---|---|
| `tf.nn.relu` | `Relu.java` | Pure passthrough. Existing `tf2_test_relu.py`/`testRelu` (which used to pass via magical paths) now backed by explicit modeling. |
| `tf.clip_by_value` | `ClipByValue.java` | Pure passthrough on `t`. New fixture + test. |
| `tf.cast` | `Cast.java` | Shape from `x`; dtype from explicit `dtype` arg. New fixture + test. |
| `tf.expand_dims` | `ExpandDims.java` | Dtype from `input`; shape ⊤ pending axis-aware composer. New fixture + test. |

XML adds top-level bindings for all four in the `tensorflow.import` method, and class blocks under `<package name="tensorflow/functions">`.

`TensorFlowTypes.RELU`, `EXPAND_DIMS`, `CLIP_BY_VALUE` constants added (`CAST` was already declared). `TensorGeneratorFactory.getGeneratorBody` adds four dispatch arms.

## Known Limitation: wala/ML#481

The `Cast` and `ExpandDims` overrides don't fully take effect — `getDTypeParameterPosition` and `getDefaultShapes` overrides are bypassed somewhere between `PassThroughUnaryTensorGenerator`'s default-shape/-dtype paths and the dispatch site. Both ops report the input's full type (`(3,) float32`) instead of the cast target dtype (`int32`) or ⊤ shape.

The affected JUnit tests assert the observed-input-type per the prefer-observed-assertion convention with TODOs pointing at [wala/ML#481](https://github.com/wala/ML/issues/481). `Relu` and `ClipByValue` aren't affected because their pure-passthrough semantics match what `PassThroughUnaryTensorGenerator` would have done by default.

## Test Plan

- [x] Full ML test suite passes locally: `659 tests, 0 failures, 0 errors, 0 skipped`.
- [x] Three new Python fixtures (`tf2_test_cast.py`, `tf2_test_expand_dims.py`, `tf2_test_clip_by_value.py`) run to completion under `python3.10` with the documented runtime asserts.
- [ ] CI confirms.

## Related

- [wala/ML#422](https://github.com/wala/ML/issues/422) — reconciliation list of originally-missing classes.
- [wala/ML#481](https://github.com/wala/ML/issues/481) — `PassThroughUnaryTensorGenerator` override bypass; blocks precise `Cast` and `ExpandDims` per-call results.