### PR TITLE
Add regression guards for `TensorType` equality on `(cellType, dims)`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
@@ -5,12 +5,15 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Locale.ROOT;
 import static org.junit.Assert.*;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import org.junit.Test;
 
 public class TensorFlowTypesTest {
@@ -61,5 +64,57 @@ public class TensorFlowTypesTest {
     // DType.UNKNOWN is a real enum value; its cellType "unknown" must round-trip too.
     TensorType t = new TensorType(DType.UNKNOWN.name().toLowerCase(ROOT), emptyList());
     assertEquals(DType.UNKNOWN, t.getDType());
+  }
+
+  // wala/ML#532 regression guards: TensorType honors equals/hashCode on (cellType, dims).
+
+  @Test
+  public void testTensorTypeEqualsSameCellTypeAndDims() {
+    TensorType a = new TensorType("float32", asList(new NumericDim(2), new NumericDim(3)));
+    TensorType b = new TensorType("float32", asList(new NumericDim(2), new NumericDim(3)));
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testTensorTypeNotEqualsDifferentCellType() {
+    TensorType a = new TensorType("float32", asList(new NumericDim(3)));
+    TensorType b = new TensorType("int32", asList(new NumericDim(3)));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testTensorTypeNotEqualsDifferentDims() {
+    TensorType a = new TensorType("float32", asList(new NumericDim(2), new NumericDim(3)));
+    TensorType b = new TensorType("float32", asList(new NumericDim(3), new NumericDim(2)));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testTensorTypeNotEqualsNumericVsSymbolicDim() {
+    TensorType a = new TensorType("float32", asList(new NumericDim(3)));
+    TensorType b = new TensorType("float32", asList(new SymbolicDim("3")));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testTensorTypeEqualsBothNullDims() {
+    TensorType a = new TensorType("float32", null);
+    TensorType b = new TensorType("float32", null);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testTensorTypeNotEqualsOneNullDims() {
+    TensorType a = new TensorType("float32", null);
+    TensorType b = new TensorType("float32", emptyList());
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testTensorTypeNotEqualsNull() {
+    TensorType a = new TensorType("float32", asList(new NumericDim(3)));
+    assertNotEquals(a, null);
   }
 }


### PR DESCRIPTION
## Summary

Seven new `TensorFlowTypesTest` cases pinning down `TensorType#equals` and `TensorType#hashCode` semantics on `(cellType, dims)`:

- Two instances with the same `cellType` and `dims` are equal (with matching `hashCode`).
- Cell-type or dims mismatch → not equal.
- Numeric vs. symbolic dim of the same surface value → not equal (subclass dispatch).
- Both `null` dims → equal; one-null-one-not → not equal.
- `null` argument → not equal.

## Context

Filed in response to wala/ML#532, which proposed adding `equals`/`hashCode` overrides to `TensorType`. Empirically the overrides already exist on master (since `5467c89a`, PR #156, line 338 / 347 of `TensorType.java`) and implement the exact `cellType + dims` semantics the issue describes. All 7 test cases pass on master without any code change.

The Hybridize-side consumer that hit this (per #532's cross-ref) likely needs a separate investigation — possibly stale jar cache, classloader split, or a different `TensorType` shadow class. These tests at least lock the Ariadne-side contract in.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -Dtest=TensorFlowTypesTest test` — 12 / 12 pass (5 existing + 7 new).
- [ ] CI green.

Closes wala/ML#532 (no-op fix; regression guards only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)