### PR TITLE
Attach fat-classifier JAR to GitHub Release on semver tag-push

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
 permissions:
-  contents: read
+  # `contents: write` (rather than `read`) is required by the
+  # `softprops/action-gh-release` step at the bottom of this job, which attaches
+  # the fat-classifier JAR to the GitHub Release on semver tag-push.
+  contents: write
   packages: write
 jobs:
   build:
@@ -120,3 +123,16 @@ jobs:
       # the ancestor-of-master check in the same step blocks feature-branch
       # tags from sneaking through.
       if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/tags/') && steps.tag_check.outputs.is_semver_release == 'true')) }}
+    # On semver tag-push, also attach the fat-classifier JAR to the GitHub
+    # Release as a downloadable asset. The default Maven deploy above publishes
+    # both jars (slim default + `-fat` classifier) to GitHub Packages, which
+    # requires a classic PAT with `read:packages` scope for downstream
+    # consumers. Attaching the fat JAR to the Release lets standalone-driver
+    # users (`java -jar`) fetch it directly with no auth.
+    - name: Upload fat JAR to GitHub Release
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && steps.tag_check.outputs.is_semver_release == 'true' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        files: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,14 +28,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
 permissions:
-  # `contents: write` (rather than `read`) is required by the
-  # `softprops/action-gh-release` step at the bottom of this job, which attaches
-  # the fat-classifier JAR to the GitHub Release on semver tag-push.
-  contents: write
+  contents: read
   packages: write
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      is_semver_release: ${{ steps.tag_check.outputs.is_semver_release }}
     steps:
     - name: Check out wala/ML sources
       uses: actions/checkout@v6
@@ -123,16 +122,40 @@ jobs:
       # the ancestor-of-master check in the same step blocks feature-branch
       # tags from sneaking through.
       if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/tags/') && steps.tag_check.outputs.is_semver_release == 'true')) }}
-    # On semver tag-push, also attach the fat-classifier JAR to the GitHub
-    # Release as a downloadable asset. The default Maven deploy above publishes
-    # both jars (slim default + `-fat` classifier) to GitHub Packages, which
-    # requires a classic PAT with `read:packages` scope for downstream
-    # consumers. Attaching the fat JAR to the Release lets standalone-driver
-    # users (`java -jar`) fetch it directly with no auth.
-    - name: Upload fat JAR to GitHub Release
+    # On semver tag-push, upload the fat-classifier JAR as a CI artifact for the
+    # downstream `release-upload` job to attach to the GitHub Release.
+    - name: Upload fat JAR artifact
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && steps.tag_check.outputs.is_semver_release == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: fat-jar
+        path: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
+        if-no-files-found: error
+        retention-days: 1
+  # Attach the fat-classifier JAR to the GitHub Release on semver tag-push. The
+  # Maven deploy step in `build` above publishes both jars (slim default + `-fat`
+  # classifier) to GitHub Packages, which requires a classic PAT with
+  # `read:packages` scope for downstream consumers. Attaching the fat JAR to the
+  # Release lets standalone-driver users (`java -jar`) fetch it directly with no
+  # auth.
+  #
+  # Run as a separate job (rather than a step in `build`) so the elevated
+  # `contents: write` permission is scoped to release tag-pushes only —
+  # PR/branch-push runs of `build` keep the workflow-level `contents: read`.
+  release-upload:
+    needs: build
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.build.outputs.is_semver_release == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Download fat JAR artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: fat-jar
+    - name: Attach fat JAR to GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        files: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
+        files: com.ibm.wala.cast.python.ml-*-fat.jar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -156,6 +156,6 @@ jobs:
     - name: Attach fat JAR to GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        files: com.ibm.wala.cast.python.ml-*-fat.jar
+        files: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/ponder-lab/ML/pull/298. After #298, the standalone driver lives in the `-fat` classifier JAR. The existing `mvn deploy` step publishes both jars (slim default + fat) to GitHub Packages, which requires a classic PAT with `read:packages` scope for downstream consumers — friction for standalone-driver users who just want `java -jar`.

Adds a `softprops/action-gh-release@v2` step after the existing deploy step that attaches the fat JAR to the GitHub Release as a downloadable asset, gated by the same semver-tag-push condition. Standalone users can then fetch it directly from the Release page with no auth.

Also bumps the job-level `contents` permission from `read` to `write` since the release upload requires it.

References wala/ML#525.

## Test Plan

- [x] YAML syntax valid (`python -c "import yaml; yaml.safe_load(...)"`).
- [x] `mvn spotless:check` clean.
- [ ] CI green on this PR (non-tag run; the upload step is gated and stays inactive).
- [ ] Next semver tag-push exercises the upload step end-to-end; verify the `-fat.jar` appears on the Release page as an asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)