### PR TITLE
Specialize `RaggedRange` to emit `NumericDim` for static scalar args

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -164,6 +164,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(2)));
 
+  private static final TensorType TENSOR_1_5_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(5)));
+
+  private static final TensorType TENSOR_1_10_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(10)));
+
   private static final TensorType TENSOR_2_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2)));
 
@@ -3687,7 +3693,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -3698,7 +3704,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -3709,7 +3715,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -3720,7 +3726,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -3731,7 +3737,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -3742,7 +3748,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "add",
         2,
         3,
-        Map.of(2, Set.of(TENSOR_1_RAGGED_INT32), 3, Set.of(TENSOR_1_RAGGED_INT32)));
+        Map.of(2, Set.of(TENSOR_1_5_INT32), 3, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test
@@ -9178,12 +9184,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   @Test
   public void testRaggedRange() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_INT32)));
+    test("tf2_test_ragged_range.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_10_INT32)));
   }
 
   @Test
   public void testRaggedRange2() throws ClassHierarchyException, CancelException, IOException {
-    test("tf2_test_ragged_range2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_INT32)));
+    test("tf2_test_ragged_range2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_10_INT32)));
   }
 
   @Test
@@ -9211,6 +9217,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_ragged_range7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
+  /**
+   * Canonical case for <a href="https://github.com/wala/ML/issues/546">wala/ML#546</a>: {@code
+   * tf.ragged.range(3, 18, 3)} — all three scalar args are compile-time literals, so the inner
+   * length is statically computable: {@code ceil((18 - 3) / 3) = 5}. The analyzer pins {@code (1,
+   * 5)} instead of {@code (1, ragged)}.
+   */
+  @Test
+  public void testRaggedRange8() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_ragged_range8.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_5_INT32)));
+  }
+
   @Test
   public void testRaggedRangeKeyword()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -9220,11 +9237,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         5,
         5,
         Map.of(
-            2, Set.of(TENSOR_1_RAGGED_INT32),
-            3, Set.of(TENSOR_1_RAGGED_INT32),
-            4, Set.of(TENSOR_1_RAGGED_INT32),
-            5, Set.of(TENSOR_1_RAGGED_INT32),
-            6, Set.of(TENSOR_1_RAGGED_INT32)));
+            2, Set.of(TENSOR_1_5_INT32),
+            3, Set.of(TENSOR_1_5_INT32),
+            4, Set.of(TENSOR_1_5_INT32),
+            5, Set.of(TENSOR_1_5_INT32),
+            6, Set.of(TENSOR_1_5_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -9228,6 +9228,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_ragged_range8.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_5_INT32)));
   }
 
