### PR TITLE
Empirical-pass regression guards: `top_p_logits`, `_take_long_axis`, `multilayer_perceptron`, `tf.constant(np_array)`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2157,13 +2157,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * <p>Empirically, {@code x} is inferred as {@code ⊤ shape / UNKNOWN dtype} — the first
    * load-bearing UNKNOWN-dtype the empirical pass has surfaced for input-signature inference. The
    * dtype axis is the load-bearing one per the audit's definition, so this function would NOT be
-   * input-signature-emittable on current master. The likely cause is the caller's {@code batch_x =
-   * tf.constant(np.ones((100, 784), dtype=np.float32))} losing dtype through the {@code numpy →
-   * tf.constant} boundary — Ariadne's modeling of this construction chain appears to not preserve
-   * the numpy dtype info.
+   * input-signature-emittable on current master. Root cause confirmed via {@link
+   * #testConstantFromNumpy}: the {@code numpy → tf.constant} dtype-loss bug, tracked as <a
+   * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>. The caller's {@code batch_x =
+   * tf.constant(np.ones((100, 784), dtype=np.float32))} loses dtype through the numpy boundary, so
+   * {@code x} arrives with UNKNOWN dtype.
    *
-   * <p>TODO: tighten to the precise type once the {@code numpy → tf.constant} dtype propagation gap
-   * is resolved.
+   * <p>TODO: tighten to {@code (100, 784) float32} once wala/ML#539 lands.
    */
   @Test
   public void testMultilayerPerceptron()
@@ -2173,6 +2173,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "multilayer_perceptron",
         1,
         14,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
+  /**
+   * Isolating fixture for the {@code numpy → tf.constant} dtype-propagation hypothesis that
+   * surfaced from {@link #testMultilayerPerceptron}. Probes whether {@code consume(x)} sees a
+   * concrete type when {@code x = tf.constant(np.ones((2, 3), dtype=np.float32))}. The hypothesis
+   * predicts UNKNOWN dtype on {@code x} (parameter to {@code consume}); a concrete inference would
+   * refute it and push the investigation back to the matmul-chain in {@code multilayer_perceptron}.
+   *
+   * <p>Counts and types intentionally minimal; tighten after first run.
+   */
+  @Test
+  public void testConstantFromNumpy()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_constant_from_numpy.py",
+        "consume",
+        1,
+        1,
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2132,15 +2132,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * of {@code tf.shape(...)}) rather than a list/tuple literal. The {@code Reshape} generator
    * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing.
    *
-   * <p>TODO: replace this {@code expected = IllegalStateException.class} with a positive assertion
-   * (pinning the inferred parameter types) once <a
-   * href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the graceful-degradation
-   * fix.
+   * <p>TODO: once <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the
+   * graceful-degradation fix, replace the {@code assertThrows} below with a positive type
+   * assertion: {@code arr} (vn=2) should resolve to {@code (2, 3) float32} and {@code indices}
+   * (vn=3) to {@code (2, 2) int32}, matching the caller-side {@code tf.constant} shapes in {@code
+   * tf2_test_take_along_axis.py}.
    */
