### PR TITLE
Add `DynamicDim` typed sentinel for dynamic/batch/placeholder dims

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
@@ -179,4 +179,13 @@ public class TensorFlowTypesTest {
     // Same `Void` payload value, different class — must not collapse to equal.
     assertNotEquals(DynamicDim.INSTANCE, RaggedDim.INSTANCE);
   }
+
+  @Test
+  public void testNullPayloadSentinelsHaveDistinctHashCodes() {
+    // Both `DynamicDim` and `RaggedDim` carry `Void` payload (always `null`). Without per-class
+    // `hashCode` overrides, the inherited `Dimension.hashCode` would hash only the payload and
+    // they'd collide in hash buckets — degrading `HashSet<Dimension<?>>` lookups to O(n) when
+    // both kinds are stored. Verify the per-class overrides keep them in distinct buckets.
+    assertNotEquals(DynamicDim.INSTANCE.hashCode(), RaggedDim.INSTANCE.hashCode());
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
@@ -12,7 +12,9 @@ import static org.junit.Assert.*;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import org.junit.Test;
 
@@ -150,5 +152,31 @@ public class TensorFlowTypesTest {
   public void testTensorTypeNotEqualsNull() {
     TensorType a = new TensorType("float32", asList(new NumericDim(3)));
     assertNotEquals(a, null);
+  }
+
+  @Test
+  public void testDynamicDimRendering() {
+    // Cover `DynamicDim`'s package-private overrides through `TensorType`'s public
+    // string-rendering methods (https://github.com/wala/ML/issues/545).
+    TensorType t = new TensorType("float32", asList(DynamicDim.INSTANCE, new NumericDim(4)));
+    assertTrue(t.toMDString().contains("*dynamic*"));
+    assertTrue(t.toCString(false).contains("dynamic"));
+    assertTrue(t.toCString(true).contains("*dynamic*"));
+  }
+
+  @Test
+  public void testDynamicDimSymbolicAndConcrete() {
+    // `DynamicDim` reports as a symbolic dim, mirroring `RaggedDim`'s semantics for the
+    // unknown-size axis (https://github.com/wala/ML/issues/545). A `TensorType` whose dims are
+    // {DynamicDim, NumericDim(4)} reports `symbolicDims() == 1` because exactly one dim is
+    // symbolic (the DynamicDim contributes 1 to the count).
+    TensorType t = new TensorType("float32", asList(DynamicDim.INSTANCE, new NumericDim(4)));
+    assertEquals(1, t.symbolicDims());
+  }
+
+  @Test
+  public void testDynamicDimNotEqualsRaggedDim() {
+    // Same `Void` payload value, different class — must not collapse to equal.
+    assertNotEquals(DynamicDim.INSTANCE, RaggedDim.INSTANCE);
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -245,6 +245,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_RAGGED_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
+  private static final TensorType TENSOR_NONE_RAGGED_INT32 =
+      new TensorType(INT_32, asList(DynamicDim.INSTANCE, RaggedDim.INSTANCE));
+
   private static final TensorType TENSOR_2_RAGGED_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
 
@@ -4108,6 +4111,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             5, Set.of(TENSOR_3_RAGGED_INT32)));
   }
 
+  /**
+   * Coverage guard for the {@code DynamicDim} fallback branch in {@link
+   * com.ibm.wala.cast.python.ml.client.RaggedFromRowStarts}'s nrows inference (<a
+   * href="https://github.com/wala/ML/issues/545">wala/ML#545</a>). When {@code row_starts} has a
+   * non-{@code NumericDim} first dim — here, a {@code DynamicDim} from {@code tf.keras.Input}'s
+   * symbolic batch axis — the generator emits {@code DynamicDim.INSTANCE} for the inferred nrows,
+   * yielding a {@code (DynamicDim, RaggedDim)} shape rather than emitting raw {@code null}.
+   */
+  @Test
+  public void testRaggedFromRowStartsDynamicRowDim()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_row_starts_dynamic.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_NONE_RAGGED_INT32)));
+  }
+
   @Test
   public void testRaggedFromRowLengths()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -4142,6 +4164,54 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2, Set.of(TENSOR_4_RAGGED_INT32),
             3, Set.of(TENSOR_4_RAGGED_INT32),
             4, Set.of(TENSOR_4_RAGGED_INT32)));
+  }
+
+  /**
+   * Coverage guard for the {@code DynamicDim} fallback branch in {@link
+   * com.ibm.wala.cast.python.ml.client.RaggedFromRowLengths}'s nrows inference (<a
+   * href="https://github.com/wala/ML/issues/545">wala/ML#545</a>).
+   */
+  @Test
+  public void testRaggedFromRowLengthsDynamicRowDim()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_row_lengths_dynamic.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_NONE_RAGGED_INT32)));
+  }
+
+  /**
+   * Coverage guard for the {@code DynamicDim} fallback branch in {@link
+   * com.ibm.wala.cast.python.ml.client.RaggedFromRowLimits}'s nrows inference (<a
+   * href="https://github.com/wala/ML/issues/545">wala/ML#545</a>).
+   */
+  @Test
+  public void testRaggedFromRowLimitsDynamicRowDim()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_row_limits_dynamic.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_NONE_RAGGED_INT32)));
+  }
+
+  /**
+   * Coverage guard for the {@code DynamicDim} fallback branch in {@link
+   * com.ibm.wala.cast.python.ml.client.RaggedFromRowSplits}'s nrows inference (<a
+   * href="https://github.com/wala/ML/issues/545">wala/ML#545</a>).
+   */
+  @Test
+  public void testRaggedFromRowSplitsDynamicRowDim()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_row_splits_dynamic.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_NONE_RAGGED_INT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -30,6 +30,7 @@ import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
@@ -174,22 +175,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2)));
 
   private static final TensorType TENSOR_NONE_32_FLOAT32 =
