### PR TITLE
Drop dead `server` local in `Ariadne` client-mode dispatch

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/Ariadne.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/driver/Ariadne.java
@@ -341,9 +341,7 @@ public class Ariadne {
         }
       case client:
         {
-          @SuppressWarnings("unused")
-          final WALAServerCore server =
-              WALAServer.launchOnClientPort(null, port, PythonDriver.python);
+          WALAServer.launchOnClientPort(null, port, PythonDriver.python);
           break;
         }
       case server:


### PR DESCRIPTION
## Summary

The `client` case of `Ariadne`'s mode switch (line 344) assigned the result of `WALAServer.launchOnClientPort` to a `final` local that was never read, marked with `@SuppressWarnings("unused")`. CodeQL alert #5202 (`java/local-variable-is-never-read`) flagged it.

The launch is the side-effect; the returned reference isn't needed. Drop the assignment — mirrors the neighbouring `stdio` case which already invokes the launcher without binding the result.

`server`/`daemon` cases retain their assignments because they actually use `server.getServerPort()` on the next line.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3.
- [x] Spotless clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
