### PR TITLE
Introduce `RaggedDim` typed sentinel for ragged dimensions (wala/ML#544)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -253,10 +253,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(
           INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(2)));
 
-  @SuppressWarnings("unused")
-  private static final TensorType TENSOR_2_NONE_NONE_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null));
-
   private static final TensorType TENSOR_2_RAGGED_RAGGED_RAGGED_FLOAT32 =
       new TensorType(
           FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim(), new RaggedDim()));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -31,6 +31,7 @@ import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
@@ -184,23 +185,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_NONE_NONE_STRING =
       new TensorType(STRING, asList(null, null));
 
-  private static final TensorType TENSOR_4_NONE_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), null, null));
+  private static final TensorType TENSOR_4_RAGGED_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_3_NONE_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), null, null));
+  private static final TensorType TENSOR_3_RAGGED_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_4_NONE_NONE_NONE_STRING =
-      new TensorType(STRING, asList(new NumericDim(4), null, null, null));
+  private static final TensorType TENSOR_4_RAGGED_RAGGED_NONE_STRING =
+      new TensorType(STRING, asList(new NumericDim(4), new RaggedDim(), new RaggedDim(), null));
 
-  private static final TensorType TENSOR_3_NONE_NONE_STRING =
-      new TensorType(STRING, asList(new NumericDim(3), null, null));
+  private static final TensorType TENSOR_3_RAGGED_RAGGED_STRING =
+      new TensorType(STRING, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_1_NONE_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), null, null));
+  private static final TensorType TENSOR_1_RAGGED_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_2_NONE_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null, null));
+  private static final TensorType TENSOR_2_RAGGED_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim()));
 
   private static final TensorType TENSOR_2_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(2)));
@@ -217,57 +218,63 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(3)));
 
-  private static final TensorType TENSOR_0_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), null));
+  private static final TensorType TENSOR_0_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim()));
 
-  private static final TensorType TENSOR_0_NONE_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), null, new NumericDim(3)));
+  private static final TensorType TENSOR_0_RAGGED_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim(), new NumericDim(3)));
 
-  private static final TensorType TENSOR_1_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), null));
+  private static final TensorType TENSOR_1_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(1), new RaggedDim()));
 
-  private static final TensorType TENSOR_1_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), null));
+  private static final TensorType TENSOR_1_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim()));
 
   private static final TensorType TENSOR_2_NONE_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), null));
 
-  private static final TensorType TENSOR_2_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), null));
+  private static final TensorType TENSOR_2_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim()));
 
-  private static final TensorType TENSOR_2_NONE_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), null, new NumericDim(2)));
+  private static final TensorType TENSOR_2_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim()));
 
-  private static final TensorType TENSOR_2_NONE_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null, new NumericDim(2)));
+  private static final TensorType TENSOR_2_RAGGED_2_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
 
-  private static final TensorType TENSOR_2_NONE_2_3_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null, new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_2_RAGGED_2_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
 
-  private static final TensorType TENSOR_2_NONE_2_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null, new NumericDim(2), new NumericDim(2)));
+  private static final TensorType TENSOR_2_RAGGED_2_3_INT32 =
+      new TensorType(
+          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(3)));
+
+  private static final TensorType TENSOR_2_RAGGED_2_2_INT32 =
+      new TensorType(
+          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(2)));
 
   @SuppressWarnings("unused")
   private static final TensorType TENSOR_2_NONE_NONE_NONE_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), null));
 
-  private static final TensorType TENSOR_2_NONE_NONE_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), null, null, null));
+  private static final TensorType TENSOR_2_RAGGED_RAGGED_RAGGED_FLOAT32 =
+      new TensorType(
+          FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_3_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), null));
+  private static final TensorType TENSOR_3_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim()));
 
-  private static final TensorType TENSOR_3_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), null));
+  private static final TensorType TENSOR_3_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim()));
 
-  private static final TensorType TENSOR_4_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), null));
+  private static final TensorType TENSOR_4_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim()));
 
-  private static final TensorType TENSOR_3_NONE_NONE_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), null, null));
+  private static final TensorType TENSOR_3_RAGGED_RAGGED_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
 
-  private static final TensorType TENSOR_3_NONE_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), null, new NumericDim(1)));
+  private static final TensorType TENSOR_3_RAGGED_1_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new NumericDim(1)));
 
   private static final TensorType TENSOR_2_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
