### PR TITLE
Bump `jython3` to `0.0.2-SNAPSHOT`; drop redundant `ProxyDeserialization` shade-exclude

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,7 +62,7 @@ jobs:
         pushd jython3
         ant
         pushd dist
-        mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.1-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true -B
+        mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.2-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true -B
         popd
         popd
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ You must install the `jython-dev.jar` to your local maven repository.
 	-Dfile=./jython-dev.jar \
 	-DgroupId="org.python" \
 	-DartifactId="jython3" \
-	-Dversion="0.0.1-SNAPSHOT" \
+	-Dversion="0.0.2-SNAPSHOT" \
 	-Dpackaging="jar" \
 	-DgeneratePom=true
 	```

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -56,7 +56,7 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <!-- `jython3` references `jnr/constants/Constant` (and other `jnr/...`)
-      from its `org.python.modules.posix.PosixModule`. The `0.0.1-SNAPSHOT`
+      from its `org.python.modules.posix.PosixModule`. The `0.0.2-SNAPSHOT`
       `jython3.jar` is registered via `mvn install:install-file
       -DgeneratePom=true` (see `CONTRIBUTING.md` and the CI workflow),
       which synthesizes a minimal POM that declares zero dependencies — so
@@ -91,8 +91,6 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
-                <!-- Default-package classes break OSGi bundle wrapping in downstream consumers (Tycho 5+ bnd rejects them); ProxyDeserialization is an unused orphan from jython3. -->
-                <exclude>ProxyDeserialization.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <!-- `jython3` references `jnr/constants/Constant` (and other `jnr/...`)
       from its `org.python.modules.posix.PosixModule`. The `0.0.2-SNAPSHOT`
-      `jython3.jar` is registered via `mvn install:install-file
+      `jython-dev.jar` is registered via `mvn install:install-file
       -DgeneratePom=true` (see `CONTRIBUTING.md` and the CI workflow),
       which synthesizes a minimal POM that declares zero dependencies — so
       Maven's dependency graph won't pull `jnr-constants` transitively. We

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>org.python</groupId>
         <artifactId>jython3</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.python</groupId>


### PR DESCRIPTION
## Summary

ponder-lab/jython3#2 (the upstream fix) compiles `tests/java/` to a separate `test-classes` directory so test fixtures no longer leak into `jython-dev.jar`. With `ProxyDeserialization.class` no longer present in the upstream JAR:

1. **Slim-JAR consumption unblocks.** Hybridize (via Tycho 5+'s bnd auto-wrap) can now resolve `jython3` transitively from the published `cast.python.ml` POM without the `The default package '.' is not permitted by the Import-Package syntax` failure.
2. **The local shade-exclude is redundant** and removed here, reverting wala/ML#418's narrow workaround now that the structural fix lives upstream.

## Changes

- Submodule pointer for `jython3` bumped to ponder-lab/jython3#2's HEAD.
- `org.python:jython3` dependency version bumped `0.0.1-SNAPSHOT` → `0.0.2-SNAPSHOT` to force a cache-bust for stale local installs.
- `CONTRIBUTING.md` and `continuous-integration.yml` install commands updated to match.
- `<exclude>ProxyDeserialization.class</exclude>` and its comment removed from the shade plugin filter.

## Verification

- `mvn clean install -DskipTests` green across all 10 modules.
- Full `mvn test` from root: **791 tests, 0 failures, 0 errors, 3 skipped** (identical to baseline).
- Fat JAR is clean of default-package classes:
  ```
  $ jar tf com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar | grep -E '^[A-Z][^/]*\.class$'
  (no output)
  ```

## Sequencing

Draft until ponder-lab/jython3#2 merges to `master`. After that, I'll re-point the submodule to the merged-master SHA and mark this ready for review.

Closes wala/ML#557.