### PR TITLE
Add throw-path fixture for wala/ML#518's `RaggedFromNestedValueRowIds` numeric-coercion site

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5375,6 +5375,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_gradient2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));
   }
 
+  /**
+   * Regression test for the wala/ML#518 throw path at {@code
+   * RaggedFromNestedValueRowIds.getShapes:123}: when a {@code nested_nrows} arg contains a
+   * non-numeric string {@link com.ibm.wala.ipa.callgraph.propagation.ConstantKey}, the {@code
+   * Long.parseLong((String) val)} site catches {@link NumberFormatException} and rethrows as {@link
+   * IllegalStateException}. The test exercises that branch by passing {@code nested_nrows=["abc"]}
+   * in the Python fixture. Closes part of <a
+   * href="https://github.com/wala/ML/issues/520">wala/ML#520</a> (the {@code
+   * RaggedFromNestedValueRowIds} portion).
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testRaggedNrowsNonNumeric()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_ragged_nrows_non_numeric.py", "f", 0, 0, Map.of());
+  }
+
   @Test
   public void testMultiply()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5376,19 +5376,27 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Regression test for the wala/ML#518 throw path at {@code
-   * RaggedFromNestedValueRowIds.getShapes:123}: when a {@code nested_nrows} arg contains a
-   * non-numeric string {@link com.ibm.wala.ipa.callgraph.propagation.ConstantKey}, the {@code
-   * Long.parseLong((String) val)} site catches {@link NumberFormatException} and rethrows as {@link
-   * IllegalStateException}. The test exercises that branch by passing {@code nested_nrows=["abc"]}
-   * in the Python fixture. Closes part of <a
-   * href="https://github.com/wala/ML/issues/520">wala/ML#520</a> (the {@code
+   * Regression test for the wala/ML#518 throw path in {@link
+   * com.ibm.wala.cast.python.ml.client.RaggedFromNestedValueRowIds#getShapes}'s {@code
+   * nested_nrows} arg-collection loop: when the arg contains a non-numeric string {@link
+   * com.ibm.wala.ipa.callgraph.propagation.ConstantKey}, the {@code Long.parseLong((String) val)}
+   * site catches {@link NumberFormatException} and rethrows as {@link IllegalStateException} (with
+   * the original NFE as {@code cause}). The test exercises that branch by passing {@code
+   * nested_nrows=["abc"]} in the Python fixture, and {@code assertThrows} captures the rethrow so
+   * the test can assert on the cause—tighter than a bare {@code @Test(expected = …)}, which would
+   * pass on any {@code IllegalStateException} raised during analysis regardless of origin. Closes
+   * part of <a href="https://github.com/wala/ML/issues/520">wala/ML#520</a> (the {@code
    * RaggedFromNestedValueRowIds} portion).
    */
-  @Test(expected = IllegalStateException.class)
-  public void testRaggedNrowsNonNumeric()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_ragged_nrows_non_numeric.py", "f", 0, 0, Map.of());
+  @Test
+  public void testRaggedNrowsNonNumeric() {
+    IllegalStateException ise =
+        assertThrows(
+            IllegalStateException.class,
+            () -> test("tf2_test_ragged_nrows_non_numeric.py", "f", 1, 1, Map.of()));
+    assertTrue(
+        "Expected cause to be NumberFormatException; got " + ise.getCause(),
+        ise.getCause() instanceof NumberFormatException);
   }
 
   @Test

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_nrows_non_numeric.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_nrows_non_numeric.py
@@ -5,12 +5,13 @@ def f(a):
     pass
 
 
