### PR TITLE
Decouple `set_shape` from cast pass_through alias chain

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5955,21 +5955,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Generator-dispatch test for {@code tf.cast(x, dtype)}. The dedicated {@link
    * com.ibm.wala.cast.python.ml.client.Cast} generator extends {@link
    * com.ibm.wala.cast.python.ml.client.PassThroughUnaryTensorGenerator} for shape and overrides the
-   * dtype-arg position to point at {@code dtype}, but the override doesn't take effect — see <a
-   * href="https://github.com/wala/ML/issues/481">wala/ML#481</a>. The static analysis currently
-   * reports the input's dtype rather than the cast target.
-   *
-   * <p>The earlier {@code tf.cast} {@code pass_through} alias is intentionally retained: removing
-   * it would unblock the {@code Cast} override here (so this assertion would tighten to {@code
-   * Set.of(TENSOR_3_INT32)}), but the dedicated {@code <new>+<return>} doesn't propagate the cast
-   * result's tensor classification through to chained consumers (e.g., {@code reshape} in {@code
-   * TestNeuroImageExamples.testEx1CG}). The pass_through alias is sound for those chains.
-   *
-   * <p>TODO: Once the dedicated-allocation chained-consumer integration tracked by <a
-   * href="https://github.com/wala/ML/issues/509">wala/ML#509</a> lands (which lets us safely drop
-   * the {@code pass_through} alias and let the {@code Cast} override fire &mdash; closing
-   * wala/ML#481's {@code Cast} arm), replace the assertion with {@code Set.of(TENSOR_3_INT32)} (the
-   * precise cast-target dtype, disjoint from the currently-asserted input dtype).
+   * dtype-arg position to point at {@code dtype}; the {@code tf.cast} {@code pass_through} alias
+   * that previously bypassed the override was removed in <a
+   * href="https://github.com/wala/ML/issues/499">wala/ML#499</a>, so the static analysis now
+   * reports the explicit cast target ({@code int32}) rather than the input's dtype ({@code
+   * float32}).
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5979,7 +5969,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testCast()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_cast.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+    test("tf2_test_cast.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5973,6 +5973,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/509">wala/ML#509</a>: a
+   * user-defined class that happens to define a {@code set_shape} method must not be classified as
+   * a tensor by the static analysis. The {@code set_shape} recognition path must restrict pinning
+   * to actual tensor types and let non-tensor receivers fall through untouched.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testSetShapeNonTensorReceiver()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_set_shape_non_tensor.py", "consume", 0, 0, Map.of());
+  }
+
+  /**
    * Generator-dispatch test for {@code tf.expand_dims(input, axis)}. The dedicated {@link
    * com.ibm.wala.cast.python.ml.client.ExpandDims} generator overrides {@code getDefaultShapes} to
    * ⊤ pending an axis-aware shape composer. Replacing the stale {@code array_ops.expand_dims}

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -69,7 +69,6 @@
         <new def="FixedLenFeature" class="Ltensorflow/functions/FixedLenFeature" />
         <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature" />
         <new def="pass_through" class="Ltensorflow/functions/pass_through" />
-        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through" />
         <new def="estimator" class="Lobject" />
         <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator" />

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -271,7 +271,17 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
             @Override
             public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
-              return lhs.state.add(setShapeTo) ? CHANGED_AND_FIXED : NOT_CHANGED;
+              // wala/ML#509: `x.set_shape(s)` is a user-supplied shape assertion that should
+              // OVERRIDE any per-op-generator init seed on the receiver, not union with it. The
+              // previous `add`-only semantics caused the cast result's Cast-generator-seeded
+              // `(?, dtype)` to leak into the post-set_shape state alongside the asserted shape.
+              // Clear-then-add mirrors `DropOp`'s clear-state pattern with CHANGED_AND_FIXED.
+              if (lhs.state.size() == 1 && lhs.state.contains(setShapeTo)) {
+                return NOT_CHANGED_AND_FIXED;
+              }
+              lhs.state.clear();
+              lhs.state.add(setShapeTo);
+              return CHANGED_AND_FIXED;
             }
 
             @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -271,7 +271,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
             @Override
             public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
-              // wala/ML#509: `x.set_shape(s)` is a user-supplied shape assertion that should
+              // https://github.com/wala/ML/issues/509: `x.set_shape(s)` is a user-supplied shape
+              // assertion that should
               // OVERRIDE any per-op-generator init seed on the receiver, not union with it. The
               // previous `add`-only semantics caused the cast result's Cast-generator-seeded
               // `(?, dtype)` to leak into the post-set_shape state alongside the asserted shape.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -805,6 +805,27 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         int receiverVn = prop.getObjectRef();
         PointerKey receiverKey =
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, receiverVn);
+        // Containment check: only pin when the PA confirms the receiver is a TF object (Tensor,
+        // feature, etc.). Non-TF Python classes that happen to define a `set_shape` method
+        // shouldn't tip into the tensor analysis. Receivers with empty PTS are still pinned —
+        // tensor variables in this codebase can legitimately have empty PTS (CLAUDE.md note on
+        // PTS-vs-TensorTypeAnalysis), and the syntactic pattern itself is strong evidence in
+        // the TF source files this analyzer targets.
+        OrdinalSet<InstanceKey> recvPts = builder.getPointerAnalysis().getPointsToSet(receiverKey);
+        boolean tfOrUnresolved = recvPts == null || recvPts.isEmpty();
+        if (!tfOrUnresolved) {
+          for (InstanceKey ik : recvPts) {
+            if (ik instanceof AllocationSiteInNode) {
+              String typeName =
+                  ((AllocationSiteInNode) ik).getConcreteType().getReference().getName().toString();
+              if (typeName.contains("tensorflow/")) {
+                tfOrUnresolved = true;
+                break;
+              }
+            }
+          }
+        }
+        if (!tfOrUnresolved) continue;
         try {
           targets.put(
               builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -162,18 +162,18 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   private static final String SET_SHAPE_ATTRIBUTE = "set_shape";
 
   /**
-   * Fully-qualified WALA allocation-type names whose Python counterparts expose a public {@code
-   * set_shape} method ({@code tf.Tensor} and {@code tf.SparseTensor}). Used as a receiver-type
-   * whitelist by {@link #getSetShapeCallsSyntactic} to filter out non-tensor receivers that happen
-   * to invoke {@code set_shape}. {@code tf.RaggedTensor} and {@code tf.IndexedSlices} aren't
-   * included pending verified test fixtures.
+   * WALA allocation types whose Python counterparts expose a public {@code set_shape} method
+   * ({@code tf.Tensor} and {@code tf.SparseTensor}). Used as a receiver-type whitelist by {@link
+   * #getSetShapeCallsSyntactic} to filter out non-tensor receivers that happen to invoke {@code
+   * set_shape}. {@code tf.RaggedTensor} and {@code tf.IndexedSlices} aren't included pending
+   * verified test fixtures.
    */
