### PR TITLE
Drop dead `logging.properties` include from `jython3.test` POM

### DIFF
--- a/com.ibm.wala.cast.python.jython3.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython3.test/pom.xml
@@ -63,7 +63,6 @@
         <includes>
           <include>META-INF/**</include>
           <include>build.properties</include>
-          <include>logging.properties</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
## Summary

- Removes the `<include>logging.properties</include>` line from `com.ibm.wala.cast.python.jython3.test/pom.xml`.
- The line packages `com.ibm.wala.cast.python.jython3.test/logging.properties`, which is a symlink to `../logging.properties` (resolves to the repo-root `logging.properties` from the module dir).
- Maven copies the *symlink* (not its target) into `target/classes/logging.properties`. The relative target `../logging.properties` then points at `target/logging.properties`, which doesn't exist — so the packaged resource is unreadable at runtime.
- The other test modules' POMs (`jython.test`, `ml.test`, `python.test`) already omit this include; their dev-time symlinks survive untouched and continue to be picked up by Surefire from the module dir.

Closes wala/ML#502.

## Verification

```
$ ls -L com.ibm.wala.cast.python.jython3.test/target/classes/logging.properties
ls: cannot access '...': No such file or directory
```

(Prior to this change, the symlink is in `target/classes/` but the readlink target doesn't exist.)

## Test Plan

- [x] No Java/Python touched; CI catches anything genuinely broken.
- [x] `target/classes/logging.properties` no longer materializes after this change (Maven simply skips the resource).
- [x] Dev-time `mvn -pl com.ibm.wala.cast.python.jython3.test test` still resolves `logging.properties` via the module-dir symlink — Surefire reads from the source tree, not `target/classes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)