### PR TITLE
Also fall back to PATH `java` when `JAVA_HOME` is set but invalid (wala/ML#542)

### DIFF
--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -8,12 +8,12 @@ DIR=`dirname $ME`
 # it isn't. Pre-fix the script unconditionally referenced `$JAVA_HOME/bin/java`,
 # which expanded to `/bin/java` if `JAVA_HOME` was unset (almost always fails).
 # See https://github.com/wala/ML/issues/542.
-if [ -n "$JAVA_HOME" ]; then
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
   JAVA="$JAVA_HOME/bin/java"
 elif command -v java >/dev/null 2>&1; then
   JAVA=java
 else
-  echo "no \`java\` executable found: set \`JAVA_HOME\` or add \`java\` to PATH." >&2
+  echo "no \`java\` executable found: set \`JAVA_HOME\` to a JDK install (with \`bin/java\` present) or add \`java\` to PATH." >&2
   exit 1
 fi
 

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -15,7 +15,7 @@ if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
 elif command -v java >/dev/null 2>&1; then
   JAVA=java
 else
-  echo "no \`java\` executable found: set \`JAVA_HOME\` to a JDK install (with \`bin/java\` present) or add \`java\` to PATH." >&2
+  echo "no \`java\` executable found: set \`JAVA_HOME\` to a JDK install with an executable \`bin/java\`, or add \`java\` to PATH." >&2
   exit 1
 fi
 

--- a/com.ibm.wala.cast.python.ml/run.sh
+++ b/com.ibm.wala.cast.python.ml/run.sh
@@ -4,9 +4,11 @@ ME=`realpath $0`
 DIR=`dirname $ME`
 
 # Resolve the `java` executable. Prefer `$JAVA_HOME/bin/java` when `JAVA_HOME` is
-# set (the common case for IDE-launched LSP); fall back to `java` on `PATH` when
-# it isn't. Pre-fix the script unconditionally referenced `$JAVA_HOME/bin/java`,
-# which expanded to `/bin/java` if `JAVA_HOME` was unset (almost always fails).
+# set AND points at a JDK with an executable `bin/java` (the common case for
+# IDE-launched LSP); fall back to `java` on `PATH` when `JAVA_HOME` is unset OR
+# set-but-invalid (stale env var, deleted/relocated JDK, switched SDK manager).
+# Pre-fix the script unconditionally referenced `$JAVA_HOME/bin/java`, which
+# expanded to `/bin/java` if `JAVA_HOME` was unset (almost always fails).
 # See https://github.com/wala/ML/issues/542.
 if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
   JAVA="$JAVA_HOME/bin/java"


### PR DESCRIPTION
## Summary

Follow-up to #315. That PR's initial guard used `[ -n "$JAVA_HOME" ]` alone — set `JAVA="$JAVA_HOME/bin/java"` whenever `JAVA_HOME` was non-empty. That misses the case where `JAVA_HOME` points at a broken or deleted JDK install (a real scenario when env vars go stale across uninstall/reinstall, switching SDK managers, or after pruning `.bashrc`). The failure would surface downstream as an opaque exec error rather than landing in the PATH fallback that's already in place.

Tighten the guard to `[ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]` so a malformed `JAVA_HOME` falls through to the PATH lookup. Also sharpen the all-paths-fail error message to mention the "JDK install with `bin/java` present" requirement.

## Test Plan

- [x] `JAVA_HOME` unset → PATH lookup, then error.
- [x] `JAVA_HOME` set to valid JDK → `$JAVA_HOME/bin/java`.
- [x] `JAVA_HOME` set but path invalid → PATH fallback, then error.
- [x] `JAVA_HOME` set, no PATH `java` → error with the sharpened message.

Generated with [Claude Code](https://claude.com/claude-code)