### PR TITLE
Add `LeakyRelu`, `ReduceMin`, `Pow` generators (wala/ML#422)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4376,6 +4376,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_reduce_max.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
   }
 
+  /**
+   * Generator-dispatch test for {@code tf.reduce_min(input_tensor)}. Mirrors {@link
+   * #testReduceMax()} — the {@link com.ibm.wala.cast.python.ml.client.ReduceMin} generator extends
+   * {@link com.ibm.wala.cast.python.ml.client.ReduceMax}, sharing the axis-collapse / keepdims
+   * shape inference and input-dtype passthrough.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testReduceMin()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_reduce_min.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
   @Test
   public void testReduceProd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -4852,6 +4869,40 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testRelu()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_relu.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.nn.leaky_relu(features)}. Pure passthrough — output shape
+   * and dtype both inherit from {@code features} (the input tensor). Mirrors {@link #testRelu()};
+   * the {@link com.ibm.wala.cast.python.ml.client.LeakyRelu} generator extends {@link
+   * com.ibm.wala.cast.python.ml.client.PassThroughUnaryTensorGenerator}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testLeakyRelu()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_leaky_relu.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.math.pow(x, y)}. Element-wise binary; output shape is the
+   * broadcast of {@code x} and {@code y} (here both {@code (3,)}, so {@code (3,)}); dtype is the
+   * unified dtype (both {@code float32} → {@code float32}). Routed through {@link
+   * com.ibm.wala.cast.python.ml.client.ElementWiseOperation}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testPow()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_pow.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4890,9 +4890,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.math.pow(x, y)}. Element-wise binary; output shape is the
-   * broadcast of {@code x} and {@code y} (here both {@code (3,)}, so {@code (3,)}); dtype is the
-   * unified dtype (both {@code float32} → {@code float32}). Routed through {@link
-   * com.ibm.wala.cast.python.ml.client.ElementWiseOperation}.
+   * broadcast of {@code x} and {@code y} (here both {@code (3,)}, so {@code (3,)}); output dtype
+   * matches {@code x} (TF requires {@code x}/{@code y} to share dtype, so dtype-from-{@code x} is
+   * sound). Routed through {@link com.ibm.wala.cast.python.ml.client.ElementWiseOperation}.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4905,6 +4905,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_pow.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
+  /**
+   * Keyword-argument variant of {@link #testPow}: {@code tf.math.pow(x=x, y=y)}. Exercises the
+   * keyword arg-resolution path through {@link
+   * com.ibm.wala.cast.python.ml.client.ElementWiseOperation}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testPowKw()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_pow_kw.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Mixed positional/keyword variant of {@link #testPow}: {@code tf.math.pow(x, y=y)}. Exercises
+   * the case where the first argument is positional and the rest are keyword arguments.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testPowMixed()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_pow_mixed.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
   @Test
   public void testRange()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -784,6 +784,18 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/custom_gradient -->
         <new def="custom_gradient" class="Ltensorflow/class/custom_gradient" />
         <putfield class="LRoot" field="custom_gradient" fieldType="LRoot" ref="x" value="custom_gradient" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu -->
+        <new def="leaky_relu" class="Ltensorflow/functions/leaky_relu" />
+        <putfield class="LRoot" field="leaky_relu" fieldType="LRoot" ref="nn" value="leaky_relu" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min -->
+        <new def="reduce_min" class="Ltensorflow/math/reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="x" value="reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math" value="reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math_ops" value="reduce_min" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow -->
+        <new def="pow" class="Ltensorflow/math/pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pow" />
         <return value="x" />
       </method>
     </class>
@@ -1105,6 +1117,20 @@
       <class name="reduce_max" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_max. Modeled as `<new>+<return>` for the same reason as `reduce_all`/`reduce_prod` — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="reduce_min" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min. Mirrors reduce_max — same axis-collapse / keepdims shape semantics, dtype inherited from input. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="pow" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow. Element-wise binary op (`x ** y`); routed through `ElementWiseOperation` for shape (broadcast) and dtype (unified). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
@@ -1805,6 +1831,13 @@
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
           <return value="y" />
+        </method>
+      </class>
+      <class name="leaky_relu" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu. Direct `<new>+<return>` paired with the dedicated `LeakyRelu` generator (full-passthrough on shape and dtype of `features`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self features alpha name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -796,6 +796,7 @@
         <new def="pow" class="Ltensorflow/math/pow" />
         <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pow" />
         <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pow" />
         <return value="x" />
       </method>
     </class>
@@ -1129,7 +1130,7 @@
         </method>
       </class>
       <class name="pow" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow. Element-wise binary op (`x ** y`); routed through `ElementWiseOperation` for shape (broadcast) and dtype (unified). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow. Element-wise binary op (`x ** y`); routed through `ElementWiseOperation` for broadcast shape and dtype-from-`x` (TF requires `x`/`y` to share dtype, so this is sound). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
@@ -1,0 +1,32 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.nn.leaky_relu(features, alpha=0.2, name=None)}. Pure passthrough — output
+ * shape and dtype both inherit from {@code features}.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/nn/leaky_relu">tf.nn.leaky_relu</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class LeakyRelu extends PassThroughUnaryTensorGenerator {
+
+  public LeakyRelu(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public LeakyRelu(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "features";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
@@ -12,6 +12,41 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
  */
 public class LeakyRelu extends PassThroughUnaryTensorGenerator {
 
+  /**
+   * Parameter positions and keyword names for {@code tf.nn.leaky_relu(features, alpha=0.2,
+   * name=None)}. Ordinals match the position in {@code tensorflow.xml}'s {@code paramNames} after
+   * the implicit {@code self} receiver, so {@code Parameters.FEATURES.getIndex() == 0} resolves to
+   * the first user-facing positional argument.
+   */
+  protected enum Parameters {
+    /** The input tensor; shape and dtype source. */
+    FEATURES,
+
+    /** Negative-slope coefficient; not consumed by this generator. */
+    ALPHA,
+
+    /** Optional debug name for the op; not consumed by this generator. */
+    NAME;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "features"}).
+     */
+    public String getName() {
+      return name().toLowerCase();
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
   public LeakyRelu(PointsToSetVariable source) {
     super(source);
   }
@@ -22,11 +57,11 @@ public class LeakyRelu extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0;
+    return Parameters.FEATURES.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "features";
+    return Parameters.FEATURES.getName();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMin.java
@@ -1,0 +1,19 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.math.reduce_min}. Mirrors {@link ReduceMax} — same axis-collapse /
+ * keepdims shape semantics inherited from {@link ReduceMean}, with input dtype passthrough (no
+ * {@code int → float32} promotion).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/reduce_min">tf.math.reduce_min</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ReduceMin extends ReduceMax {
+
+  public ReduceMin(PointsToSetVariable source) {
+    super(source);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -63,6 +63,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IDENTITY;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.INPUT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LEAKY_RELU;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LINSPACE;
@@ -88,6 +89,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ONE_HOT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.PLACEHOLDER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.POISSON;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.POISSON_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.POW;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RAGGED_CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RAGGED_RANGE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANDOM_NORMAL_INIT_CALL;
@@ -98,6 +100,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_ALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_LOGSUMEXP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MEAN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_MIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_PROD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.REDUCE_SUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RSQRT;
@@ -1084,6 +1087,7 @@ public class TensorGeneratorFactory {
       return new Cifar10InputData(source, Cifar10InputData.Y_TEST_SHAPE);
     else if (isType(calledFunction, REDUCE_MEAN.getDeclaringClass())) return new ReduceMean(source);
     else if (isType(calledFunction, REDUCE_MAX.getDeclaringClass())) return new ReduceMax(source);
+    else if (isType(calledFunction, REDUCE_MIN.getDeclaringClass())) return new ReduceMin(source);
     else if (isType(calledFunction, REDUCE_PROD.getDeclaringClass())) return new ReduceProd(source);
     else if (isType(calledFunction, REDUCE_LOGSUMEXP.getDeclaringClass()))
       return new ReduceLogSumExp(source);
@@ -1130,6 +1134,9 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
+    else if (isType(calledFunction, LEAKY_RELU.getDeclaringClass())) return new LeakyRelu(source);
+    else if (isType(calledFunction, POW.getDeclaringClass()))
+      return new ElementWiseOperation(source);
     else if (isType(calledFunction, IDENTITY.getDeclaringClass())) return new Identity(source);
     else if (isType(calledFunction, STOP_GRADIENT.getDeclaringClass()))
       return new StopGradient(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -968,6 +968,34 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/nn/leaky_relu. */
+  public static final MethodReference LEAKY_RELU =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/leaky_relu")),
+          AstMethodReference.fnSelector);
+
+  private static final String LEAKY_RELU_SIGNATURE = "tf.nn.leaky_relu()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_min. */
+  public static final MethodReference REDUCE_MIN =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_min")),
+          AstMethodReference.fnSelector);
+
+  private static final String REDUCE_MIN_SIGNATURE = "tf.math.reduce_min()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/pow. */
+  public static final MethodReference POW =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/pow")),
+          AstMethodReference.fnSelector);
+
+  private static final String POW_SIGNATURE = "tf.math.pow()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/equal. */
   public static final MethodReference EQUAL =
       MethodReference.findOrCreate(
@@ -1358,6 +1386,9 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(LEAKY_RELU.getDeclaringClass(), LEAKY_RELU_SIGNATURE),
+          Map.entry(REDUCE_MIN.getDeclaringClass(), REDUCE_MIN_SIGNATURE),
+          Map.entry(POW.getDeclaringClass(), POW_SIGNATURE),
           Map.entry(EQUAL.getDeclaringClass(), EQUAL_SIGNATURE),
           Map.entry(NOT_EQUAL.getDeclaringClass(), NOT_EQUAL_SIGNATURE),
           Map.entry(LESS.getDeclaringClass(), LESS_SIGNATURE),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -985,7 +985,7 @@ public class TensorFlowTypes extends PythonTypes {
               PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/reduce_min")),
           AstMethodReference.fnSelector);
 
-  private static final String REDUCE_MIN_SIGNATURE = "tf.math.reduce_min()";
+  private static final String REDUCE_MIN_SIGNATURE = "tf.reduce_min()";
 
   /** https://www.tensorflow.org/api_docs/python/tf/math/pow. */
   public static final MethodReference POW =

--- a/com.ibm.wala.cast.python.test/data/tf2_test_leaky_relu.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_leaky_relu.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.nn.leaky_relu` is a pure passthrough — output shape and dtype both
+# inherit from `features` (the input).
+x = tf.constant([-1.0, 0.0, 2.0])
+y = tf.nn.leaky_relu(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.float32
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_pow.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_pow.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.math.pow(x, y)` is element-wise `x ** y`. Output shape is the
+# broadcast of `x` and `y`; dtype is the unified dtype. Routed through
+# `ElementWiseOperation`.
+x = tf.constant([2.0, 3.0, 4.0])
+y = tf.constant([1.0, 2.0, 3.0])
+z = tf.math.pow(x, y)
+assert isinstance(z, tf.Tensor)
+assert z.shape == (3,)
+assert z.dtype == tf.float32
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_pow.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_pow.py
@@ -6,7 +6,8 @@ def f(a):
 
 
 # `tf.math.pow(x, y)` is element-wise `x ** y`. Output shape is the
-# broadcast of `x` and `y`; dtype is the unified dtype. Routed through
+# broadcast of `x` and `y`; output dtype matches `x` (TF requires `x`/`y` to
+# share dtype, so dtype-from-`x` is sound). Routed through
 # `ElementWiseOperation`.
 x = tf.constant([2.0, 3.0, 4.0])
 y = tf.constant([1.0, 2.0, 3.0])

--- a/com.ibm.wala.cast.python.test/data/tf2_test_pow_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_pow_kw.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Keyword-argument variant of `tf2_test_pow.py`. Same shape and dtype
+# expectation; exercises the keyword arg-resolution path.
+x = tf.constant([2.0, 3.0, 4.0])
+y = tf.constant([1.0, 2.0, 3.0])
+z = tf.math.pow(x=x, y=y)
+assert isinstance(z, tf.Tensor)
+assert z.shape == (3,)
+assert z.dtype == tf.float32
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_pow_mixed.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_pow_mixed.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Mixed positional/keyword variant of `tf2_test_pow.py`. Same shape and
+# dtype expectation; exercises the case where the first argument is
+# positional and the rest are keyword arguments.
+x = tf.constant([2.0, 3.0, 4.0])
+y = tf.constant([1.0, 2.0, 3.0])
+z = tf.math.pow(x, y=y)
+assert isinstance(z, tf.Tensor)
+assert z.shape == (3,)
+assert z.dtype == tf.float32
+f(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reduce_min.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reduce_min.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.reduce_min(input_tensor, axis=None)`: when axis is None and
+# keepdims is False (default), reduces all dims to a scalar. Dtype
+# inherits from input. Mirrors `reduce_max`'s semantics.
+x = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+y = tf.reduce_min(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == ()
+assert y.dtype == tf.float32
+f(y)


### PR DESCRIPTION
## Summary

Three more from [wala/ML#422](https://github.com/wala/ML/issues/422)'s missing-class list. All three were unmodeled (no XML, no generator) so user calls hit `ReadDataFallback` → ⊤/UNKNOWN. This PR adds full modeling for each:

| Op | Java class | Pattern |
|---|---|---|
| `tf.nn.leaky_relu` | `LeakyRelu.java` | Pure passthrough on `features`; same template as `Relu`. |
| `tf.math.reduce_min` | `ReduceMin.java` | Mirrors `reduce_max` — extends `ReduceMax` (one-line subclass). |
| `tf.math.pow` | (no class) | Element-wise binary; routed directly through `ElementWiseOperation` (default `Parameters.X`/`Y` positions match `pow`'s signature). |

## XML Adds

- Top-level bindings in the `tensorflow.import` method:
  - `leaky_relu` under `nn`.
  - `reduce_min` under `math` / `math_ops` (and top-level `tf.reduce_min`).
  - `pow` under `math` (and top-level `tf.pow`).
- Class blocks:
  - `leaky_relu` under `<package name="tensorflow/functions">`.
  - `reduce_min` and `pow` under `<package name="tensorflow/math">`.

## Java Side

- `TensorFlowTypes.LEAKY_RELU`, `REDUCE_MIN`, `POW` constants + signature entries.
- `TensorGeneratorFactory.getGeneratorBody` adds three dispatch arms.

## Test Plan

- [x] Full ML test suite passes locally: `659 tests, 0 failures, 0 errors, 0 skipped`.
- [x] All three new fixtures (`tf2_test_leaky_relu.py`, `tf2_test_reduce_min.py`, `tf2_test_pow.py`) run to completion under `python3.10` with the documented runtime asserts.
- [ ] CI confirms.

## Related

- [wala/ML#422](https://github.com/wala/ML/issues/422) — reconciliation list of originally-missing classes.
- ponder-lab/ML#255 — the previous batch (`Relu` / `Cast` / `ExpandDims` / `ClipByValue`); this PR uses the same XML modeling + dispatch template.