### PR TITLE
Remove unused `TENSOR_ITERABLE_SYNTHETIC_FUNCTION_NAME` constant

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -124,11 +124,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   /** A "fake" function name in the summaries that indicates that an API produces a new tensor. */
   public static final String TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME = "read_data";
 
-  /**
-   * A "fake" function name in the summaries that indicates that an API produces a tensor iterable.
-   */
-  private static final String TENSOR_ITERABLE_SYNTHETIC_FUNCTION_NAME = "read_dataset";
-
   private static final Logger LOGGER = Logger.getLogger(PythonTensorAnalysisEngine.class.getName());
 
   private static final MethodReference conv2d =


### PR DESCRIPTION
## Summary

`PythonTensorAnalysisEngine.TENSOR_ITERABLE_SYNTHETIC_FUNCTION_NAME = "read_dataset"` is declared at line 130 but never read anywhere in the Java source. A repo-wide grep confirms its only reference is its own declaration.

The companion `read_dataset` modeling in `tensorflow.xml` (3 sites at lines 2417/2421/2444) is XML-level dispatch: a `<method name="read_dataset">` declaration called from another XML method via `<call name="read_dataset"/>`. That mechanism doesn't go through the Java-side constant.

Dataset sources are recognized at `getDataflowSources` via allocation-type checks against `DATA_PACKAGE_PREFIX` in `definesTensorIterable` plus `next()`-iterator chasing—neither needs the method-name marker.

## Test Plan

- [x] `mvn test` from root: 782/0/0/3.
- [x] Spotless clean on commit.

## Closes

- wala/ML#553

🤖 Generated with [Claude Code](https://claude.com/claude-code)