### PR TITLE
Route `tf.random.truncated_normal` to `TruncatedNormal` via `PROPERTY_NAME_GENERATORS`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2589,6 +2589,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_rsqrt_kwarg.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
+  /**
+   * Regression guard for wala/ML#449's closing fix: {@code tf.random.truncated_normal(shape)} now
+   * dispatches to the {@code TruncatedNormal} generator (via {@code PROPERTY_NAME_GENERATORS}) and
+   * resolves to precise {@code (2, 3) float32}. Pre-fix this fell through to {@code
+   * ReadDataFallback} and emitted {@code ⊤ shape / UNKNOWN dtype}.
+   */
+  @Test
+  public void testTruncatedNormal()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_truncated_normal.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
   @Test
   public void testLogSoftmax()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -181,6 +181,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TOP_K;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRACE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM_OP;
@@ -262,7 +263,15 @@ public class TensorGeneratorFactory {
    * property reads. See wala/ML#356 for the broader context.
    */
   private static final Map<String, Function<PointsToSetVariable, TensorGenerator>>
-      PROPERTY_NAME_GENERATORS = Map.ofEntries(entry(ASTYPE_METHOD_NAME, AstypeOperation::new));
+      PROPERTY_NAME_GENERATORS =
+          Map.ofEntries(
+              entry(ASTYPE_METHOD_NAME, AstypeOperation::new),
+              // wala/ML#449: `tf.random.truncated_normal(...)` doesn't reach the per-class
+              // `isType` checks because `calledFunction` resolves to generic `LCodeBody`
+              // rather than the specific `TRUNCATED_NORMAL`/`TRUNCATED_NORMAL_OP` class.
+              // Duck-typing the property name catches it before the `ReadDataFallback`
+              // fallback would.
+              entry(TRUNCATED_NORMAL_METHOD_NAME, TruncatedNormal::new));
 
   /**
    * Resolves the {@link TypeReference} for the function call associated with the given source.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -402,6 +402,9 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String NORMAL_SIGNATURE = "tf.random.normal()";
 
+  /** Method name used in {@code tensorflow.xml} for {@link #TRUNCATED_NORMAL}. */
+  public static final String TRUNCATED_NORMAL_METHOD_NAME = "truncated_normal";
+
   /** https://www.tensorflow.org/api_docs/python/tf/random/truncated_normal. */
   public static final MethodReference TRUNCATED_NORMAL =
       MethodReference.findOrCreate(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_truncated_normal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_truncated_normal.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `tf.random.truncated_normal(shape, ...)` produces a fresh tensor with the
+# given shape and default `float32` dtype. See wala/ML#449: pre-fix this
+# routed through `ReadDataFallback` (the per-class `isType` dispatch missed
+# because `calledFunction` resolved to generic `LCodeBody`); post-fix
+# `PROPERTY_NAME_GENERATORS` catches it via `truncated_normal` →
+# `TruncatedNormal`.
+result = tf.random.truncated_normal([2, 3])
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 3)
+assert result.dtype == tf.float32
+
+f(result)


### PR DESCRIPTION
## Summary

`tf.random.truncated_normal(...)` was the only op still firing `ReadDataFallback` across the entire test suite — 32-33 fires per `mvn -pl com.ibm.wala.cast.python.ml.test test`, all on this one op.

Diagnosis: `TruncatedNormal.java` exists and the per-class `isType` dispatch in `TensorGeneratorFactory.getGenerator` is wired against `TRUNCATED_NORMAL`/`TRUNCATED_NORMAL_OP`, but `calledFunction` for this call resolves to generic `LCodeBody` rather than the specific class — so neither `isType` check matches. The call then fell through to the `read_data`-pattern property-name lookup and got `ReadDataFallback`.

Fix: register `truncated_normal` → `TruncatedNormal::new` in the existing `PROPERTY_NAME_GENERATORS` duck-typed dispatch map. This catches the call earlier in the pipeline via `dispatchByPropertyName(...)`, before the `ReadDataFallback` fallback would fire.

Two changes:

- **`TensorFlowTypes.java`** — new `TRUNCATED_NORMAL_METHOD_NAME = "truncated_normal"` constant alongside the existing `TRUNCATED_NORMAL`/`TRUNCATED_NORMAL_OP` `MethodReference`s, matching `NumpyTypes.ASTYPE_METHOD_NAME`'s precedent.
- **`TensorGeneratorFactory.java`** — register the new entry in `PROPERTY_NAME_GENERATORS`.

Closes https://github.com/wala/ML/issues/449.

## Test Plan

- [x] `mvn -pl com.ibm.wala.cast.python.ml.test test` — full suite (741 in `TestTensorflow2Model` + sibling modules) passes.
- [x] FINE-log sweep: `grep -c 'falling back to generic ⊤-shape'` drops from **33 → 0**. The acceptance criterion "no longer fires for any test" is met.
- [x] `mvn spotless:check` clean.
- [ ] CI green.

## Scope

Removal of `ReadDataFallback`, `getPropertyReadMemberNames`, and `getTensorflowReadDataPropertyNames` is **deferred to https://github.com/wala/ML/issues/461** (the "modeled API without a generator" post-retirement safety-net decision). This PR closes the load-bearing acceptance criterion ("no longer fires") and leaves the deletion question to #461.

Generated with [Claude Code](https://claude.com/claude-code)
