### PR TITLE
Drop `,null` suffix from `Dimension.toString` for `Void`-payload sentinels

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
@@ -165,6 +165,17 @@ public class TensorFlowTypesTest {
   }
 
   @Test
+  public void testVoidPayloadDimensionToString() {
+    // `Void`-payload sentinels skip the ",value" suffix so they don't collide visually
+    // with the ", " dim separator in shape renderings (https://github.com/wala/ML/issues/558).
+    assertEquals("D:Dynamic", DynamicDim.INSTANCE.toString());
+    assertEquals("D:Ragged", RaggedDim.INSTANCE.toString());
+    // Value-carrying dims still include the value suffix.
+    assertEquals("D:Constant,32", new NumericDim(32).toString());
+    assertEquals("D:Symbolic,?", new SymbolicDim("?").toString());
+  }
+
+  @Test
   public void testDynamicDimSymbolicAndConcrete() {
     // `DynamicDim` reports as a symbolic dim, mirroring `RaggedDim`'s semantics for the
     // unknown-size axis (https://github.com/wala/ML/issues/545). A `TensorType` whose dims are

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -98,7 +98,12 @@ public class TensorType implements Iterable<Dimension<?>> {
 
     @Override
     public String toString() {
-      return "D:" + type() + "," + value();
+      // Skip the ",value" suffix for `Void`-payload sentinels (e.g. `DynamicDim`,
+      // `RaggedDim`) whose `value()` is always `null`; the trailing ",null" otherwise
+      // collides visually with the ", " dim separator in shape renderings. See
+      // wala/ML#558.
+      T v = value();
+      return v == null ? "D:" + type() : "D:" + type() + "," + v;
     }
 
     @Override


### PR DESCRIPTION
## Summary

`Dimension.toString` rendered as `"D:" + type() + "," + value()`. For `Void`-payload sentinels (`DynamicDim`, `RaggedDim`) whose `value()` is always `null`, the result was `D:Dynamic,null` / `D:Ragged,null`. The interior `,` collides visually with the `, ` dim separator used between dims in a list, so a rank-2 shape like `[D:Dynamic,null, D:Constant,32]` could easily read as rank-3.

`Dimension.toString` now skips the `,value` suffix when `value()` is `null`:

| Before | After |
|---|---|
| `D:Dynamic,null` | `D:Dynamic` |
| `D:Ragged,null` | `D:Ragged` |
| `D:Constant,32` | `D:Constant,32` (unchanged) |
| `D:Symbolic,?` | `D:Symbolic,?` (unchanged) |
| `D:Compound,[...]` | `D:Compound,[...]` (unchanged) |

## Verification

- New `TensorFlowTypesTest.testVoidPayloadDimensionToString` covers all four cases.
- Full `mvn test` from root: 792/0/0/3 (baseline + the new test). No existing test string-matches the old `D:Dynamic,null` / `D:Ragged,null` form (grep-verified before commit).

Closes wala/ML#558.