@@ -296,8 +303,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_5_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5), new NumericDim(5)));
 
-  private static final TensorType TENSOR_5_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5), null));
+  private static final TensorType TENSOR_5_RAGGED_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(5), new RaggedDim()));
 
   private static final TensorType TENSOR_2_3_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));
@@ -3675,7 +3682,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3686,7 +3693,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3697,7 +3704,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3708,7 +3715,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3719,7 +3726,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3730,7 +3737,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_NONE_INT32), 3, Set.of(TENSOR_1_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -3742,7 +3749,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3754,7 +3764,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3766,7 +3779,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3778,7 +3794,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3789,7 +3808,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3800,7 +3819,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3811,7 +3830,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3822,7 +3841,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3833,7 +3852,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3844,7 +3863,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3855,7 +3874,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3866,7 +3885,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_INT32), 3, Set.of(TENSOR_3_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_INT32), 3, Set.of(TENSOR_3_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -3878,7 +3897,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3890,7 +3912,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3902,7 +3927,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3914,7 +3942,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_NONE_NONE_STRING), 3, Set.of(TENSOR_4_NONE_NONE_NONE_STRING)));
+            2,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING),
+            3,
+            Set.of(TENSOR_4_RAGGED_RAGGED_NONE_STRING)));
   }
 
   @Test
@@ -3925,7 +3956,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3936,7 +3967,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3947,7 +3978,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3958,7 +3989,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3969,7 +4000,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3980,7 +4011,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -3991,7 +4022,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -4002,7 +4033,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -4013,7 +4044,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_5_NONE_INT32), 3, Set.of(TENSOR_5_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_5_RAGGED_INT32), 3, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -4024,7 +4055,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32), 3, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32), 3, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4035,7 +4066,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32), 3, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32), 3, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4046,7 +4077,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32), 3, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32), 3, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4058,10 +4089,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_5_NONE_INT32),
-            3, Set.of(TENSOR_5_NONE_INT32),
-            4, Set.of(TENSOR_5_NONE_INT32),
-            5, Set.of(TENSOR_3_NONE_INT32)));
+            2, Set.of(TENSOR_5_RAGGED_INT32),
+            3, Set.of(TENSOR_5_RAGGED_INT32),
+            4, Set.of(TENSOR_5_RAGGED_INT32),
+            5, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -4072,7 +4103,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_row_lengths",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4083,7 +4114,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_row_limits",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4095,9 +4126,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         3,
         3,
         Map.of(
-            2, Set.of(TENSOR_4_NONE_INT32),
-            3, Set.of(TENSOR_4_NONE_INT32),
-            4, Set.of(TENSOR_4_NONE_INT32)));
+            2, Set.of(TENSOR_4_RAGGED_INT32),
+            3, Set.of(TENSOR_4_RAGGED_INT32),
+            4, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test
@@ -4108,7 +4139,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_strictness",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_INT32)));
   }
 
   @Test
@@ -4126,10 +4157,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_2_NONE_NONE_INT32),
-            3, Set.of(TENSOR_2_NONE_NONE_INT32),
-            4, Set.of(TENSOR_2_NONE_NONE_INT32),
-            5, Set.of(TENSOR_2_NONE_NONE_INT32)));
+            2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32),
+            3, Set.of(TENSOR_2_RAGGED_RAGGED_INT32),
+            4, Set.of(TENSOR_2_RAGGED_RAGGED_INT32),
+            5, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -4141,10 +4172,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_5_NONE_INT32),
-            3, Set.of(TENSOR_4_NONE_INT32),
-            4, Set.of(TENSOR_4_NONE_INT32),
-            5, Set.of(TENSOR_5_NONE_INT32)));
+            2, Set.of(TENSOR_5_RAGGED_INT32),
+            3, Set.of(TENSOR_4_RAGGED_INT32),
+            4, Set.of(TENSOR_4_RAGGED_INT32),
+            5, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
@@ -4156,10 +4187,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_2_NONE_INT32),
-            3, Set.of(TENSOR_2_NONE_INT32),
-            4, Set.of(TENSOR_2_NONE_INT32),
-            5, Set.of(TENSOR_3_NONE_INT32)));
+            2, Set.of(TENSOR_2_RAGGED_INT32),
+            3, Set.of(TENSOR_2_RAGGED_INT32),
+            4, Set.of(TENSOR_2_RAGGED_INT32),
+            5, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -4171,10 +4202,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_2_NONE_INT32),
-            3, Set.of(TENSOR_2_NONE_INT32),
-            4, Set.of(TENSOR_2_NONE_INT32),
-            5, Set.of(TENSOR_3_NONE_INT32)));
+            2, Set.of(TENSOR_2_RAGGED_INT32),
+            3, Set.of(TENSOR_2_RAGGED_INT32),
+            4, Set.of(TENSOR_2_RAGGED_INT32),
+            5, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -4188,15 +4219,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             // rt1: positional values, keyword value_rowids. inferred nrows=3.
             2,