-# Regression fixture for the wala/ML#518 throw path at
-# `RaggedFromNestedValueRowIds:123` (nested_nrows arg collection). The fixture
-# passes a non-numeric string in `nested_nrows`, which TF would reject at
-# runtime but which the static analyzer's `Long.parseLong((String) val)` must
-# handle: the post-#518 contract is to catch the `NumberFormatException` and
-# rethrow as `IllegalStateException` (with the original NFE as `cause`).
+# Regression fixture for the wala/ML#518 throw path in
+# `RaggedFromNestedValueRowIds.getShapes`'s `nested_nrows` arg-collection loop:
+# its `Long.parseLong((String) val)` site catches `NumberFormatException` and
+# rethrows as `IllegalStateException` (with the original NFE as `cause`). The
+# fixture passes a non-numeric string in `nested_nrows`, which TF would reject
+# at runtime but which the static analyzer must surface as an exception rather
+# than a silently-wrong shape.
 #
 # The Python `tf.RaggedTensor.from_nested_value_rowids` call would fail at
 # runtime; the analyzer doesn't execute it, just walks the AST and resolves

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_nrows_non_numeric.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_nrows_non_numeric.py
@@ -1,0 +1,23 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Regression fixture for the wala/ML#518 throw path at
+# `RaggedFromNestedValueRowIds:123` (nested_nrows arg collection). The fixture
+# passes a non-numeric string in `nested_nrows`, which TF would reject at
+# runtime but which the static analyzer's `Long.parseLong((String) val)` must
+# handle: the post-#518 contract is to catch the `NumberFormatException` and
+# rethrow as `IllegalStateException` (with the original NFE as `cause`).
+#
+# The Python `tf.RaggedTensor.from_nested_value_rowids` call would fail at
+# runtime; the analyzer doesn't execute it, just walks the AST and resolves
+# constants through the PA. The non-numeric "abc" reaches the throw site.
+rt = tf.RaggedTensor.from_nested_value_rowids(
+    flat_values=[1, 2, 3, 4],
+    nested_value_rowids=[[0, 0, 1, 1]],
+    nested_nrows=["abc"],
+)
+f(rt)


### PR DESCRIPTION
## Summary

Adds a Python fixture and JUnit test that exercise the `RaggedFromNestedValueRowIds:123` throw path introduced by #276 (wala/ML#518). The fixture passes `nested_nrows=["abc"]` to `tf.RaggedTensor.from_nested_value_rowids`, which produces a `ConstantKey<String>` with non-numeric value flowing through to the `Long.parseLong((String) val)` site. The catch rethrows `IllegalStateException`, asserted at the test level via `@Test(expected = IllegalStateException.class)`.

## Why Only One Of Three

Of #276's three catch-and-rethrow sites:

| Site | Reachable from Python? | Fixture in this PR |
|---|---|---|
| `RaggedFromNestedValueRowIds:123` (`nested_nrows` arg) | yes—user supplies `nested_nrows=["abc"]` | ✓ `testRaggedNrowsNonNumeric` |
| `RaggedFromNestedValueRowIds:199` (inner ragged-rank) | structurally similar (nested literal); deferred | not yet |
| `TensorGenerator.getFieldIndex` (catalog index) | **no**—WALA's PA always produces numeric-string catalog keys | n/a |

The `getFieldIndex` site is genuinely unreachable from valid Python source: the function takes `ConstantKey`s from WALA's catalog iteration over list/tuple allocations, and the catalog keys are always indices (`"0"`, `"1"`, …) by WALA's PA contract. The defensive throw covers a hypothetical PA invariant break, not a user-data path.

The `:199` site is structurally similar to `:123` but with nested literals. A fixture for it would mirror this PR's shape. Deferring until empirical demand surfaces (test-infrastructure cost vs. coverage value).

## Test Plan

- [x] `testRaggedNrowsNonNumeric` passes (throw raised + caught by `@Test(expected = …)`).
- [x] Full `TestTensorflow2Model` (729 tests including the new one) passes locally.
- [x] Python fixture is syntactically valid Python; runtime semantics is intentionally invalid (the point of the test is the analyzer reaching the throw site).

## Scope Note

Closes the `:123`-portion of wala/ML#520. The issue remains open for `:199` (if the fixture-effort/coverage tradeoff later flips) and `getFieldIndex` (which would need a Java-level unit test rather than a Python fixture, since the site isn't reachable from Python source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
