### PR TITLE
Validate `JAVA_HOME` (or fall back to `java` on PATH) in `run.sh`

### DIFF
--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -3,6 +3,20 @@
 ME=`realpath $0`
 DIR=`dirname $ME`
 
+# Resolve the `java` executable. Prefer `$JAVA_HOME/bin/java` when `JAVA_HOME` is
+# set (the common case for IDE-launched LSP); fall back to `java` on `PATH` when
+# it isn't. Pre-fix the script unconditionally referenced `$JAVA_HOME/bin/java`,
+# which expanded to `/bin/java` if `JAVA_HOME` was unset (almost always fails).
+# See https://github.com/wala/ML/issues/542.
+if [ -n "$JAVA_HOME" ]; then
+  JAVA="$JAVA_HOME/bin/java"
+elif command -v java >/dev/null 2>&1; then
+  JAVA=java
+else
+  echo "no \`java\` executable found: set \`JAVA_HOME\` or add \`java\` to PATH." >&2
+  exit 1
+fi
+
 # Locate the fat classifier JAR (built by `mvn package` per
 # https://github.com/wala/ML/issues/525). Glob avoids version-pinning
 # brittleness—the previous hardcoded `0.40.0-SNAPSHOT` path fell ~5 minor
@@ -23,4 +37,4 @@ fi
 
 JAR="${JARS[0]}"
 
-cat -u | tee -a /tmp/lsp.in.log | $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar "$JAR" --mode stdio | tee -a /tmp/lsp.out.log
+cat -u | tee -a /tmp/lsp.in.log | "$JAVA" -Xdebug -Xrunjdwp:transport=dt_socket,address=127.0.0.1:6660,server=y,suspend=n -jar "$JAR" --mode stdio | tee -a /tmp/lsp.out.log


### PR DESCRIPTION
## Summary

Pre-fix, `run.sh` unconditionally invoked `$JAVA_HOME/bin/java`. If `JAVA_HOME` is unset, the expansion is `/bin/java`, which fails on most systems with a "command not found" that doesnt tell the user how to fix it.

Resolve `java` once at the top of the script:

- If `$JAVA_HOME` is set, use `$JAVA_HOME/bin/java` (the common case for IDE-launched LSP servers).
- Else, if `java` is on `PATH`, use that.
- Else, fail fast with a clear message naming both fix paths.

Also quotes `"$JAVA"` at the invocation site so the path survives spaces.

Closes https://github.com/wala/ML/issues/542.

## Test Plan

- [x] `bash -n run.sh` syntax clean.
- [x] `mvn spotless:check` clean.
- [ ] CI green.

Generated with [Claude Code](https://claude.com/claude-code)