### PR TITLE
Normalize pom self-closing tags to Spotless's enforced spaceless form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <parallel>both</parallel>
     <logging.config.file>./logging.properties</logging.config.file>
     <jacoco-version>0.8.14</jacoco-version>
-    <argLine />
+    <argLine/>
     <junit.4.version>4.13.2</junit.4.version>
   </properties>
   <dependencyManagement>
@@ -221,8 +221,8 @@
                   <exclude>IDE/</exclude>
                   <exclude>jython3/</exclude>
                 </excludes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
               </format>
               <format>
                 <includes>
@@ -232,8 +232,8 @@
                 <excludes>
                   <exclude>**/target/</exclude>
                 </excludes>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
                 <indent>
                   <tabs>true</tabs>
                   <spacesPerTab>4</spacesPerTab>
@@ -244,7 +244,7 @@
                   <include>**/*.xml</include>
                   <include>**/.pydevproject</include>
                 </includes>
-                <toggleOffOn />
+                <toggleOffOn/>
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>**/pom.xml</exclude>
@@ -261,8 +261,8 @@
                     <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
-                <trimTrailingWhitespace />
-                <endWithNewline />
+                <trimTrailingWhitespace/>
+                <endWithNewline/>
               </format>
             </formats>
             <java>
@@ -270,8 +270,8 @@
                 <version>1.27.0</version>
                 <reflowLongStrings>true</reflowLongStrings>
               </googleJavaFormat>
-              <trimTrailingWhitespace />
-              <endWithNewline />
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
             </java>
             <pom>
               <sortPom>


### PR DESCRIPTION
## Summary

- `mvn spotless:check` was failing on master because the existing `pom.xml` had 10 spaced self-closing tags (e.g. `<trimTrailingWhitespace />`) but the Spotless `sortPom` config has `<expandEmptyElements>false</expandEmptyElements>`, which enforces the collapsed form (`<trimTrailingWhitespace/>`).
- This PR runs `mvn spotless:apply` to bring the pom into compliance — 10 tag rewrites, no Spotless config change. The collapsed form also matches what `maven-release-plugin` emits natively, so future release runs stay Spotless-clean without any preparation/completion-goal glue.

Closes wala/ML#534.

## Test plan

- [x] `mvn spotless:check` passes against this branch's `pom.xml`.
- [ ] CI green on this PR.
- [ ] Next release run produces Spotless-clean version-bump commits with no further intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
