### PR TITLE
Honor user-supplied dtype and derive float-operand promotion in `Range`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6142,8 +6142,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Regression test for wala/ML#492. When an explicit {@code dtype=} keyword is supplied to {@code
-   * tf.range}, the analyzer must honor it instead of defaulting to {@code int32}. {@code
-   * tf.range(0, 5, dtype=tf.float32)} should infer {@code float32}.
+   * tf.range}, the analyzer honors it instead of defaulting to {@code int32}. {@code tf.range(0, 5,
+   * dtype=tf.float32)} infers {@code float32} via {@link Range#getDTypes}'s dtype-arg dispatch.
    */
   @Test
   public void testRangeDType()
@@ -6175,20 +6175,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Documents a remaining limitation of {@link Range}: when no explicit {@code dtype} is supplied
-   * but the {@code start}/{@code limit}/{@code delta} arguments are {@code float}-typed, TF
-   * promotes the output to {@code float32} at runtime. The analyzer currently returns the
-   * unconditional {@code int32} default from {@code Range.getDefaultDTypes}, which this test pins
-   * down. Tracked by <a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>): when {@link
-   * Range#getDefaultDTypes} learns to derive its result from the start/limit/delta arg dtypes, flip
-   * the expected type to {@code TENSOR_5_FLOAT32}.
+   * Regression test for the implicit-dtype path of {@link Range}: when no explicit {@code dtype} is
+   * supplied but the {@code start}/{@code limit}/{@code delta} arguments are {@code float}-typed,
+   * TF promotes the output to {@code float32} at runtime. {@link Range#getDefaultDTypes} now
+   * derives its result from the numeric argument types, matching that promotion. Fix for <a
+   * href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
    */
   @Test
   public void testRangeFloatArgs()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_range_float_args.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_INT32)));