-  @Test(expected = IllegalStateException.class)
-  public void testTakeAlongAxis()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of());
+  @Test
+  public void testTakeAlongAxis() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of()));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2144,6 +2144,39 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins {@code multilayer_perceptron(x)}'s parameter type for the input-signature-inference
+   * empirical pass (issue <a
+   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
+   * Function body mirrors {@code multilayer_perceptron} from {@code
+   * YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py}, a function the
+   * previous paper's Hybridize tool refactored with {@code @tf.function}. Uses raw {@code
+   * tf.matmul} / {@code tf.add} / {@code tf.nn.sigmoid} / {@code tf.nn.softmax} against global
+   * {@code tf.Variable} weights and biases — a different pattern from the {@code Dense}-layer
+   * subclass-Model approach already covered by {@code testNeuralNetwork*}.
+   *
+   * <p>Empirically, {@code x} is inferred as {@code ⊤ shape / UNKNOWN dtype} — the first
+   * load-bearing UNKNOWN-dtype the empirical pass has surfaced for input-signature inference. The
+   * dtype axis is the load-bearing one per the audit's definition, so this function would NOT be
+   * input-signature-emittable on current master. The likely cause is the caller's {@code batch_x =
+   * tf.constant(np.ones((100, 784), dtype=np.float32))} losing dtype through the {@code numpy →
+   * tf.constant} boundary — Ariadne's modeling of this construction chain appears to not preserve
+   * the numpy dtype info.
+   *
+   * <p>TODO: tighten to the precise type once the {@code numpy → tf.constant} dtype propagation gap
+   * is resolved.
+   */
+  @Test
+  public void testMultilayerPerceptron()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_multilayer_perceptron.py",
+        "multilayer_perceptron",
+        1,
+        14,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
+  /**
    * {@code MyModel.call(self, x)} receives {@code x} from {@code model(images)} calls inside {@code
    * train_step} and {@code test_step}. {@code images} comes from iterating {@code train_ds}, {@code
    * valid_ds}, or {@code test_ds} &mdash; all created from mnist data via {@code

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -111,6 +111,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
 
+  private static final TensorType TENSOR_1_5_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(5)));
+
   private static final TensorType TENSOR_1_10_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(10)));
 
@@ -2090,6 +2093,29 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         7,
         Map.of(2, Set.of(TENSOR_256_28_28_1_FLOAT32, TENSOR_96_28_28_1_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code top_p_logits(logits, p)}'s parameter type for the input-signature-inference
+   * empirical pass (issue <a
+   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
+   * Function body mirrors {@code akanyaani/gpt-2-tensorflow2.0/sample.py}'s {@code top_p_logits}, a
+   * function the previous paper's Hybridize tool refactored with {@code @tf.function}. Exercises
+   * several ops currently routed through {@code ReadDataFallback} per wala/ML#449 ({@code tf.sort},
+   * {@code tf.cumsum}, {@code tf.stack}, {@code tf.range}, {@code tf.gather_nd}, {@code tf.where}),
+   * but the parameter type of {@code logits} comes from its caller (a {@code tf.constant} with
+   * shape {@code (1, 5)} dtype {@code float32}), so this test isolates the caller-side propagation
+   * rather than the body's op precision.
+   *
+   * <p>Empirically, {@code logits} is inferred as {@code (1, 5) float32} — concrete on both axes.
+   * The caller's {@code tf.constant([[1.0, ..., 5.0]], dtype=tf.float32)} flows in cleanly. This
+   * means none of the body's {@code ReadDataFallback}-routed ops actually block input-signature
+   * inference for this function; the parameter type is fully resolved at the call site.
+   */
+  @Test
+  public void testTopPLogits()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_top_p_logits.py", "top_p_logits", 1, 11, Map.of(2, Set.of(TENSOR_1_5_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2177,13 +2177,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Isolating fixture for the {@code numpy → tf.constant} dtype-propagation hypothesis that
-   * surfaced from {@link #testMultilayerPerceptron}. Probes whether {@code consume(x)} sees a
-   * concrete type when {@code x = tf.constant(np.ones((2, 3), dtype=np.float32))}. The hypothesis
-   * predicts UNKNOWN dtype on {@code x} (parameter to {@code consume}); a concrete inference would
-   * refute it and push the investigation back to the matmul-chain in {@code multilayer_perceptron}.
+   * Isolating regression guard for the {@code numpy → tf.constant} dtype-loss bug (<a
+   * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>), surfaced from {@link
+   * #testMultilayerPerceptron}. {@code consume(x)} where {@code x = tf.constant(np.ones((2, 3),
+   * dtype=np.float32))} infers {@code ⊤ shape / UNKNOWN dtype} despite the explicit numpy {@code
+   * dtype=np.float32}. Confirms the dtype-loss happens at the {@code numpy → tf.constant} boundary,
+   * independent of any matmul/global-Variable noise.
    *