+  /**
+   * Multi-length fallback case for <a href="https://github.com/wala/ML/issues/546">wala/ML#546</a>:
+   * {@code start} resolves to two literal values via an if/else, so the cross-product yields
+   * lengths {@code {10, 8}}. {@code computeStaticInnerLength} returns {@code null} and the inner
+   * dim falls back to {@code RaggedDim}.
+   */
+  @Test
+  public void testRaggedRange9() throws ClassHierarchyException, CancelException, IOException {
+    test("tf2_test_ragged_range9.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_RAGGED_INT32)));
+  }
+
   @Test
   public void testRaggedRangeKeyword()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -62,7 +62,7 @@ public class RaggedRange extends Range {
       OrdinalSet<InstanceKey> startPts = OrdinalSet.empty();
       OrdinalSet<InstanceKey> limitPts = OrdinalSet.empty();
       OrdinalSet<InstanceKey> deltaPts = OrdinalSet.empty();
-      // Track which args the call explicitly provides — distinct from "PTS happens to be empty".
+      // Track which args the call explicitly provides—distinct from "PTS happens to be empty".
       // `getArgumentPointsToSet` can return `OrdinalSet.empty()` for arg-present-but-unresolvable
       // cases too; treating "empty" as "omitted" would make the inferred length unsound.
       boolean startProvided = false;
@@ -70,7 +70,7 @@ public class RaggedRange extends Range {
       boolean deltaProvided = false;
 
       if (numPosArgs == 0) {
-        // Keyword only — fetched below from the keyword-fallback block.
+        // Keyword only—fetched below from the keyword-fallback block.
       } else if (numPosArgs == 1) {
         // range(limits) or range(starts, limits=X)
         if (!this.isKeywordArgumentPresent(builder, Parameters.LIMITS.getName())) {
@@ -203,7 +203,7 @@ public class RaggedRange extends Range {
    * unresolvable, when {@code delta} could be zero (invalid at runtime), or when the cross-product
    * of literal values yields multiple distinct lengths. {@code start}/{@code delta} default to
    * {@code 0}/{@code 1} only when their {@code *Provided} flag is false (the runtime default for an
-   * omitted arg) — empty PTS for a *provided* arg means "unresolvable" and forces a fallback to
+   * omitted arg)—empty PTS for a *provided* arg means "unresolvable" and forces a fallback to
    * {@code RaggedDim}.
    *
    * @param startPts Points-to set of the {@code start} argument; consulted only when {@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -64,22 +64,7 @@ public class RaggedRange extends Range {
       OrdinalSet<InstanceKey> deltaPts = OrdinalSet.empty();
 
       if (numPosArgs == 0) {
-        // Keyword only
-        startPts =
-            this.getArgumentPointsToSet(
-                builder, UNDEFINED_PARAMETER_POSITION, Parameters.STARTS.getName());
-        limitPts =
-            this.getArgumentPointsToSet(
-                builder, UNDEFINED_PARAMETER_POSITION, Parameters.LIMITS.getName());
-        deltaPts =
-            this.getArgumentPointsToSet(
-                builder, UNDEFINED_PARAMETER_POSITION, Parameters.DELTAS.getName());
-
-        if (limitPts.isEmpty() && !startPts.isEmpty()) {
-          // tf.ragged.range(starts=5) -> limits=5
-          limitPts = startPts;
-          startPts = OrdinalSet.empty();
-        }
+        // Keyword only — fetched below from the keyword-fallback block.
       } else if (numPosArgs == 1) {
         // range(limits) or range(starts, limits=X)
         if (!this.isKeywordArgumentPresent(builder, Parameters.LIMITS.getName())) {
@@ -135,6 +120,13 @@ public class RaggedRange extends Range {
                 this.getArgumentPointsToSet(
                     builder, UNDEFINED_PARAMETER_POSITION, Parameters.DELTAS.getName()));
 
+      // Keyword-only: `tf.ragged.range(starts=5)` semantically means `limits=5`. Apply the swap
+      // AFTER the keyword fallback above so re-fetching `starts` can't undo it.
+      if (numPosArgs == 0 && limitPts.isEmpty() && !startPts.isEmpty()) {
+        limitPts = startPts;
+        startPts = OrdinalSet.empty();
+      }
+
       // Check for vectors
       boolean hasVector = false;
       Integer vectorLength = null;
@@ -170,15 +162,55 @@ public class RaggedRange extends Range {
         shape.add(RaggedDim.INSTANCE);
         ret.add(shape);
       } else {
-        // All scalars.
-        // tf.ragged.range with scalars returns a 2D RaggedTensor with shape (1, None).
-        // e.g. tf.ragged.range(3, 18, 3) -> [[3, 6, 9, 12, 15]]
+        // All scalars. tf.ragged.range with scalars returns a 2D RaggedTensor with shape
+        // (1, ceil((limit - start) / delta)). When start/limit/delta are statically-known
+        // numeric literals and the cross-product yields a single length, pin that length as
+        // a NumericDim; otherwise fall back to RaggedDim. Fix for
+        // <a href="https://github.com/wala/ML/issues/546">wala/ML#546</a>.
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(1));
-        shape.add(RaggedDim.INSTANCE);
+        Integer staticLength = computeStaticInnerLength(startPts, limitPts, deltaPts);
+        shape.add(staticLength != null ? new NumericDim(staticLength) : RaggedDim.INSTANCE);
         ret.add(shape);
       }
     }
     return ret;
+  }
+
+  /**
+   * Computes the static inner-dimension length for the scalar form of {@code tf.ragged.range} when
+   * {@code start}/{@code limit}/{@code delta} all resolve to compile-time numeric literals. Returns
+   * {@code null} when any arg is non-literal, when {@code delta} could be zero (invalid at
+   * runtime), or when the cross-product of literal values yields multiple distinct lengths.
+   *
+   * @param startPts Points-to set of the {@code start} argument (empty defaults to {@code 0}).
+   * @param limitPts Points-to set of the {@code limit} argument; required.
+   * @param deltaPts Points-to set of the {@code delta} argument (empty defaults to {@code 1}).
+   * @return The single statically-computable inner length, or {@code null} if not derivable.
+   */
+  private static Integer computeStaticInnerLength(
+      OrdinalSet<InstanceKey> startPts,
+      OrdinalSet<InstanceKey> limitPts,
+      OrdinalSet<InstanceKey> deltaPts) {
+    Set<Double> limits = getPossibleDoubleValues(limitPts);
+    if (limits.isEmpty() || limits.contains(null)) return null;
+
+    Set<Double> starts = getPossibleDoubleValues(startPts);
+    if (starts.contains(null)) return null;
+    if (starts.isEmpty()) starts.add(0.0);
+
+    Set<Double> deltas = getPossibleDoubleValues(deltaPts);
+    if (deltas.contains(null)) return null;
+    if (deltas.isEmpty()) deltas.add(1.0);
+
+    Set<Integer> lengths = HashSetFactory.make();
+    for (Double s : starts)
+      for (Double l : limits)
+        for (Double d : deltas) {
+          if (d == 0.0) return null; // invalid at runtime
+          lengths.add((int) Math.max(0, Math.ceil((l - s) / d)));
+        }
+
+    return lengths.size() == 1 ? lengths.iterator().next() : null;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -253,7 +253,13 @@ public class RaggedRange extends Range {
       for (Double l : limits)
         for (Double d : deltas) {
           if (d == 0.0) return null; // invalid at runtime
+          // NaN/Infinity would silently degrade through `(int) Math.ceil(NaN) == 0`, pinning a
+          // bogus `NumericDim(0)` instead of falling back to `RaggedDim`. Force the fallback.
+          if (!Double.isFinite(s) || !Double.isFinite(l) || !Double.isFinite(d)) return null;
           lengths.add((int) Math.max(0, Math.ceil((l - s) / d)));
+          // Short-circuit: the caller only needs to know whether there's exactly one distinct
+          // length; finishing the cross-product once we've seen two is wasted work.
+          if (lengths.size() > 1) return null;
         }
 
     return lengths.size() == 1 ? lengths.iterator().next() : null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -62,6 +62,12 @@ public class RaggedRange extends Range {
       OrdinalSet<InstanceKey> startPts = OrdinalSet.empty();
       OrdinalSet<InstanceKey> limitPts = OrdinalSet.empty();
       OrdinalSet<InstanceKey> deltaPts = OrdinalSet.empty();
+      // Track which args the call explicitly provides — distinct from "PTS happens to be empty".
+      // `getArgumentPointsToSet` can return `OrdinalSet.empty()` for arg-present-but-unresolvable
+      // cases too; treating "empty" as "omitted" would make the inferred length unsound.
+      boolean startProvided = false;
+      boolean limitProvided = false;
+      boolean deltaProvided = false;
 
       if (numPosArgs == 0) {
         // Keyword only — fetched below from the keyword-fallback block.
@@ -71,60 +77,71 @@ public class RaggedRange extends Range {
           limitPts =
               this.getArgumentPointsToSet(
                   builder, Parameters.STARTS.getIndex(), Parameters.LIMITS.getName());
+          limitProvided = true;
         } else {
           startPts =
               this.getArgumentPointsToSet(
                   builder, Parameters.STARTS.getIndex(), Parameters.STARTS.getName());
+          startProvided = true;
           limitPts =
               this.getArgumentPointsToSet(
                   builder, UNDEFINED_PARAMETER_POSITION, Parameters.LIMITS.getName());
+          limitProvided = true;
         }
       } else if (numPosArgs == 2) {
         // range(starts, limits)
         startPts =
             this.getArgumentPointsToSet(
                 builder, Parameters.STARTS.getIndex(), Parameters.STARTS.getName());
+        startProvided = true;
         limitPts =
             this.getArgumentPointsToSet(
                 builder, Parameters.LIMITS.getIndex(), Parameters.LIMITS.getName());
+        limitProvided = true;
       } else if (numPosArgs >= 3) {
         // range(starts, limits, deltas)
         startPts =
             this.getArgumentPointsToSet(
                 builder, Parameters.STARTS.getIndex(), Parameters.STARTS.getName());
+        startProvided = true;
         limitPts =
             this.getArgumentPointsToSet(
                 builder, Parameters.LIMITS.getIndex(), Parameters.LIMITS.getName());
+        limitProvided = true;
         deltaPts =
             this.getArgumentPointsToSet(
                 builder, Parameters.DELTAS.getIndex(), Parameters.DELTAS.getName());
+        deltaProvided = true;
       }
 
-      // Retrieve keyword args if not already set by positional (and not empty from initialization)
-      if (startPts.isEmpty())
+      // Retrieve keyword args if not already set by positional. Use `isKeywordArgumentPresent` to
+      // know whether the arg is actually in the call, not just whether the PTS resolved.
+      if (!startProvided && this.isKeywordArgumentPresent(builder, Parameters.STARTS.getName())) {
         startPts =
-            OrdinalSet.unify(
-                startPts,
-                this.getArgumentPointsToSet(
-                    builder, UNDEFINED_PARAMETER_POSITION, Parameters.STARTS.getName()));
-      if (limitPts.isEmpty())
+            this.getArgumentPointsToSet(
+                builder, UNDEFINED_PARAMETER_POSITION, Parameters.STARTS.getName());
+        startProvided = true;
+      }
+      if (!limitProvided && this.isKeywordArgumentPresent(builder, Parameters.LIMITS.getName())) {
         limitPts =
-            OrdinalSet.unify(
-                limitPts,
-                this.getArgumentPointsToSet(
-                    builder, UNDEFINED_PARAMETER_POSITION, Parameters.LIMITS.getName()));
-      if (deltaPts.isEmpty())
+            this.getArgumentPointsToSet(
+                builder, UNDEFINED_PARAMETER_POSITION, Parameters.LIMITS.getName());
+        limitProvided = true;
+      }
+      if (!deltaProvided && this.isKeywordArgumentPresent(builder, Parameters.DELTAS.getName())) {
         deltaPts =
-            OrdinalSet.unify(
-                deltaPts,
-                this.getArgumentPointsToSet(
-                    builder, UNDEFINED_PARAMETER_POSITION, Parameters.DELTAS.getName()));
+            this.getArgumentPointsToSet(
+                builder, UNDEFINED_PARAMETER_POSITION, Parameters.DELTAS.getName());
+        deltaProvided = true;
+      }
 
       // Keyword-only: `tf.ragged.range(starts=5)` semantically means `limits=5`. Apply the swap
       // AFTER the keyword fallback above so re-fetching `starts` can't undo it.
-      if (numPosArgs == 0 && limitPts.isEmpty() && !startPts.isEmpty()) {
+      if (numPosArgs == 0 && !limitProvided && startProvided) {
         limitPts = startPts;
+        limitProvided = true;
         startPts = OrdinalSet.empty();
+        startProvided = false;
       }
 
       // Check for vectors
@@ -169,7 +186,9 @@ public class RaggedRange extends Range {
         // <a href="https://github.com/wala/ML/issues/546">wala/ML#546</a>.
         List<Dimension<?>> shape = new ArrayList<>();
         shape.add(new NumericDim(1));
-        Integer staticLength = computeStaticInnerLength(startPts, limitPts, deltaPts);
+        Integer staticLength =
+            computeStaticInnerLength(
+                startPts, startProvided, limitPts, limitProvided, deltaPts, deltaProvided);
         shape.add(staticLength != null ? new NumericDim(staticLength) : RaggedDim.INSTANCE);
         ret.add(shape);
       }
@@ -180,28 +199,54 @@ public class RaggedRange extends Range {
   /**
    * Computes the static inner-dimension length for the scalar form of {@code tf.ragged.range} when
    * {@code start}/{@code limit}/{@code delta} all resolve to compile-time numeric literals. Returns
-   * {@code null} when any arg is non-literal, when {@code delta} could be zero (invalid at
-   * runtime), or when the cross-product of literal values yields multiple distinct lengths.
+   * {@code null} when {@code limit} is omitted, when any provided arg is non-literal or
+   * unresolvable, when {@code delta} could be zero (invalid at runtime), or when the cross-product
+   * of literal values yields multiple distinct lengths. {@code start}/{@code delta} default to
+   * {@code 0}/{@code 1} only when their {@code *Provided} flag is false (the runtime default for an
+   * omitted arg) — empty PTS for a *provided* arg means "unresolvable" and forces a fallback to
+   * {@code RaggedDim}.
    *
-   * @param startPts Points-to set of the {@code start} argument (empty defaults to {@code 0}).
-   * @param limitPts Points-to set of the {@code limit} argument; required.
-   * @param deltaPts Points-to set of the {@code delta} argument (empty defaults to {@code 1}).
+   * @param startPts Points-to set of the {@code start} argument; consulted only when {@code
+   *     startProvided}.
+   * @param startProvided Whether the call provided an explicit {@code start} (positional or
+   *     keyword).
+   * @param limitPts Points-to set of the {@code limit} argument; required (mandatory at runtime).
+   * @param limitProvided Whether the call provided an explicit {@code limit}.
+   * @param deltaPts Points-to set of the {@code delta} argument; consulted only when {@code
+   *     deltaProvided}.
+   * @param deltaProvided Whether the call provided an explicit {@code delta}.
    * @return The single statically-computable inner length, or {@code null} if not derivable.
    */
   private static Integer computeStaticInnerLength(
       OrdinalSet<InstanceKey> startPts,
+      boolean startProvided,
       OrdinalSet<InstanceKey> limitPts,
-      OrdinalSet<InstanceKey> deltaPts) {
-    Set<Double> limits = getPossibleDoubleValues(limitPts);
+      boolean limitProvided,
+      OrdinalSet<InstanceKey> deltaPts,
+      boolean deltaProvided) {
+    if (!limitProvided) return null;
+
+    // `getPossibleDoubleValues` throws `IllegalStateException` on non-`ConstantKey<Number>` PTS
+    // contents (via `getConstantValues(..., requireConstants=true)`); catch and degrade to
+    // RaggedDim instead of crashing the analysis. Mirrors the established "modeling gap → soft
+    // fallback" pattern in e.g. `Reshape.getShapes`.
+    Set<Double> limits;
+    Set<Double> starts;
+    Set<Double> deltas;
+    try {
+      limits = getPossibleDoubleValues(limitPts);
+      starts = startProvided ? getPossibleDoubleValues(startPts) : new java.util.HashSet<>();
+      deltas = deltaProvided ? getPossibleDoubleValues(deltaPts) : new java.util.HashSet<>();
+    } catch (IllegalStateException e) {
+      return null;
+    }
+
     if (limits.isEmpty() || limits.contains(null)) return null;
+    if (startProvided && (starts.isEmpty() || starts.contains(null))) return null;
+    if (deltaProvided && (deltas.isEmpty() || deltas.contains(null))) return null;
 
-    Set<Double> starts = getPossibleDoubleValues(startPts);
-    if (starts.contains(null)) return null;
-    if (starts.isEmpty()) starts.add(0.0);
-
-    Set<Double> deltas = getPossibleDoubleValues(deltaPts);
-    if (deltas.contains(null)) return null;
-    if (deltas.isEmpty()) deltas.add(1.0);
+    if (!startProvided) starts.add(0.0);
+    if (!deltaProvided) deltas.add(1.0);
 
     Set<Integer> lengths = HashSetFactory.make();
     for (Double s : starts)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range8.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range8.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(x):
+    pass
+
+
+# wala/ML#546 canonical case: all three scalar args are compile-time literals,
+# so the analyzer can pin the inner row length statically: ceil((18 - 3) / 3) = 5.
+# TF's runtime .shape API conservatively reports the ragged dim as None; the
+# inner row's concrete length is exposed via r[0].shape.
+r = tf.ragged.range(3, 18, 3)
+assert isinstance(r, tf.RaggedTensor)
+assert r.shape == (1, None)
+assert r[0].shape == (5,)
+assert r.dtype == tf.int32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range9.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range9.py
@@ -1,0 +1,24 @@
+import sys
+
+import tensorflow as tf
+
+
+def f(x):
+    pass
+
+
+# wala/ML#546: when `start` resolves to multiple literal values in the PA
+# (here via an if/else merging two ConstantKeys into the phi), the
+# cross-product of static lengths yields more than one distinct value
+# (`10 - 0 = 10` vs `10 - 2 = 8`). `computeStaticInnerLength` returns
+# `null` and the inner dim falls back to `RaggedDim`. Use `sys.argv` so
+# the analyzer follows both branches; either runtime path satisfies the
+# `r.shape == (1, None)` assertion.
+if len(sys.argv) > 1:
+    s = 0
+else:
+    s = 2
+r = tf.ragged.range(s, 10, 1)
+assert isinstance(r, tf.RaggedTensor)
+assert r.shape == (1, None)
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range9.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_range9.py
@@ -21,4 +21,5 @@ else:
 r = tf.ragged.range(s, 10, 1)
 assert isinstance(r, tf.RaggedTensor)
 assert r.shape == (1, None)
+assert r.dtype == tf.int32
 f(r)


### PR DESCRIPTION
## Summary

First slice of wala/ML#546. When `tf.ragged.range`'s `start`/`limit`/`delta` are all compile-time numeric literals and the cross-product yields a single length, pin the inner dim as `NumericDim(length)` instead of `RaggedDim.INSTANCE`.

For the canonical case from the issue body:

| Call | Before | After |
|---|---|---|
| `tf.ragged.range(3, 18, 3)` | `(1, ragged)` | `(1, 5)` |
| `tf.ragged.range(10)` | `(1, ragged)` | `(1, 10)` |
| `tf.ragged.range(0, 5, deltas=1)` | `(1, ragged)` | `(1, 5)` |

Falls back to `RaggedDim` when any arg is non-literal, when `delta` could be zero (invalid at runtime), or when the cross-product yields multiple distinct lengths.

## Incidental Bug Fix

Wiring this in surfaced a pre-existing keyword-arg-ordering bug: the keyword-only `tf.ragged.range(starts=5)` swap (treating `starts=X` as `limits=X` since `limits` is mandatory) used to fire BEFORE the keyword fallback, which would then re-fetch `starts` and undo the swap. Pre-fix this was invisible because both pre- and post-swap states landed at `(1, RaggedDim)`; the static-length specialisation now surfaces it. Moved the swap to fire AFTER the fallback.

## Out of Scope

The other constructors mentioned in wala/ML#546 (`from_row_splits`, `from_row_lengths`, `from_row_limits`, `from_row_starts`, `from_value_rowids`, `from_nested_*`) each have constructor-specific arithmetic and are independent follow-up slices.

Vector-arg cases (`testRaggedRange3`–`testRaggedRange7`) keep `RaggedDim` because per-row lengths vary; vector specialisation is a separate slice.

## Test Plan

- [x] `mvn test` from root: 781/0/0/3 (new `testRaggedRange8` brought the count from 780).
- [x] `testRaggedRange`/`testRaggedRange2` tightened to `TENSOR_1_10_INT32`.
- [x] `testRaggedRangeKeyword` tightened across all five slots to `TENSOR_1_5_INT32`.
- [x] `testAdd66`–`testAdd71` (`(1, 5)` + `(1, 5)` broadcast) tightened.
- [x] Spotless clean on commit.

Closes wala/ML#546 partially—`ragged.range` arm only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)