### PR TITLE
Sanitize Javadoc and fixture comments

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2099,19 +2099,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Pins {@code generator_loss(fake_output)}'s parameter type for the input-signature-inference
-   * empirical pass (issue <a
-   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
-   * {@code fake_output} flows from {@code discriminator(generated_images, ...)}; runtime shape is
-   * {@code (batch, 1) float32} since the discriminator ends with a {@code Dense(1)} layer.
+   * Pins {@code generator_loss(fake_output)}'s parameter type. {@code fake_output} flows from
+   * {@code discriminator(generated_images, ...)}; runtime shape is {@code (batch, 1) float32} since
+   * the discriminator ends with a {@code Dense(1)} layer.
    *
    * <p>Empirically, {@code fake_output} is inferred as {@code (None, 100) float32}. The dtype is
-   * concrete (the load-bearing axis for {@code @tf.function(input_signature=[...])}), which
-   * confirms the layer-output-parameter pattern works on the dtype axis. The shape is
-   * mis-propagated: {@code 100} is the generator's noise input dim (from {@code
+   * concrete, which confirms the layer-output-parameter pattern works on the dtype axis. The shape
+   * is mis-propagated: {@code 100} is the generator's noise input dim (from {@code
    * tf.keras.Input((100,))} in {@code make_generator_model}), not the discriminator's {@code
-   * Dense(1)} output dim. The mis-routing is shape-only and orthogonal to dtype-axis
-   * input-signature emission.
+   * Dense(1)} output dim. The mis-routing is shape-only and orthogonal to dtype-axis precision.
    *
    * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}} once <a
    * href="https://github.com/wala/ML/issues/537">wala/ML#537</a> lands the shape propagation
@@ -2131,21 +2127,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Pins {@code top_p_logits(logits, p)}'s parameter type for the input-signature-inference
-   * empirical pass (issue <a
-   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
-   * Function body mirrors {@code akanyaani/gpt-2-tensorflow2.0/sample.py}'s {@code top_p_logits}, a
-   * function the previous paper's Hybridize tool refactored with {@code @tf.function}. Exercises
-   * several ops currently routed through {@code ReadDataFallback} per wala/ML#449 ({@code tf.sort},
-   * {@code tf.cumsum}, {@code tf.stack}, {@code tf.range}, {@code tf.gather_nd}, {@code tf.where}),
-   * but the parameter type of {@code logits} comes from its caller (a {@code tf.constant} with
-   * shape {@code (1, 5)} dtype {@code float32}), so this test isolates the caller-side propagation
-   * rather than the body's op precision.
+   * Pins {@code top_p_logits(logits, p)}'s parameter type. Function body mirrors {@code
+   * akanyaani/gpt-2-tensorflow2.0/sample.py}'s {@code top_p_logits}. Exercises several ops
+   * currently routed through {@code ReadDataFallback} per wala/ML#449 ({@code tf.sort}, {@code
+   * tf.cumsum}, {@code tf.stack}, {@code tf.range}, {@code tf.gather_nd}, {@code tf.where}), but
+   * the parameter type of {@code logits} comes from its caller (a {@code tf.constant} with shape
+   * {@code (1, 5)} dtype {@code float32}), so this test isolates caller-side propagation rather
+   * than the body's op precision.
    *
    * <p>Empirically, {@code logits} is inferred as {@code (1, 5) float32} — concrete on both axes.
-   * The caller's {@code tf.constant([[1.0, ..., 5.0]], dtype=tf.float32)} flows in cleanly. This
-   * means none of the body's {@code ReadDataFallback}-routed ops actually block input-signature
-   * inference for this function; the parameter type is fully resolved at the call site.
+   * The caller's {@code tf.constant([[1.0, ..., 5.0]], dtype=tf.float32)} flows in cleanly, showing
+   * that none of the body's {@code ReadDataFallback}-routed ops block caller-side propagation for
+   * this function; the parameter type is fully resolved at the call site.
    */
   @Test
   public void testTopPLogits()