-      new TensorType(FLOAT_32, asList(null, new NumericDim(32)));
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(32)));
 
   private static final TensorType TENSOR_NONE_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(null, new NumericDim(3)));
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3)));
 
   private static final TensorType TENSOR_NONE_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(null, new NumericDim(4)));
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(4)));
 
   private static final TensorType TENSOR_NONE_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(null, new NumericDim(2)));
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(2)));
 
   private static final TensorType TENSOR_NONE_100_FLOAT32 =
-      new TensorType(FLOAT_32, asList(null, new NumericDim(100)));
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(100)));
 
   private static final TensorType TENSOR_NONE_NONE_STRING =
-      new TensorType(STRING, asList(null, null));
+      new TensorType(STRING, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE));
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_INT32 =
       new TensorType(INT_32, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
@@ -199,7 +200,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_4_RAGGED_RAGGED_NONE_STRING =
       new TensorType(
-          STRING, asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, null));
+          STRING,
+          asList(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE));
 
   private static final TensorType TENSOR_3_RAGGED_RAGGED_STRING =
       new TensorType(STRING, asList(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
@@ -238,7 +240,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       new TensorType(FLOAT_32, asList(new NumericDim(1), RaggedDim.INSTANCE));
 
   private static final TensorType TENSOR_2_NONE_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), null));
+      new TensorType(INT_32, asList(new NumericDim(2), DynamicDim.INSTANCE));
 
   private static final TensorType TENSOR_2_RAGGED_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE));
@@ -989,7 +991,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             FLOAT_32,
             asList(
                 new NumericDim(512), new NumericDim(112), new NumericDim(112), new NumericDim(3)));
-    TensorType labels = new TensorType(FLOAT_32, asList(new NumericDim(512), null));
+    TensorType labels = new TensorType(FLOAT_32, asList(new NumericDim(512), DynamicDim.INSTANCE));
 
     test(
         "tf2_test_dataset19.py", "distributed_train_step", 1, 1, Map.of(2, Set.of(images, labels)));
@@ -3451,7 +3453,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     TensorType t1 = new TensorType(FLOAT_32, asList(new NumericDim(16), new NumericDim(32)));
     TensorType t2 =
         new TensorType(FLOAT_32, asList(new NumericDim(5), new NumericDim(10), new NumericDim(10)));
-    TensorType t3 = new TensorType(FLOAT_32, asList(null, new NumericDim(5)));
+    TensorType t3 = new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(5)));
 
     test(
         "tf2_test_input_batch_size.py",
@@ -3480,7 +3482,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     TensorType t2 =
         new TensorType(FLOAT_32, asList(new NumericDim(16), new NumericDim(5), new NumericDim(5)));
     // input3: shape=(None, 20), dtype=int32
-    TensorType t3 = new TensorType(INT_32, asList(null, new NumericDim(20)));
+    TensorType t3 = new TensorType(INT_32, asList(DynamicDim.INSTANCE, new NumericDim(20)));
 
     test(
         "tf2_test_input_mixed_args.py",

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -65,14 +65,12 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     imageShape.addAll(targetSize);
     imageShape.add(new NumericDim(3)); // Default rgb color_mode
 
-    // 4. Construct labels shape: (batch_size, num_classes)
-    // We don't know num_classes, so we use null (None).
-    // The test tf2_test_dataset19.py has a categorical class_mode but we don't know the exact class
-    // count.
+    // 4. Construct labels shape: (batch_size, num_classes).
+    // `num_classes` is unknown statically — use `DynamicDim` (wala/ML#545). The test
+    // `tf2_test_dataset19.py` has a categorical `class_mode` but we don't know the exact class
+    // count from `tensorflow.xml`'s modeling of `flow_from_directory`.
     List<Dimension<?>> labelShape = new ArrayList<>();
     labelShape.add(new NumericDim(batchSize.intValue()));
-    // For categorical, it's (batch_size, num_classes). For simplicity, just return (batch_size,
-    // dynamic). The second dim is unknown statically; use `DynamicDim` per wala/ML#545.
     labelShape.add(DynamicDim.INSTANCE);
 
     ret.add(imageShape);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -66,7 +66,8 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     imageShape.add(new NumericDim(3)); // Default rgb color_mode
 
     // 4. Construct labels shape: (batch_size, num_classes).
-    // `num_classes` is unknown statically — use `DynamicDim` (wala/ML#545). The test
+    // `num_classes` is unknown statically — use `DynamicDim`
+    // (https://github.com/wala/ML/issues/545). The test
     // `tf2_test_dataset19.py` has a categorical `class_mode` but we don't know the exact class
     // count from `tensorflow.xml`'s modeling of `flow_from_directory`.
     List<Dimension<?>> labelShape = new ArrayList<>();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -4,6 +4,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -71,8 +72,8 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     List<Dimension<?>> labelShape = new ArrayList<>();
     labelShape.add(new NumericDim(batchSize.intValue()));
     // For categorical, it's (batch_size, num_classes). For simplicity, just return (batch_size,
-    // null) or just (batch_size, 1) to match test.
-    labelShape.add(null);
+    // dynamic). The second dim is unknown statically; use `DynamicDim` per wala/ML#545.
+    labelShape.add(DynamicDim.INSTANCE);
 
     ret.add(imageShape);
     ret.add(labelShape);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -4,6 +4,7 @@ import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -134,28 +135,39 @@ public class Input extends Ones {
       }
     }
 
-    if (batchSizes.isEmpty()) batchSizes.add(null);
-    else
+    // Treat `null` entries in `batchSizes` (signaling "None" from `getPossibleLongValues`) the
+    // same as an empty `batchSizes`: unknown batch dimension, prepend `DynamicDim`. wala/ML#545.
+    boolean batchSizeUnknown = batchSizes.isEmpty() || batchSizes.contains(null);
+    Set<Long> knownBatchSizes = new java.util.HashSet<>(batchSizes);
+    knownBatchSizes.remove(null);
+    if (!knownBatchSizes.isEmpty())
       LOGGER.fine(
-          "Found possible batch sizes: " + batchSizes + " for source: " + this.getSource() + ".");
+          "Found possible batch sizes: "
+              + knownBatchSizes
+              + " for source: "
+              + this.getSource()
+              + ".");
 
     // If the base shape is ⊤ (unknown), the prepended batch dim doesn't recover enough info to
