### PR TITLE
Guard `Integer.parseInt` in `ClientDriver` against bad CLI args

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
@@ -133,7 +133,11 @@ public class ClientDriver implements LanguageClient {
     id.setUri(args[0]);
     HoverParams a = new HoverParams();
     a.setTextDocument(id);
-    for (int i = 1; i < args.length; i += 2) {
+    // Step by 2 so each iteration consumes a `(line, character)` pair. Stop when fewer than two
+    // args remain — `validateArgs` already enforces an odd argv length, but the explicit `i + 1
+    // < args.length` bound also silences CodeQL #5311/#5312 (`java/index-out-of-bounds`), which
+    // doesn't reason across the validation call.
+    for (int i = 1; i + 1 < args.length; i += 2) {
       Position p = new Position();
       try {
         p.setLine(Integer.parseInt(args[i]));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/ClientDriver.java
@@ -135,8 +135,22 @@ public class ClientDriver implements LanguageClient {
     a.setTextDocument(id);
     for (int i = 1; i < args.length; i += 2) {
       Position p = new Position();
-      p.setLine(Integer.parseInt(args[i]));
-      p.setCharacter(Integer.parseInt(args[i + 1]));
+      try {
+        p.setLine(Integer.parseInt(args[i]));
+        p.setCharacter(Integer.parseInt(args[i + 1]));
+      } catch (NumberFormatException e) {
+        System.err.println(
+            "expected integer (line, character) at args["
+                + i
+                + ".."
+                + (i + 1)
+                + "], got: \""
+                + args[i]
+                + "\" \""
+                + args[i + 1]
+                + "\".");
+        System.exit(2);
+      }
       a.setPosition(p);
       CompletableFuture<Hover> data = server.getTextDocumentService().hover(a);
       data.thenAccept(


### PR DESCRIPTION
## Summary

The LSP standalone driver's `main` reads pairs of `(line, character)` from `args[1..]` via `Integer.parseInt`. Non-numeric input — a real user-error mode for a CLI tool — propagates `NumberFormatException` and crashes with a stack trace. CodeQL alerts #5212 and #5213 (`java/uncaught-number-format-exception`) on `ClientDriver.java:138,139` flag both calls.

## Fix

Wrap the two `parseInt` calls in a single try/catch around the loop body. On bad input, print a focused error message naming the offending arg positions and values, then `System.exit(2)`. The arg pair is the same logical unit, so a single catch covers both indices.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3.
- [x] Spotless clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
