### PR TITLE
Register `Cast`/`Relu`/`ExpandDims`/`ClipByValue` manual generators

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2869,6 +2869,14 @@ public abstract class TensorGenerator {
         || type.equals(
             TensorFlowTypes.SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())) {
       return new SoftmaxCrossEntropy(node);
+    } else if (type.equals(TensorFlowTypes.CAST.getDeclaringClass())) {
+      return new Cast(node);
+    } else if (type.equals(TensorFlowTypes.RELU.getDeclaringClass())) {
+      return new Relu(node);
+    } else if (type.equals(TensorFlowTypes.EXPAND_DIMS.getDeclaringClass())) {
+      return new ExpandDims(node);
+    } else if (type.equals(TensorFlowTypes.CLIP_BY_VALUE.getDeclaringClass())) {
+      return new ClipByValue(node);
     } else if (type.equals(CONSTANT.getDeclaringClass())) {
       return new TensorGenerator(node) {
         @Override


### PR DESCRIPTION
## Summary

PR ponder-lab/ML#255 added dedicated `Cast`, `Relu`, `ExpandDims`, `ClipByValue` generators with `CGNode` constructors set up for manual-generator dispatch — but none of the four was registered in `TensorGenerator.createManualGenerator`. Calls to that factory for any of them fell through and returned `null`, silently producing ⊤ for any chained consumer that traced back to a fresh `<new>` `Tensor` allocation inside the producer's synthetic `do` method.

The gap is currently masked because the `pass_through` aliases for `cast` and `relu` win dispatch over the dedicated `<class name="...">` blocks; as soon as those aliases are removed (the original intent of #255), the manual-generator fallback needs to pick up the slack and currently doesn't.

## Fix

Four `else if` arms added in `createManualGenerator(CGNode, PropagationCallGraphBuilder)`, alongside the existing `Sigmoid`/`Softmax`/`SoftmaxCrossEntropy` block.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3. The change is neutral with the `pass_through` aliases still in place (the existing dispatch path still wins for cast/relu), but the manual-generator fallback is now correct for the post-alias-removal world.
- [x] Spotless clean on commit.

## Out of Scope

Does not close wala/ML#499 (the `tf.cast(x, dtype)` honor-dtype fix) or wala/ML#509 (chained-consumer propagation). Empirically verified during the wala/ML#509 probe: with these four registrations in place and the `cast` alias removed, `testEx1CG` still fails — the remaining root cause is in the dataflow seeding / set_shape interaction with the cast call's new variable identity post-alias-removal. ponder-lab/ML#327 stays draft pending that investigation.

Closes wala/ML#547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
