### PR TITLE
Sweep cellType/atom/parameter-name sites to `toLowerCase(Locale.ROOT)`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetEnumerateGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetEnumerateGenerator.java
@@ -14,6 +14,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -36,7 +37,7 @@ public class DatasetEnumerateGenerator extends DatasetGenerator {
     Set<TensorType> types = HashSetFactory.make();
 
     // Add the index type (int64 scalar)
-    types.add(new TensorType(DType.INT64.name().toLowerCase(), Collections.emptyList()));
+    types.add(new TensorType(DType.INT64.name().toLowerCase(Locale.ROOT), Collections.emptyList()));
 
     // Add the underlying dataset types
     TensorGenerator underlying = getUnderlyingGenerator(builder);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -405,7 +405,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
     Set<TensorType> ret = HashSetFactory.make();
 
     for (List<Dimension<?>> dimensionList : shapes)
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), dimensionList));
 
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -339,12 +339,14 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
     // rather than falling through to the aggregate {@code getTensorTypes}, which would silently
     // leak sibling fields' shapes. See wala/ML#396.
     if (shapes == null) {
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), null));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), null));
       return ret;
     }
 
     for (List<Dimension<?>> dimensionList : shapes)
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), dimensionList));
 
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
@@ -130,7 +130,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
           Set<DType> dTypes = this.getDTypesOfValue(builder, singletonPTS);
           for (List<Dimension<?>> shape : shapes) {
             for (DType dtype : dTypes) {
-              ret.add(new TensorType(dtype.name().toLowerCase(), shape));
+              ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), shape));
             }
           }
         }
