### PR TITLE
Scope `jython3.test`'s build resource to stop `target/` self-recursing

### DIFF
--- a/com.ibm.wala.cast.python.jython3.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython3.test/pom.xml
@@ -60,6 +60,11 @@
     <resources>
       <resource>
         <directory>.</directory>
+        <includes>
+          <include>META-INF/**</include>
+          <include>build.properties</include>
+          <include>logging.properties</include>
+        </includes>
       </resource>
     </resources>
     <plugins>


### PR DESCRIPTION
Fork-side companion to [wala/ML#493](https://github.com/wala/ML/pull/493) (which fixes the same bug at upstream's `jython/com.ibm.wala.cast.python.jython3.test/pom.xml`). On the fork the module sits at the repo root rather than under `jython/`, but the pom is otherwise identical and has the same recursive-resource bug.

## Problem

`com.ibm.wala.cast.python.jython3.test/pom.xml` declares its build resource as the module root:

```xml
<resources>
  <resource>
    <directory>.</directory>
  </resource>
</resources>
```

Maven copies that into `target/classes/` on every build. Since `target/` is itself at the module root, the second build copies the previous build's `target/` into `target/classes/target/`; the third copies that into `target/classes/target/classes/target/`; and so on. Each level contains the module's own `*-SNAPSHOT.jar`, so disk usage grows exponentially &mdash; on a local checkout this had reached **99 GB** after a handful of `mvn install` cycles. Full diagnosis at [wala/ML#494](https://github.com/wala/ML/issues/494) (the upstream bug-tracking issue; ponder-lab has issues disabled, so it lives on wala).

## Fix

Scope the resource via an explicit `<includes>` filter listing the three entries that need to be on the classpath (`META-INF/**`, `build.properties`, `logging.properties`). Preserves the JAR contents while excluding `target/` from the resource scope.

## Why an `<includes>` filter rather than a different `<directory>`

Sibling [`com.ibm.wala.cast.python.test/pom.xml`](https://github.com/ponder-lab/ML/blob/master/com.ibm.wala.cast.python.test/pom.xml) does it correctly with `<directory>data</directory>` &mdash; the cleanest pattern. It doesn't directly apply here because that sibling has no Eclipse PDE bundle metadata at the module root (its only resource is the `data/` subdir). This module ships Eclipse PDE metadata that needs to live at the bundle root:

| File | Why it needs to be at the bundle root |
|---|---|
| `META-INF/MANIFEST.MF` | OSGi bundle manifest (`Bundle-SymbolicName`, `Export-Package`, `Require-Bundle`); Eclipse PDE looks for it at the bundle root |
| `build.properties` | Eclipse PDE source/binary mapping (`source..` / `bin.includes`) |
| `logging.properties` | symlink to `../logging.properties`, copied into the JAR |

All three currently ship in the Maven JAR (verified via `jar tf`); moving them under a single `resources/` subdir would break Eclipse PDE consumers. An `<includes>` filter is the minimal-diff fix that preserves the JAR shape.

## Verification

```bash
mvn -pl com.ibm.wala.cast.python.jython3.test clean install -DskipTests
mvn -pl com.ibm.wala.cast.python.jython3.test install -DskipTests
```

Result:

```
$ ls com.ibm.wala.cast.python.jython3.test/target/classes/
META-INF
build.properties
com
logging.properties

$ du -sh com.ibm.wala.cast.python.jython3.test/target
184K
```

No self-referential `target/classes/target/`, no jar-of-jars-of-jars. Total module `target/` size 184 KB (vs. 99 GB pre-fix on multi-build accumulations).

## Test plan

- [x] Two-cycle local rebuild produces a flat `target/classes/` (above).
- [x] Built JAR contains the same set of resources as before.
- [ ] CI confirms.