-   * <p>Counts and types intentionally minimal; tighten after first run.
+   * <p>TODO: tighten to {@code (2, 3) float32} once wala/ML#539 lands.
    */
   @Test
   public void testConstantFromNumpy()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2119,6 +2119,31 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins {@code _take_long_axis(arr, indices)}'s parameter types for the input-signature-inference
+   * empirical pass (issue <a
+   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
+   * Function body mirrors {@code _take_long_axis} from {@code
+   * LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py}, a function the
+   * previous paper's Hybridize tool refactored with {@code @tf.function}.
+   *
+   * <p>This fixture surfaced a real Ariadne bug: {@code tf.reshape(arr, tf.shape(other))} crashes
+   * the analysis with {@code IllegalStateException} at {@code
+   * TensorGenerator.getShapesFromShapeArgument} because the shape argument is a Tensor (the result
+   * of {@code tf.shape(...)}) rather than a list/tuple literal. The {@code Reshape} generator
+   * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing.
+   *
+   * <p>TODO: replace this {@code expected = IllegalStateException.class} with a positive assertion
+   * (pinning the inferred parameter types) once <a
+   * href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the graceful-degradation
+   * fix.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testTakeAlongAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of());
+  }
+
+  /**
    * {@code MyModel.call(self, x)} receives {@code x} from {@code model(images)} calls inside {@code
    * train_step} and {@code test_step}. {@code images} comes from iterating {@code train_ds}, {@code
    * valid_ds}, or {@code test_ds} &mdash; all created from mnist data via {@code

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2133,16 +2133,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing.
    *
    * <p>TODO: once <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the
-   * graceful-degradation fix, replace the {@code assertThrows} below with a positive type
-   * assertion: {@code arr} (vn=2) should resolve to {@code (2, 3) float32} and {@code indices}
-   * (vn=3) to {@code (2, 2) int32}, matching the caller-side {@code tf.constant} shapes in {@code
-   * tf2_test_take_along_axis.py}.
+   * graceful-degradation fix, remove the {@code expected = IllegalStateException.class} suppression
+   * and pin precise types: {@code arr} (vn=2) should resolve to {@code (2, 3) float32} and {@code
+   * indices} (vn=3) to {@code (2, 2) int32}, matching the caller-side {@code tf.constant} shapes in
+   * {@code tf2_test_take_along_axis.py}.
    */