@@ -261,12 +261,14 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
     // rather than falling through to the aggregate {@code getTensorTypes}, which would silently
     // leak sibling fields' shapes. See wala/ML#396.
     if (shapes == null) {
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), null));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), null));
       return ret;
     }
 
     for (List<Dimension<?>> dimensionList : shapes)
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), dimensionList));
 
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
@@ -20,6 +20,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -125,12 +126,14 @@ public class DatasetGenerator extends TensorGenerator implements TupleElementPro
     // rather than falling through to the aggregate {@code getTensorTypes}, which would silently
     // leak sibling fields' shapes. See wala/ML#396.
     if (shapes == null) {
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), null));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), null));
       return ret;
     }
 
     for (List<Dimension<?>> dimensionList : shapes)
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), dimensionList));
 
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Meshgrid.java
@@ -105,7 +105,7 @@ public class Meshgrid extends TensorGenerator implements TupleElementProvider {
     // dtype with null dims. When shapes become precise, this method needs to fan out per shape.
     Set<DType> dtypes = this.getDTypesForIndex(builder, index);
     Set<TensorType> ret = HashSetFactory.make();
-    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
+    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(Locale.ROOT), null));
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
@@ -189,7 +189,7 @@ public class OneHot extends Ones {
         : "Number of "
             + OneHot.class.getName()
             + " shapes should be at least the number of "
-            + INDICES.name().toLowerCase(Locale.ROOT)
+            + INDICES.getName()
             + " shapes.";
 
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
@@ -189,7 +189,7 @@ public class OneHot extends Ones {
         : "Number of "
             + OneHot.class.getName()
             + " shapes should be at least the number of "
-            + INDICES.name().toLowerCase()
+            + INDICES.name().toLowerCase(Locale.ROOT)
             + " shapes.";
 
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -40,7 +40,11 @@ public class Reshape extends TensorGenerator {
      * attempt to resolve the `-1` based on the input tensor's shape and the known dimensions in the
      * target shape.
      */
-    SHAPE
+    SHAPE;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
   }
 
   public Reshape(PointsToSetVariable source) {
@@ -177,7 +181,7 @@ public class Reshape extends TensorGenerator {
 
   @Override
   protected String getShapeParameterName() {
-    return Parameters.SHAPE.name().toLowerCase(Locale.ROOT);
+    return Parameters.SHAPE.getName();
   }
 
   @Override
@@ -195,6 +199,6 @@ public class Reshape extends TensorGenerator {
   }
 
   protected String getValueParameterName() {
-    return Parameters.TENSOR.name().toLowerCase(Locale.ROOT);
+    return Parameters.TENSOR.getName();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -11,6 +11,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -176,7 +177,7 @@ public class Reshape extends TensorGenerator {
 
   @Override
   protected String getShapeParameterName() {
-    return Parameters.SHAPE.name().toLowerCase();
+    return Parameters.SHAPE.name().toLowerCase(Locale.ROOT);
   }
 
   @Override
@@ -194,6 +195,6 @@ public class Reshape extends TensorGenerator {
   }
 
   protected String getValueParameterName() {
-    return Parameters.TENSOR.name().toLowerCase();
+    return Parameters.TENSOR.name().toLowerCase(Locale.ROOT);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -227,12 +228,13 @@ public abstract class TensorGenerator {
     if (shapes == null) {
       // Shape is unknown (⊤), but dtype info may still be available. Emit TensorTypes with null
       // dims so the dtype information is preserved.
-      for (DType dtype : dTypes) ret.add(new TensorType(dtype.name().toLowerCase(), null));
+      for (DType dtype : dTypes)
+        ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), null));
     } else {
       // Create a tensor type for each possible shape and dtype combination.
       for (List<Dimension<?>> dimensionList : shapes)
         for (DType dtype : dTypes)
-          ret.add(new TensorType(dtype.name().toLowerCase(), dimensionList));
+          ret.add(new TensorType(dtype.name().toLowerCase(Locale.ROOT), dimensionList));
     }
 
     LOGGER.fine("Generator " + this.getClass().getSimpleName() + " produced types: " + ret);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -121,7 +121,7 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
     // dtype with null dims. When shapes become precise, this method needs to fan out per shape.
     Set<DType> dtypes = this.getDTypesForIndex(builder, index);
     Set<TensorType> ret = HashSetFactory.make();
-    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(), null));
+    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(Locale.ROOT), null));
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -8,6 +8,7 @@ import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -126,27 +127,39 @@ public class NumpyTypes extends PythonTypes {
 
   public static final FieldReference FLOAT_32 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.FLOAT32.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.FLOAT32.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   public static final FieldReference FLOAT_64 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.FLOAT64.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.FLOAT64.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   public static final FieldReference INT_32 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.INT32.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.INT32.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   public static final FieldReference INT_64 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.INT64.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.INT64.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   public static final FieldReference UINT_8 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.UINT8.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.UINT8.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   public static final FieldReference STRING =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.STRING.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.STRING.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   /** A mapping from a field reference to its associated {@link DType}, if any. */
   public static final Map<FieldReference, DType> FIELD_REFERENCE_TO_DTYPE =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -13,6 +13,7 @@ import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -1965,7 +1966,7 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference FLOAT_32 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(FLOAT32.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root, findOrCreateAsciiAtom(FLOAT32.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
   /**
    * Represents the TensorFlow float64 data type.
@@ -1976,7 +1977,7 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference FLOAT_64 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(FLOAT64.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root, findOrCreateAsciiAtom(FLOAT64.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
   /**
    * Represents the TensorFlow int32 data type.
@@ -1987,7 +1988,7 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference INT_32 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(INT32.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root, findOrCreateAsciiAtom(INT32.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
   /**
    * Represents the TensorFlow int64 data type.
@@ -1998,7 +1999,7 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference INT_64 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(INT64.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root, findOrCreateAsciiAtom(INT64.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
   /**
    * Represents the TensorFlow uint8 data type.
@@ -2009,7 +2010,7 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference UINT_8 =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(UINT8.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root, findOrCreateAsciiAtom(UINT8.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
   /**
    * Represents the TensorFlow string data type.
@@ -2020,7 +2021,9 @@ public class TensorFlowTypes extends PythonTypes {
    */
   public static final FieldReference STRING =
       FieldReference.findOrCreate(
-          PythonTypes.Root, findOrCreateAsciiAtom(DType.STRING.name().toLowerCase()), D_TYPE);
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(DType.STRING.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
 
   /** A mapping from a field reference to its associated {@link DType}, if any. */
   public static final Map<FieldReference, DType> FIELD_REFERENCE_TO_DTYPE =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -363,7 +363,7 @@ public class TensorType implements Iterable<Dimension<?>> {
     Dimension<Integer> x = new NumericDim(28);
     Dimension<Integer> y = new NumericDim(28);
     Dimension<List<Dimension<?>>> vec = new CompoundDim(Arrays.asList(x, y));
-    return new TensorType(FLOAT32.name().toLowerCase(), Arrays.asList(batch, vec));
+    return new TensorType(FLOAT32.name().toLowerCase(Locale.ROOT), Arrays.asList(batch, vec));
   }
 
   public static TensorType shapeArg(CGNode node, int literalVn) throws IOException {
@@ -439,7 +439,7 @@ public class TensorType implements Iterable<Dimension<?>> {
         dims.put(index, new SymbolicDim("?"));
       }
     }
-    return new TensorType(FLOAT32.name().toLowerCase(), new ArrayList<>(dims.values()));
+    return new TensorType(FLOAT32.name().toLowerCase(Locale.ROOT), new ArrayList<>(dims.values()));
   }
 
   @Override
@@ -496,13 +496,9 @@ public class TensorType implements Iterable<Dimension<?>> {
    * Returns the dtype of the tensor as a typed {@link DType} enum value.
    *
    * <p>The cell type is stored as a lowercase string (e.g., {@code "float32"}) for the LSP wire
-   * format. This accessor inverts that pattern using {@link Locale#ROOT} for the uppercase, so the
-   * lookup is locale-stable. Consumers can branch on the dtype as a typed value instead of doing
-   * cast-and-uppercase boilerplate inline.
-   *
-   * <p>Construction sites currently build the cell type via {@code dtype.name().toLowerCase()} (no
-   * explicit locale), which is locale-sensitive — sweeping them to {@code toLowerCase(Locale.ROOT)}
-   * is tracked at <a href="https://github.com/wala/ML/issues/521">wala/ML#521</a>.
+   * format. Both construction sites and this accessor use {@link Locale#ROOT} for the case
+   * conversion, so the round-trip is locale-stable. Consumers can branch on the dtype as a typed
+   * value instead of doing cast-and-uppercase boilerplate inline.
    *
    * @return The dtype enum value corresponding to the stored cell type.
    * @throws IllegalStateException if the stored cell type doesn't map to a {@link DType} constant.


### PR DESCRIPTION
## Summary

Sweeps 29 call sites in `com.ibm.wala.cast.python.ml.client/` and `com.ibm.wala.cast.python.ml.types/` from `name().toLowerCase()` to `name().toLowerCase(Locale.ROOT)`.

## Why

Java's `String#toLowerCase()` without an explicit `Locale` is locale-sensitive. Under Turkish locale, for example, `INT64.name().toLowerCase()` produces `"ınt64"` (with dotless i), which then fails `DType.valueOf("INT64")` after the `Locale.ROOT`-driven round-trip added in #277 (`TensorType.getDType()`). The sweep makes the entire construction-side/accessor-side pipeline locale-stable.

Mirrors the convention established in commit `82ad79be` (`Parameters` enum `getName()` sweep, closing wala/ML#497).

## Categories Swept

- **`TensorType` cellType construction** (~14 sites): `new TensorType(dtype.name().toLowerCase(...), ...)` in `DatasetFromTensorSlicesGenerator`, `TopK`, `DatasetEnumerateGenerator`, `DatasetFromGeneratorGenerator`, `Meshgrid`, `DatasetFromTensorsGenerator`, `TensorType` factory methods, `DatasetGenerator`, `TensorGenerator`.
- **Atom-based class names** (~12 sites): `findOrCreateAsciiAtom(dtype.name().toLowerCase(...))` in `NumpyTypes` and `TensorFlowTypes`.
- **Direct `Parameters.X.name().toLowerCase()` reads** (3 sites): `Reshape.java:179`/`197` and `OneHot.java:192`—these bypassed their enum's `getName()` (which was already swept in `82ad79be`).

Also updated `TensorType.getDType()`'s Javadoc to remove the wala/ML#521 follow-up note (no longer outstanding) and reflect that both construction sites and the accessor use `Locale.ROOT`.

## Test Plan

- [x] Full `TestTensorflow2Model` (728 tests) passes locally.
- [x] Mechanical change—no behavioral impact under ASCII-locale environments (which is what CI runs). Eliminates the latent portability bug.

Closes wala/ML#521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
