### PR TITLE
Catch `NumberFormatException` and rethrow as `IllegalStateException` in tensor-analysis (closes wala/ML#518)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -124,7 +124,8 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                     try {
                       nrowsArgs.add(Long.parseLong((String) val));
                     } catch (NumberFormatException e) {
-                      // Skip non-numeric value; preserves lattice ⊤ vs. crashing.
+                      throw new IllegalStateException(
+                          "nested_nrows element \"" + val + "\" is not a long.", e);
                     }
                   }
                 }
@@ -206,7 +207,11 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                                   try {
                                     lVal = Long.parseLong((String) val);
                                   } catch (NumberFormatException e) {
-                                    // Skip non-numeric value; lVal stays -1 and is filtered below.
+                                    throw new IllegalStateException(
+                                        "nested_value_rowids inner element \""
+                                            + val
+                                            + "\" is not a long.",
+                                        e);
                                   }
                                 }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -120,7 +120,13 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                   Object val = ((ConstantKey<?>) valKey).getValue();
                   if (val instanceof Integer) nrowsArgs.add(((Integer) val).longValue());
                   else if (val instanceof Long) nrowsArgs.add((Long) val);
-                  else if (val instanceof String) nrowsArgs.add(Long.parseLong((String) val));
+                  else if (val instanceof String) {
+                    try {
+                      nrowsArgs.add(Long.parseLong((String) val));
+                    } catch (NumberFormatException e) {
+                      // Skip non-numeric value; preserves lattice ⊤ vs. crashing.
+                    }
+                  }
                 }
               }
             }
@@ -196,7 +202,13 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                                 long lVal = -1;
                                 if (val instanceof Integer) lVal = ((Integer) val).longValue();
                                 else if (val instanceof Long) lVal = (Long) val;
-                                else if (val instanceof String) lVal = Long.parseLong((String) val);
+                                else if (val instanceof String) {
+                                  try {
+                                    lVal = Long.parseLong((String) val);
+                                  } catch (NumberFormatException e) {
+                                    // Skip non-numeric value; lVal stays -1 and is filtered below.
+                                  }
+                                }
 
                                 if (lVal >= 0) {
                                   if (max == null || lVal > max) max = lVal;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -493,7 +493,8 @@ public abstract class TensorGenerator {
       try {
         return Integer.parseInt((String) constantKeyValue);
       } catch (NumberFormatException e) {
-        return null;
+        throw new IllegalStateException(
+            "Catalog field index \"" + constantKeyValue + "\" is not an integer.", e);
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -489,7 +489,13 @@ public abstract class TensorGenerator {
     Object constantKeyValue = constantKey.getValue();
 
     if (constantKeyValue instanceof Integer) return (Integer) constantKeyValue;
-    else if (constantKeyValue instanceof String) return Integer.parseInt((String) constantKeyValue);
+    if (constantKeyValue instanceof String) {
+      try {
+        return Integer.parseInt((String) constantKeyValue);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
 
     return null;
   }


### PR DESCRIPTION
## Summary

Wraps the three string-to-int coercion sites flagged by CodeQL alerts [#5209](https://github.com/ponder-lab/ML/security/code-scanning/5209), [#5210](https://github.com/ponder-lab/ML/security/code-scanning/5210), and [#5211](https://github.com/ponder-lab/ML/security/code-scanning/5211) (`java/uncaught-number-format-exception`) with `try`/`catch` that rethrows as `IllegalStateException` with the original `NumberFormatException` as `cause`:

- `TensorGenerator.getFieldIndex`—catalog field-index lookup.
- `RaggedFromNestedValueRowIds:123`—explicit `nested_nrows` arg collection.
- `RaggedFromNestedValueRowIds:199`—inner ragged-rank value derivation.

Closes wala/ML#518.

## Approach

Earlier revisions of this PR took a degrade-to-null / skip approach. Copilot review surfaced three concrete correctness issues with that direction:
1. Returning `null` from `getFieldIndex` would replace `NumberFormatException` with `NullPointerException` at the non-null-checking callers (audit of the 20+ call sites confirms several dereference the result directly).
2. Skipping the unparseable `nested_nrows` element conflated explicit-but-invalid with missing, triggering the inference-from-rowids fallback and potentially fabricating a row dimension.
3. Skipping the inner rowid value left `foundAny=false`, hitting the `!foundAny` branch that adds `new NumericDim(0)`—a wrong-direction degradation (⊥ "definitely empty" rather than ⊤ "unknown").

Switched to `catch (NumberFormatException) { throw new IllegalStateException(..., e); }` at all three sites. Rationale:
- Matches the existing pattern at `TensorGenerator.java:1491` (the only other `valueOf`-style site, which already catches and rethrows ISE with the original as cause).
- Matches the design resolution from wala/ML#519 (PR #277): on coercion sites where the input should always be canonical, fail loud rather than degrade incorrectly.
- Satisfies the CodeQL rule (the literal NFE is now caught).
- Preserves the original parse error as `cause` for debugging.

Proper lattice ⊤ degradation for the `RaggedFromNestedValueRowIds` sites (bail to `null` shape set on unparseable input) is a deeper refactor and remains tracked at wala/ML#520 along with the fixture follow-up. Loud failure is the correct behavior in the meantime.

## Distinct From #274/#275

PRs #274 (wala/ML#479) and #275 (wala/ML#517) validate-and-throw at `ClientDriver.main` because uncaught exceptions inside LSP callbacks risk being swallowed by the JSON-RPC framework. This PR sits inside the tensor-analysis dataflow; the failure-mode rationale here is "fail loud on internal-invariant violation" (matching #519's pattern), not "fail fast at the CLI."

## Test Plan

- [x] Static analysis (CodeQL) was the original signal; once merged, three alerts auto-close.
- [x] No existing test asserts on the original *crash* behavior (verified by `grep -rn 'NumberFormatException' com.ibm.wala.cast.python.ml.test/`); the new `IllegalStateException` path with the same trigger conditions is a strict improvement in error clarity.

A fixture follow-up to exercise the throw-paths (and to consider lattice-correct ⊤ degradation for `RaggedFromNestedValueRowIds`) is tracked at wala/ML#520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
