### PR TITLE
Add `testSort` regression guard (wala/ML#449 Tier 6)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4914,6 +4914,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Tier-6 op (wala/ML#449): {@code tf.sort(values, ...)}. The XML routes the call through {@code
+   * convert_to_tensor} of {@code values}, so shape and dtype pass through unchanged — no dedicated
+   * generator needed.
+   */
+  @Test
+  public void testSort()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_sort.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_6_FLOAT32)));
+  }
+
+  /**
    * Generator-dispatch test for {@code tf.tensor_scatter_nd_update}. Output dtype AND shape are
    * inherited from the {@code tensor} input — true shape-and-dtype passthrough on the first arg.
    * Here the input is shape {@code (4,)} float32, so the precise expected result is {@code (4,)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sort.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sort.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.sort(values, ...)` is Tier 6 of wala/ML#449. The XML routes the call
+# through `convert_to_tensor` of `values`, so shape and dtype should pass
+# through unchanged.
+x = tf.constant([3.0, 1.0, 4.0, 1.0, 5.0, 9.0])
+y = tf.sort(x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (6,)
+assert y.dtype == tf.float32
+
+f(y)


### PR DESCRIPTION
## Summary

- Adds `testSort` for `tf.sort(values, ...)`, one of two Tier-6 ops the wala/ML#449 empirical-state survey flagged as "missing test but likely already works via XML routing." Confirmed: the XML routes through `convert_to_tensor`, producing precise `(6,) float32`. No dedicated generator needed.

## Test Plan

- [x] `mvn test -Dtest=TestTensorflow2Model#testSort` passes locally.
- [ ] CI green.

References wala/ML#449. One step on the close-out path documented in https://github.com/wala/ML/issues/449#issuecomment-4468470437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

