### PR TITLE
Re-enable the per-PR Codecov comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,15 +7,8 @@ coverage:
       default:
         informational: true
 
-# Disable the per-PR Codecov comment (was previously the primary review surface, but its
-# per-push edits flood notification inboxes). Coverage data remains accessible via:
-#   - the `codecov/patch` and `codecov/project` status checks in the PR's checks panel,
-#   - the Codecov dashboard linked from those checks, and
-#   - the inline diff annotations enabled below (red gutter on uncovered changed lines).
-comment: false
-
 # Inline annotations on changed lines in the PR's "Files changed" view, posted via the
 # GitHub Checks API. Surfaces uncovered patch lines co-located with the code under review,
-# which is what the disabled comment used to summarize.
+# alongside the per-PR Codecov comment (which is enabled by default).
 github_checks:
   annotations: true


### PR DESCRIPTION
## Why

PR #263 (`fd19bb91`) disabled the per-PR Codecov comment to avoid notification-inbox flooding from per-push edits. The replacement surfaces (status checks + inline annotations + the dashboard URL) work for status-check-style verification but make it harder to see updated coverage numbers as the PR evolves &mdash; reviewers have to click through to the dashboard to verify each push's effect on coverage.

The notification-flood concern that motivated #263 is mitigated separately by an inbox rule, so the cost-benefit tilts back to keeping the inline comment.

## What

`git revert fd19bb91` was the first attempt but went too far &mdash; it also removed the `github_checks: annotations: true` block, which is independently useful. This PR is the surgical version: just remove the `comment: false` directive, keep the inline-annotations block.

```diff
-# Disable the per-PR Codecov comment (was previously the primary review surface, but its
-# per-push edits flood notification inboxes). Coverage data remains accessible via:
-#   - the `codecov/patch` and `codecov/project` status checks in the PR's checks panel,
-#   - the Codecov dashboard linked from those checks, and
-#   - the inline diff annotations enabled below (red gutter on uncovered changed lines).
-comment: false
-
 # Inline annotations on changed lines in the PR's "Files changed" view, posted via the
 # GitHub Checks API. Surfaces uncovered patch lines co-located with the code under review,
-# which is what the disabled comment used to summarize.
+# alongside the per-PR Codecov comment (which is enabled by default).
 github_checks:
   annotations: true
```

After this lands, the per-PR Codecov comment surface returns alongside the inline annotations &mdash; reviewers see both per-line uncovered annotations on changed lines AND the summary comment that updates as new pushes land.

## Coordination With Open PR #264

PR ponder-lab/ML#264 (still open) modifies the existing `coverage.status.{project,patch}` blocks (changes `informational: true` to `informational: false` with thresholds). The two PRs don't touch overlapping lines, so they should merge in any order without conflict.

## Test Plan

- [x] Local: config-only change; `mvn test` is a no-op.
- [ ] CI confirms.
- [ ] Post-merge: verify the next push to any open PR triggers a Codecov comment with updated coverage numbers.