### PR TITLE
Replace stale `<!-- Pandas model -->` headers in three non-Pandas summary XMLs

### DIFF
--- a/com.ibm.wala.cast.python.jython/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython/data/functools.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- functools model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">

--- a/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- NumPy turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python.jython/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython/data/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- Turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python.jython3/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython3/data/functools.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- functools model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">

--- a/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- NumPy turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python.jython3/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython3/data/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- Turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python/data/functools.xml
+++ b/com.ibm.wala.cast.python/data/functools.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- `functools` stdlib model. -->
+<!-- functools model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">

--- a/com.ibm.wala.cast.python/data/functools.xml
+++ b/com.ibm.wala.cast.python/data/functools.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- `functools` stdlib model. -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">

--- a/com.ibm.wala.cast.python/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python/data/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- NumPy turtle stubs (placeholder summaries for unmodeled NumPy ops). -->
+<!-- NumPy turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python/data/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- NumPy turtle stubs (placeholder summaries for unmodeled NumPy ops). -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python/data/turtles.xml
+++ b/com.ibm.wala.cast.python/data/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Turtle stubs (placeholder summaries spanning multiple unmodeled libraries: numpy, sklearn, pandas, patsy, seaborn, statsmodels, scipy, matplotlib, IPython, mpl_toolkits, tensorflow). -->
+<!-- Turtle model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/com.ibm.wala.cast.python/data/turtles.xml
+++ b/com.ibm.wala.cast.python/data/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- Turtle stubs (placeholder summaries spanning multiple unmodeled libraries: numpy, sklearn, pandas, patsy, seaborn, statsmodels, scipy, matplotlib, IPython, mpl_toolkits, tensorflow). -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">


### PR DESCRIPTION
## Summary

Sweeps the stale `<!-- Pandas model -->` header in 9 summary XML files across three data directories—same three files (`functools.xml`, `numpy_turtle.xml`, `turtles.xml`) per directory:

- `com.ibm.wala.cast.python/data/`
- `com.ibm.wala.cast.python.jython/data/`
- `com.ibm.wala.cast.python.jython3/data/`

Each file's header is replaced with a short `<!-- <Name> model -->` header matching the existing convention from `abseil.xml` / `click.xml` / `pandas.xml`:

- `functools.xml` → `<!-- functools model -->`
- `numpy_turtle.xml` → `<!-- NumPy turtle model -->`
- `turtles.xml` → `<!-- Turtle model -->`

`pandas.xml` itself keeps its `<!-- Pandas model -->` header (genuine Pandas model, untouched).

Closes wala/ML#524.

## Why

The header is the only in-file documentation of what each summary covers, so a stale header trips up maintainers reading the file first time and any regeneration tooling that uses the header as a hint.

## Test Plan

- [x] Pure documentation change; no behavioral impact. Headers are comments, not parsed by the summary-spec loader.
- [x] CI catches anything genuinely broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)