### PR TITLE
Document bidirectional Python/JUnit assertion sync + DL-program caveat in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ black --fast .
 
 - Always verify that newly created Python test files run to completion using `python3.10`.
 - Always add `assert` statements in Python test files for tensor `shape` and `dtype`.
-- Ensure that `assert` statements in Python test files match the expectations defined in the corresponding JUnit test cases.
+- Ensure that `assert` statements in Python test files match the expectations defined in the corresponding JUnit test cases. The sync is **bidirectional**: whenever you specify or change a shape or dtype in a JUnit test case, add or update the corresponding `assert` statements in the Python fixture (and vice versa). Mismatches between the two surfaces are a red flag.
+- Some test files are full DL training scripts (e.g., `tensorflow_gan_tutorial.py`'s GAN training loop) where running to completion with `python3.10` is impractical due to runtime (multi-minute or longer, especially on CPU). In those cases, prefer a short-timeout run (`timeout 60 python3.10 file.py`) and confirm no `AssertionError` fires before the timeout, plus visual inspection that the assertion site is reachable from the script's main code path. Document the limitation in the JUnit Javadoc or commit message so reviewers know runtime-to-completion verification wasn't performed.
 
 ## Tensor Type Generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,8 @@ black --fast .
 
 - Always verify that newly created Python test files run to completion using `python3.10`.
 - Always add `assert` statements in Python test files for tensor `shape` and `dtype`.
-- Ensure that `assert` statements in Python test files match the expectations defined in the corresponding JUnit test cases. The sync is **bidirectional**: whenever you specify or change a shape or dtype in a JUnit test case, add or update the corresponding `assert` statements in the Python fixture (and vice versa). Mismatches between the two surfaces are a red flag.
-- Some test files are full DL training scripts (e.g., `tensorflow_gan_tutorial.py`'s GAN training loop) where running to completion with `python3.10` is impractical due to runtime (multi-minute or longer, especially on CPU). In those cases, prefer a short-timeout run (`timeout 60 python3.10 file.py`) and confirm no `AssertionError` fires before the timeout, plus visual inspection that the assertion site is reachable from the script's main code path. Document the limitation in the JUnit Javadoc or commit message so reviewers know runtime-to-completion verification wasn't performed.
+- Keep `assert` statements in Python test files in sync with the corresponding JUnit test cases—in both directions. Mismatches between the two are a red flag.
+- For full DL training scripts (e.g., `tensorflow_gan_tutorial.py`), running to completion with `python3.10` may be impractical. Run with a short timeout, confirm no `AssertionError`, and document the limitation in the JUnit Javadoc or commit message.
 
 ## Tensor Type Generators
 


### PR DESCRIPTION
## Summary

Extends the "Python Testing" section of `CONTRIBUTING.md` with two clarifications:

- The Python `assert` ↔ JUnit-expectation sync is **bidirectional**. Changing a shape or dtype in a JUnit test case requires updating the corresponding `assert` statements in the Python fixture (and vice versa). Mismatches between the two surfaces are a red flag.
- Some test files are full DL training scripts where `python3.10`-to-completion verification is impractical (e.g., `tensorflow_gan_tutorial.py`'s GAN training loop, multi-minute runtime on CPU). In those cases, prefer a short-timeout run (`timeout 60 python3.10 file.py`) and confirm no `AssertionError` fires before the timeout, plus visual inspection that the assertion site is reachable. Document the limitation in the JUnit Javadoc or commit message so reviewers know.

## Test Plan

- [x] `mvn spotless:check` clean.
- [x] Markdown renders correctly.
- [ ] CI green.

Generated with [Claude Code](https://claude.com/claude-code)