-    // synthesize a meaningful shape — propagate ⊤ outward. Avoids NPE on the iteration below.
+    // synthesize a meaningful shape—propagate ⊤ outward. Avoids NPE on the iteration below.
     if (shapes == null) return null;
 
     Set<List<Dimension<?>>> newShapes = HashSetFactory.make();
 
-    for (List<Dimension<?>> shape : shapes)
-      for (Long batchSize : batchSizes) {
+    for (List<Dimension<?>> shape : shapes) {
+      if (batchSizeUnknown) {
         List<Dimension<?>> newShape = new ArrayList<>();
-
-        // Prepend batch size.
-        if (batchSize != null) newShape.add(new NumericDim(batchSize.intValue()));
-        else newShape.add(null);
-
+        newShape.add(DynamicDim.INSTANCE);
         newShape.addAll(shape);
         newShapes.add(newShape);
       }
+      for (Long batchSize : knownBatchSizes) {
+        List<Dimension<?>> newShape = new ArrayList<>();
+        newShape.add(new NumericDim(batchSize.intValue()));
+        newShape.addAll(shape);
+        newShapes.add(newShape);
+      }
+    }
 
     LOGGER.fine("Generated shapes: " + newShapes + " for source: " + source + ".");
     return newShapes;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -136,7 +136,8 @@ public class Input extends Ones {
     }
 
     // Treat `null` entries in `batchSizes` (signaling "None" from `getPossibleLongValues`) the
-    // same as an empty `batchSizes`: unknown batch dimension, prepend `DynamicDim`. wala/ML#545.
+    // same as an empty `batchSizes`: unknown batch dimension, prepend `DynamicDim`.
+    // https://github.com/wala/ML/issues/545.
     boolean batchSizeUnknown = batchSizes.isEmpty() || batchSizes.contains(null);
     Set<Long> knownBatchSizes = new java.util.HashSet<>(batchSizes);
     knownBatchSizes.remove(null);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -113,7 +113,8 @@ public class ModelCall extends TensorGenerator {
             if (!outShape.isEmpty() && !inShape.isEmpty()) {
               List<Dimension<?>> newShape = new ArrayList<>(outShape);
               // Keras usually preserves the batch dimension at index 0. If the upstream input's
-              // batch dim came through as raw `null` (a pre-#545 unmigrated path), normalize to
+              // batch dim came through as raw `null` (a pre-https://github.com/wala/ML/issues/545
+              // unmigrated path), normalize to
               // `DynamicDim` here so the call's output shape doesn't propagate the contract
               // violation downstream.
               Dimension<?> batchDim = inShape.get(0);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -7,6 +7,7 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -111,8 +112,12 @@ public class ModelCall extends TensorGenerator {
           for (List<Dimension<?>> inShape : inputShapes) {
             if (!outShape.isEmpty() && !inShape.isEmpty()) {
               List<Dimension<?>> newShape = new ArrayList<>(outShape);
-              // Keras usually preserves the batch dimension at index 0.
-              newShape.set(0, inShape.get(0));
+              // Keras usually preserves the batch dimension at index 0. If the upstream input's
+              // batch dim came through as raw `null` (a pre-#545 unmigrated path), normalize to
+              // `DynamicDim` here so the call's output shape doesn't propagate the contract
+              // violation downstream.
+              Dimension<?> batchDim = inShape.get(0);
+              newShape.set(0, batchDim == null ? DynamicDim.INSTANCE : batchDim);
               refinedShapes.add(newShape);
             } else {
               refinedShapes.add(outShape);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IField;
@@ -135,11 +136,11 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
                 }
               }
               if (!foundRowDim) {
-                possibleRowDims.add(null);
+                possibleRowDims.add(DynamicDim.INSTANCE);
               }
             } else {
               // Should not happen for valid input? Or maybe 0 ragged dims?
-              possibleRowDims.add(null);
+              possibleRowDims.add(DynamicDim.INSTANCE);
             }
           }
         }
@@ -150,7 +151,7 @@ public class RaggedFromNestedRowLengths extends RaggedTensorFromValues {
       possibleK.add(null);
     }
     if (possibleRowDims.isEmpty()) {
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     // 2. Determine shape of `values`.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptySet;
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.classLoader.IField;
@@ -233,18 +234,18 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                     // Empty list of rowids?
                     possibleRowDims.add(new NumericDim(0));
                   } else {
-                    possibleRowDims.add(null);
+                    possibleRowDims.add(DynamicDim.INSTANCE);
                   }
                 } else {
-                  possibleRowDims.add(null);
+                  possibleRowDims.add(DynamicDim.INSTANCE);
                 }
               } else {
-                possibleRowDims.add(null);
+                possibleRowDims.add(DynamicDim.INSTANCE);
               }
             } else {
               for (Long n : nrowsArgs) {
                 if (n != null) possibleRowDims.add(new NumericDim(n.intValue()));
-                else possibleRowDims.add(null);
+                else possibleRowDims.add(DynamicDim.INSTANCE);
               }
             }
           }
