### PR TITLE
Restructure shade plugin: plain default jar + fat classifier for standalone driver

### DIFF
--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -59,15 +59,14 @@
       from its `org.python.modules.posix.PosixModule`. The `0.0.1-SNAPSHOT`
       `jython3.jar` is registered via `mvn install:install-file
       -DgeneratePom=true` (see `CONTRIBUTING.md` and the CI workflow),
-      which synthesizes a minimal POM that declares zero dependencies. So
-      neither the Maven dependency graph nor the shaded fat-jar pulls
-      `jnr-constants` in unless we declare it here. Declaring it makes
-      `maven-shade-plugin` include `jnr/constants/*` in the published
-      fat-jar that downstream consumers (e.g.
-      `ponder-lab/Hybridize-Functions-Refactoring`) load through Tycho —
-      without it, code paths that reach `PosixModule` (e.g. the TensorFlow
-      GAN tutorial fixture) fail at runtime with
-      `NoClassDefFoundError: jnr/constants/Constant`. See wala/ML#453. -->
+      which synthesizes a minimal POM that declares zero dependencies — so
+      Maven's dependency graph won't pull `jnr-constants` transitively. We
+      declare it explicitly here so library consumers receive it via the
+      plain default jar's POM, and the `fat` classifier bundles it for the
+      standalone driver. Without this declaration, code paths that reach
+      `PosixModule` (e.g. the TensorFlow GAN tutorial fixture) fail at
+      runtime with `NoClassDefFoundError: jnr/constants/Constant`. See
+      wala/ML#453. -->
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -107,20 +107,24 @@
             </goals>
             <phase>package</phase>
             <configuration>
+              <!-- Attach the shaded output as a `fat` classifier so the
+                default published jar stays plain (Ariadne classes only,
+                no Main-Class). Library consumers depend on the default
+                jar and resolve `com.ibm.wala.{core,cast,shrike,util}`,
+                `jython3`, `jnr-constants`, etc. transitively. The
+                standalone driver uses the `fat` classifier via
+                `java -jar com.ibm.wala.cast.python.ml-X.Y.Z-fat.jar`.
+                See wala/ML#525. -->
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>fat</shadedClassifierName>
               <transformers>
-                <!-- add Main-Class to manifest file -->
+                <!-- Add `Main-Class` to manifest file. Only present on
+                  the fat classifier; the default jar's manifest stays
+                  clean. -->
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>com.ibm.wala.cast.python.ml.driver.Ariadne</mainClass>
                 </transformer>
               </transformers>
-              <artifactSet>
-                <excludes>
-                  <exclude>com.ibm.wala:com.ibm.wala.core</exclude>
-                  <exclude>com.ibm.wala:com.ibm.wala.util</exclude>
-                  <exclude>com.ibm.wala:com.ibm.wala.shrike</exclude>
-                  <exclude>com.ibm.wala:com.ibm.wala.cast</exclude>
-                </excludes>
-              </artifactSet>
             </configuration>
           </execution>
         </executions>

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -117,6 +117,15 @@
                 See wala/ML#525. -->
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>fat</shadedClassifierName>
+              <!-- Without this, `maven-shade-plugin` would replace the
+                default jar's POM with a "dependency-reduced" version
+                that strips the shaded-in `<dependency>` entries — so
+                even though the default jar stays plain, library
+                consumers would receive a POM with zero declared
+                transitive deps and fail at runtime. Keep the original
+                POM so consumers resolve WALA / `jython3` /
+                `jnr-constants` etc. transitively. -->
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <!-- Add `Main-Class` to manifest file. Only present on
                   the fat classifier; the default jar's manifest stays


### PR DESCRIPTION
## Summary

- The standalone driver (`Main-Class: com.ibm.wala.cast.python.ml.driver.Ariadne`) has been broken on all published 0.40.0+ releases because the shaded default jar strips the four WALA framework artifacts that the driver imports. See wala/ML#525 for the full diagnostic.
- Restructure `maven-shade-plugin` so that the **default published jar stays plain** (Ariadne classes only, no `Main-Class`, library consumers get WALA/`jython3`/`jnr-constants` etc. transitively via the already-declared `<dependency>` entries) and the **shaded output is attached as a `fat` classifier** for the standalone driver use case.

Closes wala/ML#525.

## What Changed

- Removed the `<artifactSet><excludes>` block that stripped `com.ibm.wala:{core,util,shrike,cast}`—WALA now lives in the fat classifier as it should for `java -jar` use.
- Added `<shadedArtifactAttached>true</shadedArtifactAttached>` and `<shadedClassifierName>fat</shadedClassifierName>` so the shaded output attaches as `com.ibm.wala.cast.python.ml-X.Y.Z-fat.jar` rather than replacing the default jar.
- Tightened the comments to describe the new structure.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests` produces both jars:
  - `com.ibm.wala.cast.python.ml-0.45.0-SNAPSHOT.jar` (570KB, 0 WALA classes, no `Main-Class`, 288 Ariadne classes)
  - `com.ibm.wala.cast.python.ml-0.45.0-SNAPSHOT-fat.jar` (17MB, 1223 WALA classes, 1055 `jnr-constants` classes, `Main-Class: com.ibm.wala.cast.python.ml.driver.Ariadne`)
- [x] `java -jar com.ibm.wala.cast.python.ml-0.45.0-SNAPSHOT-fat.jar --help` prints usage cleanly with no `NoClassDefFoundError`—confirms the standalone driver is fixed.
- [x] Sample tests in `com.ibm.wala.cast.python.ml.test` pass—confirms the test module's transitive dep resolution still works against the plain default jar.
- [ ] CI green on this PR (full test suite).
- [ ] Hybridize snapshot consumption verification (separate follow-up on the Hybridize side after this lands and a snapshot is published).

## Follow-Up

The wala/ML#453 `jnr-constants` workaround comment (lines 58-74 of `com.ibm.wala.cast.python.ml/pom.xml`) describes the shade-time inclusion behavior, but the dep is still required for transitive resolution by library consumers (its presence in `<dependencies>` is what makes it flow to Hybridize via Tycho now). The comment text can be tightened in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


