### PR TITLE
Validate `ClientDriver` argv to prevent index-out-of-bounds (closes wala/ML#479)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
@@ -301,6 +301,12 @@ public class ClientDriver implements LanguageClient {
 
   public static void main(String[] args, InputStream in, OutputStream out, Consumer<Object> process)
       throws IOException, InterruptedException, ExecutionException {
+    if (args.length < 1 || args.length % 2 != 1) {
+      throw new IllegalArgumentException(
+          "Expected URI followed by zero or more (line, character) pairs; got "
+              + args.length
+              + " arg(s).");
+    }
     ClientDriver client = new ClientDriver();
     client.args = args;
     client.process = process;


### PR DESCRIPTION
## Summary

- Adds an argv-shape precondition check at the canonical `main(args, in, out, process)` entry point in `ClientDriver`.
- Contract: `args.length == 1 + 2k` (one URI followed by zero-or-more `(line, character)` pairs). Throws `IllegalArgumentException` otherwise.
- CodeQL was flagging `args[i + 1]` in the pairing loop (`publishDiagnostics`, lines 136-140) as `java/index-out-of-bounds` (severity: error) because the loop bound only checks `i`, not `i + 1`. Any caller passing an even-length argv crashes mid-LSP-callback.

Closes wala/ML#479.

## Why At `main` Rather Than At The Loop

The issue offers two recipes:
1. Tighten the loop bound (`i + 1 < args.length`) — silently drops orphan trailing args.
2. Validate at entry, fail loud.

Going with option 2 per the issue's recommendation, but placing the check at `main` entry rather than immediately before the loop:

- `publishDiagnostics` is an LSP callback that fires repeatedly; validating once at startup is cheaper and clearer.
- Exceptions thrown inside an LSP callback risk being captured by the JSON-RPC framework's `CompletableFuture` chain and surfaced only as stderr noise. A launcher-time crash is the better failure mode for malformed argv.

## Reproducer (Pre-Fix Behavior)

```
$ java ... ClientDriver file.py 10 5 20
... → ArrayIndexOutOfBoundsException at ClientDriver.publishDiagnostics:139
```

Post-fix:
```
$ java ... ClientDriver file.py 10 5 20
Exception: Expected URI followed by zero or more (line, character) pairs; got 4 arg(s).
```

## Test Plan

- [x] No existing test exercises `ClientDriver.main` (it's an LSP driver entry point); CodeQL was the surfacing signal.
- [x] CI runs the full suite for regressions; the validation only affects callers that were already crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)