### PR TITLE
Compose `tf.expand_dims` output shape as input shape with a length-1 dim at `axis`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -111,6 +111,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
 
+  private static final TensorType TENSOR_1_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(3)));
+
+  private static final TensorType TENSOR_3_1_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(1)));
+
   @SuppressWarnings("unused")
   private static final TensorType TENSOR_32_INT32 =
       new TensorType(INT_32, asList(new NumericDim(32)));
@@ -5782,7 +5788,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testExpandDims()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_expand_dims.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_expand_dims.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_3_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testExpandDims()} for {@code axis=-1}: trailing length-1 dim. Input shape
+   * {@code (3,)} produces output shape {@code (3, 1)}.
+   */
+  @Test
+  public void testExpandDimsAxisNeg1()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_expand_dims_axis_neg1.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_1_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -1,17 +1,24 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.expand_dims(input, axis, name=None)}. Output dtype inherits from {@code
- * input}; output shape is {@code input.shape} with a length-1 dim inserted at {@code axis}.
- * Currently emits ⊤ shape (the precise insertion-at-axis composition is left for a follow-up).
+ * input}; output shape is {@code input.shape} with a length-1 dim inserted at {@code axis} (see <a
+ * href="https://github.com/wala/ML/issues/500">wala/ML#500</a>).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/expand_dims">tf.expand_dims</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -72,16 +79,51 @@ public class ExpandDims extends PassThroughUnaryTensorGenerator {
   }
 
   /**
-   * Override the inherited shape passthrough to ⊤ — {@code expand_dims} inserts a new length-1 dim
-   * at {@code axis}, so the input's shape is not the output's shape (rank differs by 1). Composing
-   * the precise output shape requires reading the input's shape and the constant {@code axis};
-   * deferred to follow-up. Dtype passthrough from the parent class IS sound.
+   * Computes the output shape: input shape with a length-1 dim inserted at {@code axis}. For an
+   * input of rank {@code r}, {@code axis} is in {@code [-(r+1), r]}; negative values count from the
+   * end ({@code -1} means "last position in the output", i.e., a trailing length-1 dim).
+   * Per-context input shape unions produce per-context output shapes; an unresolved {@code axis}
+   * returns ⊤.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return {@code null} — ⊤, unknown shape.
+   * @return The composed output shapes, one per (input shape, axis value) combination; {@code null}
+   *     when the input shape or axis can't be resolved.
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    int inputVn =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName(), false);
+    if (inputVn <= 0) return null;
+    Set<List<Dimension<?>>> inputShapes = this.getShapes(builder, inputVn);
+    if (inputShapes == null) return null;
+
+    OrdinalSet<InstanceKey> axisPts =
+        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+    if (axisPts == null || axisPts.isEmpty()) return null;
+    Set<Integer> axisValues = new HashSet<>();
+    for (InstanceKey ik : axisPts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof Number)) return null;
+      axisValues.add(((Number) val).intValue());
+    }
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      int rank = inputShape.size();
+      for (int axis : axisValues) {
+        int normalized = axis < 0 ? axis + rank + 1 : axis;
+        if (normalized < 0 || normalized > rank) continue;
+        List<Dimension<?>> newShape = new ArrayList<>(rank + 1);
+        for (int i = 0; i < rank + 1; i++) {
+          if (i == normalized) newShape.add(new NumericDim(1));
+          else if (i < normalized) newShape.add(inputShape.get(i));
+          else newShape.add(inputShape.get(i - 1));
+        }
+        ret.add(newShape);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_expand_dims_axis_neg1.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_expand_dims_axis_neg1.py
@@ -1,0 +1,18 @@
+"""Companion fixture for `tf2_test_expand_dims.py`: axis=-1 inserts a trailing length-1 dim.
+
+For input shape ``(3,)``, ``tf.expand_dims(x, axis=-1)`` produces shape ``(3, 1)``.
+"""
+
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.expand_dims(x, axis=-1)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3, 1)
+assert y.dtype == tf.float32
+f(y)


### PR DESCRIPTION
## Summary

`ExpandDims.getDefaultShapes` previously returned `null` (⊤). Replaces that with a concrete shape composition: read the `input`'s shape union and the `axis` constant from the call site, insert a length-1 dim at the normalized position. Supports negative `axis` per TF semantics: `[-rank-1, rank]`.

## Test Updates

- `testExpandDims` tightens from `TENSOR_UNKNOWN_SHAPE_FLOAT32` to `TENSOR_1_3_FLOAT32` (input `(3,)` + `axis=0` → output `(1, 3)`).
- New `testExpandDimsAxisNeg1` exercises `axis=-1` → `(3, 1)` (trailing length-1 dim).

## Test Plan

- [x] `mvn clean install -DskipTests` from repo root.
- [x] `mvn -pl com.ibm.wala.cast.python.ml.test test` — 755 / 755 pass, 0 fail, 3 skip; matches baseline.
- [ ] CI green.

Closes wala/ML#500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)