### PR TITLE
Fix Tier-1 generator Javadoc inaccuracies flagged on #324 review

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8339,10 +8339,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * fresh tensor with the same shape and dtype as {@code value} (bias is broadcast-added but
    * doesn't change the receiver's shape). Unlike {@link #testIdentity()} / {@link
    * #testStopGradient()} — which got dedicated {@link com.ibm.wala.cast.python.ml.client.Identity}
-   * / {@link com.ibm.wala.cast.python.ml.client.StopGradient} generators — {@code bias_add} is
-   * modeled in {@code tensorflow.xml} as {@code <new>+<return>} routing through {@code
-   * convert_to_tensor} (no dedicated Java generator), which suffices for the
-   * shape/dtype-passthrough semantics this test exercises.
+   * / {@link com.ibm.wala.cast.python.ml.client.StopGradient} generators paired with a direct
+   * {@code <new>+<return>} in the XML — {@code bias_add} is modeled in {@code tensorflow.xml} as a
+   * delegation: {@code <new>} of a {@code convert_to_tensor} function-object, {@code <call>} of its
+   * {@code do} with {@code value} as the argument, then {@code <return>} of that result (no
+   * dedicated Java generator; the actual tensor allocation happens inside {@code
+   * convert_to_tensor.do()}). That delegation suffices for the shape/dtype-passthrough semantics
+   * this test exercises.
    */
   @Test
   public void testBiasAdd()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8315,9 +8315,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Tier-1 generator (wala/ML#449): {@code tf.nn.bias_add(value, bias)} returns a fresh tensor with
-   * the same shape and dtype as {@code value} (bias is broadcast-added but doesn't change the
-   * receiver's shape).
+   * Lock-in test for wala/ML#449 Tier-1 coverage of {@code tf.nn.bias_add(value, bias)}: returns a
+   * fresh tensor with the same shape and dtype as {@code value} (bias is broadcast-added but
+   * doesn't change the receiver's shape). Unlike {@link #testIdentity()} / {@link
+   * #testStopGradient()} — which got dedicated {@link com.ibm.wala.cast.python.ml.client.Identity}
+   * / {@link com.ibm.wala.cast.python.ml.client.StopGradient} generators — {@code bias_add} is
+   * modeled in {@code tensorflow.xml} as {@code <new>+<return>} routing through {@code
+   * convert_to_tensor} (no dedicated Java generator), which suffices for the
+   * shape/dtype-passthrough semantics this test exercises.
    */
   @Test
   public void testBiasAdd()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Identity.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Identity.java
@@ -55,8 +55,11 @@ public class Identity extends TensorGenerator {
   }
 
   /**
-   * Constructs an {@code Identity} anchored to a manual node. Used by {@link
-   * TensorGenerator#createManualGenerator}.
+   * Constructs an {@code Identity} anchored to a manual node. Provided as a public node-anchored
+   * entry point parallel to the {@link PointsToSetVariable} ctor; not currently wired into {@link
+   * TensorGenerator#createManualGenerator}'s dispatch (the standard path is the factory's
+   * source-based dispatch in {@code TensorGeneratorFactory.getGenerator}). Kept for downstream
+   * callers and for forward wiring if manual-dispatch coverage is added later.
    *
    * @param node The {@link CGNode} for the {@code identity.do()} synthetic method.
    */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/StopGradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/StopGradient.java
@@ -58,12 +58,13 @@ public class StopGradient extends TensorGenerator {
   }
 
   /**
-   * Constructs a {@code StopGradient} anchored to a manual node. Used by {@link
-   * TensorGenerator#createManualGenerator}.
+   * Constructs a {@code StopGradient} anchored to a manual node. Provided as a public node-anchored
+   * entry point parallel to the {@link PointsToSetVariable} ctor; not currently wired into {@link
+   * TensorGenerator#createManualGenerator}'s dispatch (the standard path is the factory's
+   * source-based dispatch in {@code TensorGeneratorFactory.getGenerator}). Kept for downstream
+   * callers and for forward wiring if manual-dispatch coverage is added later.
    *
-   * @param node The {@link CGNode} for the {@code stop_gradient.do()} synthetic method. (Pre-fix
-   *     this could also be the {@code read_data()} synthetic, but the new XML model uses {@code
-   *     <new>+<return>} in {@code do()} directly — no {@code read_data} entry point.)
+   * @param node The {@link CGNode} for the {@code stop_gradient.do()} synthetic method.
    */
   public StopGradient(CGNode node) {
     super(node);


### PR DESCRIPTION
## Summary
Documentation-only follow-up to the Copilot review on [#324](https://github.com/ponder-lab/ML/pull/324). All three concerns are valid critiques of pre-existing master content from [#202](https://github.com/ponder-lab/ML/pull/202) that were out of scope for #324's kwarg-tests salvage; this PR addresses them in isolation.

- **`Identity(CGNode)` / `StopGradient(CGNode)` Javadoc** — the previous wording claimed "Used by `TensorGenerator#createManualGenerator`", but `createManualGenerator` doesn't dispatch on the `identity` / `stop_gradient` synthetic types. The standard path is the factory's source-based dispatch in `TensorGeneratorFactory.getGenerator` (lines 1294-1296). Rewrite the Javadoc to describe these constructors as public node-anchored entry points kept for downstream callers / forward wiring, without the false dispatch claim. The constructors themselves are **retained** as public API.
- **`testBiasAdd` Javadoc** — the previous wording called `tf.nn.bias_add` a "Tier-1 generator", but there's no `BiasAdd.java`. `bias_add` is modeled in `tensorflow.xml` (lines 2161-2168) as `<new>+<return>` routing through `convert_to_tensor`, not via a dedicated Java generator. Reframe as "lock-in test for Tier-1 coverage" and call out the XML-only modeling explicitly, contrasting it with the dedicated `Identity` / `StopGradient` generators.

## Test plan
- [x] `mvn spotless:apply` clean
- [x] `mvn -pl com.ibm.wala.cast.python.ml.test -am test-compile` clean
- [x] `testIdentity` / `testStopGradient` / `testBiasAdd` pass locally (`Tests run: 3, Failures: 0, Errors: 0`)
- [ ] Full `mvn test` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)