-  @Test
-  public void testTakeAlongAxis() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of()));
+  @Test(expected = IllegalStateException.class)
+  public void testTakeAlongAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of());
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
@@ -1,0 +1,20 @@
+# Minimal fixture isolating the `numpy → tf.constant` dtype-propagation hypothesis
+# from the multilayer_perceptron empirical-pass finding (ponder-lab/
+# Input-Signature-Inference-Paper#22, wala/ML#TBD). The hypothesis: Ariadne
+# loses dtype info when a tensor is constructed via `tf.constant(np_array)`
+# rather than from a literal Python list/scalar or a modeled API (mnist
+# load_data, Dense layer chain, etc.).
+import numpy as np
+import tensorflow as tf
+
+
+def consume(x):
+    """Sink function — pins the dtype/shape of whatever flows in as `x`."""
+    return x
+
+
+# Path A: `tf.constant` of a numpy array. The hypothesis says dtype is lost here.
+arr_from_np = tf.constant(np.ones((2, 3), dtype=np.float32))
+assert arr_from_np.shape == (2, 3)
+assert arr_from_np.dtype == tf.float32
+consume(arr_from_np)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
@@ -1,9 +1,9 @@
-# Minimal fixture isolating the `numpy → tf.constant` dtype-propagation hypothesis
-# from the multilayer_perceptron empirical-pass finding (ponder-lab/
-# Input-Signature-Inference-Paper#22, wala/ML#TBD). The hypothesis: Ariadne
-# loses dtype info when a tensor is constructed via `tf.constant(np_array)`
-# rather than from a literal Python list/scalar or a modeled API (mnist
-# load_data, Dense layer chain, etc.).
+# Minimal fixture isolating the `numpy → tf.constant` dtype-loss bug
+# (wala/ML#539) surfaced by the multilayer_perceptron empirical-pass finding
+# (ponder-lab/Input-Signature-Inference-Paper#22). Ariadne loses dtype info
+# when a tensor is constructed via `tf.constant(np_array)` rather than from
+# a literal Python list/scalar or a modeled API (mnist load_data, Dense
+# layer chain, etc.).
 import numpy as np
 import tensorflow as tf
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_multilayer_perceptron.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_multilayer_perceptron.py
@@ -1,0 +1,46 @@
+# Minimal fixture for the input-signature-inference empirical pass
+# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `multilayer_perceptron`
+# from `YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py`
+# — a function the previous paper's Hybridize tool refactored with `@tf.function`.
+# Uses raw `tf.matmul`/`tf.add`/`tf.nn.sigmoid` instead of Keras `Dense` layers,
+# with global weight/bias `tf.Variable`s — a different pattern from the
+# `NeuralNet.call` cases already covered by `testNeuralNetwork*`.
+import numpy as np
+import tensorflow as tf
+
+# Network parameters from the original.
+n_input = 784
+n_hidden_1 = 256
+n_hidden_2 = 256
+n_classes = 10
+
+weights = {
+    "h1": tf.Variable(tf.random.normal([n_input, n_hidden_1])),
+    "h2": tf.Variable(tf.random.normal([n_hidden_1, n_hidden_2])),
+    "out": tf.Variable(tf.random.normal([n_hidden_2, n_classes])),
+}
+biases = {
+    "b1": tf.Variable(tf.random.normal([n_hidden_1])),
+    "b2": tf.Variable(tf.random.normal([n_hidden_2])),
+    "out": tf.Variable(tf.random.normal([n_classes])),
+}
+
+
+def multilayer_perceptron(x):
+    layer_1 = tf.add(tf.matmul(x, weights["h1"]), biases["b1"])
+    layer_1 = tf.nn.sigmoid(layer_1)
+    layer_2 = tf.add(tf.matmul(layer_1, weights["h2"]), biases["b2"])
+    layer_2 = tf.nn.sigmoid(layer_2)
+    output = tf.matmul(layer_2, weights["out"]) + biases["out"]
+    return tf.nn.softmax(output)
+
+
+# Driver: build a flattened mnist-style batch and pass through.
+batch_x = tf.constant(np.ones((100, 784), dtype=np.float32))
+
+assert batch_x.shape == (100, 784)
+assert batch_x.dtype == tf.float32
+
+result = multilayer_perceptron(batch_x)
+assert result.shape == (100, 10)
+assert result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_take_along_axis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_take_along_axis.py
@@ -1,0 +1,32 @@
+# Minimal fixture for the input-signature-inference empirical pass
+# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `_take_long_axis`
+# from `LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py`
+# — a function the previous paper's Hybridize tool refactored with `@tf.function`.
+# Tests caller-side type propagation when the function takes two tensor params
+# (`arr` and `indices`) with different dtypes (float32 and int32).
+import tensorflow as tf
+
+
+def _take_long_axis(arr, indices):
+    """Take elements from arr at indices specified by indices (2D)."""
+    row_indices = tf.tile(
+        tf.expand_dims(tf.range(tf.shape(indices)[0]), 1), [1, tf.shape(indices)[1]]
+    )
+    gather_indices = tf.concat(
+        [tf.reshape(row_indices, (-1, 1)), tf.reshape(indices, (-1, 1))], axis=1
+    )
+    return tf.reshape(tf.gather_nd(arr, gather_indices), tf.shape(indices))
+
+
+# Driver: build known input tensors and pass them through.
+arr = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=tf.float32)
+indices = tf.constant([[0, 1], [2, 0]], dtype=tf.int32)
+
+assert arr.shape == (2, 3), f"arr shape was {arr.shape}"
+assert arr.dtype == tf.float32
+assert indices.shape == (2, 2), f"indices shape was {indices.shape}"
+assert indices.dtype == tf.int32
+
+result = _take_long_axis(arr, indices)
+assert result.shape == (2, 2)
+assert result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
@@ -1,0 +1,44 @@
+# Minimal fixture for the input-signature-inference empirical pass
+# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `top_p_logits` from
+# akanyaani/gpt-2-tensorflow2.0/sample.py — a function the previous paper's
+# Hybridize tool refactored with `@tf.function`. This fixture's purpose is to
+# let Ariadne's `TestTensorflow2Model` test pin the inferred parameter type
+# for `logits` and observe whether ops in the body (tf.sort, tf.cumsum,
+# tf.stack, tf.range, tf.gather_nd, tf.where) are load-bearing on the dtype
+# axis for input-signature emission.
+import tensorflow as tf
+
+
+def top_p_logits(logits, p):
+    """Took from OpenAI GPT-2 Implementation."""
+    batch = tf.shape(logits)[0]
+    sorted_logits = tf.sort(logits, direction="DESCENDING", axis=-1)
+    cumulative_probs = tf.cumsum(tf.nn.softmax(sorted_logits, axis=-1), axis=-1)
+    indices = tf.stack(
+        [
+            tf.range(0, batch),
+            tf.maximum(
+                tf.reduce_sum(tf.cast(cumulative_probs <= p, tf.int32), axis=-1) - 1, 0
+            ),
+        ],
+        axis=-1,
+    )
+    min_values = tf.gather_nd(sorted_logits, indices)
+    return tf.where(
+        logits < min_values,
+        tf.ones_like(logits) * -1e10,
+        logits,
+    )
+
+
+# Driver: build a known logits tensor and pass it through.
+logits = tf.constant([[1.0, 2.0, 3.0, 4.0, 5.0]], dtype=tf.float32)
+p = 0.9
+
+# Verify Python runtime types match what we expect Ariadne to infer.
+assert logits.shape == (1, 5), f"logits shape was {logits.shape}"
+assert logits.dtype == tf.float32
+
+result = top_p_logits(logits, p)
+assert result.shape == (1, 5)
+assert result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 
 
 def top_p_logits(logits, p):