+    test("tf2_test_range_float_args.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -248,32 +248,6 @@ public class Range extends TensorGenerator {
   }
 
   /**
-   * Honours an explicit {@code dtype=} keyword by resolving the argument's points-to set, mirroring
-   * the canonical dispatch in {@link TensorGenerator#getDTypes}. The override is defensive — the
-   * inherited path already produces the same answer — but stating it locally keeps {@code Range}'s
-   * dtype handling self-documenting alongside {@link #getDefaultDTypes}, which derives the dtype
-   * from {@code start}/{@code limit}/{@code delta} when no explicit {@code dtype} is supplied. Fix
-   * for <a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
-   *
-   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The resolved {@code dtype} argument when explicitly passed, else the value derived from
-   *     numeric argument types (see {@link #getDefaultDTypes}).
-   */
-  @Override
-  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
-    int valNum =
-        this.getArgumentValueNumber(
-            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName(), true);
-    if (valNum <= 0) return this.getDefaultDTypes(builder);
-
-    OrdinalSet<InstanceKey> pointsToSet =
-        this.getArgumentPointsToSet(
-            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName());
-    if (pointsToSet == null || pointsToSet.isEmpty()) return this.getDefaultDTypes(builder);
-    return this.getDTypesFromDTypeArgument(builder, pointsToSet);
-  }
-
-  /**
    * Derives the output dtype from the numeric {@code start}/{@code limit}/{@code delta} arguments
    * when no explicit {@code dtype=} keyword is supplied, matching {@code tf.range}'s runtime
    * promotion rule: any float operand promotes the result to {@code float32}, otherwise it stays

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -276,10 +276,15 @@ public class Range extends TensorGenerator {
             this.getArgumentPointsToSet(
                 builder, getDeltaParameterPosition(), getDeltaParameterName()));
 
-    if (argPts == null || argPts.isEmpty()) return EnumSet.of(DType.INT32);
+    if (argPts.isEmpty()) return EnumSet.of(DType.INT32);
 
     Set<DType> derived = this.getDTypesOfValue(builder, argPts);
     if (derived == null || derived.isEmpty()) return EnumSet.of(DType.INT32);
+
+    // TF's runtime promotion: any float operand promotes the entire result to float32, dropping
+    // integer dtypes from the mix. E.g., `tf.range(0, 5.0)` → float32, not {INT32, FLOAT32}.
+    if (derived.contains(DType.FLOAT32) || derived.contains(DType.FLOAT64))
+      return EnumSet.of(DType.FLOAT32);
     return derived;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -32,6 +32,12 @@ import java.util.logging.Logger;
  * <p>This class is used to generate a tensor that contains a sequence of numbers, similar to the
  * range function in Python.
  *
+ * <p>Output dtype follows {@code tf.range}'s runtime behaviour: an explicit {@code dtype=} keyword
+ * is honoured; otherwise the dtype is derived from the {@code start}/{@code limit}/{@code delta}
+ * argument types (any float operand promotes the result to {@code float32}), defaulting to {@code
+ * int32} when nothing more precise is available. Fix for <a
+ * href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
+ *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/range">TensorFlow range
  *     documentation</a>.
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -241,9 +247,66 @@ public class Range extends TensorGenerator {
     return ret;
   }
 
+  /**
+   * Honours an explicit {@code dtype=} keyword by resolving the argument's points-to set, mirroring
+   * the canonical dispatch in {@link TensorGenerator#getDTypes}. The override is defensive — the
+   * inherited path already produces the same answer — but stating it locally keeps {@code Range}'s
+   * dtype handling self-documenting alongside {@link #getDefaultDTypes}, which derives the dtype
+   * from {@code start}/{@code limit}/{@code delta} when no explicit {@code dtype} is supplied. Fix
+   * for <a href="https://github.com/wala/ML/issues/492">wala/ML#492</a>.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The resolved {@code dtype} argument when explicitly passed, else the value derived from
+   *     numeric argument types (see {@link #getDefaultDTypes}).
+   */
+  @Override
+  protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    int valNum =
+        this.getArgumentValueNumber(
+            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName(), true);
+    if (valNum <= 0) return this.getDefaultDTypes(builder);
+
+    OrdinalSet<InstanceKey> pointsToSet =
+        this.getArgumentPointsToSet(
+            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName());
+    if (pointsToSet == null || pointsToSet.isEmpty()) return this.getDefaultDTypes(builder);
+    return this.getDTypesFromDTypeArgument(builder, pointsToSet);
+  }
+
+  /**
+   * Derives the output dtype from the numeric {@code start}/{@code limit}/{@code delta} arguments
+   * when no explicit {@code dtype=} keyword is supplied, matching {@code tf.range}'s runtime
+   * promotion rule: any float operand promotes the result to {@code float32}, otherwise it stays
+   * {@code int32}. Falls back to {@code int32} when nothing about the operand types is recoverable
+   * (the conservative default at runtime).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype set derived from the numeric arguments, or {@code int32} as a fallback.
+   */
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    return EnumSet.of(DType.INT32);
+    OrdinalSet<InstanceKey> argPts = OrdinalSet.empty();
+    argPts =
+        OrdinalSet.unify(
+            argPts,
+            this.getArgumentPointsToSet(
+                builder, getStartParameterPosition(), getStartParameterName()));
+    argPts =
+        OrdinalSet.unify(
+            argPts,
+            this.getArgumentPointsToSet(
+                builder, getLimitParameterPosition(), getLimitParameterName()));
+    argPts =
+        OrdinalSet.unify(
+            argPts,
+            this.getArgumentPointsToSet(
+                builder, getDeltaParameterPosition(), getDeltaParameterName()));
+
+    if (argPts == null || argPts.isEmpty()) return EnumSet.of(DType.INT32);
+
+    Set<DType> derived = this.getDTypesOfValue(builder, argPts);
+    if (derived == null || derived.isEmpty()) return EnumSet.of(DType.INT32);
+    return derived;
   }
 
   @Override


### PR DESCRIPTION
## Summary

`Range.getDefaultDTypes` previously hardcoded `EnumSet.of(DType.INT32)`, ignoring two distinct precision signals:

1. **Explicit `dtype=` keyword:** `tf.range(0, 5, dtype=tf.float32)` was inferred as `int32` because the default-dtype path bypassed the dtype-arg dispatch. The inherited `TensorGenerator.getDTypes` already consults `getDTypeParameterPosition` / `getDTypeParameterName`, but the assertion was uncovered — no fixture exercised an explicit `dtype=` kwarg until PR ponder-lab/ML#271 added `tf2_test_range_dtype.py` / `_int64` / `_1arg`.
2. **Float operand promotion:** `tf.range(0.0, 5.0)` is `float32` at runtime (any float operand promotes the output), but the static analysis returned `int32`. PR ponder-lab/ML#271 pinned this gap with `testRangeFloatArgs` expecting the imprecise `TENSOR_5_INT32` plus a TODO.

## Fix

Rewrite `Range.getDefaultDTypes` to union the points-to sets of `start` / `limit` / `delta`, derive their dtypes via `getDTypesOfValue`, and fall back to `int32` only when nothing is recoverable. The explicit-`dtype=` path is already handled by `TensorGenerator.getDTypes`'s inherited dispatch — no `Range`-side override needed there.

Flip `testRangeFloatArgs` from `TENSOR_5_INT32` (imprecise) to `TENSOR_5_FLOAT32` (precise) and remove its TODO. Refresh `testRangeDType`'s Javadoc.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3.
- [x] `testRangeDType`, `testRangeDTypeInt64`, `testRangeDType1Arg`, `testRangeFloatArgs` all pass.
- [x] Spotless clean on commit.

Closes wala/ML#492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