-  private static final Set<String> SET_SHAPE_RECEIVER_TYPES =
+  private static final Set<TypeReference> SET_SHAPE_RECEIVER_TYPES =
       Set.of(
-          "Ltensorflow/functions/Tensor",
-          "Ltensorflow/python/framework/ops/Tensor",
-          "Ltensorflow/functions/SparseTensor",
-          "Ltensorflow/python/framework/sparse_tensor/SparseTensor");
+          TensorFlowTypes.TENSOR_FUNCTIONS_TYPE,
+          TensorFlowTypes.TENSOR_TYPE,
+          TensorFlowTypes.SPARSE_TENSOR_FUNCTIONS_TYPE,
+          TensorFlowTypes.SPARSE_TENSOR_TYPE);
 
   private static final MethodReference convert_to_tensor =
       MethodReference.findOrCreate(
@@ -850,12 +850,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // `ConstantKey` wrappers — mirrors the pattern used at lines 386 and 714 of this
             // file and avoids missing tensor receivers that flow through closures or constants.
             AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-            if (asin != null) {
-              String typeName = asin.getConcreteType().getReference().getName().toString();
-              if (SET_SHAPE_RECEIVER_TYPES.contains(typeName)) {
-                receiverEligible = true;
-                break;
-              }
+            if (asin != null
+                && SET_SHAPE_RECEIVER_TYPES.contains(asin.getConcreteType().getReference())) {
+              receiverEligible = true;
+              break;
             }
           }
         }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -175,13 +175,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           "Ltensorflow/functions/SparseTensor",
           "Ltensorflow/python/framework/sparse_tensor/SparseTensor");
 
-  private static final MethodReference set_shape =
-      MethodReference.findOrCreate(
-          TypeReference.findOrCreate(
-              PythonTypes.pythonLoader,
-              TypeName.string2TypeName("Ltensorflow/functions/" + SET_SHAPE_ATTRIBUTE)),
-          AstMethodReference.fnSelector);
-
   private static final MethodReference convert_to_tensor =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
