### PR TITLE
Restore `spotless`-compliant self-closing tag style in root `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <parallel>both</parallel>
     <logging.config.file>./logging.properties</logging.config.file>
     <jacoco-version>0.8.14</jacoco-version>
-    <argLine />
+    <argLine/>
     <junit.4.version>4.13.2</junit.4.version>
   </properties>
   <dependencyManagement>
@@ -221,8 +221,8 @@
                   <exclude>IDE/</exclude>
                   <exclude>jython3/</exclude>
                 </excludes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
               </format>
               <format>
                 <includes>
@@ -232,8 +232,8 @@
                 <excludes>
                   <exclude>**/target/</exclude>
                 </excludes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
                 <indent>
                   <tabs>true</tabs>
                   <spacesPerTab>4</spacesPerTab>
@@ -244,7 +244,7 @@
                   <include>**/*.xml</include>
                   <include>**/.pydevproject</include>
                 </includes>
-                <toggleOffOn />
+                <toggleOffOn/>
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>**/pom.xml</exclude>
@@ -261,8 +261,8 @@
                     <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
               </format>
             </formats>
             <java>
@@ -270,8 +270,8 @@
                 <version>1.27.0</version>
                 <reflowLongStrings>true</reflowLongStrings>
               </googleJavaFormat>
-              <trimTrailingWhitespace />
-              <endWithNewline />
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
             </java>
             <pom>
               <sortPom>


### PR DESCRIPTION
## Summary

`mvn release:prepare` for 0.43.0 emitted self-closing XML tags with a leading space (`<tag />`) in root `pom.xml`: `<argLine />`, `<trimTrailingWhitespace />`, `<endWithNewline />`, `<toggleOffOn />` (10 sites total). Spotless's pom format enforces the no-space form (`<tag/>`). The release-plugin commit bypassed the `spotless-apply` pre-commit hook (via `SKIP=spotless-apply`, set to avoid a separate commit-vs-hook conflict during the release), so the deviation landed on master.

Master tip's `Check formatting with Spotless` CI step is now failing. This PR runs `mvn spotless:apply` to revert the 10 affected self-closing tags to the no-space form.

## Why

The pre-commit hook reformats files mid-commit, which makes the release plugin's `scm-commit-release` phase fail (`git-commit command failed; files were modified by this hook`). To unblock the release, the hook was bypassed for the duration. The cost is this trailing fix-up: spotless's preferred form for the pom didn't match the release-plugin's XML emitter, so a small whitespace delta needs cleanup post-release.

No semantic change to the pom; pure whitespace. Master's CI returns to green once this lands.

## Test Plan

- [x] Local `mvn spotless:check` passes after the fix.
- [x] No `pom.xml` content changes beyond self-closing-tag whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)