### PR TITLE
Document per-variable aggregated-state lattice in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The per-variable result aggregated from the per-axis lattice tables above follow
 | empty set | ⊥—the variable is provably not a tensor. |
 | non-empty set | The variable has at least one possible `TensorType`. Individual elements may still carry `getDims() == null` (shape-⊤) or `getDType() == DType.UNKNOWN` (dtype-⊤). |
 
-Downstream consumers iterating aggregated state (e.g., `TensorTypeAnalysis.iterator()`) filter to `state != null && !state.isEmpty()`. Under contract-compliant generators (per the per-axis tables above), an empty/missing entry corresponds to ⊥ at the variable level; a non-empty entry may still contain shape-⊤ or dtype-⊤ on individual `TensorType` instances, which consumers must handle.
+Downstream consumers iterating aggregated state (e.g., `TensorTypeAnalysis.iterator()`) filter to `state != null && !state.isEmpty()`, which collapses ⊥ (empty Set) and ⊤ (null Set) into a single "absent from iterator" outcome—a missing entry can represent either. Consumers that need to distinguish ⊥ from ⊤ must read `state` directly rather than via `iterator()`. A non-empty entry may still contain shape-⊤ or dtype-⊤ on individual `TensorType` instances, which consumers must handle.
 
 ### Checklist When Adding a New Generator
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,16 @@ Never return a bare empty set to mean "unknown dtype"—that collides with the "
 
 Shapes and dtypes are orthogonal. When the shape is unknown but the dtype is known, `getTensorTypes` emits `TensorType` instances with `null` dims so dtype information is preserved. `TensorType` is null-dims-safe; any code that consumes `TensorType`s must handle `getDims() == null`.
 
+The per-variable result aggregated from the per-axis lattice tables above follows its own lattice on the returned `Set<TensorType>`:
+
+| Return value | Meaning |
+|---|---|
+| `null` | ⊤—the variable is known to be a tensor, but neither its shape nor its dtype can be determined. |
+| empty set | ⊥—the variable is provably not a tensor. |
+| non-empty set | The variable has at least one possible `TensorType`. Individual elements may still carry `getDims() == null` (shape-⊤) or `getDType() == DType.UNKNOWN` (dtype-⊤). |
+
+Downstream consumers iterating aggregated state (e.g., `TensorTypeAnalysis.iterator()`) filter to `state != null && !state.isEmpty()`. Under contract-compliant generators (per the per-axis tables above), an empty/missing entry corresponds to ⊥ at the variable level; a non-empty entry may still contain shape-⊤ or dtype-⊤ on individual `TensorType` instances, which consumers must handle.
+
 ### Checklist When Adding a New Generator
 
 - [ ] Audit every final-fallback return in `getDefaultShapes` and `getDefaultDTypes` against the tables above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,11 +110,11 @@ The per-variable result aggregated from the per-axis lattice tables above follow
 
 | Return value | Meaning |
 |---|---|
-| `null` | ⊤—the variable is known to be a tensor, but neither its shape nor its dtype can be determined. |
+| `null` | Defensive fallback for contract violation (dtype set is `null`/empty rather than `EnumSet.of(DType.UNKNOWN)`, and shape is also `null`). Under contract-compliant generators this case shouldn't occur. |
 | empty set | ⊥—the variable is provably not a tensor. |
-| non-empty set | The variable has at least one possible `TensorType`. Individual elements may still carry `getDims() == null` (shape-⊤) or `getDType() == DType.UNKNOWN` (dtype-⊤). |
+| non-empty set | The variable has at least one possible `TensorType`. ⊤ at the variable level (known to be a tensor, shape and dtype unknown) is encoded here too, as a non-empty Set containing `TensorType(UNKNOWN, null)`. Individual elements may still carry `getDims() == null` (shape-⊤) or `getDType() == DType.UNKNOWN` (dtype-⊤). |
 
-Downstream consumers iterating aggregated state (e.g., `TensorTypeAnalysis.iterator()`) filter to `state != null && !state.isEmpty()`, which collapses ⊥ (empty Set) and ⊤ (null Set) into a single "absent from iterator" outcome—a missing entry can represent either. Consumers that need to distinguish ⊥ from ⊤ must read `state` directly rather than via `iterator()`. A non-empty entry may still contain shape-⊤ or dtype-⊤ on individual `TensorType` instances, which consumers must handle.
+Downstream consumers iterating aggregated state (e.g., `TensorTypeAnalysis.iterator()`) filter to `state != null && !state.isEmpty()`. Under contract-compliant generators this filters out ⊥ (empty Set); ⊤ at the variable level remains visible to the iterator as a non-empty Set with `TensorType(UNKNOWN, null)` inside. A non-empty entry may carry shape-⊤ or dtype-⊤ on individual `TensorType` instances, which consumers must handle.
 
 ### Checklist When Adding a New Generator
 


### PR DESCRIPTION
## Summary

- Extends the "Tensor Type Generators" section of `CONTRIBUTING.md` with the **per-variable** lattice that `getTensorTypes` (`Set<TensorType>`) follows, in addition to the existing per-axis tables.
- Adds a consumer note describing how `TensorTypeAnalysis.iterator()` (`state != null && !state.isEmpty()`) maps onto this lattice under contract-compliant generators — load-bearing for downstream consumers like Hybridize.

Closes wala/ML#540.

## Test Plan

- [x] `mvn spotless:check` clean.
- [x] Markdown renders correctly (em-dashes adjacent to text, table renders, em-dashes inside the table cells match the existing style of `### Shapes—getDefaultShapes` / `### Dtypes—getDefaultDTypes`).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)