### PR TITLE
Fix shallow-fetch breakage in tag-push deploy gate

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,12 +99,19 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # Verify any tag-push deploy is on a commit that's an ancestor of master
-    # (per wala/ML#421). Without this, a feature-branch tag could trigger a
-    # release deploy. Also confirm the tag name is semver-shaped — the deploy
+    # (per https://github.com/wala/ML/issues/421). Without this, a feature-branch tag could trigger
+    # a release deploy. Also confirm the tag name is semver-shaped — the deploy
     # step's `if:` does the same regex via `endsWith`/`startsWith`, but we
     # additionally guard the ancestor check itself so non-semver tags don't
     # error out the run on the merge-base call. The `actions/checkout` above
-    # is shallow so we need a fetch first to get master's history.
+    # is shallow (default `fetch-depth: 1`), and the previous `--depth=1`
+    # fetch of master left both the tag commit and master's tip with no
+    # parent chain in the local object database — so `merge-base
+    # --is-ancestor` couldn't link them even when the tag was on master.
+    # The release-plugin's tag commit lands at master~1 (immediately followed
+    # by the SNAPSHOT-bump), so `--depth=50` gives plenty of headroom while
+    # staying tight. This is the root cause of the 0.44.0/0.45.0 deploy-gate
+    # misses tracked at https://github.com/wala/ML/issues/454.
     - name: Verify tag is a semver release tag on master
       if: startsWith(github.ref, 'refs/tags/')
       run: |
@@ -113,7 +120,7 @@ jobs:
           echo "is_semver_release=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        git fetch --no-tags --depth=1 origin master
+        git fetch --no-tags --depth=50 origin master
         git merge-base --is-ancestor ${{ github.sha }} origin/master
         echo "is_semver_release=true" >> "$GITHUB_OUTPUT"
       id: tag_check


### PR DESCRIPTION
## Summary

- Swap the `tag_check` step's `git fetch --no-tags --depth=1 origin master` for `--depth=50` so `git merge-base --is-ancestor <tag-sha> origin/master` actually has the parent chain it needs to resolve.
- Refresh the inline comment to spell out the failure mode and the choice of depth (release-plugin tag lands at `master~1`; 50 is plenty of headroom).

## Why

`actions/checkout@v6` defaults to `fetch-depth: 1`. The depth-1 fetch of master then left both refs with no parent chain in the local object database, and `merge-base --is-ancestor` exited 1 even when the tag was on master. Deploy step's `if:` skipped silently as a result.

This is the root cause of the 0.44.0 (2026-05-16) and 0.45.0 (2026-05-26) deploys never reaching GitHub Packages and the fat JAR never being attached to the GitHub Release. Tracked at https://github.com/wala/ML/issues/454.

0.45.0 has now been recovered manually via local `mvn deploy` and `gh release upload`; this PR closes the gap so 0.46.0+ flow through CI cleanly.

## Test plan

- [ ] CI passes (PR-context run — non-tag, so the new fetch line doesn't execute; `spotless`/`black`/build/tests should all behave as before).
- [ ] On the next semver tag push after this lands, verify the `Verify tag is a semver release tag on master` step completes successfully and `Deploy with Maven` fires.

Closes wala/ML#454

🤖 Generated with [Claude Code](https://claude.com/claude-code)