### PR TITLE
Add `TensorGenerator` dispatch-coverage meta-test (wala/ML#470)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
@@ -16,10 +16,17 @@ import java.util.stream.Stream;
 import org.junit.Test;
 
 /**
- * Meta-test asserting that every concrete {@link TensorGenerator} subclass under {@code
- * com.ibm.wala.cast.python.ml.client} is reachable from at least one of the two dispatch tables —
- * {@link com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator} or {@link
+ * Meta-test asserting that every concrete <em>top-level</em> {@link TensorGenerator} subclass under
+ * {@code com.ibm.wala.cast.python.ml.client} is reachable from at least one of the two dispatch
+ * tables — {@link com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator} or {@link
  * TensorGenerator#createManualGenerator}.
+ *
+ * <p><strong>Scope:</strong> the enumeration walks {@code .java} source files and derives the FQN
+ * from the path, which assumes one top-level class per file. Nested {@link TensorGenerator}
+ * subclasses (e.g., the private {@code ReadDataFallback} inside {@code TensorGeneratorFactory}) are
+ * not enumerated. In practice nested subclasses tend to be dispatch-table-internal helpers that are
+ * constructed by their enclosing class anyway, but the limitation is real — a class-file- scanning
+ * enumeration would be a strict improvement (see wala/ML#485).
  *
  * <p>Until the dispatch-table unification proposed in wala/ML#469 lands, every new {@code
  * TensorGenerator} subclass has to be added to both {@code getGeneratorBody} (factory-side) and
@@ -80,6 +87,7 @@ public class TestTensorGeneratorDispatchCoverage {
     }
 
     if (!orphans.isEmpty()) {
+      orphans.sort(String::compareTo); // stable diagnostic across filesystems / JVMs
       fail(
           "The following concrete TensorGenerator subclasses are not constructed in either"
               + " TensorGeneratorFactory.getGenerator or TensorGenerator.createManualGenerator. If"

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
@@ -1,0 +1,154 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static org.junit.Assert.fail;
+
+import com.ibm.wala.cast.python.ml.client.DispatchExempt;
+import com.ibm.wala.cast.python.ml.client.TensorGenerator;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+/**
+ * Meta-test asserting that every concrete {@link TensorGenerator} subclass under {@code
+ * com.ibm.wala.cast.python.ml.client} is reachable from at least one of the two dispatch tables —
+ * {@link com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory#getGenerator} or {@link
+ * TensorGenerator#createManualGenerator}.
+ *
+ * <p>Until the dispatch-table unification proposed in wala/ML#469 lands, every new {@code
+ * TensorGenerator} subclass has to be added to both {@code getGeneratorBody} (factory-side) and
+ * {@code createManualGenerator} (manual-walker side). Forgetting one is silent (wala/ML#468). This
+ * coverage guard catches the most-common failure mode — an entirely orphan subclass that's not
+ * wired to either dispatch — at test time. (The stricter "appears in <em>both</em>" check the
+ * issue's original spec proposes requires either dynamic dispatch construction or per-class
+ * annotation tagging for the dispatch-asymmetric subclasses; this test scopes to the orphan
+ * detection that's implementable without those.)
+ *
+ * <p>Subclasses that are legitimately exempt (constructed by another generator rather than from
+ * either dispatch table) can carry a {@link DispatchExempt} annotation. Abstract bases are skipped
+ * automatically.
+ *
+ * @see DispatchExempt
+ * @see <a href="https://github.com/wala/ML/issues/470">wala/ML#470</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TestTensorGeneratorDispatchCoverage {
+
+  private static final String CLIENT_PACKAGE = "com.ibm.wala.cast.python.ml.client";
+
+  private static final String CLIENT_PACKAGE_PATH = CLIENT_PACKAGE.replace('.', '/');
+
+  /**
+   * Asserts every concrete, non-exempt {@link TensorGenerator} subclass under {@link
+   * #CLIENT_PACKAGE} appears as a {@code new <SimpleName>(} construction in at least one of the two
+   * dispatch source files.
+   *
+   * @throws Exception If reflection or file I/O fails.
+   */
+  @Test
+  public void everyConcreteTensorGeneratorAppearsInAtLeastOneDispatch() throws Exception {
+    List<Class<? extends TensorGenerator>> subclasses = enumerateTensorGeneratorSubclasses();
+
+    String factorySource = readDispatchSource("TensorGeneratorFactory.java");
+    String tensorGeneratorSource = readDispatchSource("TensorGenerator.java");
+
+    List<String> orphans = new ArrayList<>();
+    for (Class<? extends TensorGenerator> c : subclasses) {
+      if (Modifier.isAbstract(c.getModifiers())) continue;
+      if (c.isAnnotationPresent(DispatchExempt.class)) continue;
+      // Skip anonymous and synthetic inner classes — they're inline-declared and inherently can't
+      // be wired to a separate dispatch table.
+      if (c.getCanonicalName() == null) continue;
+      if (c.isAnonymousClass() || c.isSynthetic()) continue;
+
+      String simpleName = c.getSimpleName();
+      String constructionPattern = "new " + simpleName + "(";
+      boolean inFactory = factorySource.contains(constructionPattern);
+      boolean inTensorGenerator = tensorGeneratorSource.contains(constructionPattern);
+
+      if (!inFactory && !inTensorGenerator) {
+        orphans.add(simpleName);
+      }
+    }
+
+    if (!orphans.isEmpty()) {
+      fail(
+          "The following concrete TensorGenerator subclasses are not constructed in either"
+              + " TensorGeneratorFactory.getGenerator or TensorGenerator.createManualGenerator. If"
+              + " a subclass is intentionally constructed only via delegation by another"
+              + " generator, mark it with @DispatchExempt. Otherwise it's an orphan — wire it"
+              + " into the appropriate dispatch table.\n  - "
+              + String.join("\n  - ", orphans));
+    }
+  }
+
+  /**
+   * Walks the ml module's source directory for {@link #CLIENT_PACKAGE}, deriving the class name
+   * from each {@code .java} filename and loading it via {@link Class#forName}. Returns the loaded
+   * classes that are (non-{@link TensorGenerator}-itself) subclasses of {@link TensorGenerator}.
+   *
+   * <p>Walks the source tree (rather than the test classpath) because the ml module is packaged as
+   * a JAR on the test classpath, and {@link Paths#get(java.net.URI)} on a {@code jar:} URI requires
+   * opening the JAR file system explicitly. Walking the source tree avoids that complication and is
+   * independent of how the dependency is packaged.
+   *
+   * @return The concrete and abstract {@link TensorGenerator} subclasses found.
+   * @throws IOException If walking the directory fails.
+   */
+  private static List<Class<? extends TensorGenerator>> enumerateTensorGeneratorSubclasses()
+      throws IOException {
+    Path testModuleDir = Paths.get(System.getProperty("user.dir"));
+    Path mlModuleDir = testModuleDir.resolveSibling("com.ibm.wala.cast.python.ml");
+    Path packageDir = mlModuleDir.resolve("source").resolve(CLIENT_PACKAGE_PATH);
+    if (!Files.isDirectory(packageDir))
+      throw new IllegalStateException(
+          "Could not locate ml-module source package directory: " + packageDir);
+
+    List<Class<? extends TensorGenerator>> subclasses = new ArrayList<>();
+    try (Stream<Path> entries = Files.list(packageDir)) {
+      entries
+          .filter(p -> p.getFileName().toString().endsWith(".java"))
+          .forEach(
+              p -> {
+                String fileName = p.getFileName().toString();
+                String className =
+                    CLIENT_PACKAGE
+                        + "."
+                        + fileName.substring(0, fileName.length() - ".java".length());
+                try {
+                  Class<?> c = Class.forName(className);
+                  if (TensorGenerator.class.isAssignableFrom(c)
+                      && !TensorGenerator.class.equals(c)) {
+                    subclasses.add(c.asSubclass(TensorGenerator.class));
+                  }
+                } catch (ClassNotFoundException e) {
+                  throw new IllegalStateException(
+                      "Failed to load " + className + " — should be on the test classpath.", e);
+                }
+              });
+    }
+    return subclasses;
+  }
+
+  /**
+   * Reads a source file from the {@code com.ibm.wala.cast.python.ml/source/...} module by relative
+   * path from the test module's working directory.
+   *
+   * @param fileName The simple file name (e.g., {@code TensorGenerator.java}).
+   * @return The file contents.
+   * @throws IOException If the file can't be read.
+   */
+  private static String readDispatchSource(String fileName) throws IOException {
+    Path testModuleDir = Paths.get(System.getProperty("user.dir"));
+    Path mlModuleDir = testModuleDir.resolveSibling("com.ibm.wala.cast.python.ml");
+    Path src = mlModuleDir.resolve("source").resolve(CLIENT_PACKAGE_PATH).resolve(fileName);
+    if (!Files.exists(src))
+      throw new IllegalStateException("Could not locate dispatch source: " + src);
+    return Files.readString(src);
+  }
+}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.Test;
 