@@ -853,9 +846,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         boolean receiverEligible = recvPts == null || recvPts.isEmpty();
         if (!receiverEligible) {
           for (InstanceKey ik : recvPts) {
-            if (ik instanceof AllocationSiteInNode) {
-              String typeName =
-                  ((AllocationSiteInNode) ik).getConcreteType().getReference().getName().toString();
+            // Use the `getAllocationSiteInNode` helper to unwrap `ScopeMappingInstanceKey` /
+            // `ConstantKey` wrappers — mirrors the pattern used at lines 386 and 714 of this
+            // file and avoids missing tensor receivers that flow through closures or constants.
+            AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+            if (asin != null) {
+              String typeName = asin.getConcreteType().getReference().getName().toString();
               if (SET_SHAPE_RECEIVER_TYPES.contains(typeName)) {
                 receiverEligible = true;
                 break;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -793,17 +793,31 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       if (ir == null) continue;
       SymbolTable st = ir.getSymbolTable();
       DefUse du = caller.getDU();
+      // Walk every SSA instruction in the caller's IR. We are looking for the two-instruction
+      // pattern that a Python attribute-call lowers into: a `PythonPropertyRead` defining the
+      // call target, followed by a `PythonInvokeInstruction` consuming that target.
       for (Iterator<SSAInstruction> it = ir.iterateAllInstructions(); it.hasNext(); ) {
         SSAInstruction inst = it.next();
         if (!(inst instanceof PythonInvokeInstruction)) continue;
         PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+        // `use(0)` of a Python invoke is the call target (the property-read result); `use(1)` is
+        // the receiver. We need both to identify an `x.set_shape(shape)` site, so skip invokes
+        // with fewer than 2 uses (e.g., zero-arg property invocations).
         if (call.getNumberOfUses() < 2) continue;
+        // Resolve the call target's defining instruction. If the target wasn't produced by a
+        // property read, this isn't an attribute call (could be a function-typed local, a
+        // closure, etc.) and we ignore it.
         SSAInstruction targetDef = du.getDef(call.getUse(0));
         if (!(targetDef instanceof PythonPropertyRead)) continue;
         PythonPropertyRead prop = (PythonPropertyRead) targetDef;
+        // The property-read's `memberRef` value-number identifies the attribute name. We only
+        // pin on the literal string `"set_shape"`; dynamic attribute names (rare in TF source)
+        // can't be matched syntactically and are out of scope.
         int memberVn = prop.getMemberRef();
         if (!st.isStringConstant(memberVn)) continue;
         if (!"set_shape".equals(st.getStringValue(memberVn))) continue;
+        // The property-read's `objectRef` value-number is the receiver — the `x` in
+        // `x.set_shape(shape)`. That's what we pin to the asserted shape.
         int receiverVn = prop.getObjectRef();
         PointerKey receiverKey =
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, receiverVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -161,6 +161,20 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   /** The Python attribute name for {@code tf.Tensor.set_shape}, used by the IR-syntactic scan. */
   private static final String SET_SHAPE_ATTRIBUTE = "set_shape";
 
+  /**
+   * Fully-qualified WALA allocation-type names whose Python counterparts expose a public {@code
+   * set_shape} method ({@code tf.Tensor} and {@code tf.SparseTensor}). Used as a receiver-type
+   * whitelist by {@link #getSetShapeCallsSyntactic} to filter out non-tensor receivers that happen
+   * to invoke {@code set_shape}. {@code tf.RaggedTensor} and {@code tf.IndexedSlices} aren't
+   * included pending verified test fixtures.
+   */
+  private static final Set<String> SET_SHAPE_RECEIVER_TYPES =
+      Set.of(
+          "Ltensorflow/functions/Tensor",
+          "Ltensorflow/python/framework/ops/Tensor",
+          "Ltensorflow/functions/SparseTensor",
+          "Ltensorflow/python/framework/sparse_tensor/SparseTensor");
+
   private static final MethodReference set_shape =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
@@ -824,19 +838,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         int receiverVn = prop.getObjectRef();
         PointerKey receiverKey =
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, receiverVn);
-        // Containment check: only pin when the receiver's PA allocation type is one that supports
-        // `set_shape` in real TF — `tf.Tensor` and `tf.SparseTensor` (both expose a public
-        // `set_shape`). Other tensor-like types (RaggedTensor, IndexedSlices) aren't currently
-        // included; add them here if a test fixture surfaces one with `set_shape`.
+        // Containment check: only pin when the receiver's PA allocation type is one that
+        // supports `set_shape` in real TF. See `SET_SHAPE_RECEIVER_TYPES` for the whitelist.
         //
-        // Receivers with empty PTS are still pinned. Empty PTS is not the design intent of the
-        // PA — it's a propagation gap: XML summaries don't always flow allocations correctly to
-        // all consumers (CLAUDE.md, "PTS vs `TensorTypeAnalysis`"). In particular,
-        // `pass_through.do`
-        // returns its `data` argument verbatim with no fresh `<new>`, so a Tensor flowing through
-        // it loses allocation-site context at the receiver. The syntactic `set_shape` pattern is
-        // strong evidence in the TF source files this analyzer targets, so pinning on empty PTS
-        // is correct-on-balance even though it's a workaround for the summary-propagation gap.
+        // Receivers with empty PTS are still pinned. Empty PTS occurs when a TF API in the call
+        // chain upstream of the `set_shape` site has no XML summary (or the summary doesn't
+        // model its return as a fresh allocation) — see CLAUDE.md, "PTS vs `TensorTypeAnalysis`".
+        // The syntactic `set_shape` pattern itself is strong evidence in the TF source files
+        // this analyzer targets, so pinning on empty PTS is correct-on-balance.
         OrdinalSet<InstanceKey> recvPts = builder.getPointerAnalysis().getPointsToSet(receiverKey);
         boolean receiverEligible = recvPts == null || recvPts.isEmpty();
         if (!receiverEligible) {
@@ -844,7 +853,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             if (ik instanceof AllocationSiteInNode) {
               String typeName =
                   ((AllocationSiteInNode) ik).getConcreteType().getReference().getName().toString();
-              if (typeName.endsWith("/Tensor") || typeName.endsWith("/SparseTensor")) {
+              if (SET_SHAPE_RECEIVER_TYPES.contains(typeName)) {
                 receiverEligible = true;
                 break;
               }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -41,9 +41,11 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationSystem;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.nCFAContextSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.DefUse;
+import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
@@ -787,11 +789,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       PropagationCallGraphBuilder builder) {
     Map<PointsToSetVariable, TensorType> targets = HashMapFactory.make();
     for (CGNode caller : builder.getCallGraph()) {
-      com.ibm.wala.ssa.IR ir = caller.getIR();
+      IR ir = caller.getIR();
       if (ir == null) continue;
-      com.ibm.wala.ssa.SymbolTable st = ir.getSymbolTable();
+      SymbolTable st = ir.getSymbolTable();
       DefUse du = caller.getDU();
-      for (java.util.Iterator<SSAInstruction> it = ir.iterateAllInstructions(); it.hasNext(); ) {
+      for (Iterator<SSAInstruction> it = ir.iterateAllInstructions(); it.hasNext(); ) {
         SSAInstruction inst = it.next();
         if (!(inst instanceof PythonInvokeInstruction)) continue;
         PythonInvokeInstruction call = (PythonInvokeInstruction) inst;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -817,9 +817,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         SSAInstruction inst = it.next();
         if (!(inst instanceof PythonInvokeInstruction)) continue;
         PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
-        // `use(0)` of a Python invoke is the call target (the property-read result); `use(1)` is
-        // the receiver. We need both to identify an `x.set_shape(shape)` site, so skip invokes
-        // with fewer than 2 uses (e.g., zero-arg property invocations).
+        // Python invoke uses are `[callTarget, arg1, arg2, ...]`; there is no explicit receiver
+        // slot in the invoke. `use(0)` is the call target (the `PythonPropertyRead` result), and
+        // `use(1)` is the first positional argument — for `x.set_shape(shape)`, that's the shape.
+        // The receiver `x` is recovered separately below from the property-read's `objectRef`.
+        // We need at least the call target plus one argument to identify an `x.set_shape(shape)`
+        // site, so skip invokes with fewer than 2 uses.
         if (call.getNumberOfUses() < 2) continue;
         // Resolve the call target's defining instruction. If the target wasn't produced by a
         // property read, this isn't an attribute call (could be a function-typed local, a

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -4,6 +4,10 @@ import static com.google.common.collect.Sets.newHashSet;
 import static com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory.getGenerator;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATA_PACKAGE_PREFIX;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR_FUNCTIONS_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR_FUNCTIONS_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR_TYPE;
 import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
@@ -169,11 +173,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * verified test fixtures.
    */
   private static final Set<TypeReference> SET_SHAPE_RECEIVER_TYPES =
-      Set.of(
-          TensorFlowTypes.TENSOR_FUNCTIONS_TYPE,
-          TensorFlowTypes.TENSOR_TYPE,
-          TensorFlowTypes.SPARSE_TENSOR_FUNCTIONS_TYPE,
-          TensorFlowTypes.SPARSE_TENSOR_TYPE);
+      Set.of(TENSOR_FUNCTIONS_TYPE, TENSOR_TYPE, SPARSE_TENSOR_FUNCTIONS_TYPE, SPARSE_TENSOR_TYPE);
 
   private static final MethodReference convert_to_tensor =
       MethodReference.findOrCreate(
@@ -788,9 +788,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * field). See wala/ML#509.
    *
    * <p>Syntactic recognition decouples the {@code set_shape} pin from the attribute-attachment
-   * chain. In TF code, {@code set_shape} unambiguously refers to {@code tf.Tensor.set_shape};
-   * non-TF Python classes don't typically define this method, so the false-positive surface is
-   * effectively zero.
+   * chain. False positives are possible—any Python class can define a {@code set_shape} method, and
+   * a user-defined class that happens to do so would otherwise tip into the tensor analysis. The
+   * {@link #SET_SHAPE_RECEIVER_TYPES} whitelist is a required safeguard: receivers whose PA
+   * allocation type isn't in the whitelist are skipped, with the empty-PTS allowance documented
+   * inline at the containment-check site. {@code testSetShapeNonTensorReceiver} is the regression
+   * guard for this filtering.
    *
    * @param builder The propagation call graph builder.
    * @return Map from receiver {@link PointsToSetVariable} to the asserted {@link TensorType}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -824,12 +824,19 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         int receiverVn = prop.getObjectRef();
         PointerKey receiverKey =
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, receiverVn);
-        // Containment check: only pin when the PA confirms the receiver is a TF object (Tensor,
-        // feature, etc.). Non-TF Python classes that happen to define a `set_shape` method
-        // shouldn't tip into the tensor analysis. Receivers with empty PTS are still pinned —
-        // tensor variables in this codebase can legitimately have empty PTS (CLAUDE.md note on
-        // PTS-vs-TensorTypeAnalysis), and the syntactic pattern itself is strong evidence in
-        // the TF source files this analyzer targets.
+        // Containment check: only pin when the receiver's PA allocation type is one that supports
+        // `set_shape` in real TF — `tf.Tensor` and `tf.SparseTensor` (both expose a public
+        // `set_shape`). Other tensor-like types (RaggedTensor, IndexedSlices) aren't currently
+        // included; add them here if a test fixture surfaces one with `set_shape`.
+        //
+        // Receivers with empty PTS are still pinned. Empty PTS is not the design intent of the
+        // PA — it's a propagation gap: XML summaries don't always flow allocations correctly to
+        // all consumers (CLAUDE.md, "PTS vs `TensorTypeAnalysis`"). In particular,
+        // `pass_through.do`
+        // returns its `data` argument verbatim with no fresh `<new>`, so a Tensor flowing through
+        // it loses allocation-site context at the receiver. The syntactic `set_shape` pattern is
+        // strong evidence in the TF source files this analyzer targets, so pinning on empty PTS
+        // is correct-on-balance even though it's a workaround for the summary-propagation gap.
         OrdinalSet<InstanceKey> recvPts = builder.getPointerAnalysis().getPointsToSet(receiverKey);
         boolean receiverEligible = recvPts == null || recvPts.isEmpty();
         if (!receiverEligible) {
@@ -837,7 +844,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             if (ik instanceof AllocationSiteInNode) {
               String typeName =
                   ((AllocationSiteInNode) ik).getConcreteType().getReference().getName().toString();
-              if (typeName.contains("tensorflow/")) {
+              if (typeName.endsWith("/Tensor") || typeName.endsWith("/SparseTensor")) {
                 receiverEligible = true;
                 break;
               }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -762,6 +762,61 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     return targets;
   }
 
+  /**
+   * Finds {@code x.set_shape(shape)} call sites by scanning the IR directly for {@link
+   * PythonPropertyRead}s of the {@code set_shape} attribute followed by an invoke on the
+   * property-read result. Returns a map keyed by the *receiver's* points-to-set variable (the
+   * {@code x}) to the shape-arg {@link TensorType}.
+   *
+   * <p>The legacy {@link #getShapeSourceCalls} path resolves the {@code set_shape} method via
+   * WALA's call-graph dispatch on the {@code Ltensorflow/functions/set_shape} synthetic class. That
+   * dispatch only fires when the receiver has the {@code set_shape} attribute attached via the
+   * {@code FixedLenFeature.do} {@code <putfield>} chain — broken when {@code tf.cast}'s {@code
+   * pass_through} alias is removed (the freshly-allocated {@code Tensor} has no {@code set_shape}
+   * field). See wala/ML#509.
+   *
+   * <p>Syntactic recognition decouples the {@code set_shape} pin from the attribute-attachment
+   * chain. In TF code, {@code set_shape} unambiguously refers to {@code tf.Tensor.set_shape};
+   * non-TF Python classes don't typically define this method, so the false-positive surface is
+   * effectively zero.
+   *
+   * @param builder The propagation call graph builder.
+   * @return Map from receiver {@link PointsToSetVariable} to the asserted {@link TensorType}.
+   */
+  private Map<PointsToSetVariable, TensorType> getSetShapeCallsSyntactic(
+      PropagationCallGraphBuilder builder) {
+    Map<PointsToSetVariable, TensorType> targets = HashMapFactory.make();
+    for (CGNode caller : builder.getCallGraph()) {
+      com.ibm.wala.ssa.IR ir = caller.getIR();
+      if (ir == null) continue;
+      com.ibm.wala.ssa.SymbolTable st = ir.getSymbolTable();
+      DefUse du = caller.getDU();
+      for (java.util.Iterator<SSAInstruction> it = ir.iterateAllInstructions(); it.hasNext(); ) {
+        SSAInstruction inst = it.next();
+        if (!(inst instanceof PythonInvokeInstruction)) continue;
+        PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+        if (call.getNumberOfUses() < 2) continue;
+        SSAInstruction targetDef = du.getDef(call.getUse(0));
+        if (!(targetDef instanceof PythonPropertyRead)) continue;
+        PythonPropertyRead prop = (PythonPropertyRead) targetDef;
+        int memberVn = prop.getMemberRef();
+        if (!st.isStringConstant(memberVn)) continue;
+        if (!"set_shape".equals(st.getStringValue(memberVn))) continue;
+        int receiverVn = prop.getObjectRef();
+        PointerKey receiverKey =
+            builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, receiverVn);
+        try {
+          targets.put(
+              builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
+              TensorType.shapeArg(caller, call.getUse(1)));
+        } catch (IOException e) {
+          throw new RuntimeException("Error while processing set_shape call: " + call, e);
+        }
+      }
+    }
+    return targets;
+  }
+
   private Set<PointsToSetVariable> getKeysDefinedByCall(
       MethodReference op, PropagationCallGraphBuilder builder) {
     Set<PointsToSetVariable> lvals = HashSetFactory.make();
@@ -876,24 +931,17 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     for (Map.Entry<PointsToSetVariable, TensorType> e : placeholders.entrySet())
       init.put(e.getKey(), Set.of(e.getValue()));
 
-    Map<PointsToSetVariable, TensorType> setCalls = HashMapFactory.make();
-    Map<PointsToSetVariable, TensorType> set_shapes = getShapeSourceCalls(set_shape, builder, 1);
+    // wala/ML#509: recognize `x.set_shape(s)` via IR scanning rather than call-graph dispatch on
+    // the `Ltensorflow/functions/set_shape` synthetic class. The legacy dispatch path requires
+    // the receiver to have the `set_shape` attribute attached (via FixedLenFeature.do's
+    // <putfield>) and breaks when the cast pass_through alias is removed.
+    Map<PointsToSetVariable, TensorType> setCalls = getSetShapeCallsSyntactic(builder);
 
-    for (Map.Entry<PointsToSetVariable, TensorType> x : set_shapes.entrySet()) {
-      LocalPointerKey localPointerKey = (LocalPointerKey) x.getKey().getPointerKey();
-      CGNode setNode = localPointerKey.getNode();
-      int defVn = localPointerKey.getValueNumber();
-      SSAInstruction read = setNode.getDU().getDef(defVn);
-      SSAInstruction call = setNode.getDU().getDef(read.getUse(0));
-
-      PointerKey setKey =
-          builder
-              .getPointerAnalysis()
-              .getHeapModel()
-              .getPointerKeyForLocal(setNode, call.getUse(0));
-
-      setCalls.put(builder.getPropagationSystem().findOrCreatePointsToSet(setKey), x.getValue());
-    }
+    // wala/ML#509: `set_shape` is a user-supplied OVERRIDE of any per-op-generator init seed on
+    // the receiver. Remove receivers from `init` so the SetShapeOp edge transfer is the sole
+    // source of state for those variables; otherwise the meet-time union re-introduces the
+    // generator-seeded type (e.g., Cast generator's (?, float32) on the cast-result variable).
+    for (PointsToSetVariable recv : setCalls.keySet()) init.remove(recv);
 
     // Route subscript results through `setCalls` so `TensorTypeAnalysis`'s edge-transfer replaces
     // predecessor types rather than unioning them — the receiver's pre-subscript shape would

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -158,11 +158,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               TypeName.string2TypeName("Ltensorflow/functions/placeholder")),
           AstMethodReference.fnSelector);
 
+  /** The Python attribute name for {@code tf.Tensor.set_shape}, used by the IR-syntactic scan. */
+  private static final String SET_SHAPE_ATTRIBUTE = "set_shape";
+
   private static final MethodReference set_shape =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
               PythonTypes.pythonLoader,
-              TypeName.string2TypeName("Ltensorflow/functions/set_shape")),
+              TypeName.string2TypeName("Ltensorflow/functions/" + SET_SHAPE_ATTRIBUTE)),
           AstMethodReference.fnSelector);
 
   private static final MethodReference convert_to_tensor =
@@ -815,7 +818,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // can't be matched syntactically and are out of scope.
         int memberVn = prop.getMemberRef();
         if (!st.isStringConstant(memberVn)) continue;
-        if (!"set_shape".equals(st.getStringValue(memberVn))) continue;
+        if (!SET_SHAPE_ATTRIBUTE.equals(st.getStringValue(memberVn))) continue;
         // The property-read's `objectRef` value-number is the receiver — the `x` in
         // `x.set_shape(shape)`. That's what we pin to the asserted shape.
         int receiverVn = prop.getObjectRef();
@@ -828,20 +831,20 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // PTS-vs-TensorTypeAnalysis), and the syntactic pattern itself is strong evidence in
         // the TF source files this analyzer targets.
         OrdinalSet<InstanceKey> recvPts = builder.getPointerAnalysis().getPointsToSet(receiverKey);
-        boolean tfOrUnresolved = recvPts == null || recvPts.isEmpty();
-        if (!tfOrUnresolved) {
+        boolean receiverEligible = recvPts == null || recvPts.isEmpty();
+        if (!receiverEligible) {
           for (InstanceKey ik : recvPts) {
             if (ik instanceof AllocationSiteInNode) {
               String typeName =
                   ((AllocationSiteInNode) ik).getConcreteType().getReference().getName().toString();
               if (typeName.contains("tensorflow/")) {
-                tfOrUnresolved = true;
+                receiverEligible = true;
                 break;
               }
             }
           }
         }
-        if (!tfOrUnresolved) continue;
+        if (!receiverEligible) continue;
         try {
           targets.put(
               builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -93,6 +93,10 @@ public class TensorFlowTypes extends PythonTypes {
       TypeReference.findOrCreate(
           pythonLoader, TypeName.findOrCreate("Ltensorflow/python/framework/ops/Tensor"));
 
+  public static final TypeReference TENSOR_FUNCTIONS_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/functions/Tensor"));
+
   public static final TypeReference CONVERT_TO_TENSOR_TYPE =
       TypeReference.findOrCreate(
           pythonLoader,
@@ -124,6 +128,10 @@ public class TensorFlowTypes extends PythonTypes {
       TypeReference.findOrCreate(
           pythonLoader,
           TypeName.findOrCreate("Ltensorflow/python/framework/sparse_tensor/SparseTensor"));
+
+  public static final TypeReference SPARSE_TENSOR_FUNCTIONS_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/functions/SparseTensor"));
 
   public static final TypeReference LINALG_OPS_EYE =
       TypeReference.findOrCreate(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_set_shape_non_tensor.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_set_shape_non_tensor.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#509 regression guard: a user-defined class that happens to define
+# `set_shape` must not be classified as a tensor by the static analysis.
+# The `set_shape` recognition path—regardless of whether it's implemented
+# Java-side (IR pattern matching) or XML-side (class-method dispatch)—must
+# restrict pinning to actual tensor types and let non-tensor receivers
+# fall through untouched.
+class FakeShape:
+    def set_shape(self, shape):
+        return self
+
+
+fake = FakeShape()
+fake.set_shape([1, 2, 3])
+consume(fake)
+
+# Tensor-typed call kept in the same module so that `tf` is non-vacuous;
+# without this the script analyzer doesn't load any TF modeling, which
+# changes the call-graph shape relative to the other tensor fixtures.
+t = tf.constant([1.0, 2.0, 3.0])
+assert t.shape == (3,)
+assert t.dtype == tf.float32


### PR DESCRIPTION
## Summary

The `tf.cast` `pass_through` alias was retained because removing it broke chained consumers like `reshape(cast(...))` in `TestNeuroImageExamples.testEx1CG`. Root cause traced through three steps (full investigation in wala/ML#509 day-1/2/3 comments):

1. `set_shape` is attached to `feature` instances via `FixedLenFeature.do`'s `<putfield>`. Pass-through aliasing preserved the feature instance identity through `decode_raw` and `cast`, so `image.set_shape(...)` resolved via call-graph dispatch on `Ltensorflow/functions/set_shape`. Remove the cast alias and the fresh Tensor allocation lacks the `set_shape` attribute → PropertyRead yields empty PTS → set_shape call site is absent from the call graph.
2. Even attaching `set_shape` per-allocation (133 XML sites) only restores call-graph reachability. The cast-result variable then carries BOTH the `Cast` generator's init seed `(?, float32)` AND the set_shape pin `(64000, float32)` as a union—the previous `SetShapeOp.evaluate` was `lhs.state.add(setShapeTo)`, never displacing the init seed.
3. The receiver-mutating semantics of `set_shape` don't fit the standard `TensorGenerator` pattern, so the generator framework can't replace the special-case path.

## Three Coupled Changes (No XML Edits Beyond Removing the Alias)

- **`PythonTensorAnalysisEngine.getSetShapeCallsSyntactic`**: new IR-scanning recognizer. Pattern-matches `PythonPropertyRead("set_shape")` + invoke, returns receiver → asserted-`TensorType` directly. Bypasses the attribute-attachment dependency that the legacy `getShapeSourceCalls(set_shape, ...)` path requires. Consistent with the engine's existing TF-API awareness (six hardcoded `MethodReference` constants for `conv2d`, `conv3d`, `reshape`, `placeholder`, `set_shape`, `convert_to_tensor`)—just a different recognition strategy for the same identifier.
- **`TensorTypeAnalysis.SetShapeOp.evaluate`**: clear-then-add semantics (mirrors `DropOp`). `set_shape` is a user-supplied OVERRIDE of per-op-generator inference on the receiver, not an additional contribution.
- **`PythonTensorAnalysisEngine.performAnalysis`**: `init.remove(recv)` for each set_shape receiver. The edge transfer's `CHANGED_AND_FIXED` doesn't suppress the init seed that `initializeVariables` writes at solver start; removing the receiver from `init` makes the `SetShapeOp` the sole source of state for that variable.

Plus delete the `cast` `pass_through` alias from `tensorflow.xml`, and flip `testCast` from `TENSOR_3_FLOAT32` to `TENSOR_3_INT32` (matches the Python truth in `tf2_test_cast.py`).

## Load-Bearing vs Preventive

Empirically (Monday worktree probe, wala/ML#509 https://github.com/wala/ML/issues/509#issuecomment-4534972055), for `testEx1CG` specifically `lhs.state` is `[]` when `SetShapeOp.evaluate` fires, so:

- The **IR-syntactic recognition** (`getSetShapeCallsSyntactic` + `init.remove(recv)`) is the load-bearing change. Without it, `testEx1CG`'s receiver isn't recognized and the edge transfer never installs.
- The **`SetShapeOp.evaluate` clear-then-add** is the semantically correct behavior (`set_shape` is an override, not a union contribution) and mirrors `DropOp`'s existing pattern, but is preventive rather than required for the cited test. Kept here because the union semantics are a latent bug—a leaked receiver-shape predecessor on any future set_shape receiver would silently pollute the result.

## Test Plan

- [x] `mvn test` from root: 780/0/0/3.
- [x] Spotless clean on commit.

## Closes

- wala/ML#509 (chained-consumer propagation through cast)
- wala/ML#499 (`tf.cast` honoring user-supplied dtype)
- wala/ML#481 (`Cast` override fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)