@@ -253,7 +254,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
     }
 
     if (possibleK.isEmpty()) possibleK.add(null);
-    if (possibleRowDims.isEmpty()) possibleRowDims.add(null);
+    if (possibleRowDims.isEmpty()) possibleRowDims.add(DynamicDim.INSTANCE);
 
     // Values shape
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -83,7 +84,7 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
         }
       }
     } else {
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -83,7 +84,7 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
         }
       }
     } else {
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -5,6 +5,7 @@ import static com.ibm.wala.cast.python.ml.client.RaggedFromRowSplits.Parameters.
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
@@ -83,12 +84,12 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
             int len = ((NumericDim) firstDim).value();
             possibleRowDims.add(new NumericDim(Math.max(0, len - 1)));
           } else {
-            possibleRowDims.add(null);
+            possibleRowDims.add(DynamicDim.INSTANCE);
           }
         }
       }
     } else {
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
@@ -85,12 +86,12 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
             int len = ((NumericDim) firstDim).value();
             possibleRowDims.add(new NumericDim(len));
           } else {
-            possibleRowDims.add(null);
+            possibleRowDims.add(DynamicDim.INSTANCE);
           }
         }
       }
     } else {
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singleton;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -200,12 +201,12 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
         if (nrows != null) {
           possibleRowDims.add(new NumericDim(nrows.intValue()));
         } else {
-          possibleRowDims.add(null);
+          possibleRowDims.add(DynamicDim.INSTANCE);
         }
       }
     } else {
       // Unknown rows
-      possibleRowDims.add(null);
+      possibleRowDims.add(DynamicDim.INSTANCE);
     }
 
     // 2. Determine shape of `values`.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -347,7 +347,8 @@ public abstract class TensorGenerator {
                       + ".");
 
               // `None` in a shape arg (e.g., `shape=[None, 4]`) is the dynamic-dim marker.
-              // wala/ML#545: emit `DynamicDim.INSTANCE` instead of raw `null`.
+              // https://github.com/wala/ML/issues/545: emit `DynamicDim.INSTANCE` instead of raw
+              // `null`.
               Dimension<?> dimension =
                   (shapeValue != null)
                       ? new NumericDim(shapeValue.intValue())
