### PR TITLE
Add `tags: '**'` to `on.push` so release tag pushes trigger CI again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,12 @@ on:
     # `merge_group:` be the sole trigger for queue-branch pushes.
     branches-ignore:
       - 'gh-readonly-queue/**'
+    # When only `branches`/`branches-ignore` is set on `push:`, GitHub Actions silently
+    # filters out tag-push events too. The release-deploy gate at the bottom of this
+    # workflow depends on `refs/tags/0.*` pushes firing the workflow, so explicitly
+    # allow all tags here.
+    tags:
+      - '**'
   pull_request:
   merge_group:
 concurrency:


### PR DESCRIPTION
## Summary

Adds `tags: '**'` to the `on.push` block of `continuous-integration.yml` so tag pushes trigger CI again.

## Why

GitHub Actions silently filters tag-push events out when `on.push` specifies a branch filter (`branches:` or `branches-ignore:`) without a co-specified `tags:` filter. From [the docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-filters): *"If you only define one type of filter (like branches), workflows won't run on the other (like tags)."*

Commit 92436f59 (PR #218, "Filter `push:` trigger off queue branches") added `branches-ignore: gh-readonly-queue/**` to stop merge-queue branches from double-triggering the workflow. That branch-only filter inadvertently disabled tag-push triggering — defeating the 2026-04-30 deploy-gate fix that wired the deploy step's `if:` to fire on `refs/tags/0.*` pushes. The deploy step is wired correctly; the workflow simply doesn't fire on tag events anymore.

Surfaced when the `0.43.0` release tag push produced no CI run today (verified via `gh run list --branch '0.43.0' --repo ponder-lab/ML` returning empty).

## Effect

After this lands:
- Tag pushes once again trigger `Continuous integration`.
- The deploy step's existing `if: ... startsWith(github.ref, 'refs/tags/0.')` guard then fires the `mvn deploy` to `maven.pkg.github.com`.
- Recovery for the already-tagged-but-not-deployed `0.43.0`: `git push --delete origin 0.43.0 && git push origin 0.43.0` to re-trigger the tag-push event.

The deploy step's own `if:` filter still gates per-tag-name, so this re-enables the full release flow without weakening it.

## Test Plan

- [x] After this lands, re-push the `0.43.0` tag (delete + push) and observe a tag-push CI run appears that runs the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)