### PR TITLE
`Reshape` graceful-degradation for `tf.shape(...)` argument (wala/ML#538)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2169,8 +2169,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * by <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a>; parameter types pin
    * precisely.
    *
-   * <p>TODO: the post-fix local-tensor count of 9 captures every intermediate runtime-shape tensor
-   * flowing through the body. Tighten once the body-level imprecision is addressed.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/543">wala/ML#543</a>): the post-fix
+   * local-tensor count of 9 captures every intermediate runtime-shape tensor flowing through the
+   * body. Tighten once the body-level imprecision is addressed.
    */
   @Test
   public void testTakeAlongAxis()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8221,30 +8221,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
-   * {@code (2, 3)} of {@code float32}. Post this PR's wala/ML#489 root-cause fix (`tensorflow.xml`
-   * allocates a fresh `Ltensorflow/python/framework/ops/Tensor` for `tf.shape(...)` instead of
-   * aliasing through `pass_through`), the helper's else-branch fires cleanly for the unrecognized
-   * allocation type and throws {@link IllegalStateException}. {@link
-   * com.ibm.wala.cast.python.ml.client.Reshape} doesn't localize the catch (unlike {@link
-   * com.ibm.wala.cast.python.ml.client.BroadcastTo}), per this PR's keep-throw-everywhere-except-
-   * BroadcastTo design, so the exception propagates up and aborts the analysis on this fixture.
-   * That's the design choice: missing modeling on `Reshape`'s runtime-tensor shape path surfaces as
-   * a loud signal rather than a silent ⊤.
+   * {@code (2, 3)} of {@code float32}. Post wala/ML#538's graceful-degradation fix in {@link
+   * com.ibm.wala.cast.python.ml.client.Reshape} (mirroring {@link
+   * com.ibm.wala.cast.python.ml.client.BroadcastTo}'s localized try/catch), the analysis no longer
+   * throws on the {@code tf.shape(...)} shape arg. The inferred parameter type for {@code x} (vn=2)
+   * is currently the imprecise union {@code [() of float32, (⊤) of float32]} rather than the
+   * precise {@code (2, 3) float32}.
    *
-   * <p>The {@code expected} types map below ({@code Map.of(2, Set.of(TENSOR_2_3_FLOAT32))}) is
-   * unreachable while the {@code @Test(expected = IllegalStateException.class)} suppression is in
-   * place; it's staged for the eventual flip so that lifting the suppression brings the
-   * precise-shape assertion back without further edits to this method.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): when the helper
-   * learns to recognize {@code tf.shape(y)} as a shape arg (or {@code Reshape} gains a localized
-   * try/catch mirroring {@code BroadcastTo}'s), tighten this test to assert {@link
-   * #TENSOR_2_3_FLOAT32} (or ⊤) and remove the {@code expected} suppression.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): tighten the parameter
+   * type to {@link #TENSOR_2_3_FLOAT32} when the helper learns to resolve {@code tf.shape(y)}'s
+   * shape leaves precisely.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testReshapeRuntimeShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+    test(
+        "tf2_test_reshape_runtime_shape.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32, new TensorType(FLOAT_32, null))));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2165,18 +2165,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * the analysis with {@code IllegalStateException} at {@code
    * TensorGenerator.getShapesFromShapeArgument} because the shape argument is a Tensor (the result
    * of {@code tf.shape(...)}) rather than a list/tuple literal. The {@code Reshape} generator
-   * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing.
+   * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing. Resolved
+   * by <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a>; parameter types pin
+   * precisely.
    *
-   * <p>TODO: once <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the
-   * graceful-degradation fix, remove the {@code expected = IllegalStateException.class} suppression
-   * and pin precise types: {@code arr} (vn=2) should resolve to {@code (2, 3) float32} and {@code
-   * indices} (vn=3) to {@code (2, 2) int32}, matching the caller-side {@code tf.constant} shapes in
-   * {@code tf2_test_take_along_axis.py}.
+   * <p>TODO: the post-fix local-tensor count of 9 captures every intermediate runtime-shape tensor
+   * flowing through the body. Tighten once the body-level imprecision is addressed.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTakeAlongAxis()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of());
+    test(
+        "tf2_test_take_along_axis.py",
+        "_take_long_axis",
+        2,
+        9,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32), 3, Set.of(TENSOR_2_2_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -392,6 +392,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                   // that tensor type propagation continues. The shape may be inaccurate, but users
                   // can inspect the error messages to find out about it. See
                   // https://github.com/wala/ML/issues/195.
+                  if (lhs.state == null) {
+                    lhs.state = HashSetFactory.make();
+                  }
                   changed |= lhs.state.add(newType);
 
                   if (t.symbolicDims() != ssz || t.concreteSize() != csz) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -71,7 +71,19 @@ public class Reshape extends TensorGenerator {
             builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
     if (shapePts != null && !shapePts.isEmpty()) {
-      Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
+      Set<List<Dimension<?>>> rawShapes;
+      try {
+        // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it
+        // doesn't recognize. For `Reshape` specifically, `tf.reshape(arr, tf.shape(other))`
+        // is a common pattern where the shape argument is itself a runtime Tensor (the result
+        // of `tf.shape(...)`), so we tolerate the throw and degrade to ⊤ ("output shape
+        // unknown"). Other callers let the throw propagate as a loud signal that modeling
+        // work is missing. Mirrors the established `BroadcastTo#getDefaultShapes` precedent;
+        // see wala/ML#538 for the surfacing fixture (`tf2_test_take_along_axis.py`).
+        rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
+      } catch (IllegalStateException e) {
+        return null;
+      }
       // Soundness: when the `shape` argument is present but unparseable, the output shape is ⊤
       // (the result is determined by `shape`, not the input tensor — falling back to input-shape
       // inference would be unsound).


### PR DESCRIPTION
## Summary

`tf.reshape(arr, tf.shape(other))` is a common TF idiom (e.g., `_take_long_axis` from `deep_recommenders`). Pre-fix, `Reshape.getShapes` propagated the `IllegalStateException` from `TensorGenerator.getShapesFromShapeArgument`'s strict "unrecognized shape form" check, aborting the entire analysis. The crash was captured by `testTakeAlongAxis`.

Fix: wrap the call site in `Reshape.getShapes` in `try/catch (IllegalStateException) → return null`. Mirrors the established `BroadcastTo#getDefaultShapes` precedent for the same `tf.shape(...)` shape-argument pattern.

The Javadoc on `getShapesFromShapeArgument` distinguishes two failure modes: `null` return = "structure recognized, leaves unresolvable"; `IllegalStateException` = "kind not modeled" (load-bearing as a modeling-gap signal). Per the doc's own guidance, "tolerance to runtime tensors is localized to the one caller where it's the legitimate use case — `BroadcastTo`." This PR adds `Reshape` as a second such legitimate-use-case caller; the global contract is unchanged.

Bundled in (Option A from the original draft): a second-order NPE that the Reshape fix exposed in `TensorTypeAnalysis$ReshapeOp.evaluate`. Pre-fix, the analysis aborted before reaching the dataflow operator. Post-fix, the operator runs and hits `lhs.state.add(newType)` when `lhs.state` is null. Lazy-init the set, mirroring the `nodeOp.evaluate` precedent on the adjacent operator.

`testTakeAlongAxis` and `testReshapeRuntimeShape` flip from `@Test(expected = IllegalStateException.class)` to plain `@Test` with observed-behavior assertions. `testTakeAlongAxis` now pins parameter types precisely (`arr` → `(2, 3) float32`, `indices` → `(2, 2) int32`); its local-tensor count (9) tracks wala/ML#543 for tightening.

Closes wala/ML#538.

## Test Plan

- [x] `mvn spotless:check` clean.
- [x] `mvn test` green (full multi-module run from root).
- [x] `testTakeAlongAxis` passes as a positive regression guard.
- [x] `testReshapeRuntimeShape` passes as a positive regression guard.

Generated with [Claude Code](https://claude.com/claude-code)