-            Set.of(TENSOR_3_NONE_INT32),
+            Set.of(TENSOR_3_RAGGED_INT32),
 
             // rt2: positional values, keyword value_rowids, keyword nrows=5.
             3,
-            Set.of(TENSOR_5_NONE_INT32),
+            Set.of(TENSOR_5_RAGGED_INT32),
 
             // rt3: positional values, positional value_rowids, keyword nrows=3.
             4,
-            Set.of(TENSOR_3_NONE_INT32)));
+            Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -4209,7 +4240,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         Map.of(
             // rt: positional values, positional value_rowids, positional nrows=3.
-            2, Set.of(TENSOR_3_NONE_INT32)));
+            2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -5567,13 +5598,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testGradient()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gradient.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));
+    test("tf2_test_gradient.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_FLOAT32)));
   }
 
   @Test
   public void testGradient2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gradient2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));
+    test("tf2_test_gradient2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_FLOAT32)));
   }
 
   /**
@@ -8978,22 +9009,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testRaggedConstant() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_constant.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedConstant2() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_constant2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedConstant3() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant3.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_INT32)));
+    test("tf2_test_ragged_constant3.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedConstant4() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant4.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_NONE_FLOAT32)));
+    test("tf2_test_ragged_constant4.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_FLOAT32)));
   }
 
   @Test
@@ -9003,7 +9034,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_NONE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_RAGGED_FLOAT32)));
   }
 
   @Test
@@ -9013,52 +9044,57 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testRaggedConstant7() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_constant7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedConstant8() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant8.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_FLOAT32)));
+    test("tf2_test_ragged_constant8.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant9() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant9.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_NONE_FLOAT32)));
+    test(
+        "tf2_test_ragged_constant9.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant10() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant10.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_1_FLOAT32)));
+    test("tf2_test_ragged_constant10.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_1_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant11() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant11.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));
+    test("tf2_test_ragged_constant11.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant12() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant12.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_2_FLOAT32)));
+    test("tf2_test_ragged_constant12.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_2_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant13() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant13.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_0_NONE_FLOAT32)));
+    test("tf2_test_ragged_constant13.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_0_RAGGED_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant14() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant14.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_0_NONE_3_FLOAT32)));
+    test("tf2_test_ragged_constant14.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_0_RAGGED_3_FLOAT32)));
   }
 
   @Test
   public void testRaggedConstant15() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant15.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_2_INT32)));
+    test("tf2_test_ragged_constant15.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_2_INT32)));
   }
 
   @Test
   public void testRaggedConstant16() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant16.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_2_INT32)));
+    test("tf2_test_ragged_constant16.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_2_INT32)));
   }
 
   /**
@@ -9068,13 +9104,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    */
   @Test(expected = AssertionError.class)
   public void testRaggedConstant17() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant17.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_2_3_INT32)));
+    test("tf2_test_ragged_constant17.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_2_3_INT32)));
   }
 
   /** This one works because the inner dimensions are uniform. */
   @Test
   public void testRaggedConstant18() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_constant18.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_NONE_2_2_INT32)));
+    test("tf2_test_ragged_constant18.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_RAGGED_2_2_INT32)));
   }
 
   @Test
@@ -9086,9 +9122,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         3,
         3,
         Map.of(
-            2, Set.of(TENSOR_2_NONE_INT32),
-            3, Set.of(TENSOR_2_NONE_INT32),
-            4, Set.of(TENSOR_2_NONE_INT32)));
+            2, Set.of(TENSOR_2_RAGGED_INT32),
+            3, Set.of(TENSOR_2_RAGGED_INT32),
+            4, Set.of(TENSOR_2_RAGGED_INT32)));
   }
 
   @Test