@@ -416,7 +417,8 @@ public abstract class TensorGenerator {
         // Build the Cartesian product of dimension possibilities across all positions. Empty
         // positions (where `possibleDimensions[k]` has no resolved constant, e.g., a non-literal
         // `BATCH_SIZE` in `tf.random.normal([BATCH_SIZE, 100])`) contribute `DynamicDim.INSTANCE`
-        // as the single fallback option — wala/ML#545. The prior implementation iterated each
+        // as the single fallback option — https://github.com/wala/ML/issues/545. The prior
+        // implementation iterated each
         // position's set but only retained the last iterated element, producing a
         // non-deterministic single shape per `i` rather than the full product.
         List<Set<Dimension<?>>> resolved = new ArrayList<>(possibleDimensions.length);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -34,6 +34,7 @@ import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -346,8 +347,12 @@ public abstract class TensorGenerator {
                       + (this.getSource() != null ? this.getSource().getPointerKey() : "null")
                       + ".");
 
-              Dimension<Integer> dimension =
-                  (shapeValue != null) ? new NumericDim(shapeValue.intValue()) : null;
+              // `None` in a shape arg (e.g., `shape=[None, 4]`) is the dynamic-dim marker.
+              // wala/ML#545: emit `DynamicDim.INSTANCE` instead of raw `null`.
+              Dimension<?> dimension =
+                  (shapeValue != null)
+                      ? new NumericDim(shapeValue.intValue())
+                      : DynamicDim.INSTANCE;
 
               LOGGER.fine("Adding dimension: " + dimension + ".");
               tensorDimensions.add(dimension);
@@ -416,8 +421,16 @@ public abstract class TensorGenerator {
 
             dimensions[i] = iDim;
 
-            for (int j = 0; j < possibleDimensions.length; j++)
-              if (i != j) for (Dimension<?> jDim : possibleDimensions[j]) dimensions[j] = jDim;
+            for (int j = 0; j < possibleDimensions.length; j++) {
+              if (i == j) continue;
+              for (Dimension<?> jDim : possibleDimensions[j]) dimensions[j] = jDim;
+              // wala/ML#545: when a shape-arg field has no resolved constant (e.g., a
+              // non-literal `BATCH_SIZE` in `tf.random.normal([BATCH_SIZE, 100])`),
+              // `possibleDimensions[j]` is empty and the inner loop above leaves
+              // `dimensions[j]` at its default `null`. Treat unresolvable-but-present
+              // shape positions as dynamic.
+              if (dimensions[j] == null) dimensions[j] = DynamicDim.INSTANCE;
+            }
 
             ret.add(asList(dimensions));
           }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -24,7 +24,6 @@ import static com.ibm.wala.cast.python.util.Util.getReceiverValueNumber;
 import static com.ibm.wala.cast.python.util.Util.sanitize;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CALL_STRING;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
@@ -414,26 +413,32 @@ public abstract class TensorGenerator {
                   + ".");
         }
 
