### PR TITLE
Bump WALA to 1.7.2 and migrate `FakeRootMethod` constructor

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
@@ -323,7 +323,7 @@ public class PythonLanguage implements Language {
   @Override
   public AbstractRootMethod getFakeRootMethod(
       IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
-    return new FakeRootMethod(new FakeRootClass(PythonTypes.pythonLoader, cha), options, cache);
+    return new FakeRootMethod(new FakeRootClass(PythonTypes.pythonLoader, cha), cache);
   }
 
   @Override

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
@@ -322,11 +322,17 @@ public class PythonLanguage implements Language {
 
   @Override
   public AbstractRootMethod getFakeRootMethod(
-      IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+      IClassHierarchy cha,
+      @SuppressWarnings("unused") AnalysisOptions options,
+      IAnalysisCacheView cache) {
     // `options` is retained in the signature to satisfy the `Language.getFakeRootMethod`
-    // interface contract (the parent's signature still takes it in WALA 1.7.2), but the
-    // 2-arg `FakeRootMethod(IClass, IAnalysisCacheView)` ctor introduced in 1.7.2 doesn't
-    // consume it. Drop the parameter only if the upstream interface drops it.
+    // interface contract (the parent's signature still takes it in WALA 1.7.2) but is
+    // unused at this call site. WALA's own 1.7.2 source marks the deprecated 3-arg
+    // `FakeRootMethod(IClass, AnalysisOptions, IAnalysisCacheView)` constructor's
+    // `options` parameter with the same `@SuppressWarnings("unused")` and the
+    // deprecation Javadoc explicitly says the rationale is "to remove unused options
+    // parameter" — i.e., `options` was always vestigial in this code path. Drop the
+    // parameter on our side only if the upstream `Language` interface drops it.
     return new FakeRootMethod(new FakeRootClass(PythonTypes.pythonLoader, cha), cache);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.version>3.15.0</maven.compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-alias>b000</build-alias>
-    <wala.version>1.7.1</wala.version>
+    <wala.version>1.7.2</wala.version>
     <spotless.version>3.4.0</spotless.version>
     <maven.surefire.version>3.5.5</maven.surefire.version>
     <parallel>both</parallel>


### PR DESCRIPTION
## Summary

Bumps WALA 1.7.1 → 1.7.2 and migrates the call site that the bump breaks. Supersedes Dependabot's https://github.com/ponder-lab/ML/pull/309 (which can only do the version bump, not the migration—and the migration uses an API that doesn't exist in 1.7.1, so they must ship together).

Two changes:

- **`pom.xml`** — `wala.version` 1.7.1 → 1.7.2.
- **`PythonLanguage.java:326`** — drop `options` from the `FakeRootMethod` constructor call. WALA 1.7.2 marks the 3-arg `FakeRootMethod(IClass, AnalysisOptions, IAnalysisCacheView)` constructor as `@Deprecated(forRemoval=true)` and adds a 2-arg replacement `FakeRootMethod(IClass, IAnalysisCacheView)`. With `-Werror`, the deprecation-for-removal warning fails compilation—that's the failure surface on #309.

The `options` parameter on the `getFakeRootMethod` override stays in place (the parent interface mandates it); it's just no longer threaded into the underlying WALA call.

## Bonus

WALA 1.7.2 is the release that publishes `com.ibm.wala.ide` to Maven Central (wala/WALA#1903)—the upstream enabler referenced in the Hybridize-side dependency refactoring (ponder-lab/Hybridize-Functions-Refactoring#474). Landing this unblocks that downstream work.

## Test Plan

- [x] `mvn test` from root passes: 741/0/0/0 in `TestTensorflow2Model` plus sibling suites all green on 1.7.2.
- [x] `mvn spotless:check` clean.
- [ ] CI green.

Generated with [Claude Code](https://claude.com/claude-code)