@@ -9100,44 +9136,44 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         3,
         3,
         Map.of(
-            2, Set.of(TENSOR_5_NONE_INT32),
-            3, Set.of(TENSOR_5_NONE_INT32),
-            4, Set.of(TENSOR_5_NONE_INT32)));
+            2, Set.of(TENSOR_5_RAGGED_INT32),
+            3, Set.of(TENSOR_5_RAGGED_INT32),
+            4, Set.of(TENSOR_5_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_NONE_INT32)));
+    test("tf2_test_ragged_range.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange2() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_NONE_INT32)));
+    test("tf2_test_ragged_range2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange3() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range3.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_range3.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange4() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range4.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_range4.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange5() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range5.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_range5.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange6() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range6.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_range6.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
   public void testRaggedRange7() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_NONE_INT32)));
+    test("tf2_test_ragged_range7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
   @Test
@@ -9149,11 +9185,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         5,
         5,
         Map.of(
-            2, Set.of(TENSOR_1_NONE_INT32),
-            3, Set.of(TENSOR_1_NONE_INT32),
-            4, Set.of(TENSOR_1_NONE_INT32),
-            5, Set.of(TENSOR_1_NONE_INT32),
-            6, Set.of(TENSOR_1_NONE_INT32)));
+            2, Set.of(TENSOR_1_RAGGED_INT32),
+            3, Set.of(TENSOR_1_RAGGED_INT32),
+            4, Set.of(TENSOR_1_RAGGED_INT32),
+            5, Set.of(TENSOR_1_RAGGED_INT32),
+            6, Set.of(TENSOR_1_RAGGED_INT32)));
   }
 
   @Test
@@ -9201,7 +9237,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_lengths",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9212,7 +9248,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_lengths_keyword",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9223,7 +9259,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_lengths_keyword2",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9234,7 +9270,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_splits_positional",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9245,7 +9281,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_splits_keyword",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9256,7 +9292,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "test_ragged_from_nested_row_splits_mixed",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9267,7 +9303,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_STRING)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_STRING)));
   }
 
   @Test
@@ -9278,7 +9314,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_STRING)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_STRING)));
   }
 
   @Test
@@ -9289,7 +9325,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_3_NONE_NONE_STRING)));
+        Map.of(2, Set.of(TENSOR_3_RAGGED_RAGGED_STRING)));
   }
 
   @Test
@@ -9300,7 +9336,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9311,7 +9347,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9322,7 +9358,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
   }
 
   @Test
@@ -9333,7 +9369,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_1_NONE_NONE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_RAGGED_FLOAT32)));
   }
 
   @Test
@@ -9344,7 +9380,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_1_NONE_NONE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_RAGGED_FLOAT32)));
   }
 
   @Test
@@ -9355,7 +9391,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_rt",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_1_NONE_NONE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_1_RAGGED_RAGGED_FLOAT32)));
   }
 
   @Test
@@ -9367,7 +9403,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_1",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
 
     // check_case_2: [4, None], int32
     test(
@@ -9375,7 +9411,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_2",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
 
     // check_case_3: [4, None], int32
     test(
@@ -9383,7 +9419,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_3",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
 
     // check_case_4: [4, None], int32
     test(
@@ -9391,7 +9427,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_4",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
 
     // check_case_5: [2, None, None], int32
     test(
@@ -9399,7 +9435,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_5",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_RAGGED_INT32)));
 
     // check_case_6: [2, None], float32
     test(
@@ -9407,7 +9443,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_6",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_2_NONE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_2_RAGGED_FLOAT32)));
 
     // check_case_7: [4, None], int32
     test(
@@ -9415,7 +9451,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "check_case_7",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_NONE_INT32)));
+        Map.of(2, Set.of(TENSOR_4_RAGGED_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -186,22 +186,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(STRING, asList(null, null));
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_NONE_STRING =
-      new TensorType(STRING, asList(new NumericDim(4), new RaggedDim(), new RaggedDim(), null));
+      new TensorType(
+          STRING, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, null));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_STRING =
-      new TensorType(STRING, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(STRING, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_1_RAGGED_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim(), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(1), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(2)));
@@ -219,58 +220,61 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(3)));
 
   private static final TensorType TENSOR_0_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(0), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_0_RAGGED_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim(), new NumericDim(3)));
