### PR TITLE
Add kwarg test variants for Tier-1 generators (#449)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8301,6 +8301,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Companion to {@link #testIdentity()} exercising the keyword-argument call site {@code
+   * tf.identity(input=...)}. The arg-resolution helpers in {@link
+   * com.ibm.wala.cast.python.ml.client.Identity} (and the underlying {@code
+   * getArgumentPointsToSet(builder, paramPos, paramName)}) resolve keyword args via {@code
+   * paramName}; without a kwarg fixture that branch is dead-on-arrival in the test data.
+   */
+  @Test
+  public void testIdentityKwarg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_identity_kwarg.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
+  }
+
+  /**
    * Tier-1 generator (wala/ML#449): {@code tf.stop_gradient(input)} returns a fresh tensor with the
    * same shape and dtype as {@code input}. Pre-fix this routed through {@code ReadDataFallback}
    * (the alloc has no value/dtype field bindings, just a {@code read_data} marker) and emitted
@@ -8314,6 +8327,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_stop_gradient.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
   }
 
+  /** Companion to {@link #testStopGradient()} exercising the keyword-argument call site. */
+  @Test
+  public void testStopGradientKwarg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_stop_gradient_kwarg.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
   /**
    * Tier-1 generator (wala/ML#449): {@code tf.nn.bias_add(value, bias)} returns a fresh tensor with
    * the same shape and dtype as {@code value} (bias is broadcast-added but doesn't change the
@@ -8323,6 +8343,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testBiasAdd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_bias_add.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testBiasAdd()} exercising the all-keyword call site {@code
+   * tf.nn.bias_add(value=..., bias=...)}.
+   */
+  @Test
+  public void testBiasAddKwarg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_bias_add_kwarg.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_bias_add_kwarg.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_bias_add_kwarg.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+value = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+bias = tf.constant([0.1, 0.2, 0.3])
+y = tf.nn.bias_add(value=value, bias=bias)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (2, 3)
+assert y.dtype == tf.float32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_identity_kwarg.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_identity_kwarg.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([1, 2, 3], tf.int32)
+y = tf.identity(input=x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_stop_gradient_kwarg.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_stop_gradient_kwarg.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+x = tf.constant([1.0, 2.0, 3.0])
+y = tf.stop_gradient(input=x)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.float32
+
+f(y)


### PR DESCRIPTION
## Summary
Salvages [`9dc5b7d2`](https://github.com/ponder-lab/ML/commit/9dc5b7d2f82ca7d6f08cd725e2ef4748a8c69e36), which was pushed onto the `fix/449-tier1-identity-stop-gradient-bias-add` branch ~17 minutes *after* [#202](https://github.com/ponder-lab/ML/pull/202) merged on 2026-05-01 and was never opened as its own PR.

Same rationale as the Tier-2 kwarg tests on [#204](https://github.com/ponder-lab/ML/pull/204): the existing `testIdentity` / `testStopGradient` / `testBiasAdd` only exercise positional-argument call sites, leaving the kwarg branch in `getArgumentPointsToSet(builder, paramPos, paramName)` dead-on-arrival. This PR adds three companion tests with the same inputs and expected types:

- `testIdentityKwarg` — `tf.identity(input=...)`
- `testStopGradientKwarg` — `tf.stop_gradient(input=...)`
- `testBiasAddKwarg` — `tf.nn.bias_add(value=..., bias=...)` (all-kwargs to also exercise the second-arg case for `BiasAdd`)

## Test plan
- [x] `mvn spotless:apply` clean
- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -am ... test` — all 3 new tests pass locally (`Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`)
- [ ] Full `mvn test` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)