### PR TITLE
Fix `EstimatorSpec.do()` to allocate `Ltensorflow/estimator/EstimatorSpec` not `Tensor`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4530,6 +4530,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_estimator_spec.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
   }
 
+  /**
+   * Regression test for <a href="https://github.com/wala/ML/issues/523">wala/ML#523</a>: the {@code
+   * EstimatorSpec.do()} constructor's fresh allocation must be a {@code
+   * Ltensorflow/estimator/EstimatorSpec} (a namedtuple-like spec object) rather than a {@code
+   * Ltensorflow/python/framework/ops/Tensor}. The fixture passes the {@code spec} directly to
+   * {@code f}; if {@code spec} is misclassified as a tensor allocation, {@code f}'s parameter would
+   * be a tensor (and the expected count would be 1 / 1). With the correct non-tensor class, {@code
+   * f} has 0 tensor parameters and 0 tensor variables.
+   */
+  @Test
+  public void testEstimatorSpecNotTensor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_estimator_spec_not_tensor.py", "f", 0, 0, Map.of());
+  }
+
   @Test
   public void testReduceMean2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2190,9 +2190,10 @@
         </method>
       </class>
       <class name="EstimatorSpec" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — fresh allocation (not pass-through) so the resulting spec is a distinct object from any input. Each named parameter is stored as a field on the result, mirroring the namedtuple shape of the real API. See wala/ML#429. -->
+        <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — fresh allocation (not pass-through) so the resulting spec is a distinct object from any input. Each named parameter is stored as a field on the result, mirroring the namedtuple shape of the real API. Allocated as `Ltensorflow/estimator/EstimatorSpec`
+          (the proper class type that's already registered for the estimator-namespace binding), not as a `Tensor` — `EstimatorSpec` is a namedtuple-like spec object, not a tensor. See wala/ML#429 (binding + body) and wala/ML#523 (allocation-class fix). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self mode predictions loss train_op eval_metric_ops export_outputs">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <new def="res" class="Ltensorflow/estimator/EstimatorSpec" />
           <putfield class="LRoot" field="mode" fieldType="LRoot" ref="res" value="mode" />
           <putfield class="LRoot" field="predictions" fieldType="LRoot" ref="res" value="predictions" />
           <putfield class="LRoot" field="loss" fieldType="LRoot" ref="res" value="loss" />

--- a/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec_not_tensor.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_estimator_spec_not_tensor.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+loss_tensor = tf.constant(1.0)
+assert isinstance(loss_tensor, tf.Tensor)
+
+spec = tf.estimator.EstimatorSpec(
+    mode=tf.estimator.ModeKeys.EVAL,
+    predictions=None,
+    loss=loss_tensor,
+    train_op=None,
+    eval_metric_ops={},
+    export_outputs=None,
+)
+
+# spec is a namedtuple-like object, NOT a tensor. The static analyzer must
+# allocate it as `Ltensorflow/estimator/EstimatorSpec`, not as a tensor class
+# (wala/ML#523). If misclassified as Tensor, `f` would have 1 tensor parameter
+# at value number 2; with the correct allocation class, `f` has 0 tensor
+# parameters.
+assert not isinstance(spec, tf.Tensor)
+f(spec)


### PR DESCRIPTION
## Summary

`tensorflow.xml`'s `EstimatorSpec.do()` was allocating `<new class="Ltensorflow/python/framework/ops/Tensor"/>` for the spec result. `tf.estimator.EstimatorSpec` is a namedtuple-like spec object, not a tensor—so tensor-type-analysis misclassified `EstimatorSpec(...)` return-flow as tensor-typed and the `<putfield>`s for `mode`/`predictions`/`loss`/etc. landed on a `Tensor` instance key.

Change the `<new>` class to `Ltensorflow/estimator/EstimatorSpec`, which is already registered in the model at the estimator-namespace binding (`tensorflow.xml` line 145). The 6 `<putfield>` operations stay—field access doesn't depend on class membership in the WALA model. No Java-side dispatch changes needed; `EstimatorSpec` isn't a tensor-producing op and shouldn't have a generator.

Closes wala/ML#523.

## Context

Decision-record from `#459` (canonical `Tensor` allocations for function-typed allocs) drove the original choice—correct for tensor-producing ops but wrong for structural constructors like `EstimatorSpec`. wala/ML#464 (`tape.gradient` on list-shaped sources) is the other surfaced instance of the same `#459`-migration bug class. Both were filed today; this PR fixes one of them.

## Regression Test

Added `testEstimatorSpecNotTensor` with new fixture `tf2_test_estimator_spec_not_tensor.py`. The fixture passes `spec` directly to a sink `f`. With the bug, `f` would have 1 tensor parameter; with the fix, 0. Locks in the corrected classification.

Existing `testEstimatorSpec` (asserts the `spec.loss` round-trip via field read) is unchanged and continues to pass—field lookup doesn't care about class membership, so the round-trip works on either allocation class.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest='TestTensorflow2Model#testEstimatorSpec+testEstimatorSpecNotTensor' test`—2/2 pass.
- [x] Full `TestTensorflow2Model` (729 tests) passes locally.
- [x] Python fixture runs to completion under `python3.10` with all `assert` lines holding (including the new `assert not isinstance(spec, tf.Tensor)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)