+      new TensorType(FLOAT_32, asList(new NumericDim(0), RaggedDim.INSTANCE, new NumericDim(3)));
 
   private static final TensorType TENSOR_1_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(1), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_1_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(1), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_NONE_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), null));
 
   private static final TensorType TENSOR_2_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
+      new TensorType(FLOAT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_2_3_INT32 =
       new TensorType(
-          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(3)));
+          INT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2), new NumericDim(3)));
 
   private static final TensorType TENSOR_2_RAGGED_2_2_INT32 =
       new TensorType(
-          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(2)));
+          INT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2), new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_RAGGED_RAGGED_FLOAT32 =
       new TensorType(
-          FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim(), new RaggedDim()));
+          FLOAT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(3), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_4_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(4), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new NumericDim(1)));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, new NumericDim(1)));
 
   private static final TensorType TENSOR_2_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
@@ -300,7 +304,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(INT_32, asList(new NumericDim(5), new NumericDim(5)));
 
   private static final TensorType TENSOR_5_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(5), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_3_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -429,7 +429,7 @@ public class RaggedConstant extends Constant {
           // The first R dimensions are ragged.
           // Dim 1 to R: These are assigned None (or ? in older outputs) in the static shape,
           // indicating they can vary.
-          for (long i = 0L; i < R; i++) shape.add(new RaggedDim());
+          for (long i = 0L; i < R; i++) shape.add(RaggedDim.INSTANCE);
 
           // Part B: The Uniform Portion (Dimensions R + 1 to K)
           // If R < K - 1 (meaning you requested fewer ragged dimensions than the total depth),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -15,6 +15,7 @@ import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
@@ -428,7 +429,7 @@ public class RaggedConstant extends Constant {
           // The first R dimensions are ragged.
           // Dim 1 to R: These are assigned None (or ? in older outputs) in the static shape,
           // indicating they can vary.
-          for (Long i = 0L; i < R; i++) shape.add(null); // Unknown size for ragged dimensions.
+          for (Long i = 0L; i < R; i++) shape.add(new RaggedDim());
 
           // Part B: The Uniform Portion (Dimensions R + 1 to K)
           // If R < K - 1 (meaning you requested fewer ragged dimensions than the total depth),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -429,7 +429,7 @@ public class RaggedConstant extends Constant {
           // The first R dimensions are ragged.
           // Dim 1 to R: These are assigned None (or ? in older outputs) in the static shape,
           // indicating they can vary.
-          for (Long i = 0L; i < R; i++) shape.add(new RaggedDim());
+          for (long i = 0L; i < R; i++) shape.add(new RaggedDim());
 
           // Part B: The Uniform Portion (Dimensions R + 1 to K)
           // If R < K - 1 (meaning you requested fewer ragged dimensions than the total depth),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.core.util.strings.Atom;
@@ -177,9 +178,9 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
           // First dimension is nrows (length of first list in nested_row_lengths)
           shape.add(rowDim);
 
-          // Then K ragged dimensions (represented as null)
+          // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(null);
+            shape.add(new RaggedDim());
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -180,7 +180,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
 
           // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(new RaggedDim());
+            shape.add(RaggedDim.INSTANCE);
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -280,7 +280,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
 
           // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(new RaggedDim());
+            shape.add(RaggedDim.INSTANCE);
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -17,6 +17,7 @@ import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -277,9 +278,9 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
           // First dimension
           shape.add(rowDim);
 
-          // Then K ragged dimensions
+          // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(null);
+            shape.add(new RaggedDim());
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -166,7 +167,7 @@ public class RaggedRange extends Range {
         // Return 2D ragged tensor shape
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(vectorLength != null ? vectorLength : -1));
-        shape.add(null); // Ragged dimension
+        shape.add(new RaggedDim());
         ret.add(shape);
       } else {
         // All scalars.
@@ -174,7 +175,7 @@ public class RaggedRange extends Range {
         // e.g. tf.ragged.range(3, 18, 3) -> [[3, 6, 9, 12, 15]]
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(1));
-        shape.add(null); // Ragged dimension
+        shape.add(new RaggedDim());
         ret.add(shape);
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -167,7 +167,7 @@ public class RaggedRange extends Range {
         // Return 2D ragged tensor shape
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(vectorLength != null ? vectorLength : -1));
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       } else {
         // All scalars.
@@ -175,7 +175,7 @@ public class RaggedRange extends Range {
         // e.g. tf.ragged.range(3, 18, 3) -> [[3, 6, 9, 12, 15]]
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(1));
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -56,7 +56,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (Dimension<?> rowDim : possibleRowDims) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       }
       LOGGER.fine(
@@ -69,7 +69,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (List<Dimension<?>> valShape : valuesShapes) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
 
         if (valShape.size() > 1) {
           shape.addAll(valShape.subList(1, valShape.size()));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -55,7 +56,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (Dimension<?> rowDim : possibleRowDims) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(null); // Ragged dimension
+        shape.add(new RaggedDim());
         ret.add(shape);
       }
       LOGGER.fine(
@@ -68,7 +69,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (List<Dimension<?>> valShape : valuesShapes) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(null); // Ragged dimension
+        shape.add(new RaggedDim());
 
         if (valShape.size() > 1) {
           shape.addAll(valShape.subList(1, valShape.size()));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -210,17 +210,20 @@ public class TensorType implements Iterable<Dimension<?>> {
    * href="https://github.com/wala/ML/issues/544">wala/ML#544</a>.
    *
    * <p>The {@link Dimension#value() value} is always {@code null} &mdash; raggedness carries no
-   * payload beyond its identity.
+   * payload beyond its identity. Because every instance is structurally equal to every other, use
+   * the shared {@link #INSTANCE} rather than allocating fresh objects.
    */
   public static class RaggedDim extends Dimension<Void> {
+    /** Shared singleton; {@code RaggedDim} carries no per-instance state. */
+    public static final RaggedDim INSTANCE = new RaggedDim();
+
     /**
-     * Constructs a {@code RaggedDim}.
-     *
-     * @implNote The {@code super(null)} call is mechanical: {@link Dimension} requires a value of
-     *     type {@code T}, and {@code Void} has no instances, so {@code null} is the only legal
-     *     argument. Raggedness carries no payload beyond the type's identity.
+     * @implNote Private — all callers should use {@link #INSTANCE}. The {@code super(null)} call is
+     *     mechanical: {@link Dimension} requires a value of type {@code T}, and {@code Void} has no
+     *     instances, so {@code null} is the only legal argument. Raggedness carries no payload
+     *     beyond the type's identity.
      */
-    public RaggedDim() {
+    private RaggedDim() {
       super(null);
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -214,9 +214,11 @@ public class TensorType implements Iterable<Dimension<?>> {
    */
   public static class RaggedDim extends Dimension<Void> {
     /**
-     * Constructs a {@code RaggedDim}. The {@code super(null)} call is mechanical: {@link Dimension}
-     * requires a value of type {@code T}, and {@code Void} has no instances, so {@code null} is the
-     * only legal argument. Raggedness carries no payload beyond the type's identity.
+     * Constructs a {@code RaggedDim}.
+     *
+     * @implNote The {@code super(null)} call is mechanical: {@link Dimension} requires a value of
+     *     type {@code T}, and {@code Void} has no instances, so {@code null} is the only legal
+     *     argument. Raggedness carries no payload beyond the type's identity.
      */
     public RaggedDim() {
       super(null);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -54,7 +54,8 @@ public class TensorType implements Iterable<Dimension<?>> {
   enum DimensionType {
     Constant,
     Symbolic,
-    Compound
+    Compound,
+    Ragged
   };
 
   public abstract static class Dimension<T> {
@@ -194,6 +195,60 @@ public class TensorType implements Iterable<Dimension<?>> {
     @Override
     String toCString(boolean useMarkdown) {
       return value().toString();
+    }
+  }
+
+  /**
+   * Marker for a ragged dimension &mdash; a dimension whose size varies across rows of a single
+   * ragged tensor instance (e.g., the second axis of {@code tf.ragged.constant([[1, 2], [3]])}).
+   *
+   * <p>Ragged dimensions used to be encoded as raw {@code null} entries in {@code TensorType.dims};
+   * the typed sentinel restores the implicit non-null-element contract of {@link
+   * TensorType#iterator()} and lets downstream consumers (e.g., Hybridize's input-signature
+   * inference) discriminate ragged from "unknown size" (which is still encoded as raw {@code null}
+   * for dynamic-batch / placeholder dims, distinct semantics). See <a
+   * href="https://github.com/wala/ML/issues/544">wala/ML#544</a>.
+   *
+   * <p>The {@link Dimension#value() value} is always {@code null} &mdash; raggedness carries no
+   * payload beyond its identity.
+   */
+  public static class RaggedDim extends Dimension<Void> {
+    /**
+     * Constructs a {@code RaggedDim}. The {@code super(null)} call is mechanical: {@link Dimension}
+     * requires a value of type {@code T}, and {@code Void} has no instances, so {@code null} is the
+     * only legal argument. Raggedness carries no payload beyond the type's identity.
+     */
+    public RaggedDim() {
+      super(null);
+    }
+
+    @Override
+    DimensionType type() {
+      return DimensionType.Ragged;
+    }
+
+    @Override
+    int concreteSize() {
+      return -1;
+    }
+
+    @Override
+    int symbolicDims() {
+      return 1;
+    }
+
+    @Override
+    String toMDString() {
+      return "*ragged*";
+    }
+
+    @Override
+    String toCString(boolean useMarkdown) {
+      if (useMarkdown) {
+        return "*ragged*";
+      } else {
+        return "ragged";
+      }
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
@@ -4,6 +4,7 @@ import static java.lang.Math.max;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import java.util.List;
 
 public class TensorShapeUtil {
@@ -17,8 +18,11 @@ public class TensorShapeUtil {
       Dimension<?> xDim = i < (maxRank - xRank) ? null : xShape.get(i - (maxRank - xRank));
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
-      if (xDim == null || yDim == null) {
-        continue; // One of the dimensions is missing, treat as size 1
+      // Either side missing (out of rank), a raw-null placeholder, or a ragged dim is treated as
+      // broadcast-compatible — we lack the precision to reason about the actual extent, so be
+      // permissive. wala/ML#544 introduced RaggedDim; the prior behavior covered only raw null.
+      if (xDim == null || yDim == null || xDim instanceof RaggedDim || yDim instanceof RaggedDim) {
+        continue;
       }
 
       if (xDim instanceof NumericDim && yDim instanceof NumericDim) {
@@ -44,7 +48,12 @@ public class TensorShapeUtil {
       Dimension<?> xDim = i < (maxRank - xRank) ? null : xShape.get(i - (maxRank - xRank));
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
-      if (xDim == null) ret.add(yDim);
+      // Propagate raggedness when either side is ragged — broadcasting a ragged operand against
+      // anything (including another ragged of compatible extent) preserves the ragged dim in the
+      // result. wala/ML#544.
+      if (xDim instanceof RaggedDim) ret.add(xDim);
+      else if (yDim instanceof RaggedDim) ret.add(yDim);
+      else if (xDim == null) ret.add(yDim);
       else if (yDim == null) ret.add(xDim);
       else if (xDim instanceof NumericDim && yDim instanceof NumericDim) {
         int xSize = ((NumericDim) xDim).value();


### PR DESCRIPTION
## Summary
- Introduces a typed sentinel `TensorType.RaggedDim` (extends `Dimension<Void>`) so ragged dimensions are no longer encoded as raw `null` entries in `TensorType.dims`. This restores the implicit non-null-element contract of `TensorType#iterator()` and lets downstream consumers (e.g., Hybridize's input-signature inference) discriminate ragged from "unknown size" (still encoded as raw `null` for dynamic-batch/placeholder dims — distinct semantics). See [wala/ML#544](https://github.com/wala/ML/issues/544).
- Migrates the five ragged-emitting `TensorGenerator`s (`RaggedConstant`, `RaggedRange`, `RaggedFromNestedRowLengths`, `RaggedFromNestedValueRowIds`, `RaggedTensorFromValues`) and all `TestTensorflow2Model` fixtures to emit `RaggedDim` instead of `null`.
- Adds `RaggedDim.INSTANCE` as the canonical shared singleton and makes the constructor `private`, since `RaggedDim` carries no per-instance state (`Void` value, equals-indistinguishable instances) — fresh allocations at each call site were pure waste.
- Minor follow-ups carried on the branch: `@implNote`-tag the `RaggedDim` ctor note; primitive `long` loop counter in `RaggedConstant`'s ragged-dim emit; remove a misnamed unused test fixture.

## Test plan
- [x] `mvn spotless:apply` clean
- [x] Targeted ragged tests pass locally (`testRaggedFromRowLengths`, `testRaggedKeywordArgsNested`)
- [ ] Full `mvn test` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)