### PR TITLE
Share single `RaggedDim` instance via `INSTANCE`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -186,22 +186,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(STRING, asList(null, null));
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_NONE_STRING =
-      new TensorType(STRING, asList(new NumericDim(4), new RaggedDim(), new RaggedDim(), null));
+      new TensorType(
+          STRING, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, null));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_STRING =
-      new TensorType(STRING, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(STRING, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_1_RAGGED_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim(), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(1), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(2)));
@@ -219,58 +220,61 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(3)));
 
   private static final TensorType TENSOR_0_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(0), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_0_RAGGED_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), new RaggedDim(), new NumericDim(3)));
+      new TensorType(FLOAT_32, asList(new NumericDim(0), RaggedDim.INSTANCE, new NumericDim(3)));
 
   private static final TensorType TENSOR_1_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(1), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_1_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(1), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_NONE_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), null));
 
   private static final TensorType TENSOR_2_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
+      new TensorType(FLOAT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2)));
+      new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_2_3_INT32 =
       new TensorType(
-          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(3)));
+          INT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2), new NumericDim(3)));
 
   private static final TensorType TENSOR_2_RAGGED_2_2_INT32 =
       new TensorType(
-          INT_32, asList(new NumericDim(2), new RaggedDim(), new NumericDim(2), new NumericDim(2)));
+          INT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, new NumericDim(2), new NumericDim(2)));
 
   private static final TensorType TENSOR_2_RAGGED_RAGGED_RAGGED_FLOAT32 =
       new TensorType(
-          FLOAT_32, asList(new NumericDim(2), new RaggedDim(), new RaggedDim(), new RaggedDim()));
+          FLOAT_32,
+          asList(new NumericDim(2), RaggedDim.INSTANCE, RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(3), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_4_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(4), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new RaggedDim()));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new RaggedDim(), new NumericDim(1)));
+      new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, new NumericDim(1)));
 
   private static final TensorType TENSOR_2_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
@@ -300,7 +304,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(INT_32, asList(new NumericDim(5), new NumericDim(5)));
 
   private static final TensorType TENSOR_5_RAGGED_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5), new RaggedDim()));
+      new TensorType(INT_32, asList(new NumericDim(5), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_3_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -429,7 +429,7 @@ public class RaggedConstant extends Constant {
           // The first R dimensions are ragged.
           // Dim 1 to R: These are assigned None (or ? in older outputs) in the static shape,
           // indicating they can vary.
-          for (long i = 0L; i < R; i++) shape.add(new RaggedDim());
+          for (long i = 0L; i < R; i++) shape.add(RaggedDim.INSTANCE);
 
           // Part B: The Uniform Portion (Dimensions R + 1 to K)
           // If R < K - 1 (meaning you requested fewer ragged dimensions than the total depth),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -180,7 +180,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
 
           // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(new RaggedDim());
+            shape.add(RaggedDim.INSTANCE);
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -280,7 +280,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
 
           // Then K ragged dimensions.
           for (int i = 0; i < k; i++) {
-            shape.add(new RaggedDim());
+            shape.add(RaggedDim.INSTANCE);
           }
 
           // Then add values.shape[1:]

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -167,7 +167,7 @@ public class RaggedRange extends Range {
         // Return 2D ragged tensor shape
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(vectorLength != null ? vectorLength : -1));
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       } else {
         // All scalars.
@@ -175,7 +175,7 @@ public class RaggedRange extends Range {
         // e.g. tf.ragged.range(3, 18, 3) -> [[3, 6, 9, 12, 15]]
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(1));
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -56,7 +56,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (Dimension<?> rowDim : possibleRowDims) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       }
       LOGGER.fine(
@@ -69,7 +69,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       for (List<Dimension<?>> valShape : valuesShapes) {
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(rowDim);
-        shape.add(new RaggedDim());
+        shape.add(RaggedDim.INSTANCE);
 
         if (valShape.size() > 1) {
           shape.addAll(valShape.subList(1, valShape.size()));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -210,17 +210,20 @@ public class TensorType implements Iterable<Dimension<?>> {
    * href="https://github.com/wala/ML/issues/544">wala/ML#544</a>.
    *
    * <p>The {@link Dimension#value() value} is always {@code null} &mdash; raggedness carries no
-   * payload beyond its identity.
+   * payload beyond its identity. Because every instance is structurally equal to every other, use
+   * the shared {@link #INSTANCE} rather than allocating fresh objects.
    */
   public static class RaggedDim extends Dimension<Void> {
+    /** Shared singleton; {@code RaggedDim} carries no per-instance state. */
+    public static final RaggedDim INSTANCE = new RaggedDim();
+
     /**
-     * Constructs a {@code RaggedDim}.
-     *
-     * @implNote The {@code super(null)} call is mechanical: {@link Dimension} requires a value of
-     *     type {@code T}, and {@code Void} has no instances, so {@code null} is the only legal
-     *     argument. Raggedness carries no payload beyond the type's identity.
+     * @implNote Private — all callers should use {@link #INSTANCE}. The {@code super(null)} call is
+     *     mechanical: {@link Dimension} requires a value of type {@code T}, and {@code Void} has no
+     *     instances, so {@code null} is the only legal argument. Raggedness carries no payload
+     *     beyond the type's identity.
      */
-    public RaggedDim() {
+    private RaggedDim() {
       super(null);
     }
 


### PR DESCRIPTION
## Summary
- `TensorType.RaggedDim` extends `Dimension<Void>` and carries no per-instance state — `Void` has no instances, so its `value` is structurally always `null`, and every `new RaggedDim()` is `equals`-indistinguishable from every other. Allocating a fresh object at each call site was pure waste.
- Adds `RaggedDim.INSTANCE` as the canonical shared singleton and makes the constructor `private` to funnel all callers through it.
- Migrates the five production call sites in `client/Ragged*.java` and the `TestTensorflow2Model` fixtures from `new RaggedDim()` to `RaggedDim.INSTANCE`.

Follow-up to [#320](https://github.com/ponder-lab/ML/pull/320).

## Test plan
- [x] `mvn spotless:apply` clean
- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -am test-compile` clean
- [x] Targeted ragged tests pass locally (`testRaggedFromRowLengths`, `testRaggedKeywordArgsNested`)
- [ ] Full `mvn test` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)