### PR TITLE
Coveralls-style Codecov: disable PR comment, enable inline diff annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,16 @@ coverage:
     patch:
       default:
         informational: true
+
+# Disable the per-PR Codecov comment (was previously the primary review surface, but its
+# per-push edits flood notification inboxes). Coverage data remains accessible via:
+#   - the `codecov/patch` and `codecov/project` status checks in the PR's checks panel,
+#   - the Codecov dashboard linked from those checks, and
+#   - the inline diff annotations enabled below (red gutter on uncovered changed lines).
+comment: false
+
+# Inline annotations on changed lines in the PR's "Files changed" view, posted via the
+# GitHub Checks API. Surfaces uncovered patch lines co-located with the code under review,
+# which is what the disabled comment used to summarize.
+github_checks:
+  annotations: true


### PR DESCRIPTION
## Summary
- `comment: false` — disables the per-PR Codecov comment. Per-push edits to that comment have been a major source of email-notification volume for PR authors and watchers.
- `github_checks.annotations: true` — replaces the comment's "where are the uncovered patch lines" summary with inline red-gutter annotations on the actual changed lines in the PR's "Files changed" view.

## What you still see during review
- **`codecov/patch` and `codecov/project` status checks** in the PR's checks panel (with `informational: true` from #243 still in effect, neither blocks the merge queue).
- **Codecov dashboard** linked from each status check's `Details` link — full file-level coverage, line-by-line annotations, and the diff view.
- **Inline annotations on the PR diff** — uncovered changed lines marked in red where you read the code, rather than summarized in a separate comment.

## What changes
- No more inline comment summary in the PR conversation thread.
- No more per-push edit notifications to your email inbox.

## Test plan
- [ ] Codecov posts the two status checks on the next push (verify on this PR's own checks panel).
- [ ] Codecov does *not* post a comment on this PR.
- [ ] Inline annotations appear on the PR's "Files changed" view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)