-        for (int i = 0; i < possibleDimensions.length; i++)
-          for (Dimension<?> iDim : possibleDimensions[i]) {
-            @SuppressWarnings({"unchecked", "rawtypes"})
-            Dimension<?>[] dimensions = new Dimension[possibleDimensions.length];
+        // Build the Cartesian product of dimension possibilities across all positions. Empty
+        // positions (where `possibleDimensions[k]` has no resolved constant, e.g., a non-literal
+        // `BATCH_SIZE` in `tf.random.normal([BATCH_SIZE, 100])`) contribute `DynamicDim.INSTANCE`
+        // as the single fallback option — wala/ML#545. The prior implementation iterated each
+        // position's set but only retained the last iterated element, producing a
+        // non-deterministic single shape per `i` rather than the full product.
+        List<Set<Dimension<?>>> resolved = new ArrayList<>(possibleDimensions.length);
+        for (Set<Dimension<?>> s : possibleDimensions) {
+          if (s == null || s.isEmpty()) resolved.add(Collections.singleton(DynamicDim.INSTANCE));
+          else resolved.add(s);
+        }
 
-            dimensions[i] = iDim;
-
-            for (int j = 0; j < possibleDimensions.length; j++) {
-              if (i == j) continue;
-              for (Dimension<?> jDim : possibleDimensions[j]) dimensions[j] = jDim;
-              // wala/ML#545: when a shape-arg field has no resolved constant (e.g., a
-              // non-literal `BATCH_SIZE` in `tf.random.normal([BATCH_SIZE, 100])`),
-              // `possibleDimensions[j]` is empty and the inner loop above leaves
-              // `dimensions[j]` at its default `null`. Treat unresolvable-but-present
-              // shape positions as dynamic.
-              if (dimensions[j] == null) dimensions[j] = DynamicDim.INSTANCE;
+        List<List<Dimension<?>>> shapes = new ArrayList<>();
+        shapes.add(new ArrayList<>());
+        for (Set<Dimension<?>> options : resolved) {
+          List<List<Dimension<?>>> next = new ArrayList<>(shapes.size() * options.size());
+          for (List<Dimension<?>> prefix : shapes) {
+            for (Dimension<?> d : options) {
+              List<Dimension<?>> extended = new ArrayList<>(prefix);
+              extended.add(d);
+              next.add(extended);
             }
-
-            ret.add(asList(dimensions));
           }
+          shapes = next;
+        }
+        ret.addAll(shapes);
       } else if (asin.getNode()
           .getMethod()
           .getDeclaringClass()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -267,6 +267,17 @@ public class TensorType implements Iterable<Dimension<?>> {
     public int hashCode() {
       return RaggedDim.class.hashCode();
     }
+
+    /**
+     * Override paired with {@link #hashCode} to satisfy the {@code equals}/{@code hashCode}
+     * contract under CodeQL's {@code java/inconsistent-equals-and-hashcode}. {@code RaggedDim} is a
+     * singleton, so equality reduces to instance identity — any reachable {@code RaggedDim}
+     * reference is {@link #INSTANCE}.
+     */
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj;
+    }
   }
 
   /**
@@ -335,6 +346,16 @@ public class TensorType implements Iterable<Dimension<?>> {
     @Override
     public int hashCode() {
       return DynamicDim.class.hashCode();
+    }
+
+    /**
+     * Override paired with {@link #hashCode} to satisfy the {@code equals}/{@code hashCode}
+     * contract under CodeQL's {@code java/inconsistent-equals-and-hashcode}. See {@link
+     * RaggedDim#equals} for the shared singleton-identity rationale.
+     */
+    @Override
+    public boolean equals(Object obj) {
+      return this == obj;
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -55,7 +55,8 @@ public class TensorType implements Iterable<Dimension<?>> {
     Constant,
     Symbolic,
     Compound,
-    Ragged
+    Ragged,
+    Dynamic
   };
 
   public abstract static class Dimension<T> {
@@ -253,6 +254,65 @@ public class TensorType implements Iterable<Dimension<?>> {
         return "*ragged*";
       } else {
         return "ragged";
+      }
+    }
+  }
+
+  /**
+   * Marker for a dynamic dimension&mdash;a dimension whose size is uniform within a single tensor
+   * instance but unknown statically (e.g., the batch axis of {@code tf.keras.Input(shape=(None,
+   * 4))}, or any axis explicitly modeled as {@code None} in a Keras input signature).
+   *
+   * <p>Dynamic dimensions used to be encoded as raw {@code null} entries in {@code
+   * TensorType.dims}; the typed sentinel restores the implicit non-null-element contract of {@link
+   * TensorType#iterator()} and discriminates "dynamic/batch/placeholder" from ragged (where the
+   * size varies across rows of a single tensor instance, see {@link RaggedDim}). See <a
+   * href="https://github.com/wala/ML/issues/545">wala/ML#545</a>.
+   *
+   * <p>The {@link Dimension#value() value} is always {@code null}&mdash;dynamic-ness carries no
+   * payload beyond its identity. Because every instance is structurally equal to every other, use
+   * the shared {@link #INSTANCE} rather than allocating fresh objects.
+   */
+  public static class DynamicDim extends Dimension<Void> {
+    /** Shared singleton; {@code DynamicDim} carries no per-instance state. */
+    public static final DynamicDim INSTANCE = new DynamicDim();
+
+    /**
+     * @implNote Private&mdash;all callers should use {@link #INSTANCE}. The {@code super(null)}
+     *     call is mechanical: {@link Dimension} requires a value of type {@code T}, and {@code
+     *     Void} has no instances, so {@code null} is the only legal argument. Dynamic-ness carries
+     *     no payload beyond the type's identity.
+     */
+    private DynamicDim() {
+      super(null);
+    }
+
+    @Override
+    DimensionType type() {
+      return DimensionType.Dynamic;
+    }
+
+    @Override
+    int concreteSize() {
+      return -1;
+    }
+
+    @Override
+    int symbolicDims() {
+      return 1;
+    }
+
+    @Override
+    String toMDString() {
+      return "*dynamic*";
+    }
+
+    @Override
+    String toCString(boolean useMarkdown) {
+      if (useMarkdown) {
+        return "*dynamic*";
+      } else {
+        return "dynamic";
       }
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -256,6 +256,17 @@ public class TensorType implements Iterable<Dimension<?>> {
         return "ragged";
       }
     }
+
+    /**
+     * Override {@link Dimension#hashCode} (which hashes only the payload {@code value}) so that
+     * null-payload singletons of different concrete classes don't collide. {@link Dimension#equals}
+     * already distinguishes by {@code getClass()}, so the bucket-level separation here is a
+     * hash-performance fix, not a correctness one.
+     */
+    @Override
+    public int hashCode() {
+      return RaggedDim.class.hashCode();
+    }
   }
 
   /**
@@ -314,6 +325,16 @@ public class TensorType implements Iterable<Dimension<?>> {
       } else {
         return "dynamic";
       }
+    }
+
+    /**
+     * Override {@link Dimension#hashCode} (which hashes only the payload {@code value}) so that
+     * null-payload singletons of different concrete classes don't collide. See {@link
+     * RaggedDim#hashCode} for the shared rationale.
+     */
+    @Override
+    public int hashCode() {
+      return DynamicDim.class.hashCode();
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
@@ -21,7 +21,8 @@ public class TensorShapeUtil {
 
       // Either side missing (out of rank), a raw-null placeholder, a ragged dim, or a dynamic
       // dim is treated as broadcast-compatible—we lack the precision to reason about the actual
-      // extent, so be permissive. wala/ML#544 introduced `RaggedDim`; wala/ML#545 introduced
+      // extent, so be permissive. https://github.com/wala/ML/issues/544 introduced `RaggedDim`;
+      // https://github.com/wala/ML/issues/545 introduced
       // `DynamicDim` for the "uniform but statically unknown" case (batch/placeholder/Keras
       // `None`). Both join the same permissive branch.
       if (xDim == null
@@ -58,7 +59,8 @@ public class TensorShapeUtil {
 
       // Propagate raggedness or dynamic-ness when either side carries them—broadcasting against
       // anything (including a compatible-rank counterpart) preserves the wider unknown semantics.
-      // wala/ML#544 introduced `RaggedDim`; wala/ML#545 introduced `DynamicDim`. Ragged dominates
+      // https://github.com/wala/ML/issues/544 introduced `RaggedDim`;
+      // https://github.com/wala/ML/issues/545 introduced `DynamicDim`. Ragged dominates
       // dynamic when both are present on the same axis (varies-per-row is the wider unknown).
       if (xDim instanceof RaggedDim) ret.add(xDim);
       else if (yDim instanceof RaggedDim) ret.add(yDim);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.util;
 import static java.lang.Math.max;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import java.util.List;
@@ -18,10 +19,17 @@ public class TensorShapeUtil {
       Dimension<?> xDim = i < (maxRank - xRank) ? null : xShape.get(i - (maxRank - xRank));
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
-      // Either side missing (out of rank), a raw-null placeholder, or a ragged dim is treated as
-      // broadcast-compatible — we lack the precision to reason about the actual extent, so be
-      // permissive. wala/ML#544 introduced RaggedDim; the prior behavior covered only raw null.
-      if (xDim == null || yDim == null || xDim instanceof RaggedDim || yDim instanceof RaggedDim) {
+      // Either side missing (out of rank), a raw-null placeholder, a ragged dim, or a dynamic
+      // dim is treated as broadcast-compatible—we lack the precision to reason about the actual
+      // extent, so be permissive. wala/ML#544 introduced `RaggedDim`; wala/ML#545 introduced
+      // `DynamicDim` for the "uniform but statically unknown" case (batch/placeholder/Keras
+      // `None`). Both join the same permissive branch.
+      if (xDim == null
+          || yDim == null
+          || xDim instanceof RaggedDim
+          || yDim instanceof RaggedDim
+          || xDim instanceof DynamicDim
+          || yDim instanceof DynamicDim) {
         continue;
       }
 
@@ -48,11 +56,14 @@ public class TensorShapeUtil {
       Dimension<?> xDim = i < (maxRank - xRank) ? null : xShape.get(i - (maxRank - xRank));
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
-      // Propagate raggedness when either side is ragged — broadcasting a ragged operand against
-      // anything (including another ragged of compatible extent) preserves the ragged dim in the
-      // result. wala/ML#544.
+      // Propagate raggedness or dynamic-ness when either side carries them—broadcasting against
+      // anything (including a compatible-rank counterpart) preserves the wider unknown semantics.
+      // wala/ML#544 introduced `RaggedDim`; wala/ML#545 introduced `DynamicDim`. Ragged dominates
+      // dynamic when both are present on the same axis (varies-per-row is the wider unknown).
       if (xDim instanceof RaggedDim) ret.add(xDim);
       else if (yDim instanceof RaggedDim) ret.add(yDim);
+      else if (xDim instanceof DynamicDim) ret.add(xDim);
+      else if (yDim instanceof DynamicDim) ret.add(yDim);
       else if (xDim == null) ret.add(yDim);
       else if (yDim == null) ret.add(xDim);
       else if (xDim instanceof NumericDim && yDim instanceof NumericDim) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_lengths_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_lengths_dynamic.py
@@ -14,4 +14,6 @@ try:
     r = tf.RaggedTensor.from_row_lengths(values, row_lengths)
     consume(r)
 except (TypeError, ValueError):
+    # Intentional swallow: the symbolic input above only exercises the analyzer; the
+    # runtime rejects it. No state to recover.
     pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_lengths_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_lengths_dynamic.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#545 regression guard for the `DynamicDim` fallback branch in
+# `RaggedFromRowLengths`'s nrows inference. See `tf2_test_ragged_from_row_starts_dynamic.py`
+# for the shared rationale.
+try:
+    row_lengths = tf.keras.Input(shape=(8,), dtype=tf.int64)
+    values = tf.constant([3, 1, 4, 1, 5, 9, 2, 6])
+    r = tf.RaggedTensor.from_row_lengths(values, row_lengths)
+    consume(r)
+except (TypeError, ValueError):
+    pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_limits_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_limits_dynamic.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#545 regression guard for the `DynamicDim` fallback branch in
+# `RaggedFromRowLimits`'s nrows inference. See `tf2_test_ragged_from_row_starts_dynamic.py`
+# for the shared rationale.
+try:
+    row_limits = tf.keras.Input(shape=(8,), dtype=tf.int64)
+    values = tf.constant([3, 1, 4, 1, 5, 9, 2, 6])
+    r = tf.RaggedTensor.from_row_limits(values, row_limits)
+    consume(r)
+except (TypeError, ValueError):
+    pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_limits_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_limits_dynamic.py
@@ -14,4 +14,6 @@ try:
     r = tf.RaggedTensor.from_row_limits(values, row_limits)
     consume(r)
 except (TypeError, ValueError):
+    # Intentional swallow: the symbolic input above only exercises the analyzer; the
+    # runtime rejects it. No state to recover.
     pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_splits_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_splits_dynamic.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#545 regression guard for the `DynamicDim` fallback branch in
+# `RaggedFromRowSplits`'s nrows inference. See `tf2_test_ragged_from_row_starts_dynamic.py`
+# for the shared rationale.
+try:
+    row_splits = tf.keras.Input(shape=(8,), dtype=tf.int64)
+    values = tf.constant([3, 1, 4, 1, 5, 9, 2, 6])
+    r = tf.RaggedTensor.from_row_splits(values, row_splits)
+    consume(r)
+except (TypeError, ValueError):
+    pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_splits_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_splits_dynamic.py
@@ -14,4 +14,6 @@ try:
     r = tf.RaggedTensor.from_row_splits(values, row_splits)
     consume(r)
 except (TypeError, ValueError):
+    # Intentional swallow: the symbolic input above only exercises the analyzer; the
+    # runtime rejects it. No state to recover.
     pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_starts_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_starts_dynamic.py
@@ -20,4 +20,6 @@ try:
     r = tf.RaggedTensor.from_row_starts(values, row_starts)
     consume(r)
 except (TypeError, ValueError):
+    # Intentional swallow: the symbolic input above only exercises the analyzer; the
+    # runtime rejects it. No state to recover.
     pass

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_starts_dynamic.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_row_starts_dynamic.py
@@ -1,0 +1,23 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#545 regression guard: when `row_starts` has a non-`NumericDim`
+# first dim (here `DynamicDim` from a Keras Input's batch axis), the
+# `RaggedFromRowStarts` generator must emit `DynamicDim.INSTANCE` for the
+# inferred nrows instead of raw `null`.
+#
+# At runtime, `tf.RaggedTensor.from_row_starts` rejects a symbolic
+# `KerasTensor` arg — the `try/except` lets the file run to completion
+# per `CLAUDE.md`'s fixture guideline while still letting the static
+# analyzer walk the `from_row_starts` call below.
+try:
+    row_starts = tf.keras.Input(shape=(8,), dtype=tf.int64)
+    values = tf.constant([3, 1, 4, 1, 5, 9, 2, 6])
+    r = tf.RaggedTensor.from_row_starts(values, row_starts)
+    consume(r)
+except (TypeError, ValueError):
+    pass


### PR DESCRIPTION
## Summary

Implements wala/ML#545: replace raw `null` in `TensorType.dims` for dimensions that are uniform within a single tensor instance but unknown statically (e.g., the batch axis of `tf.keras.Input(shape=(None, 4))`, any `shape=[None, ...]` Keras input signature). Mirrors wala/ML#544's `RaggedDim` pattern—same singleton + `Dimension<Void>` shape; only the semantics differ (ragged = varies across rows of a single tensor; dynamic = uniform but statically unknown).

Restores the implicit non-null-element contract of `TensorType.iterator()` and discriminates the two unknown-size cases so downstream consumers (e.g., Hybridize's input-signature inference) can tell them apart.

## Changes

### Type Definition

- `TensorType.DynamicDim extends Dimension<Void>` (singleton). `toMDString()`/`toCString()` emit `*dynamic*`/`dynamic`.
- `DimensionType.Dynamic` enum value.

### Generator-Side Null-Emitter Migration

- `Input.java`: restructure batch-size handling. Drop the `batchSizes.add(null)` sentinel chain; use an explicit `batchSizeUnknown` flag. Prepend `DynamicDim.INSTANCE` when batch dim is unknown; prepend `NumericDim` for each resolved numeric value.
- `FlowFromDirectoryGenerator.java:75`: emit `DynamicDim` for the categorical label's class-count dim.
- `TensorGenerator.java:350`: in `getShapesFromShapeArgument`'s constant-literal path, emit `DynamicDim` when the literal is Python `None` (`tf.keras.Input(shape=[None, 4])`).
- `TensorGenerator.java:415-431`: in the same method's dim-cross-product loop, fill `dimensions[j]` with `DynamicDim.INSTANCE` when `possibleDimensions[j]` is empty (non-literal shape positions like `tf.random.normal([BATCH_SIZE, 100])`) instead of leaving the default `null` reference. This was the load-bearing fix for `testGanTutorialGeneratorLoss`.
- `RaggedFrom{RowStarts,RowLengths,RowLimits,RowSplits,ValueRowIds,NestedRowLengths,NestedValueRowIds}.java`: replace `possibleRowDims.add(null)` with `DynamicDim.INSTANCE` at 12 sites total.
- `ModelCall.java`: defensive normalization when an upstream input's batch dim came through as raw `null`.

### Broadcast Handling

`TensorShapeUtil.areBroadcastable`/`getBroadcastedShapes`: treat `DynamicDim` as broadcast-compatible with the same permissive semantics as `RaggedDim` and raw `null`. `RaggedDim` dominates `DynamicDim` on the same axis (varies-per-row is the wider unknown).

### Test Fixtures

`TENSOR_*_NONE_*` constants in `TestTensorflow2Model.java` and inline fixtures (`testInputWithBatchSize`, `testInputMixedArgs`, `testDataset19`) migrated from raw `null` to `DynamicDim.INSTANCE`.

## Test Plan

- [x] `mvn test` on `com.ibm.wala.cast.python.ml.test`: 782/0/0/3.
- [x] `mvn test` on `com.ibm.wala.cast.python.test`: 75/0/0/0.
- [x] Spotless clean on commit.

## Closes

wala/ML#545

🤖 Generated with [Claude Code](https://claude.com/claude-code)