### PR TITLE
Add `testMlpAccuracy` regression guard

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2213,6 +2213,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins {@code accuracy(y_pred, y_true)}'s parameter types. Function body mirrors {@code accuracy}
+   * from {@code YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py}.
+   * Distinct from {@link #testNeuralNetwork4}'s {@code accuracy} (which is the {@code
+   * Dense}-layer-chain variant from a different repo); this is the raw-{@code tf.matmul} MLP
+   * companion, paired with {@link #testMultilayerPerceptron}.
+   *
+   * <p>Empirically, both parameters are concrete: {@code y_pred} (vn=2) is {@code (2, 2) float32}
+   * and {@code y_true} (vn=3) is {@code (2,) int64}, matching the caller-side {@code tf.constant}
+   * shapes.
+   */
+  @Test
+  public void testMlpAccuracy()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_mlp_accuracy.py",
+        "accuracy",
+        2,
+        7,
+        Map.of(2, Set.of(TENSOR_2_2_FLOAT32), 3, Set.of(TENSOR_2_INT64)));
+  }
+
+  /**
    * Isolating regression guard for the {@code numpy → tf.constant} dtype-loss bug (<a
    * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>), surfaced from {@link
    * #testMultilayerPerceptron}. {@code consume(x)} where {@code x = tf.constant(np.ones((2, 3),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_mlp_accuracy.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_mlp_accuracy.py
@@ -1,0 +1,24 @@
+# Minimal fixture for `tf2_test_multilayer_perceptron.py`'s companion
+# function. Mirrors `accuracy` from
+# `YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py`.
+# Distinct from `neural_network.py`'s `accuracy` (Dense-layer-chain variant
+# from a different repo, covered by `testNeuralNetwork4`); this is the
+# raw-`tf.matmul` MLP companion.
+import tensorflow as tf
+
+
+def accuracy(y_pred, y_true):
+    correct_prediction = tf.equal(tf.argmax(y_pred, 1), tf.cast(y_true, tf.int64))
+    return tf.reduce_mean(tf.cast(correct_prediction, tf.float32), axis=-1)
+
+
+# Driver: shapes mirror `multilayer_perceptron`'s output (batch, num_classes).
+y_pred = tf.constant([[0.1, 0.9], [0.7, 0.3]], dtype=tf.float32)
+y_true = tf.constant([1, 0], dtype=tf.int64)
+
+assert y_pred.shape == (2, 2)
+assert y_pred.dtype == tf.float32
+assert y_true.shape == (2,)
+assert y_true.dtype == tf.int64
+
+accuracy(y_pred, y_true)


### PR DESCRIPTION
Pins `accuracy(y_pred, y_true)` from `YunYang1994/TensorFlow2.0-Examples/2-Basical_Models/Multilayer_Perceptron.py`. Distinct from `testNeuralNetwork4`'s `accuracy` (the `Dense`-layer-chain variant from a different repo); this is the raw-`tf.matmul` MLP companion, paired with the existing `testMultilayerPerceptron`.

Empirically, both parameters resolve concretely:

- `y_pred` (vn=2): `(2, 2) float32`
- `y_true` (vn=3): `(2,) int64`

## Test Plan

- [x] `mvn spotless:check` clean.
- [x] `mvn test -Dtest=TestTensorflow2Model#testMlpAccuracy` passes locally.
- [ ] CI green.

Generated with [Claude Code](https://claude.com/claude-code)