### PR TITLE
Drop dead `CG`/`analysis` locals in Turtle smoke-test `main` methods

### DIFF
--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtlePandaMergeCallGraphShape.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtlePandaMergeCallGraphShape.java
@@ -7,13 +7,11 @@ import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.EdgeType;
 import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.TurtlePath;
 import com.ibm.wala.cast.python.client.PythonTurtlePandasMergeAnalysis;
 import com.ibm.wala.classLoader.Module;
-import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.labeled.LabeledGraph;
 import java.io.File;
 import java.io.IOException;
@@ -54,10 +52,7 @@ public class TestPythonTurtlePandaMergeCallGraphShape extends TestPythonTurtleCa
 
     SSAPropagationCallGraphBuilder builder =
         (SSAPropagationCallGraphBuilder) E.defaultCallGraphBuilder();
-    @SuppressWarnings("unused")
-    CallGraph CG = builder.makeCallGraph(E.getOptions(), new NullProgressMonitor());
-
-    @SuppressWarnings("unused")
-    Graph<TurtlePath> analysis = E.performAnalysis(builder);
+    builder.makeCallGraph(E.getOptions(), new NullProgressMonitor());
+    E.performAnalysis(builder);
   }
 }

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtleSKLearnClassifierCallGraphShape.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonTurtleSKLearnClassifierCallGraphShape.java
@@ -7,7 +7,6 @@ import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.EdgeType;
 import com.ibm.wala.cast.python.client.PythonTurtleAnalysisEngine.TurtlePath;
 import com.ibm.wala.cast.python.client.PythonTurtleSKLearnClassifierAnalysis;
 import com.ibm.wala.classLoader.Module;
-import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
@@ -15,7 +14,6 @@ import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.labeled.LabeledGraph;
 import java.io.File;
 import java.io.IOException;
@@ -56,10 +54,7 @@ public class TestPythonTurtleSKLearnClassifierCallGraphShape
     PythonAnalysisEngine<LabeledGraph<TurtlePath, EdgeType>> E = driver.makeEngine(args);
 
     CallGraphBuilder<? super InstanceKey> builder = E.defaultCallGraphBuilder();
-    @SuppressWarnings("unused")
-    CallGraph CG = builder.makeCallGraph(E.getOptions(), new NullProgressMonitor());
-
-    @SuppressWarnings("unused")
-    Graph<TurtlePath> analysis = E.performAnalysis((SSAPropagationCallGraphBuilder) builder);
+    builder.makeCallGraph(E.getOptions(), new NullProgressMonitor());
+    E.performAnalysis((SSAPropagationCallGraphBuilder) builder);
   }
 }


### PR DESCRIPTION
## Summary

Per CodeQL alerts #5203/#5204 (`TestPythonTurtlePandaMergeCallGraphShape.java:57,60`) and #5205/#5206 (`TestPythonTurtleSKLearnClassifierCallGraphShape.java:59,62`): each smoke-test `main` constructs a `CallGraph` and a `Graph<TurtlePath>` only to assign them to locals marked `@SuppressWarnings("unused")` and never read.

The construction is the side-effect ("does the pipeline run without throwing?"); the returned references aren't consumed. Drop the assignments — call the methods directly. Remove the now-orphaned `CallGraph` and `Graph` imports.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3.
- [x] Spotless clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
