### PR TITLE
Sweep `Parameters` enum's `getName()` to use `Locale.ROOT` (closes wala/ML#497)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Acosh.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Acosh.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.acosh}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Acosh extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Asin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Asin.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.asin}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Asin extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Asinh.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Asinh.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.asinh}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Asinh extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Atan.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Atan.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.atan}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Atan extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Atanh.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Atanh.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.atanh}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Atanh extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -45,7 +46,7 @@ public class BroadcastTo extends TensorGenerator {
      * @return The lowercased enum name (e.g. {@code "input"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cast.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.cast(x, dtype, name=None)}. Intended output shape inherits from {@code
@@ -44,7 +45,7 @@ public class Cast extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ClipByValue.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.clip_by_value(t, clip_value_min, clip_value_max, name=None)}. Pure
@@ -37,7 +38,7 @@ public class ClipByValue extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "t"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -27,6 +27,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -78,7 +79,7 @@ public class Concat extends TensorGenerator {
      * @return The lowercased enum name (e.g. {@code "values"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
@@ -8,6 +8,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -26,7 +27,7 @@ public class Constant extends TensorGenerator {
     VERIFY_SHAPE;
 
     public String getName() {
-      return this.name().toLowerCase();
+      return this.name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ConvertToTensor.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ConvertToTensor.java
@@ -6,6 +6,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -39,7 +40,7 @@ public class ConvertToTensor extends Constant {
     PREFERRED_DTYPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cosh.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cosh.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.cosh}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Cosh extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -33,7 +34,7 @@ public class DatasetBatchGenerator extends DatasetGenerator {
     BATCH_SIZE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -53,7 +54,7 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
     STOP_ON_EMPTY_DATASET;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -24,6 +24,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -50,7 +51,7 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -46,7 +47,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
@@ -23,6 +23,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetRangeGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetRangeGenerator.java
@@ -8,6 +8,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -31,7 +32,7 @@ public class DatasetRangeGenerator extends DatasetGenerator {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
@@ -29,6 +29,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -54,7 +55,7 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
     STOP_ON_EMPTY_DATASET;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetZipGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetZipGenerator.java
@@ -23,6 +23,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /** A generator for datasets created by {@code tf.data.Dataset.zip}. */
@@ -33,7 +34,7 @@ public class DatasetZipGenerator extends DatasetGenerator implements TupleElemen
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -50,7 +51,7 @@ public class DenseCall extends TensorGenerator {
     INPUTS;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -5,6 +5,7 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -48,7 +49,7 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "inputs"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -18,6 +18,7 @@ import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -37,7 +38,7 @@ public class ElementWiseOperation extends ZerosLike {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Erf.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Erf.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.erf}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Erf extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Erfc.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Erfc.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.erfc}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Erfc extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -5,6 +5,7 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -39,7 +40,7 @@ public class ExpandDims extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "input"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Expm1.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Expm1.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.expm1}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Expm1 extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class Eye extends SparseEye {
@@ -21,7 +22,7 @@ public class Eye extends SparseEye {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -4,6 +4,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -23,7 +24,7 @@ public class Fill extends Constant {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
@@ -9,6 +9,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -29,7 +30,7 @@ public class Gamma extends Ones {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -32,7 +33,7 @@ public class Gradient extends TensorGenerator {
     UNCONNECTED_GRADIENTS;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Identity.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Identity.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -36,7 +37,7 @@ public class Identity extends TensorGenerator {
     INPUT;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -14,6 +14,7 @@ import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -38,7 +39,7 @@ public class Input extends Ones {
     TYPE_SPEC;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/LeakyRelu.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.nn.leaky_relu(features, alpha=0.2, name=None)}. Pure passthrough — output
@@ -34,7 +35,7 @@ public class LeakyRelu extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "features"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Linspace.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -62,7 +63,7 @@ public class Linspace extends TensorGenerator {
      * @return The lowercased enum name (e.g. {@code "start"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Log1p.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Log1p.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.log1p}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Log1p extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
@@ -11,6 +11,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -55,7 +56,7 @@ public class Meshgrid extends TensorGenerator implements TupleElementProvider {
      * @return The lowercased enum name (e.g. {@code "args"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Queue;
 import java.util.Set;
 
@@ -37,7 +38,7 @@ public class Model extends TensorGenerator {
     OUTPUTS;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 
@@ -53,7 +54,7 @@ public class Model extends TensorGenerator {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -20,6 +20,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -49,7 +50,7 @@ public class ModelCall extends TensorGenerator {
     MASK;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
@@ -14,6 +14,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -53,7 +54,7 @@ public class NdarrayReshape extends TensorGenerator {
     SHAPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class OneHot extends Ones {
@@ -35,7 +36,7 @@ public class OneHot extends Ones {
     DTYPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Ones.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Ones.java
@@ -12,6 +12,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -32,7 +33,7 @@ public class Ones extends TensorGenerator {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Poisson.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Poisson.java
@@ -9,6 +9,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -28,7 +29,7 @@ public class Poisson extends Ones {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -55,7 +56,7 @@ public class RaggedConstant extends Constant {
     ROW_SPLITS_DTYPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -25,6 +25,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -45,7 +46,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowSplits.java
@@ -6,6 +6,7 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 /**
@@ -26,7 +27,7 @@ public class RaggedFromNestedRowSplits extends RaggedFromNestedRowLengths {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -32,6 +32,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -54,7 +55,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -29,7 +30,7 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -29,7 +30,7 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -12,6 +12,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -32,7 +33,7 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -10,6 +10,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -30,7 +31,7 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -24,6 +24,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -46,7 +47,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
     VALIDATE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -14,6 +14,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -39,7 +40,7 @@ public class RaggedRange extends Range {
     ROW_SPLITS_DTYPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -22,6 +22,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -45,7 +46,7 @@ public class Range extends TensorGenerator {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReadDataSets.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReadDataSets.java
@@ -13,6 +13,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /** A representation of the `read_data_sets()` function in TensorFlow. */
@@ -31,7 +32,7 @@ public class ReadDataSets extends Ones {
     SOURCE_URL;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reciprocal.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reciprocal.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.reciprocal}. Pure passthrough — output shape and dtype both inherit
@@ -32,7 +33,7 @@ public class Reciprocal extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -30,7 +31,7 @@ public class ReduceMean extends TensorGenerator {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Relu.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.nn.relu(features, name=None)}. Pure passthrough — output shape and dtype
@@ -30,7 +31,7 @@ public class Relu extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "features"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Round.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Round.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.round}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Round extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Sigmoid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Sigmoid.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -31,7 +32,7 @@ public class Sigmoid extends TensorGenerator {
     X;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Sinh.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Sinh.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.sinh}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Sinh extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softmax.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -29,7 +30,7 @@ public class Softmax extends TensorGenerator {
     LOGITS;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SoftmaxCrossEntropy.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SoftmaxCrossEntropy.java
@@ -11,6 +11,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -55,7 +56,7 @@ public class SoftmaxCrossEntropy extends TensorGenerator {
      *     TensorGenerator#getArgumentPointsToSet}.
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softplus.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softplus.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.softplus}. Pure passthrough — output shape and dtype both inherit
@@ -31,7 +32,7 @@ public class Softplus extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "features"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softsign.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Softsign.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.softsign}. Pure passthrough — output shape and dtype both inherit
@@ -31,7 +32,7 @@ public class Softsign extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "features"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -17,6 +17,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class SparseAdd extends ElementWiseOperation {
@@ -28,7 +29,7 @@ public class SparseAdd extends ElementWiseOperation {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseEye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseEye.java
@@ -10,6 +10,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,7 +27,7 @@ public class SparseEye extends Ones {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseFromDense.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseFromDense.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * A representation of the `tf.sparse.from_dense()` API in TensorFlow.
@@ -17,7 +18,7 @@ public class SparseFromDense extends ConvertToTensor {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseTensor.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseTensor.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -19,7 +20,7 @@ public class SparseTensor extends Ones {
     DENSE_SHAPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Square.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Square.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.square}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Square extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
@@ -27,6 +27,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -71,7 +72,7 @@ public class Stack extends TensorGenerator {
      * @return The lowercased enum name (e.g. {@code "values"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/StopGradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/StopGradient.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -39,7 +40,7 @@ public class StopGradient extends TensorGenerator {
     INPUT;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tan.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tan.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * Generator for {@code tf.math.tan}. Pure passthrough — output shape and dtype both inherit from
@@ -31,7 +32,7 @@ public class Tan extends PassThroughUnaryTensorGenerator {
      * @return The lowercased enum name (e.g. {@code "x"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorCall.java
@@ -9,6 +9,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -22,7 +23,7 @@ public class TensorCall extends TensorGenerator {
     DTYPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -11,6 +11,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -66,7 +67,7 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
      * @return The lowercased enum name.
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Uniform.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Uniform.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * A representation of the `random.uniform()` function in TensorFlow.
@@ -21,7 +22,7 @@ public class Uniform extends Ones {
     NAME;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Variable.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Variable.java
@@ -8,6 +8,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -35,7 +36,7 @@ public class Variable extends TensorGenerator {
     SHAPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Where.java
@@ -10,6 +10,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -67,7 +68,7 @@ public class Where extends TensorGenerator {
      * @return The lowercased enum name (e.g. {@code "condition"}).
      */
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ZerosLike.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ZerosLike.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
 
 /**
  * A generator for tensors created by the `zeros_like()` function in TensorFlow.
@@ -19,7 +20,7 @@ public class ZerosLike extends Constant {
     SHAPE;
 
     public String getName() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
 
     public int getIndex() {


### PR DESCRIPTION
## Summary

Closes wala/ML#497. The `Parameters` enum convention used across many generators implements `getName()` as `name().toLowerCase()` without a locale. On a Turkish-default JVM, `name().toLowerCase()` on `DIMENSION` produces `dımensıon` (dotless `ı`), which doesn't match the lower-case-ASCII keyword `dimension` that `tensorflow.xml` uses. The keyword-arg lookup silently fails on that locale.

## Changes

Replaced `name().toLowerCase()` with `name().toLowerCase(Locale.ROOT)` across **78 generators** in `com.ibm.wala.cast.python.ml.client`. Scoped narrowly to the `return name().toLowerCase();` line pattern (the `Parameters` enum's `getName()` form) so unrelated locale-stable callers (e.g., `DType.INT64.name().toLowerCase()` in `DatasetEnumerateGenerator`) are untouched. Added `import java.util.Locale;` to each affected file.

## Test Plan

- [x] Full ML test suite passes: 723 / 0 / 0 / 0 on `TestTensorflow2Model`; 4 / 0 / 0 / 1 skipped on `TestNeuroImageExamples`.
- [x] CI is locale-stable on en_US-default JVMs (today's default), so no behavioural change is observable in the test suite. The value is correctness on locale-divergent JVMs (Turkish, Azerbaijani, Lithuanian).
- [ ] CI confirms.

## Cross-Refs

- wala/ML#497 &mdash; the tracking issue, with the original `Argmax.java` precedent fix at `fbe44700` on PR ponder-lab/ML#246.
- The 17 tier-1 unary generators on PR ponder-lab/ML#258 (`Acosh`, `Asin`, `Asinh`, `Atan`, `Atanh`, `Cosh`, `Erf`, `Erfc`, `Expm1`, `Log1p`, `Reciprocal`, `Round`, `Sinh`, `Softplus`, `Softsign`, `Square`, `Tan`) are all included in this sweep, plus `Where`, `Einsum`, `Meshgrid`, `LeakyRelu`, `Concat`, `TopK`, `BroadcastTo`, and the additional ~50 generators that already had the pattern.