@@ -2154,12 +2147,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Pins {@code _take_long_axis(arr, indices)}'s parameter types for the input-signature-inference
-   * empirical pass (issue <a
-   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
-   * Function body mirrors {@code _take_long_axis} from {@code
-   * LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py}, a function the
-   * previous paper's Hybridize tool refactored with {@code @tf.function}.
+   * Pins {@code _take_long_axis(arr, indices)}'s parameter types. Function body mirrors {@code
+   * _take_long_axis} from {@code
+   * LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py}.
    *
    * <p>This fixture surfaced a real Ariadne bug: {@code tf.reshape(arr, tf.shape(other))} crashes
    * the analysis with {@code IllegalStateException} at {@code
@@ -2180,22 +2170,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Pins {@code multilayer_perceptron(x)}'s parameter type for the input-signature-inference
-   * empirical pass (issue <a
-   * href="https://github.com/ponder-lab/Input-Signature-Inference-Paper/issues/22">ponder-lab/Input-Signature-Inference-Paper#22</a>).
-   * Function body mirrors {@code multilayer_perceptron} from {@code
-   * YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py}, a function the
-   * previous paper's Hybridize tool refactored with {@code @tf.function}. Uses raw {@code
+   * Pins {@code multilayer_perceptron(x)}'s parameter type. Function body mirrors {@code
+   * multilayer_perceptron} from {@code
+   * YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py}. Uses raw {@code
    * tf.matmul} / {@code tf.add} / {@code tf.nn.sigmoid} / {@code tf.nn.softmax} against global
    * {@code tf.Variable} weights and biases — a different pattern from the {@code Dense}-layer
    * subclass-Model approach already covered by {@code testNeuralNetwork*}.
    *
-   * <p>Empirically, {@code x} is inferred as {@code ⊤ shape / UNKNOWN dtype} — the first
-   * load-bearing UNKNOWN-dtype the empirical pass has surfaced for input-signature inference. The
-   * dtype axis is the load-bearing one per the audit's definition, so this function would NOT be
-   * input-signature-emittable on current master. Root cause confirmed via {@link
-   * #testConstantFromNumpy}: the {@code numpy → tf.constant} dtype-loss bug, tracked as <a
-   * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>. The caller's {@code batch_x =
+   * <p>Empirically, {@code x} is inferred as {@code ⊤ shape / UNKNOWN dtype}. Root cause confirmed
+   * via {@link #testConstantFromNumpy}: the {@code numpy → tf.constant} dtype-loss bug, tracked as
+   * <a href="https://github.com/wala/ML/issues/539">wala/ML#539</a>. The caller's {@code batch_x =
    * tf.constant(np.ones((100, 784), dtype=np.float32))} loses dtype through the numpy boundary, so
    * {@code x} arrives with UNKNOWN dtype.
    *
@@ -5721,8 +5705,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   // Tier-A pure-passthrough math ops (wala/ML#422). Each is shape and dtype passthrough on `x`;
   // routes to a per-op subclass of `PassThroughUnaryTensorGenerator`. The point of dedicated
   // generators (vs. leaving these on `ReadDataFallback`) is dtype propagation: without these,
-  // `tf.math.sqrt(x)` etc. produce ⊤/UNKNOWN, blocking downstream input-signature inference
-  // through any function whose parameters flow from these ops.
+  // `tf.math.sqrt(x)` etc. produce ⊤/UNKNOWN, blocking downstream dtype-axis precision through
+  // any function whose parameters flow from these ops.
 
   /**
    * Pure passthrough on {@code x}. See {@link com.ibm.wala.cast.python.ml.client.Sqrt}.

--- a/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_numpy.py
@@ -1,9 +1,7 @@
 # Minimal fixture isolating the `numpy → tf.constant` dtype-loss bug
-# (wala/ML#539) surfaced by the multilayer_perceptron empirical-pass finding
-# (ponder-lab/Input-Signature-Inference-Paper#22). Ariadne loses dtype info
-# when a tensor is constructed via `tf.constant(np_array)` rather than from
-# a literal Python list/scalar or a modeled API (mnist load_data, Dense
-# layer chain, etc.).
+# (wala/ML#539). Ariadne loses dtype info when a tensor is constructed via
+# `tf.constant(np_array)` rather than from a literal Python list/scalar or a
+# modeled API (mnist load_data, Dense layer chain, etc.).
 import numpy as np
 import tensorflow as tf
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_multilayer_perceptron.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_multilayer_perceptron.py
@@ -1,7 +1,5 @@
-# Minimal fixture for the input-signature-inference empirical pass
-# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `multilayer_perceptron`
-# from `YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py`
-# — a function the previous paper's Hybridize tool refactored with `@tf.function`.
+# Minimal fixture mirroring `multilayer_perceptron` from
+# `YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py`.
 # Uses raw `tf.matmul`/`tf.add`/`tf.nn.sigmoid` instead of Keras `Dense` layers,
 # with global weight/bias `tf.Variable`s — a different pattern from the
 # `NeuralNet.call` cases already covered by `testNeuralNetwork*`.

--- a/com.ibm.wala.cast.python.test/data/tf2_test_take_along_axis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_take_along_axis.py
@@ -1,7 +1,5 @@
-# Minimal fixture for the input-signature-inference empirical pass
-# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `_take_long_axis`
-# from `LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py`
-# — a function the previous paper's Hybridize tool refactored with `@tf.function`.
+# Minimal fixture mirroring `_take_long_axis` from
+# `LongmaoTeamTf/deep_recommenders/keras/models/retrieval/factorized_top_k.py`.
 # Tests caller-side type propagation when the function takes two tensor params
 # (`arr` and `indices`) with different dtypes (float32 and int32).
 import tensorflow as tf

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_p_logits.py
@@ -1,11 +1,10 @@
-# Minimal fixture for the input-signature-inference empirical pass
-# (ponder-lab/Input-Signature-Inference-Paper#22). Mirrors `top_p_logits` from
-# akanyaani/gpt-2-tensorflow2.0/sample.py — a function the previous paper's
-# Hybridize tool refactored with `@tf.function`. This fixture's purpose is to
-# let Ariadne's `TestTensorflow2Model` test pin the inferred parameter type
-# for `logits` and observe whether ops in the body (tf.sort, tf.cumsum,
-# tf.stack, tf.range, tf.gather_nd, tf.where) are load-bearing on the dtype
-# axis for input-signature emission.
+# Minimal fixture mirroring `top_p_logits` from
+# `akanyaani/gpt-2-tensorflow2.0/sample.py`. The function's body exercises
+# several ops currently routed through `ReadDataFallback` per wala/ML#449
+# (`tf.sort`, `tf.cumsum`, `tf.stack`, `tf.range`, `tf.gather_nd`,
+# `tf.where`); the fixture lets `TestTensorflow2Model.testTopPLogits` pin
+# the parameter type of `logits` and verify that body-op precision isn't
+# load-bearing for caller-side type propagation.
 import tensorflow as tf
 
 


### PR DESCRIPTION
The 5 Javadoc blocks on `testGanTutorialGeneratorLoss`, `testTopPLogits`, `testTakeAlongAxis`, `testMultilayerPerceptron`, and `testConstantFromNumpy`, plus the header comments on 4 Python fixtures (`tf2_test_multilayer_perceptron.py`, `tf2_test_take_along_axis.py`, `tf2_test_constant_from_numpy.py`, `tf2_test_top_p_logits.py`), contained cross-references to a private collaborator repository and framing phrasing tied to that work. Those references should not be in public-repo artifacts.

Strip the cross-references and rephrase the framing in purely technical terms—function names, source repositories (the public TF example repos the fixtures mirror), and the wala/ML issues that track the surfaced Ariadne bugs (wala/ML#537, #538, #539). The technical content of each test Javadoc—what the test pins, what is currently imprecise, what the eventual target is—is preserved.

## Test Plan

- [x] `mvn spotless:check` clean.
- [x] All 5 affected tests pass post-rewrite.
- [ ] CI green.

Note: the leaked references remain in git history (commit messages, prior file contents) since rewriting history is not on the table. This PR scrubs the current state of source files, which is what reviewers and casual repo viewers see.

Generated with [Claude Code](https://claude.com/claude-code)