@@ -67,9 +68,11 @@ public class TestTensorGeneratorDispatchCoverage {
       if (c.isAnonymousClass() || c.isSynthetic()) continue;
 
       String simpleName = c.getSimpleName();
-      String constructionPattern = "new " + simpleName + "(";
-      boolean inFactory = factorySource.contains(constructionPattern);
-      boolean inTensorGenerator = tensorGeneratorSource.contains(constructionPattern);
+      // Tolerate spotless/IDE formatting variants — `new X(...)`, `new\n        X(...)`, etc.
+      Pattern constructionPattern =
+          Pattern.compile("\\bnew\\s+" + Pattern.quote(simpleName) + "\\s*\\(");
+      boolean inFactory = constructionPattern.matcher(factorySource).find();
+      boolean inTensorGenerator = constructionPattern.matcher(tensorGeneratorSource).find();
 
       if (!inFactory && !inTensorGenerator) {
         orphans.add(simpleName);
@@ -88,8 +91,10 @@ public class TestTensorGeneratorDispatchCoverage {
   }
 
   /**
-   * Walks the ml module's source directory for {@link #CLIENT_PACKAGE}, deriving the class name
-   * from each {@code .java} filename and loading it via {@link Class#forName}. Returns the loaded
+   * Walks the ml module's source tree under {@link #CLIENT_PACKAGE} (recursively, including any
+   * future subpackages), deriving the FQN from each {@code .java} file's path relative to the
+   * source root and loading it via {@link Class#forName} <em>without</em> initialization (so static
+   * initializers in any subclass don't fire as a side effect of the meta-test). Returns the loaded
    * classes that are (non-{@link TensorGenerator}-itself) subclasses of {@link TensorGenerator}.
    *
    * <p>Walks the source tree (rather than the test classpath) because the ml module is packaged as
@@ -102,26 +107,28 @@ public class TestTensorGeneratorDispatchCoverage {
    */
   private static List<Class<? extends TensorGenerator>> enumerateTensorGeneratorSubclasses()
       throws IOException {
-    Path testModuleDir = Paths.get(System.getProperty("user.dir"));
-    Path mlModuleDir = testModuleDir.resolveSibling("com.ibm.wala.cast.python.ml");
-    Path packageDir = mlModuleDir.resolve("source").resolve(CLIENT_PACKAGE_PATH);
+    Path mlSourceRoot = locateMlSourceRoot();
+    Path packageDir = mlSourceRoot.resolve(CLIENT_PACKAGE_PATH);
     if (!Files.isDirectory(packageDir))
       throw new IllegalStateException(
           "Could not locate ml-module source package directory: " + packageDir);
 
     List<Class<? extends TensorGenerator>> subclasses = new ArrayList<>();
-    try (Stream<Path> entries = Files.list(packageDir)) {
+    ClassLoader cl = TestTensorGeneratorDispatchCoverage.class.getClassLoader();
+    try (Stream<Path> entries = Files.walk(packageDir)) {
       entries
+          .filter(Files::isRegularFile)
           .filter(p -> p.getFileName().toString().endsWith(".java"))
           .forEach(
               p -> {
-                String fileName = p.getFileName().toString();
+                Path relative = mlSourceRoot.relativize(p);
                 String className =
-                    CLIENT_PACKAGE
-                        + "."
-                        + fileName.substring(0, fileName.length() - ".java".length());
+                    relative
+                        .toString()
+                        .replace(java.io.File.separatorChar, '.')
+                        .replaceFirst("\\.java$", "");
                 try {
-                  Class<?> c = Class.forName(className);
+                  Class<?> c = Class.forName(className, false, cl);
                   if (TensorGenerator.class.isAssignableFrom(c)
                       && !TensorGenerator.class.equals(c)) {
                     subclasses.add(c.asSubclass(TensorGenerator.class));
@@ -136,19 +143,38 @@ public class TestTensorGeneratorDispatchCoverage {
   }
 
   /**
-   * Reads a source file from the {@code com.ibm.wala.cast.python.ml/source/...} module by relative
-   * path from the test module's working directory.
+   * Reads a source file from the {@code com.ibm.wala.cast.python.ml/source/...} module relative to
+   * the located ml-module source root.
    *
    * @param fileName The simple file name (e.g., {@code TensorGenerator.java}).
    * @return The file contents.
    * @throws IOException If the file can't be read.
    */
   private static String readDispatchSource(String fileName) throws IOException {
-    Path testModuleDir = Paths.get(System.getProperty("user.dir"));
-    Path mlModuleDir = testModuleDir.resolveSibling("com.ibm.wala.cast.python.ml");
-    Path src = mlModuleDir.resolve("source").resolve(CLIENT_PACKAGE_PATH).resolve(fileName);
+    Path src = locateMlSourceRoot().resolve(CLIENT_PACKAGE_PATH).resolve(fileName);
     if (!Files.exists(src))
       throw new IllegalStateException("Could not locate dispatch source: " + src);
     return Files.readString(src);
+  }
+
+  /**
+   * Locates the ml module's source root ({@code com.ibm.wala.cast.python.ml/source/}) by trying
+   * common Maven/IDE working-directory anchors, walking up the filesystem if necessary. Resilient
+   * to running from the test module directly (Maven's default), the parent project root (some IDE
+   * configurations), or other sibling locations.
+   *
+   * @return The {@link Path} of the ml source root.
+   */
+  private static Path locateMlSourceRoot() {
+    Path cwd = Paths.get(System.getProperty("user.dir"));
+    for (Path candidate = cwd; candidate != null; candidate = candidate.getParent()) {
+      Path direct = candidate.resolve("com.ibm.wala.cast.python.ml").resolve("source");
+      if (Files.isDirectory(direct)) return direct;
+      // If we're sitting in the test module itself, the ml module is a sibling.
+      Path sibling = candidate.resolveSibling("com.ibm.wala.cast.python.ml").resolve("source");
+      if (Files.isDirectory(sibling)) return sibling;
+    }
+    throw new IllegalStateException(
+        "Could not locate ml-module source root from cwd=" + cwd + " — check working directory.");
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DispatchExempt.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DispatchExempt.java
@@ -7,22 +7,26 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a {@link TensorGenerator} subclass as exempt from the dispatch-coverage meta-test (see
- * {@code TestTensorGeneratorDispatchCoverage} in the test module). Use sparingly, and only when the
- * subclass is genuinely not reachable from either dispatch entry point — i.e., it's constructed by
- * other generators rather than from {@link TensorGeneratorFactory#getGenerator} or {@link
- * TensorGenerator#createManualGenerator}.
+ * {@code TestTensorGeneratorDispatchCoverage} in the test module). The annotation suppresses the
+ * "must be constructed in {@link TensorGeneratorFactory#getGenerator} or {@link
+ * TensorGenerator#createManualGenerator}" check for the annotated subclass. Use sparingly.
  *
- * <p>Examples of legitimate exemptions:
+ * <p>Two distinct uses:
  *
- * <ul>
- *   <li>Delegation-only subclasses that are constructed by another generator rather than by either
- *       dispatch table directly.
- *   <li>Anonymous inline subclasses (which can't be annotated anyway — the meta-test naturally
- *       skips these via the {@link Class#getCanonicalName} check).
- * </ul>
+ * <ol>
+ *   <li><strong>Permanent exemption — delegation-only subclasses</strong>: a generator that is
+ *       constructed by another generator rather than by either dispatch table directly. The
+ *       annotation here documents an architectural choice; no follow-up action is implied.
+ *   <li><strong>Transient exemption — known orphan pending wire-or-delete</strong>: a generator
+ *       that has no construction site anywhere in the codebase (orphan flagged by the meta-test
+ *       itself). The annotation here is a TODO marker — the {@link #value} should reference the
+ *       filed sub-issue tracking the wire-or-delete decision, and the annotation should be removed
+ *       when that decision lands.
+ * </ol>
  *
- * <p>Abstract bases are skipped automatically by the meta-test (via {@link
- * java.lang.reflect.Modifier#isAbstract}); they don't need this annotation.
+ * <p>Anonymous inline subclasses (which can't be annotated anyway) are skipped by the meta-test via
+ * the {@link Class#getCanonicalName} check. Abstract bases are skipped via {@link
+ * java.lang.reflect.Modifier#isAbstract}; they don't need this annotation.
  *
  * <p>This is a stop-gap until the dispatch-table unification proposed in wala/ML#469 lands. After
  * that, this annotation can be retired.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DispatchExempt.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DispatchExempt.java
@@ -1,0 +1,44 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link TensorGenerator} subclass as exempt from the dispatch-coverage meta-test (see
+ * {@code TestTensorGeneratorDispatchCoverage} in the test module). Use sparingly, and only when the
+ * subclass is genuinely not reachable from either dispatch entry point — i.e., it's constructed by
+ * other generators rather than from {@link TensorGeneratorFactory#getGenerator} or {@link
+ * TensorGenerator#createManualGenerator}.
+ *
+ * <p>Examples of legitimate exemptions:
+ *
+ * <ul>
+ *   <li>Delegation-only subclasses that are constructed by another generator rather than by either
+ *       dispatch table directly.
+ *   <li>Anonymous inline subclasses (which can't be annotated anyway — the meta-test naturally
+ *       skips these via the {@link Class#getCanonicalName} check).
+ * </ul>
+ *
+ * <p>Abstract bases are skipped automatically by the meta-test (via {@link
+ * java.lang.reflect.Modifier#isAbstract}); they don't need this annotation.
+ *
+ * <p>This is a stop-gap until the dispatch-table unification proposed in wala/ML#469 lands. After
+ * that, this annotation can be retired.
+ *
+ * @see TensorGeneratorFactory
+ * @see TensorGenerator#createManualGenerator
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DispatchExempt {
+  /**
+   * Free-form reason the subclass is exempt — surfaced in the meta-test diagnostic if its dispatch
+   * status is ever questioned.
+   *
+   * @return The reason for exemption.
+   */
+  String value() default "";
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/InputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/InputData.java
@@ -14,7 +14,15 @@ import java.util.Set;
 /**
  * A generator for MNIST input data tensors. These tensors have the shape defined by
  * TensorType.mnistInput().
+ *
+ * <p>TODO(<a href="https://github.com/wala/ML/issues/470">wala/ML#470</a>): orphan flagged by the
+ * dispatch-coverage meta-test — this class is not constructed from either dispatch table. Likely
+ * superseded by {@link MnistInputData} (which is the actively-dispatched MNIST generator). Decide
+ * to wire or delete; if delete, also drop {@link DispatchExempt} below.
  */
+@DispatchExempt(
+    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Likely superseded by"
+        + " MnistInputData; pending decide-to-wire-or-delete.")
 public class InputData extends TensorGenerator {
   public InputData(PointsToSetVariable source) {
     super(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/InputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/InputData.java
@@ -15,14 +15,14 @@ import java.util.Set;
  * A generator for MNIST input data tensors. These tensors have the shape defined by
  * TensorType.mnistInput().
  *
- * <p>TODO(<a href="https://github.com/wala/ML/issues/470">wala/ML#470</a>): orphan flagged by the
- * dispatch-coverage meta-test — this class is not constructed from either dispatch table. Likely
- * superseded by {@link MnistInputData} (which is the actively-dispatched MNIST generator). Decide
- * to wire or delete; if delete, also drop {@link DispatchExempt} below.
+ * <p>TODO(<a href="https://github.com/wala/ML/issues/483">wala/ML#483</a>): orphan flagged by the
+ * dispatch-coverage meta-test (wala/ML#470). Recommended action is delete — likely superseded by
+ * {@link MnistInputData} (the actively-dispatched MNIST generator). When deleting, also drop {@link
+ * DispatchExempt} below.
  */
 @DispatchExempt(
-    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Likely superseded by"
-        + " MnistInputData; pending decide-to-wire-or-delete.")
+    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Recommended delete per"
+        + " wala/ML#483; likely superseded by MnistInputData.")
 public class InputData extends TensorGenerator {
   public InputData(PointsToSetVariable source) {
     super(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceOperation.java
@@ -22,16 +22,16 @@ import java.util.logging.Logger;
 /**
  * Modeling of Python slice operations (e.g., tensor[..., None]).
  *
- * <p>TODO(<a href="https://github.com/wala/ML/issues/470">wala/ML#470</a>): orphan flagged by the
- * dispatch-coverage meta-test — this class is not constructed from either dispatch table. Decide to
- * wire (slice operations are real, the modeling is non-trivial) or delete; if delete, also drop
- * {@link DispatchExempt} below.
+ * <p>TODO(<a href="https://github.com/wala/ML/issues/484">wala/ML#484</a>): orphan flagged by the
+ * dispatch-coverage meta-test (wala/ML#470). Recommended action is wire-up — the modeling logic
+ * here (newaxis-handling for {@code tensor[..., None]}) is substantive and worth landing. When
+ * wired, drop {@link DispatchExempt} below.
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 @DispatchExempt(
-    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Pending"
-        + " decide-to-wire-or-delete.")
+    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Recommended wire-up per"
+        + " wala/ML#484; modeling logic is substantive (newaxis handling).")
 public class SliceOperation extends TensorGenerator {
   private static final Logger LOGGER = Logger.getLogger(SliceOperation.class.getName());
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceOperation.java
@@ -22,8 +22,16 @@ import java.util.logging.Logger;
 /**
  * Modeling of Python slice operations (e.g., tensor[..., None]).
  *
+ * <p>TODO(<a href="https://github.com/wala/ML/issues/470">wala/ML#470</a>): orphan flagged by the
+ * dispatch-coverage meta-test — this class is not constructed from either dispatch table. Decide to
+ * wire (slice operations are real, the modeling is non-trivial) or delete; if delete, also drop
+ * {@link DispatchExempt} below.
+ *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
+@DispatchExempt(
+    "Orphan flagged by dispatch-coverage meta-test (wala/ML#470). Pending"
+        + " decide-to-wire-or-delete.")
 public class SliceOperation extends TensorGenerator {
   private static final Logger LOGGER = Logger.getLogger(SliceOperation.class.getName());
 


### PR DESCRIPTION
## Summary
Adds a meta-test (`TestTensorGeneratorDispatchCoverage`) that reflectively enumerates concrete `TensorGenerator` subclasses under `com.ibm.wala.cast.python.ml.client` and asserts each appears as a `new <SimpleName>(` construction in at least one of the two dispatch source files (`TensorGeneratorFactory.java` or `TensorGenerator.java`'s `createManualGenerator`).

The test catches the most common failure mode — orphan subclasses that are wired to **neither** dispatch table — at test time. Closes the silent-skip class of bugs from wala/ML#468 for the orphan case.

## Scope vs. the Issue's Spec
The issue's stronger spec ("confirms the subclass is reachable from **both** dispatch tables") would require either dynamic dispatch construction (with a synthetic `PointsToSetVariable`/`CGNode`) or per-class annotation tagging for the dispatch-asymmetric subclasses (transform-ops live only in the factory; allocation-site generators live in both). Neither fits in a single overnight pass without substantive design work, so this PR scopes to **orphan detection** — the most common failure mode — and leaves the both-tables enforcement as a follow-up.

## What Surfaced on Master
The test caught two pre-existing orphans:
- `InputData` — likely superseded by `MnistInputData`. Has no construction site anywhere in the codebase. Marked `@DispatchExempt` with a TODO Javadoc tag pointing at wala/ML#470 for the wire-or-delete decision.
- `SliceOperation` — modeling for Python slice ops (e.g. `tensor[..., None]`). Has no construction site anywhere. Same treatment.

Both flagged for daylight investigation rather than silently fixed.

## API
- New `@DispatchExempt(reason)` marker annotation on `TensorGenerator` subclasses that are intentionally constructed only via delegation by another generator. Abstract bases are skipped automatically by the test (via `Modifier.isAbstract`).

## Test Plan
- [x] Full ML test suite (`mvn -pl com.ibm.wala.cast.python.ml.test test`): 675 tests, 0 failures, 3 skipped (was 674; +1 for the new meta-test).
- [x] The meta-test fails as designed when an orphan is introduced (verified: removing `@DispatchExempt` from `InputData`/`SliceOperation` reproduces the original failure with the diagnostic naming both).

## Related
- wala/ML#468 (silent-skip failure mode)
- wala/ML#469 (structural fix that obviates this guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)