### PR TITLE
Add dedicated `Cifar100InputData` generator for `int64` label dtype (closes wala/ML#487)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -345,6 +345,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_50000_1_UINT8 =
       new TensorType(UINT_8, asList(new NumericDim(50000), new NumericDim(1)));
 
+  private static final TensorType TENSOR_50000_1_INT64 =
+      new TensorType(INT_64, asList(new NumericDim(50000), new NumericDim(1)));
+
   private static final TensorType TENSOR_8982_UNKNOWN =
       new TensorType(UNKNOWN, asList(new NumericDim(8982)));
 
@@ -361,6 +364,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_10000_1_UINT8 =
       new TensorType(UINT_8, asList(new NumericDim(10000), new NumericDim(1)));
+
+  private static final TensorType TENSOR_10000_1_INT64 =
+      new TensorType(INT_64, asList(new NumericDim(10000), new NumericDim(1)));
 
   private static final TensorType TENSOR_10000_28_28_UINT8 =
       new TensorType(UINT_8, asList(new NumericDim(10000), new NumericDim(28), new NumericDim(28)));
@@ -5152,14 +5158,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator test for {@code tf.keras.datasets.cifar100.load_data()}. Shapes are identical to
-   * {@code cifar10.load_data()}; the modeling reuses {@link
-   * com.ibm.wala.cast.python.ml.client.Cifar10InputData}, so the inferred dtype is {@code uint8}
-   * for both label arrays. Asserts on all four unpacked arrays at {@code vn=2..5}.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/487">wala/ML#487</a>): the inferred {@code
-   * uint8} for {@code y_train} / {@code y_test} is imprecise &mdash; the runtime dtype of {@code
-   * cifar100}'s labels is {@code int64} (the Python fixture asserts that). Tighten to {@code
-   * int64}-dtype variants once the modeling is updated.
+   * {@code cifar10.load_data()}, but the {@code y_train} / {@code y_test} dtype is {@code int64}
+   * (cifar100's class indices) rather than {@code uint8} (cifar10's class indices). The dispatch
+   * routes through the dedicated {@link com.ibm.wala.cast.python.ml.client.Cifar100InputData}
+   * generator (closes wala/ML#487's mis-routing through {@code Cifar10InputData}). Asserts on all
+   * four unpacked arrays at {@code vn=2..5}.
    */
   @Test
   public void testCifar100LoadData()
@@ -5171,9 +5174,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         Map.of(
             2, Set.of(TENSOR_50000_32_32_3_UINT8),
-            3, Set.of(TENSOR_50000_1_UINT8),
+            3, Set.of(TENSOR_50000_1_INT64),
             4, Set.of(TENSOR_10000_32_32_3_UINT8),
-            5, Set.of(TENSOR_10000_1_UINT8)));
+            5, Set.of(TENSOR_10000_1_INT64)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar100InputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar100InputData.java
@@ -1,0 +1,147 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator for ndarrays returned by {@code tf.keras.datasets.cifar100.load_data()}.
+ *
+ * <p>Shapes mirror {@link Cifar10InputData} exactly: image arrays are 4-D RGB images {@code (N, 32,
+ * 32, 3)}; label arrays are 2-D label columns {@code (N, 1)}. The dtype, however, diverges from
+ * cifar10:
+ *
+ * <ul>
+ *   <li>{@code x_train} / {@code x_test}: {@link DType#UINT8} (same as cifar10).
+ *   <li>{@code y_train} / {@code y_test}: {@link DType#INT64} &mdash; cifar100's labels are 64-bit
+ *       integer class indices, NOT {@link DType#UINT8} as for cifar10. This is the key reason
+ *       cifar100 has its own generator class instead of reusing {@code Cifar10InputData}'s
+ *       hardcoded uint8 dtype.
+ * </ul>
+ *
+ * Per-array shape and dtype are passed in by the dispatch site in {@link TensorGeneratorFactory}
+ * (paired through the four {@code CIFAR100_*} {@link
+ * com.ibm.wala.cast.python.ml.types.TensorFlowTypes} arms) so a single class handles all four
+ * arrays.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/keras/datasets/cifar100/load_data">tf.keras.datasets.cifar100.load_data</a>
+ * @see <a href="https://github.com/wala/ML/issues/487">wala/ML#487</a>
+ */
+public class Cifar100InputData extends TensorGenerator {
+
+  private final List<Dimension<?>> shape;
+
+  private final Set<DType> dtypes;
+
+  /**
+   * Constructs from a points-to source.
+   *
+   * @param source The {@link PointsToSetVariable} representing the tensor.
+   * @param shape The cifar100 shape &mdash; one of {@link #X_TRAIN_SHAPE}, {@link #Y_TRAIN_SHAPE},
+   *     {@link #X_TEST_SHAPE}, {@link #Y_TEST_SHAPE}.
+   * @param dtypes The dtype set: {@link #X_DTYPES} ({@code uint8}) for image arrays, {@link
+   *     #Y_DTYPES} ({@code int64}) for label arrays.
+   */
+  public Cifar100InputData(
+      PointsToSetVariable source, List<Dimension<?>> shape, Set<DType> dtypes) {
+    super(source);
+    this.shape = shape;
+    this.dtypes = dtypes;
+  }
+
+  /**
+   * Constructs from a CG node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   * @param shape The cifar100 shape to report.
+   * @param dtypes The dtype set.
+   */
+  public Cifar100InputData(CGNode node, List<Dimension<?>> shape, Set<DType> dtypes) {
+    super(node);
+    this.shape = shape;
+    this.dtypes = dtypes;
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return Collections.singleton(shape);
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return dtypes;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+
+  /** Number of training examples in cifar100's {@code load_data()} output. */
+  public static final int NUM_TRAIN_EXAMPLES = 50000;
+
+  /** Number of test examples in cifar100's {@code load_data()} output. */
+  public static final int NUM_TEST_EXAMPLES = 10000;
+
+  /** Side length (height and width) of each cifar100 image, in pixels. */
+  public static final int IMAGE_SIDE = 32;
+
+  /** Number of color channels per cifar100 pixel (RGB). */
+  public static final int NUM_CHANNELS = 3;
+
+  /** Cifar100 training/test images: {@code (N, 32, 32, 3)} of {@code uint8}. */
+  public static List<Dimension<?>> imagesShape(int n) {
+    return List.of(
+        new NumericDim(n),
+        new NumericDim(IMAGE_SIDE),
+        new NumericDim(IMAGE_SIDE),
+        new NumericDim(NUM_CHANNELS));
+  }
+
+  /** Cifar100 training/test labels: {@code (N, 1)} of {@code int64}. */
+  public static List<Dimension<?>> labelsShape(int n) {
+    return List.of(new NumericDim(n), new NumericDim(1));
+  }
+
+  /** Shape of {@code cifar100.load_data()[0][0]}: {@code (50000, 32, 32, 3)} of {@code uint8}. */
+  public static final List<Dimension<?>> X_TRAIN_SHAPE = imagesShape(NUM_TRAIN_EXAMPLES);
+
+  /** Shape of {@code cifar100.load_data()[0][1]}: {@code (50000, 1)} of {@code int64}. */
+  public static final List<Dimension<?>> Y_TRAIN_SHAPE = labelsShape(NUM_TRAIN_EXAMPLES);
+
+  /** Shape of {@code cifar100.load_data()[1][0]}: {@code (10000, 32, 32, 3)} of {@code uint8}. */
+  public static final List<Dimension<?>> X_TEST_SHAPE = imagesShape(NUM_TEST_EXAMPLES);
+
+  /** Shape of {@code cifar100.load_data()[1][1]}: {@code (10000, 1)} of {@code int64}. */
+  public static final List<Dimension<?>> Y_TEST_SHAPE = labelsShape(NUM_TEST_EXAMPLES);
+
+  /** Dtype set for cifar100's {@code x_*} image arrays: {@code uint8}. */
+  public static final Set<DType> X_DTYPES = EnumSet.of(DType.UINT8);
+
+  /** Dtype set for cifar100's {@code y_*} label arrays: {@code int64}. */
+  public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1160,13 +1160,17 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, FASHION_MNIST_Y_TEST))
       return new MnistInputData(source, MnistInputData.Y_TEST_SHAPE);
     else if (isType(calledFunction, CIFAR100_X_TRAIN))
-      return new Cifar10InputData(source, Cifar10InputData.X_TRAIN_SHAPE);
+      return new Cifar100InputData(
+          source, Cifar100InputData.X_TRAIN_SHAPE, Cifar100InputData.X_DTYPES);
     else if (isType(calledFunction, CIFAR100_Y_TRAIN))
-      return new Cifar10InputData(source, Cifar10InputData.Y_TRAIN_SHAPE);
+      return new Cifar100InputData(
+          source, Cifar100InputData.Y_TRAIN_SHAPE, Cifar100InputData.Y_DTYPES);
     else if (isType(calledFunction, CIFAR100_X_TEST))
-      return new Cifar10InputData(source, Cifar10InputData.X_TEST_SHAPE);
+      return new Cifar100InputData(
+          source, Cifar100InputData.X_TEST_SHAPE, Cifar100InputData.X_DTYPES);
     else if (isType(calledFunction, CIFAR100_Y_TEST))
-      return new Cifar10InputData(source, Cifar10InputData.Y_TEST_SHAPE);
+      return new Cifar100InputData(
+          source, Cifar100InputData.Y_TEST_SHAPE, Cifar100InputData.Y_DTYPES);
     else if (isType(calledFunction, REUTERS_X_TRAIN))
       return new ReutersInputData(
           source, ReutersInputData.X_TRAIN_SHAPE, ReutersInputData.X_DTYPES);

--- a/com.ibm.wala.cast.python.test/data/tf2_test_cifar100_load_data.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_cifar100_load_data.py
@@ -1,8 +1,8 @@
 # Test of tf.keras.datasets.cifar100.load_data(). Shapes match cifar10's:
 # x_train (50000, 32, 32, 3), y_train (50000, 1), x_test (10000, 32, 32, 3), y_test (10000, 1).
 # Image arrays carry uint8 (matching cifar10). LABEL arrays carry int64 — a divergence from
-# cifar10's uint8 labels that the analyzer's reuse of `Cifar10InputData` doesn't yet capture
-# (see wala/ML#487).
+# cifar10's uint8 labels that the dedicated `Cifar100InputData` generator now models precisely
+# (closes wala/ML#487).
 import numpy as np
 import tensorflow as tf
 
@@ -18,10 +18,8 @@ assert x_test.shape == (10000, 32, 32, 3)
 assert y_test.shape == (10000, 1)
 assert x_train.dtype == np.uint8
 assert x_test.dtype == np.uint8
-# `cifar100`'s `y_train` / `y_test` are `int64` at runtime (vs `uint8` for `cifar10`). The
-# analyzer reuses `Cifar10InputData` and currently reports `uint8` — see wala/ML#487. The
-# Python assert here documents runtime truth; the JUnit expectation captures the analyzer's
-# current imprecise answer until #487 lands.
+# `cifar100`'s `y_train` / `y_test` are `int64` at runtime (vs `uint8` for `cifar10`); see
+# wala/ML#487. The dedicated `Cifar100InputData` generator now reports `int64` precisely.
 assert y_train.dtype == np.int64
 assert y_test.dtype == np.int64
 f(x_train, y_train, x_test, y_test)


### PR DESCRIPTION
## Summary

Closes wala/ML#487. `tf.keras.datasets.cifar100.load_data()`'s `y_train` / `y_test` arrays carry `int64` class indices at runtime (cifar100's labels are 64-bit integer indices over 100 classes), but the four `CIFAR100_*` dispatch arms in `TensorGeneratorFactory` previously routed through the cifar10-specific `Cifar10InputData` generator, which hardcodes `uint8`. The mis-routing reported `uint8` for both label and image arrays.

## Changes

- **New `Cifar100InputData.java`** mirroring `Cifar10InputData`'s shape semantics (image arrays `(N, 32, 32, 3)`, label arrays `(N, 1)`) but parameterising the dtype like `ReutersInputData` does &mdash; passing `X_DTYPES = EnumSet.of(DType.UINT8)` for image arrays and `Y_DTYPES = EnumSet.of(DType.INT64)` for label arrays.
- **`TensorGeneratorFactory`**: repointed the four `CIFAR100_*` dispatch arms from `Cifar10InputData` to `Cifar100InputData`, passing the correct shape + dtype pair per arm.
- **`testCifar100LoadData`**: now asserts the precise `int64` label dtype (`TENSOR_50000_1_INT64` at vn=3, `TENSOR_10000_1_INT64` at vn=5) instead of the imprecise `uint8`. Added the two new dtype constants. Cleared the staleness annotations from the Python fixture and the JUnit Javadoc since wala/ML#487 is now closed.

## Test Plan

- [x] Full ML test suite passes: 723 / 0 / 0 / 0 on `TestTensorflow2Model`, 4 / 0 / 0 / 1 skipped on `TestNeuroImageExamples`.
- [x] `tf2_test_cifar100_load_data.py` runs to completion under `python3.10` with the documented runtime asserts (no change in semantics).
- [ ] CI confirms.

## Cross-Refs

- wala/ML#487 &mdash; the tracking issue.
- ponder-lab/ML#260 &mdash; the original cifar100 modeling that landed with the temporary `Cifar10InputData` reuse.