### PR TITLE
Add regression guard for Keras functional Model output shape mis-routing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -175,6 +175,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_NONE_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(null, new NumericDim(2)));
 
+  private static final TensorType TENSOR_NONE_100_FLOAT32 =
+      new TensorType(FLOAT_32, asList(null, new NumericDim(100)));
+
   private static final TensorType TENSOR_NONE_NONE_STRING =
       new TensorType(STRING, asList(null, null));
 
@@ -2090,6 +2093,36 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         7,
         Map.of(2, Set.of(TENSOR_256_28_28_1_FLOAT32, TENSOR_96_28_28_1_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code generator_loss(fake_output)}'s parameter type for the input-signature-inference
+   * empirical pass (issue <a
+   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
+   * {@code fake_output} flows from {@code discriminator(generated_images, ...)}; runtime shape is
+   * {@code (batch, 1) float32} since the discriminator ends with a {@code Dense(1)} layer.
+   *
+   * <p>Empirically, {@code fake_output} is inferred as {@code (None, 100) float32}. The dtype is
+   * concrete (the load-bearing axis for {@code @tf.function(input_signature=[...])}), which
+   * confirms the layer-output-parameter pattern works on the dtype axis. The shape is
+   * mis-propagated: {@code 100} is the generator's noise input dim (from {@code
+   * tf.keras.Input((100,))} in {@code make_generator_model}), not the discriminator's {@code
+   * Dense(1)} output dim. The mis-routing is shape-only and orthogonal to dtype-axis
+   * input-signature emission.
+   *
+   * <p>TODO: tighten to {@code (None, 1) float32} once <a
+   * href="https://github.com/wala/ML/issues/537">wala/ML#537</a> lands the shape propagation
+   * through Keras functional-model chains.
+   */
+  @Test
+  public void testGanTutorialGeneratorLoss()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tensorflow_gan_tutorial.py",
+        "generator_loss",
+        1,
+        2,
+        Map.of(2, Set.of(TENSOR_NONE_100_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2110,9 +2110,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Dense(1)} output dim. The mis-routing is shape-only and orthogonal to dtype-axis
    * input-signature emission.
    *
-   * <p>TODO: tighten to {@code (None, 1) float32} once <a
+   * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}} once <a
    * href="https://github.com/wala/ML/issues/537">wala/ML#537</a> lands the shape propagation
-   * through Keras functional-model chains.
+   * through Keras functional-model chains. Concrete batch dims (256 / 96) come from {@code
+   * train_step}'s {@code images} parameter (per {@link #testGanTutorial}); a complete fix would
+   * propagate those through the discriminator chain rather than dropping to {@code None}.
    */
   @Test
   public void testGanTutorialGeneratorLoss()

--- a/com.ibm.wala.cast.python.test/data/tensorflow_gan_tutorial.py
+++ b/com.ibm.wala.cast.python.test/data/tensorflow_gan_tutorial.py
@@ -76,6 +76,9 @@ def train_step(
 
         real_output = discriminator(images, training=True)
         fake_output = discriminator(generated_images, training=True)
+        # asserts confirming the runtime types asserted in testGanTutorialGeneratorLoss.
+        assert fake_output.shape == (256, 1) or fake_output.shape == (96, 1)
+        assert fake_output.dtype == tf.float32
 
         gen_loss = generator_loss(fake_output)
         disc_loss = discriminator_loss(real_output, fake_output)


### PR DESCRIPTION
## Summary

- Captures the current imprecise inference of `generator_loss(fake_output)` parameter shape (`(None, 100) float32` vs runtime `(batch, 1) float32`) as a positive regression guard.
- The dtype is concrete; only the shape is mis-routed (the noise dim `100` flows through unchanged via Keras functional `Model.__call__` instead of being narrowed by the discriminator `Dense(1)` chain).
- Javadoc TODO points at wala/ML#537 to tighten once the shape propagation through Keras functional-model chains is fixed.

## Test Plan

- [x] `mvn test -Dtest=TestTensorflow2Model#testGanTutorialGeneratorLoss` passes locally.
- [ ] CI green.

References wala/ML#537. Does NOT close it—closes when the underlying fix lands and the assertion is tightened to `(None, 1) float32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

