### PR TITLE
Update run.sh to use the fat classifier JAR

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,6 +71,24 @@ jobs:
         popd
     - name: Build with Maven
       run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco
+    # Catch the kind of drift that prompted https://github.com/wala/ML/issues/525:
+    # `run.sh`'s JAR path falling behind the project's actual version (previously
+    # hardcoded `0.40.0-SNAPSHOT`, ~5 minor versions stale). Verifies post-build
+    # that the script's glob resolves to exactly one fat JAR and that the JAR
+    # carries the standalone driver's `Main-Class` manifest entry.
+    - name: Smoke-test `run.sh` fat-JAR resolution
+      run: |
+        cd com.ibm.wala.cast.python.ml
+        shopt -s nullglob
+        JARS=(target/com.ibm.wala.cast.python.ml-*-fat.jar)
+        if [ ${#JARS[@]} -ne 1 ]; then
+          echo "Expected exactly one fat JAR in com.ibm.wala.cast.python.ml/target/; got ${#JARS[@]}: ${JARS[*]}" >&2
+          exit 1
+        fi
+        unzip -p "${JARS[0]}" META-INF/MANIFEST.MF \
+          | grep -q "^Main-Class: com.ibm.wala.cast.python.ml.driver.Ariadne" \
+          || { echo "fat JAR ${JARS[0]} missing expected Main-Class manifest entry" >&2; exit 1; }
+      shell: bash
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -3,4 +3,14 @@
 ME=`realpath $0`
 DIR=`dirname $ME`
 
-cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar $DIR/target/com.ibm.wala.cast.python.ml-0.40.0-SNAPSHOT.jar --mode stdio | tee -a /tmp/lsp.out.log
+# Locate the fat classifier JAR (built by `mvn package` per wala/ML#525). Glob
+# avoids version-pinning brittleness — the previous hardcoded `0.40.0-SNAPSHOT`
+# path fell ~5 minor versions behind the project's actual `pom.xml` version.
+JAR=$(ls "$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar 2>/dev/null | head -1)
+
+if [ -z "$JAR" ]; then
+  echo "fat JAR not found in $DIR/target/. Run \`mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
+  exit 1
+fi
+
+cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar "$JAR" --mode stdio | tee -a /tmp/lsp.out.log

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -12,7 +12,7 @@ JARS=("$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar)
 shopt -u nullglob
 
 if [ ${#JARS[@]} -eq 0 ]; then
-  echo "fat JAR not found in $DIR/target/. Run \`mvn -f $DIR/../pom.xml -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
+  echo "fat JAR not found in $DIR/target/. Run \`mvn -f \"$DIR/../pom.xml\" -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
   exit 1
 fi
 

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -7,11 +7,20 @@ DIR=`dirname $ME`
 # https://github.com/wala/ML/issues/525). Glob avoids version-pinning
 # brittleness—the previous hardcoded `0.40.0-SNAPSHOT` path fell ~5 minor
 # versions behind the project's actual `pom.xml` version.
-JAR=$(ls "$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar 2>/dev/null | head -1)
+shopt -s nullglob
+JARS=("$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar)
+shopt -u nullglob
 
-if [ -z "$JAR" ]; then
+if [ ${#JARS[@]} -eq 0 ]; then
   echo "fat JAR not found in $DIR/target/. Run \`mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
   exit 1
 fi
+
+if [ ${#JARS[@]} -gt 1 ]; then
+  echo "Multiple fat JARs in $DIR/target/: ${JARS[*]}. Remove stale ones or run a \`clean package\` to get a single matching jar." >&2
+  exit 1
+fi
+
+JAR="${JARS[0]}"
 
 cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar "$JAR" --mode stdio | tee -a /tmp/lsp.out.log

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -12,7 +12,7 @@ JARS=("$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar)
 shopt -u nullglob
 
 if [ ${#JARS[@]} -eq 0 ]; then
-  echo "fat JAR not found in $DIR/target/. Run \`mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
+  echo "fat JAR not found in $DIR/target/. Run \`mvn -f $DIR/../pom.xml -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first." >&2
   exit 1
 fi
 

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -3,9 +3,10 @@
 ME=`realpath $0`
 DIR=`dirname $ME`
 
-# Locate the fat classifier JAR (built by `mvn package` per wala/ML#525). Glob
-# avoids version-pinning brittleness — the previous hardcoded `0.40.0-SNAPSHOT`
-# path fell ~5 minor versions behind the project's actual `pom.xml` version.
+# Locate the fat classifier JAR (built by `mvn package` per
+# https://github.com/wala/ML/issues/525). Glob avoids version-pinning
+# brittleness—the previous hardcoded `0.40.0-SNAPSHOT` path fell ~5 minor
+# versions behind the project's actual `pom.xml` version.
 JAR=$(ls "$DIR"/target/com.ibm.wala.cast.python.ml-*-fat.jar 2>/dev/null | head -1)
 
 if [ -z "$JAR" ]; then


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/ponder-lab/ML/pull/298. After #298 lands, the default published jar (`com.ibm.wala.cast.python.ml-X.Y.Z.jar`) is plain—no `Main-Class`, no WALA—so the previous `java -jar target/...-SNAPSHOT.jar` invocation in `run.sh` no longer works for the standalone driver. The driver entrypoint moves to the `fat` classifier.

Two changes:

- Switch the JAR path to glob `target/com.ibm.wala.cast.python.ml-*-fat.jar`. Avoids version-pinning brittleness: the previous path hardcoded `0.40.0-SNAPSHOT`, which had fallen ~5 minor versions behind the project actual `pom.xml` version (currently `0.45.0-SNAPSHOT`).
- Add a fail-fast guard with a build instruction if the fat JAR is absent.

Closes https://github.com/wala/ML/issues/526 (run.sh stale version pin), https://github.com/wala/ML/issues/527 (no CI coverage for standalone driver). References https://github.com/wala/ML/issues/525.

## Test Plan

After https://github.com/ponder-lab/ML/pull/298 lands on master:

```bash
git checkout master && git pull
mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests
cd com.ibm.wala.cast.python.ml

# 1. Verify the glob resolves to exactly one jar.
ls target/com.ibm.wala.cast.python.ml-*-fat.jar
# Expect: one file, currently `com.ibm.wala.cast.python.ml-0.45.0-SNAPSHOT-fat.jar`.

# 2. Verify run.sh picks it up. `bash -x` traces the JAR resolution; piping `</dev/null` exits cleanly because LSP stdio mode sees EOF on stdin.
bash -x ./run.sh </dev/null
# Expect: `+ JAR=.../com.ibm.wala.cast.python.ml-0.45.0-SNAPSHOT-fat.jar` in the trace, then a clean exit (no `NoClassDefFoundError`).

# 3. Verify the fail-fast guard. Move the jar out of the way, re-run, expect a non-zero exit with the build-instruction message.
mv target/com.ibm.wala.cast.python.ml-*-fat.jar /tmp/
./run.sh </dev/null; echo "exit=$?"
# Expect: `fat JAR not found in .../target/. Run \`mvn -pl com.ibm.wala.cast.python.ml -am clean package -DskipTests\` first.` on stderr, exit=1.
mv /tmp/com.ibm.wala.cast.python.ml-*-fat.jar target/   # restore
```

- [x] `bash -n run.sh` syntax clean.
- [x] `mvn spotless:check` clean.
- [ ] CI green.
- [ ] End-to-end verification per the steps above, after #298 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
