### PR TITLE
Add identity `hashCode` to `PythonSummarizedFunction` (wala/ML#477)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2169,8 +2169,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * by <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a>; parameter types pin
    * precisely.
    *
-   * <p>TODO: the post-fix local-tensor count of 9 captures every intermediate runtime-shape tensor
-   * flowing through the body. Tighten once the body-level imprecision is addressed.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/543">wala/ML#543</a>): the post-fix
+   * local-tensor count of 9 captures every intermediate runtime-shape tensor flowing through the
+   * body. Tighten once the body-level imprecision is addressed.
    */
   @Test
   public void testTakeAlongAxis()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8221,30 +8221,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
-   * {@code (2, 3)} of {@code float32}. Post this PR's wala/ML#489 root-cause fix (`tensorflow.xml`
-   * allocates a fresh `Ltensorflow/python/framework/ops/Tensor` for `tf.shape(...)` instead of
-   * aliasing through `pass_through`), the helper's else-branch fires cleanly for the unrecognized
-   * allocation type and throws {@link IllegalStateException}. {@link
-   * com.ibm.wala.cast.python.ml.client.Reshape} doesn't localize the catch (unlike {@link
-   * com.ibm.wala.cast.python.ml.client.BroadcastTo}), per this PR's keep-throw-everywhere-except-
-   * BroadcastTo design, so the exception propagates up and aborts the analysis on this fixture.
-   * That's the design choice: missing modeling on `Reshape`'s runtime-tensor shape path surfaces as
-   * a loud signal rather than a silent ⊤.
+   * {@code (2, 3)} of {@code float32}. Post wala/ML#538's graceful-degradation fix in {@link
+   * com.ibm.wala.cast.python.ml.client.Reshape} (mirroring {@link
+   * com.ibm.wala.cast.python.ml.client.BroadcastTo}'s localized try/catch), the analysis no longer
+   * throws on the {@code tf.shape(...)} shape arg. The inferred parameter type for {@code x} (vn=2)
+   * is currently the imprecise union {@code [() of float32, (⊤) of float32]} rather than the
+   * precise {@code (2, 3) float32}.
    *
-   * <p>The {@code expected} types map below ({@code Map.of(2, Set.of(TENSOR_2_3_FLOAT32))}) is
-   * unreachable while the {@code @Test(expected = IllegalStateException.class)} suppression is in
-   * place; it's staged for the eventual flip so that lifting the suppression brings the
-   * precise-shape assertion back without further edits to this method.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): when the helper
-   * learns to recognize {@code tf.shape(y)} as a shape arg (or {@code Reshape} gains a localized
-   * try/catch mirroring {@code BroadcastTo}'s), tighten this test to assert {@link
-   * #TENSOR_2_3_FLOAT32} (or ⊤) and remove the {@code expected} suppression.
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): tighten the parameter
+   * type to {@link #TENSOR_2_3_FLOAT32} when the helper learns to resolve {@code tf.shape(y)}'s
+   * shape leaves precisely.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testReshapeRuntimeShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_reshape_runtime_shape.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+    test(
+        "tf2_test_reshape_runtime_shape.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32, new TensorType(FLOAT_32, null))));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2165,18 +2165,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * the analysis with {@code IllegalStateException} at {@code
    * TensorGenerator.getShapesFromShapeArgument} because the shape argument is a Tensor (the result
    * of {@code tf.shape(...)}) rather than a list/tuple literal. The {@code Reshape} generator
-   * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing.
+   * should gracefully degrade to ⊤ shape per the lattice conventions instead of throwing. Resolved
+   * by <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a>; parameter types pin
+   * precisely.
    *
-   * <p>TODO: once <a href="https://github.com/wala/ML/issues/538">wala/ML#538</a> lands the
-   * graceful-degradation fix, remove the {@code expected = IllegalStateException.class} suppression
-   * and pin precise types: {@code arr} (vn=2) should resolve to {@code (2, 3) float32} and {@code
-   * indices} (vn=3) to {@code (2, 2) int32}, matching the caller-side {@code tf.constant} shapes in
-   * {@code tf2_test_take_along_axis.py}.
+   * <p>TODO: the post-fix local-tensor count of 9 captures every intermediate runtime-shape tensor
+   * flowing through the body. Tighten once the body-level imprecision is addressed.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testTakeAlongAxis()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_take_along_axis.py", "_take_long_axis", 2, 2, Map.of());
+    test(
+        "tf2_test_take_along_axis.py",
+        "_take_long_axis",
+        2,
+        9,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32), 3, Set.of(TENSOR_2_2_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -392,6 +392,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                   // that tensor type propagation continues. The shape may be inaccurate, but users
                   // can inspect the error messages to find out about it. See
                   // https://github.com/wala/ML/issues/195.
+                  if (lhs.state == null) {
+                    lhs.state = HashSetFactory.make();
+                  }
                   changed |= lhs.state.add(newType);
 
                   if (t.symbolicDims() != ssz || t.concreteSize() != csz) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -71,7 +71,19 @@ public class Reshape extends TensorGenerator {
             builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
     if (shapePts != null && !shapePts.isEmpty()) {
-      Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
+      Set<List<Dimension<?>>> rawShapes;
+      try {
+        // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it
+        // doesn't recognize. For `Reshape` specifically, `tf.reshape(arr, tf.shape(other))`
+        // is a common pattern where the shape argument is itself a runtime Tensor (the result
+        // of `tf.shape(...)`), so we tolerate the throw and degrade to ⊤ ("output shape
+        // unknown"). Other callers let the throw propagate as a loud signal that modeling
+        // work is missing. Mirrors the established `BroadcastTo#getDefaultShapes` precedent;
+        // see wala/ML#538 for the surfacing fixture (`tf2_test_take_along_axis.py`).
+        rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
+      } catch (IllegalStateException e) {
+        return null;
+      }
       // Soundness: when the `shape` argument is present but unparseable, the output shape is ⊤
       // (the result is determined by `shape`, not the input tensor — falling back to input-shape
       // inference would be unsound).

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSummarizedFunction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSummarizedFunction.java
@@ -32,6 +32,11 @@ public class PythonSummarizedFunction extends SummarizedMethodWithNames {
   }
 
   @Override
+  public int hashCode() {
+    return System.identityHashCode(this);
+  }
+
+  @Override
   public InducedCFG makeControlFlowGraph(SSAInstruction[] instructions) {
     return new PythonInducedCFG(instructions, this, Everywhere.EVERYWHERE);
   }


### PR DESCRIPTION
## Summary

Bundles three issues that landed together — the wala/ML#538 reshape graceful-degradation chain (4 commits) plus two adjacent fixes:

- **wala/ML#538** — Reshape graceful degradation: `Reshape.getShapes` now catches `IllegalStateException` from `getShapesFromShapeArgument` (the established "modeling gap" signal, but `tf.reshape(arr, tf.shape(other))` is a legitimate runtime-tensor caller mirroring `BroadcastTo`). A second-order `TensorTypeAnalysis$ReshapeOp.evaluate` NPE surfaced by the catch is fixed via lazy-init on `lhs.state`. The two `@Test(expected = ...)` tests this unblocks (`testTakeAlongAxis`, `testReshapeRuntimeShape`) flip to positive regression guards encoding the observed analysis output.
- **wala/ML#477** — Identity `hashCode` for `PythonSummarizedFunction`: pairs the existing identity-`equals` override with `System.identityHashCode(this)`. CodeQL `java/inconsistent-equals-and-hashcode` (severity: error) flags this on master. Option 1 from the issue body; Option 2 (delete the `equals` override) was rejected because it would broaden equality to the inherited `(declaringClass, method)` field-based semantics — a silent behavior change.
- **wala/ML#543** — TODO anchor wired into `testTakeAlongAxis`'s tightening note for downstream follow-up.

## Per-commit breakdown

| Commit | Issue | Change |
|---|---|---|
| `43089207` | wala/ML#538 | Catch `IllegalStateException` from `getShapesFromShapeArgument` in `Reshape` |
| `4dc4c1a8` | wala/ML#538 | Lazy-init `lhs.state` in `TensorTypeAnalysis$ReshapeOp.evaluate` (second-order NPE surfaced by the catch) |
| `25509020` | wala/ML#538 | Convert `testTakeAlongAxis` to positive regression guard |
| `0ba7ffc5` | wala/ML#538 | Convert `testReshapeRuntimeShape` to positive regression guard |
| `a8cfe3bf` | wala/ML#543 | Wire wala/ML#543 into `testTakeAlongAxis`'s tightening TODO |
| `ce10d7c5` | wala/ML#477 | Add identity `hashCode` to `PythonSummarizedFunction` |

## Test Plan

- [x] `mvn test` green (full multi-module run from root).
- [x] CodeQL alert #60 (`java/inconsistent-equals-and-hashcode` on `PythonSummarizedFunction`) clears on next scan.
- [x] `testTakeAlongAxis` and `testReshapeRuntimeShape` flip from `@Test(expected = ...)` to positive regression guards encoding the observed analysis output.

Closes wala/ML#477.

Generated with [Claude Code](https://claude.com/claude-code)
