### PR TITLE
Add fixtures for `tf.range` dtype paths and pin the remaining gap (wala/ML#492)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -444,6 +444,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5)));
 
+  private static final TensorType TENSOR_5_INT64 =
+      new TensorType(INT_64, asList(new NumericDim(5)));
+
   private static final TensorType TENSOR_4_INT32 =
       new TensorType(INT_32, asList(new NumericDim(4)));
 
@@ -5824,6 +5827,57 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testRange5()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_range5.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_4_INT32)));
+  }
+
+  /**
+   * Regression test for wala/ML#492. When an explicit {@code dtype=} keyword is supplied to {@code
+   * tf.range}, the analyzer must honor it instead of defaulting to {@code int32}. {@code
+   * tf.range(0, 5, dtype=tf.float32)} should infer {@code float32}.
+   */
+  @Test
+  public void testRangeDType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_range_dtype.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testRangeDType()} — explicit {@code dtype=tf.int64} should be honored (not
+   * collapsed to the {@code int32} default). Pinpoints that the dtype-arg path resolves arbitrary
+   * {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType} values, not just {@code
+   * float32}.
+   */
+  @Test
+  public void testRangeDTypeInt64()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_range_dtype_int64.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_INT64)));
+  }
+
+  /**
+   * Companion to {@link #testRangeDType()} — 1-positional form {@code tf.range(limit, dtype=...)}.
+   * Verifies that the dtype-arg dispatch fires regardless of how many positional args are present
+   * (the {@link Range} class's call-string-based shape resolution is independent of dtype lookup).
+   */
+  @Test
+  public void testRangeDType1Arg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_range_dtype_1arg.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT32)));
+  }
+
+  /**
+   * Documents a remaining limitation of {@link Range}: when no explicit {@code dtype} is supplied
+   * but the {@code start}/{@code limit}/{@code delta} arguments are {@code float}-typed, TF
+   * promotes the output to {@code float32} at runtime. The analyzer currently returns the
+   * unconditional {@code int32} default from {@code Range.getDefaultDTypes}, which this test pins
+   * down. Tracked by <a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>): when {@link
+   * Range#getDefaultDTypes} learns to derive its result from the start/limit/delta arg dtypes, flip
+   * the expected type to {@code TENSOR_5_FLOAT32}.
+   */
+  @Test
+  public void testRangeFloatArgs()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_range_float_args.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype.py
@@ -1,0 +1,16 @@
+# Exercises tf.range's dtype= keyword argument (wala/ML#492).
+# tf.range honors an explicit dtype override; the analyzer should infer
+# float32 here, not the int32 default.
+
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+r = tf.range(0, 5, dtype=tf.float32)
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5,)
+assert r.dtype == tf.float32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype_1arg.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype_1arg.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# 1-positional form: tf.range(limit, dtype=...)
+r = tf.range(5, dtype=tf.float32)
+assert r.shape == (5,)
+assert r.dtype == tf.float32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype_int64.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_range_dtype_int64.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+r = tf.range(0, 5, dtype=tf.int64)
+assert r.shape == (5,)
+assert r.dtype == tf.int64
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_range_float_args.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_range_float_args.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Float args; no explicit dtype. Runtime promotes to float32.
+r = tf.range(0.0, 5.0)
+assert r.shape == (5,)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
## Summary

- Investigates wala/ML#492 (`tf.range` ignores user-supplied `dtype`).
- Three fixtures pin the explicit-`dtype` paths (which already work via the base `TensorGenerator.getDTypes` machinery) for `dtype=tf.float32`, `dtype=tf.int64`, and the 1-positional `tf.range(limit, dtype=...)` form.
- One fixture pins the actual remaining gap: `tf.range(0.0, 5.0)` runtime-promotes to `float32` from arg dtypes, but `Range.getDefaultDTypes` returns the unconditional `int32` default. Captured as `testRangeFloatArgs` asserting the imprecise observed result with a Javadoc TODO pointing at #492 (per the capture-observed-in-assertion convention).

## Why The Issue's Premise Was Partially Wrong

wala/ML#492 reads `Range.getDefaultDTypes`'s `return EnumSet.of(DType.INT32)` and concludes the explicit-`dtype=` keyword is ignored. But the base `TensorGenerator.getDTypes(builder)` already dispatches to `getDTypesFromDTypeArgument` when the dtype-arg PTS is non-empty &mdash; falling back to `getDefaultDTypes` only when the dtype arg is absent. So `tf.range(0, 5, dtype=tf.float32)` correctly infers `float32` today; the new `testRangeDType*` fixtures verify this and lock the behavior in.

The actual remaining gap is the *default* path: `Range.getDefaultDTypes` doesn't derive from the start/limit/delta arg dtypes, so `tf.range(0.0, 5.0)` infers `int32`. The fix is local to `Range.getDefaultDTypes`; left to a follow-up so this PR is purely fixture-coverage with no behavioral change.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest='TestTensorflow2Model#testRange+testRange2+testRange3+testRange4+testRange5+testRangeIterationElementType+testRangeDType+testRangeDTypeInt64+testRangeDType1Arg+testRangeFloatArgs' test` &mdash; 10/10 pass.
- [x] Each Python fixture runs to completion under `python3.10` and the asserts encode the runtime ground-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)