### PR TITLE
Add `@Override` annotations across `analysis/ap` access-path classes

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/ArrayContents.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/ArrayContents.java
@@ -11,12 +11,14 @@ public class ArrayContents implements IPathElement {
 
   private ArrayContents() {}
 
+  @Override
   public boolean matches(IPathElement other) {
     return this.equals(other)
         || other instanceof UnknownPathElement
         || other instanceof StarPathElement;
   }
 
+  @Override
   public String toString() {
     return "[*]";
   }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/CallbackAP.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/CallbackAP.java
@@ -44,6 +44,7 @@ public class CallbackAP implements IAPRoot {
     return parameterVn;
   }
 
+  @Override
   public String toString() {
     return "callback " + function.getDeclaringClass().getName() + " " + parameterVn;
   }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/GlobalVarAP.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/GlobalVarAP.java
@@ -16,6 +16,7 @@ public class GlobalVarAP implements IAPRoot {
     this.varName = varName;
   }
 
+  @Override
   public Kind getKind() {
     return Kind.GLOBAL;
   }
@@ -40,6 +41,7 @@ public class GlobalVarAP implements IAPRoot {
     return true;
   }
 
+  @Override
   public int length() {
     return 1;
   }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/LexicalAP.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/LexicalAP.java
@@ -23,10 +23,12 @@ public class LexicalAP implements IAPRoot {
     return definer;
   }
 
+  @Override
   public Kind getKind() {
     return Kind.LEXICAL;
   }
 
+  @Override
   public int length() {
     return 1;
   }
@@ -51,6 +53,7 @@ public class LexicalAP implements IAPRoot {
     return true;
   }
 
+  @Override
   public String toString() {
     return "(" + name + "," + definer + ")";
   }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/ListAP.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/ListAP.java
@@ -31,10 +31,12 @@ public class ListAP implements IAccessPath {
     return Collections.unmodifiableList(path);
   }
 
+  @Override
   public Kind getKind() {
     return Kind.LIST;
   }
 
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;
@@ -43,6 +45,7 @@ public class ListAP implements IAccessPath {
     return result;
   }
 
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (obj == null) return false;
@@ -57,10 +60,12 @@ public class ListAP implements IAccessPath {
     return true;
   }
 
+  @Override
   public int length() {
     return path.size() + 1;
   }
 
+  @Override
   public String toString() {
     StringBuffer result = new StringBuffer(root.toString());
     for (IPathElement e : path) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/LocalAP.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/LocalAP.java
@@ -42,14 +42,17 @@ public class LocalAP implements IAPRoot {
     return true;
   }
 
+  @Override
   public Kind getKind() {
     return Kind.LOCAL;
   }
 
+  @Override
   public int length() {
     return 1;
   }
 
+  @Override
   public String toString() {
     if (valueNumber == RETURN_VALUE_NUMBER) {
       return "ret";

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/PropertyPathElement.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/PropertyPathElement.java
@@ -49,6 +49,7 @@ public class PropertyPathElement implements IPathElement {
         return callbackTaintedParams;
       }
 
+      @Override
       public boolean equals(Object o) {
         return super.equals(o)
             && (o instanceof CallbackPathElement)
@@ -56,6 +57,7 @@ public class PropertyPathElement implements IPathElement {
             && ((CallbackPathElement) o).getCalleeTaintedParameters().equals(callbackTaintedParams);
       }
 
+      @Override
       public String toString() {
         return super.toString();
       }
@@ -96,6 +98,7 @@ public class PropertyPathElement implements IPathElement {
     return true;
   }
 
+  @Override
   public boolean matches(IPathElement other) {
     return this.equals(other)
         || other instanceof UnknownPathElement

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/StarPathElement.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/StarPathElement.java
@@ -19,6 +19,7 @@ public class StarPathElement implements IPathElement {
     return "*";
   }
 
+  @Override
   public boolean matches(IPathElement other) {
     return true;
   }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/UnknownPathElement.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/analysis/ap/UnknownPathElement.java
@@ -18,6 +18,7 @@ public class UnknownPathElement implements IPathElement {
     return "?";
   }
 
+  @Override
   public boolean matches(IPathElement other) {
     return true;
   }


### PR DESCRIPTION
## Summary

Resolves 19 `java/missing-override-annotation` CodeQL alerts on the 9 files in `com.ibm.wala.cast.python.analysis.ap`. Annotation-only; no behavioral change.

- `IPathElement#matches` impls on `ArrayContents`, `PropertyPathElement`, `StarPathElement`, `UnknownPathElement`.
- `IAccessPath#getKind`/`length` impls on `GlobalVarAP`, `LexicalAP`, `ListAP`, `LocalAP`.
- `Object#hashCode`/`equals`/`toString` overrides on `CallbackAP`, `ListAP`, `LexicalAP`, `LocalAP`, and the inner `CallbackPathElement`.

Companion to #288 (other note-severity CodeQL cleanups in the same package). Either order is fine; rebase should be conflict-free.

## Test plan

- [x] `mvn clean install -DskipTests` from repo root.
- [ ] CI green (full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)