-    """Took from OpenAI GPT-2 Implementation."""
+    """Taken from OpenAI GPT-2 implementation."""
     batch = tf.shape(logits)[0]
     sorted_logits = tf.sort(logits, direction="DESCENDING", axis=-1)
     cumulative_probs = tf.cumsum(tf.nn.softmax(sorted_logits, axis=-1), axis=-1)


### PR DESCRIPTION
## Summary

Four empirical-pass regression guards probing input-signature inference on previously-untested perf-eval functions. Each test pins the current inferred type (concrete or imprecise) as a positive assertion, with a Javadoc TODO pointing at the relevant filed issue.

- **`testTopPLogits`**—concrete `(1, 5) float32`. Confirms `ReadDataFallback`-routed ops (`tf.sort`, `tf.cumsum`, `tf.stack`, `tf.range`, `tf.gather_nd`, `tf.where`) are not load-bearing for this function parameter type (parameter flows from caller `tf.constant`, not from body ops).
- **`testTakeAlongAxis`**—analysis crashes; captured via `@Test(expected = IllegalStateException.class)`. Surfaces wala/ML#538: `Reshape` generator throws when the shape arg is a `tf.shape(...)` Tensor instead of a list/tuple.
- **`testMultilayerPerceptron`**—first load-bearing UNKNOWN-dtype finding (`⊤ shape, UNKNOWN dtype`). Surfaces wala/ML#539: `tf.constant(np_array)` loses numpy dtype/shape.
- **`testConstantFromNumpy`**—minimal isolating fixture for wala/ML#539. Proves the root cause without any matmul/global-Variable noise: `tf.constant(np.ones((2, 3), dtype=np.float32))` produces a tensor whose dtype Ariadne can not infer.

## Test Plan

- [x] All four tests pass locally.
- [ ] CI green.

References wala/ML#538 and wala/ML#539. Does NOT close either—each test Javadoc TODO is the cue to tighten the assertion once the underlying issue is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

