### PR TITLE
Seed tensor sources by allocation type, not only by containing method name

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -297,14 +297,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   private static boolean pointsToTensorAllocation(
       PointerKey key, PointerAnalysis<InstanceKey> pointerAnalysis) {
     for (InstanceKey ik : pointerAnalysis.getPointsToSet(key)) {
-      TypeReference allocType;
-      if (ik instanceof AllocationSiteInNode) {
-        allocType = ((AllocationSiteInNode) ik).getConcreteType().getReference();
-      } else if (ik instanceof ConcreteTypeKey) {
-        allocType = ((ConcreteTypeKey) ik).getType().getReference();
-      } else {
-        continue;
-      }
+      if (!(ik instanceof AllocationSiteInNode)) continue;
+      TypeReference allocType = ((AllocationSiteInNode) ik).getConcreteType().getReference();
       if (allocType.equals(TensorFlowTypes.TENSOR_TYPE)) {
         return true;
       }
@@ -342,8 +336,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           methodName.equals(TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME)
               || methodName.equals(DO_METHOD_NAME);
       // wala/ML#378: broaden seeding to recognize any allocation of a registered tensor class as a
-      // tensor source, regardless of containing-method name. Lets direct `__call__`/`call` modeling
-      // (post wala/ML#127) seed without depending on the `do`/`read_data` method-name convention.
+      // tensor source, regardless of containing-method name. This lets direct `__call__`/`call`
+      // modeling (post wala/ML#127) seed without depending on the `do`/`read_data` method-name
+      // convention.
       boolean allocIsTensor =
           !methodNameSeedable && pointsToTensorAllocation(src.getPointerKey(), pointerAnalysis);
       if (methodNameSeedable || allocIsTensor) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -283,6 +283,36 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
+   * Returns whether the given pointer key's points-to set contains any allocation of a registered
+   * tensor class. Used by wala/ML#378's alloc-type-based seeding broadening: a call whose return
+   * value flows from a {@code <new class="Ltensorflow/python/framework/ops/Tensor"/>} site is a
+   * tensor source even if the containing method is not named {@code do} or {@code read_data}.
+   *
+   * @param key The pointer key whose points-to set is inspected.
+   * @param pointerAnalysis The pointer analysis providing the points-to set.
+   * @return {@code true} iff any {@link InstanceKey} in {@code key}'s points-to set has an
+   *     allocation class equal to {@link TensorFlowTypes#TENSOR_TYPE} (the canonical tensor type
+   *     post wala/ML#459).
+   */
+  private static boolean pointsToTensorAllocation(
+      PointerKey key, PointerAnalysis<InstanceKey> pointerAnalysis) {
+    for (InstanceKey ik : pointerAnalysis.getPointsToSet(key)) {
+      TypeReference allocType;
+      if (ik instanceof AllocationSiteInNode) {
+        allocType = ((AllocationSiteInNode) ik).getConcreteType().getReference();
+      } else if (ik instanceof ConcreteTypeKey) {
+        allocType = ((ConcreteTypeKey) ik).getType().getReference();
+      } else {
+        continue;
+      }
+      if (allocType.equals(TensorFlowTypes.TENSOR_TYPE)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Processes the given {@link SSAAbstractInvokeInstruction}, adding the given {@link PointsToSetVariable} to the given {@link Set} of {@link PointsToSetVariable}s as a dataflow source if the given {@link SSAAbstractInvokeInstruction} results in a tensor value.
    *
    * @param instruction The {@link SSAAbstractInvokeInstruction} to consider.
@@ -308,8 +338,15 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     // don't consider exceptions as a data source.
     if (instruction.getException() != vn) {
       String methodName = instruction.getCallSite().getDeclaredTarget().getName().toString();
-      if (methodName.equals(TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME)
-          || methodName.equals(DO_METHOD_NAME)) {
+      boolean methodNameSeedable =
+          methodName.equals(TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME)
+              || methodName.equals(DO_METHOD_NAME);
+      // wala/ML#378: broaden seeding to recognize any allocation of a registered tensor class as a
+      // tensor source, regardless of containing-method name. Lets direct `__call__`/`call` modeling
+      // (post wala/ML#127) seed without depending on the `do`/`read_data` method-name convention.
+      boolean allocIsTensor =
+          !methodNameSeedable && pointsToTensorAllocation(src.getPointerKey(), pointerAnalysis);
+      if (methodNameSeedable || allocIsTensor) {
         try {
           TensorGenerator generator = getGenerator(src, builder);
           LOGGER.fine(() -> "Found tensor generator: " + generator + " for source: " + src + ".");


### PR DESCRIPTION
## Summary

Broadens the seeding gate in `PythonTensorAnalysisEngine.getDataflowSources` so a call whose return value's points-to set contains an allocation of `Ltensorflow/python/framework/ops/Tensor` is seeded as a tensor source even when the containing method is not named `do` or `read_data`. Adds a `pointsToTensorAllocation(...)` helper and ORs its result into the existing method-name check. The method-name path is unchanged — this is an additive widening.

## Why

The method-name criterion was an XML modeling-convention artifact, not a semantic one: it worked only because every modeled tensor-producing API today lives in a `do`-named or `read_data`-named summary. Post wala/ML#127 (direct `__call__` / `call` modeling) and wala/ML#459 (canonical `Ltensorflow/python/framework/ops/Tensor` for all modeled tensor results), the alloc-class criterion is the right one. Concretely:

- Decouples seeding from the XML modeling-method-name convention. Adding a new TF API no longer requires its body live in a `do` / `read_data` method to be seedable.
- Removes a fragile dual signal (method-name check + `read_data` markers in `tensorflow.xml`).
- Makes wala/ML#380's read-data inlining work obsolete in the seeding direction.

See wala/ML#378's "Independence From Other Issues" section for the full rationale.

## Empirical Result on the Current Corpus

I instrumented the new branch with a `LOGGER.fine` marker and ran the full `TestTensorflow2Model` suite (732 tests across direct `__call__` / `call` modeling for Dense, Flatten, Model, etc.). **Hit count: 0.**

The reason is the synthetic-method PTS-loss tracked in wala/ML#402: the `<new class="Ltensorflow/python/framework/ops/Tensor"/>` allocations inside `__call__` / `call` summary bodies don't propagate out through the PA to the caller's local pointer key, so `pointsToTensorAllocation(...)` always returns `false` on the current corpus. The new branch is correct by design but operationally dead until wala/ML#402's upstream WALA fix lands.

This isn't a bug in #290 — it's the structural-vs-operational distinction wala/ML#378's body explicitly calls out (*"No currently observable failures on master"*). #290 lands the seeding criterion that's correct semantically; the upstream PA fix lands the propagation that makes the criterion actually fire.

## What's Tested

- Full reactor suite: **755 / 755 passing, 3 skipped** — identical to master baseline. Zero regressions.
- Empirical hit-count: 0 on current corpus (documented above).

## Test Plan

- [x] `mvn clean install -DskipTests` from repo root.
- [x] `mvn test` — 755 / 755 pass, 0 fail, 3 skip; matches baseline exactly.
- [x] Instrumented hit-count: 0 (confirms synthetic-method PTS-loss is the operational blocker, not seeding).
- [ ] CI green.

Closes wala/ML#378. Operational unblocking depends on wala/ML#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)