### PR TITLE
Make `PassThroughUnaryTensorGenerator`'s input-arg getters non-abstract with sensible defaults (wala/ML#472)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -60,17 +60,30 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    * Positional index of the input argument, <em>excluding</em> the modeled {@code self} receiver.
    * Almost always {@code 0} (the first user-facing positional after {@code self}).
    *
-   * @return The input arg's positional index.
+   * <p>Default is {@link #UNDEFINED_PARAMETER_POSITION}, signalling "no input arg" — appropriate
+   * for subclasses that override {@link #getDefaultShapes} and {@link #getDefaultDTypes} entirely
+   * and don't read from an input argument's PTS (mirrors the existing pattern for {@link
+   * #getShapeParameterPosition} / {@link #getDTypeParameterPosition} on {@link TensorGenerator}).
+   *
+   * @return The input arg's positional index, or {@link #UNDEFINED_PARAMETER_POSITION} if not
+   *     applicable.
    */
-  protected abstract int getInputParameterPosition();
+  protected int getInputParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
 
   /**
    * Keyword name of the input argument as declared in the XML (e.g. {@code "x"}, {@code "input"},
    * {@code "logits"}). Used for keyword-argument resolution when the call site uses kwargs.
    *
-   * @return The input arg's keyword name.
+   * <p>Default is {@code null}, signalling "no input arg" — see {@link
+   * #getInputParameterPosition()}.
+   *
+   * @return The input arg's keyword name, or {@code null} if not applicable.
    */
-  protected abstract String getInputParameterName();
+  protected String getInputParameterName() {
+    return null;
+  }
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
@@ -93,6 +106,7 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    */
   private Set<List<Dimension<?>>> shapesOfArg(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    if (paramPos == UNDEFINED_PARAMETER_POSITION) return null;
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pts);
@@ -111,6 +125,7 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    */
   private Set<DType> dtypesOfArg(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    if (paramPos == UNDEFINED_PARAMETER_POSITION) return null;
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<DType> dtypes = this.getDTypesOfValue(builder, pts);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -61,12 +61,13 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    * Almost always {@code 0} (the first user-facing positional after {@code self}).
    *
    * <p>Default is {@link #UNDEFINED_PARAMETER_POSITION}, signalling "no input arg" — appropriate
-   * for subclasses that override {@link #getDefaultShapes} and {@link #getDefaultDTypes} entirely
-   * and don't read from an input argument's PTS (mirrors the existing pattern for {@link
-   * #getShapeParameterPosition} / {@link #getDTypeParameterPosition} on {@link TensorGenerator}).
+   * <em>only</em> for subclasses that override both {@link #getDefaultShapes} and {@link
+   * #getDefaultDTypes} entirely and never reach {@link #shapesOfArg} / {@link #dtypesOfArg}. If the
+   * parent's default methods <em>are</em> reached with an undefined position, that's a
+   * misconfiguration: throw {@link IllegalStateException} rather than silently producing ⊤.
    *
-   * @return The input arg's positional index, or {@link #UNDEFINED_PARAMETER_POSITION} if not
-   *     applicable.
+   * @return The input arg's positional index, or {@link #UNDEFINED_PARAMETER_POSITION} if the
+   *     subclass doesn't read from an input argument.
    */
   protected int getInputParameterPosition() {
     return UNDEFINED_PARAMETER_POSITION;
@@ -77,9 +78,10 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    * {@code "logits"}). Used for keyword-argument resolution when the call site uses kwargs.
    *
    * <p>Default is {@code null}, signalling "no input arg" — see {@link
-   * #getInputParameterPosition()}.
+   * #getInputParameterPosition()} for when this default is appropriate.
    *
-   * @return The input arg's keyword name, or {@code null} if not applicable.
+   * @return The input arg's keyword name, or {@code null} if the subclass doesn't read from an
+   *     input argument.
    */
   protected String getInputParameterName() {
     return null;
@@ -106,7 +108,14 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    */
   private Set<List<Dimension<?>>> shapesOfArg(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
-    if (paramPos == UNDEFINED_PARAMETER_POSITION) return null;
+    if (paramPos == UNDEFINED_PARAMETER_POSITION)
+      throw new IllegalStateException(
+          getClass().getSimpleName()
+              + " uses "
+              + PassThroughUnaryTensorGenerator.class.getSimpleName()
+              + "'s default `getDefaultShapes` (which reads from the input arg) but did not"
+              + " override `getInputParameterPosition`. Either override the input-arg getters or"
+              + " override `getDefaultShapes` entirely.");
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pts);
@@ -125,7 +134,14 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
    */
   private Set<DType> dtypesOfArg(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
-    if (paramPos == UNDEFINED_PARAMETER_POSITION) return null;
+    if (paramPos == UNDEFINED_PARAMETER_POSITION)
+      throw new IllegalStateException(
+          getClass().getSimpleName()
+              + " uses "
+              + PassThroughUnaryTensorGenerator.class.getSimpleName()
+              + "'s default `getDefaultDTypes` (which reads from the input arg) but did not"
+              + " override `getInputParameterPosition`. Either override the input-arg getters or"
+              + " override `getDefaultDTypes` entirely.");
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<DType> dtypes = this.getDTypesOfValue(builder, pts);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -113,9 +113,9 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
           getClass().getSimpleName()
               + " uses "
               + PassThroughUnaryTensorGenerator.class.getSimpleName()
-              + "'s default `getDefaultShapes` (which reads from the input arg) but did not"
-              + " override `getInputParameterPosition`. Either override the input-arg getters or"
-              + " override `getDefaultShapes` entirely.");
+              + "'s default getDefaultShapes (which reads from the input arg) but did not"
+              + " override getInputParameterPosition. Either override the input-arg getters or"
+              + " override getDefaultShapes entirely.");
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, pts);
@@ -139,9 +139,9 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
           getClass().getSimpleName()
               + " uses "
               + PassThroughUnaryTensorGenerator.class.getSimpleName()
-              + "'s default `getDefaultDTypes` (which reads from the input arg) but did not"
-              + " override `getInputParameterPosition`. Either override the input-arg getters or"
-              + " override `getDefaultDTypes` entirely.");
+              + "'s default getDefaultDTypes (which reads from the input arg) but did not"
+              + " override getInputParameterPosition. Either override the input-arg getters or"
+              + " override getDefaultDTypes entirely.");
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<DType> dtypes = this.getDTypesOfValue(builder, pts);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -33,16 +33,6 @@ public class SequenceMask extends PassThroughUnaryTensorGenerator {
   }
 
   @Override
-  protected int getInputParameterPosition() {
-    return 0;
-  }
-
-  @Override
-  protected String getInputParameterName() {
-    return "lengths";
-  }
-
-  @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     return null;
   }


### PR DESCRIPTION
## Summary
- `getInputParameterPosition` now defaults to `UNDEFINED_PARAMETER_POSITION`; `getInputParameterName` defaults to `null`. Mirrors the existing pattern for the `getShape*` / `getDType*` getters on `TensorGenerator`.
- `shapesOfArg` / `dtypesOfArg` throw `IllegalStateException` when the position is undefined. That combination only happens via misconfiguration (subclass uses the parent's default `getDefaultShapes`/`getDefaultDTypes` without overriding the input-arg getters) — surfacing it loudly is better than silently producing ⊤.
- `SequenceMask` (the existing fixed-dtype subclass) drops the dead overrides; its 50% patch coverage gap surfaced on #239 closes.
- All other subclasses (`Exp`, `Rsqrt`, `LogSoftmax`, the post-#258/#260 unary math ops, etc.) keep their explicit overrides and behave identically.

## Why
Closes wala/ML#472. The audit on https://github.com/ponder-lab/ML/pull/239#issuecomment-4388895772 surfaced the pattern: subclasses overriding `getDefaultShapes`/`getDefaultDTypes` entirely had two dead-code overrides each.

## Test plan
- [x] Full ML test suite (`mvn -pl com.ibm.wala.cast.python.ml.test test`): 674 tests, 0 failures, 3 skipped (unchanged from master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)