### PR TITLE
Add regression guards for layer-output flowing into a script-level consumer

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -113,7 +113,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_1_10_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(10)));
-  
+
   private static final TensorType TENSOR_1_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(3)));
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -111,6 +111,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
 
+  private static final TensorType TENSOR_1_10_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(10)));
+
   @SuppressWarnings("unused")
   private static final TensorType TENSOR_32_INT32 =
       new TensorType(INT_32, asList(new NumericDim(32)));
@@ -9539,6 +9542,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
         "tf2_test_model_call_consume.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_20_10_FLOAT32)));
+  }
+
+  /**
+   * Regression guard for the "layer-output flows into script-level consumer" pattern: a downstream
+   * function whose tensor parameter comes from a layer call's output. Companion to {@link
+   * #testModelCallConsume()}, which calls {@code consume(x)} <em>inside</em> {@code
+   * SequentialModel.__call__}; this fixture calls {@code consume(pred)} at script-level after the
+   * layer call — the same surface shape, but a different caller. The existing {@code
+   * DenseCall.getDefaultShapes} SSA-chain fallback recovers the result type when the direct PTS
+   * walk doesn't carry the synthetic {@code <new>} alloc through.
+   */
+  @Test
+  public void testLayerOutputParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_layer_output_param.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_1_10_FLOAT32)));
+  }
+
+  /**
+   * Variant of {@link #testLayerOutputParam()} that interposes a user-defined {@code
+   * tf.keras.Model} subclass between the {@code Dense} layers and the script-level consumer —
+   * exercises the same fallback through one extra level of call indirection.
+   */
+  @Test
+  public void testLayerOutputParamViaModel()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_layer_output_param_via_model.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_1_10_FLOAT32)));
   }
 
   private void test(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param.py
@@ -1,0 +1,23 @@
+"""Regression guard for the "layer-output flows into script-level consumer" pattern.
+
+Companion to ``tf2_test_model_call_consume.py``, which calls ``consume(x)`` inside the model
+class's ``__call__`` body. Here the consumer is at script level, after the layer call returns.
+``DenseCall.getDefaultShapes``'s SSA-chain fallback recovers ``consume``'s tensor parameter
+type when the PTS walk doesn't carry the synthetic ``<new>`` alloc through directly.
+"""
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+input_tensor = tf.constant([[1.0, 2.0, 3.0]], dtype=tf.float32)
+assert input_tensor.shape == (1, 3)
+assert input_tensor.dtype == tf.float32
+
+dense = tf.keras.layers.Dense(10)
+pred = dense(input_tensor)
+# Runtime shape (1, 10), dtype float32 — matches the JUnit assertion.
+consume(pred)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param.py
@@ -9,7 +9,7 @@ type when the PTS walk doesn't carry the synthetic ``<new>`` alloc through direc
 import tensorflow as tf
 
 
-def consume(t):
+def consume(tensor):
     pass
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param_via_model.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param_via_model.py
@@ -9,7 +9,7 @@ fallback), but exercised across one extra level of call indirection.
 import tensorflow as tf
 
 
-def consume(t):
+def consume(tensor):
     pass
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param_via_model.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_output_param_via_model.py
@@ -1,0 +1,30 @@
+"""Regression guard: layer-output → user-defined `Model.__call__` → script-level consumer.
+
+Variant of ``tf2_test_layer_output_param.py`` that interposes a user-defined
+``tf.keras.Model`` subclass between the ``Dense`` layers and the script-level consumer.
+Same recovery mechanism as the companion fixture (``DenseCall.getDefaultShapes`` SSA-chain
+fallback), but exercised across one extra level of call indirection.
+"""
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class NeuralNet(tf.keras.Model):
+    def __init__(self):
+        super().__init__()
+        self.d1 = tf.keras.layers.Dense(16, activation="relu")
+        self.d2 = tf.keras.layers.Dense(10)
+
+    def __call__(self, x):
+        x = self.d1(x)
+        return self.d2(x)
+
+
+batch_x = tf.constant([[1.0, 2.0, 3.0]], dtype=tf.float32)
+neural_net = NeuralNet()
+pred = neural_net(batch_x)
+consume(pred)


### PR DESCRIPTION
## Summary

Two test fixtures that pin down Ariadne's existing behavior on the "layer-output flows into downstream consumer's tensor parameter" pattern:

- `testLayerOutputParam` — direct `Dense(input)` call, `consume(pred)` at script level.
- `testLayerOutputParamViaModel` — same shape with a user-defined `tf.keras.Model` subclass interposed between the layers and the consumer.

Both assert `consume`'s parameter is `TENSOR_1_10_FLOAT32` and pass on master through the existing `DenseCall.getDefaultShapes` SSA-chain fallback. Companion to `testModelCallConsume`, which exercises the in-`__call__`-body variant.

## Why

The pattern was conjectured to be unsupported (basis for wala/ML#378's framing); empirically it isn't. These fixtures lock that in as a regression guard so future investigations of the same pattern don't re-raise it.

## Test Plan

- [x] `mvn clean install -DskipTests` from repo root.
- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest='TestTensorflow2Model#testLayerOutputParam+testLayerOutputParamViaModel' test` — 2 / 2 pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)