### PR TITLE
Hash `PythonInvokeInstruction` on `iIndex()` for consistency with inherited `equals`

### DIFF
--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertTrue;
 
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction.Dispatch;
-import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.collections.Pair;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,10 +27,8 @@ import org.junit.Test;
 public class TestPythonInvokeInstructionHashCode {
 
   private static CallSiteReference site(int pc) {
-    MethodReference m =
-        MethodReference.findOrCreate(
-            PythonTypes.CodeBody, "do", "()Lcom/ibm/wala/cast/python/CodeBody;");
-    return CallSiteReference.make(pc, m, Dispatch.VIRTUAL);
+    return CallSiteReference.make(
+        pc, AstMethodReference.fnReference(PythonTypes.CodeBody), Dispatch.VIRTUAL);
   }
 
   private static PythonInvokeInstruction make(

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
@@ -17,6 +17,12 @@ import org.junit.Test;
  * Regression guards for <a href="https://github.com/wala/ML/issues/478">wala/ML#478</a>: {@link
  * PythonInvokeInstruction#hashCode} must be consistent with the inherited {@code final} {@code
  * SSAInstruction.equals}, which compares only the instruction index.
+ *
+ * <p>The {@code result} value number and {@code site}'s program counter intentionally differ
+ * between {@code a} and {@code b}: the prior buggy hash was {@code getCallSite().hashCode() *
+ * result}, so identical {@code result}/{@code site} between fixtures would let the pre-fix
+ * implementation pass these tests too. Differing them ensures the regression actually catches the
+ * old behavior.
  */
 public class TestPythonInvokeInstructionHashCode {
 
@@ -27,24 +33,25 @@ public class TestPythonInvokeInstructionHashCode {
     return CallSiteReference.make(pc, m, Dispatch.VIRTUAL);
   }
 
-  private static PythonInvokeInstruction make(int iindex, int[] positional) {
+  private static PythonInvokeInstruction make(
+      int iindex, int result, int sitePC, int[] positional) {
     @SuppressWarnings({"unchecked", "rawtypes"})
     Pair<String, Integer>[] kw = new Pair[0];
-    return new PythonInvokeInstruction(iindex, 100, 101, site(42), positional, kw);
+    return new PythonInvokeInstruction(iindex, result, 101, site(sitePC), positional, kw);
   }
 
   @Test
   public void equalInstructionsHashEqually() {
-    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
-    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    PythonInvokeInstruction a = make(7, 100, 42, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, 200, 43, new int[] {4, 5});
     assertEquals(a, b);
     assertEquals("equal objects must have equal hash codes", a.hashCode(), b.hashCode());
   }
 
   @Test
   public void equalInstructionsDedupInHashSet() {
-    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
-    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    PythonInvokeInstruction a = make(7, 100, 42, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, 200, 43, new int[] {4, 5});
     HashSet<PythonInvokeInstruction> set = new HashSet<>();
     set.add(a);
     set.add(b);
@@ -55,8 +62,8 @@ public class TestPythonInvokeInstructionHashCode {
 
   @Test
   public void equalInstructionsRoundTripThroughHashMap() {
-    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
-    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    PythonInvokeInstruction a = make(7, 100, 42, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, 200, 43, new int[] {4, 5});
     HashMap<PythonInvokeInstruction, String> map = new HashMap<>();
     map.put(a, "found");
     assertEquals("found", map.get(b));

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPythonInvokeInstructionHashCode.java
@@ -1,0 +1,64 @@
+package com.ibm.wala.cast.python.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
+import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction.Dispatch;
+import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.util.collections.Pair;
+import java.util.HashMap;
+import java.util.HashSet;
+import org.junit.Test;
+
+/**
+ * Regression guards for <a href="https://github.com/wala/ML/issues/478">wala/ML#478</a>: {@link
+ * PythonInvokeInstruction#hashCode} must be consistent with the inherited {@code final} {@code
+ * SSAInstruction.equals}, which compares only the instruction index.
+ */
+public class TestPythonInvokeInstructionHashCode {
+
+  private static CallSiteReference site(int pc) {
+    MethodReference m =
+        MethodReference.findOrCreate(
+            PythonTypes.CodeBody, "do", "()Lcom/ibm/wala/cast/python/CodeBody;");
+    return CallSiteReference.make(pc, m, Dispatch.VIRTUAL);
+  }
+
+  private static PythonInvokeInstruction make(int iindex, int[] positional) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    Pair<String, Integer>[] kw = new Pair[0];
+    return new PythonInvokeInstruction(iindex, 100, 101, site(42), positional, kw);
+  }
+
+  @Test
+  public void equalInstructionsHashEqually() {
+    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    assertEquals(a, b);
+    assertEquals("equal objects must have equal hash codes", a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void equalInstructionsDedupInHashSet() {
+    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    HashSet<PythonInvokeInstruction> set = new HashSet<>();
+    set.add(a);
+    set.add(b);
+    assertEquals(1, set.size());
+    assertTrue(set.contains(a));
+    assertTrue(set.contains(b));
+  }
+
+  @Test
+  public void equalInstructionsRoundTripThroughHashMap() {
+    PythonInvokeInstruction a = make(7, new int[] {1, 2, 3});
+    PythonInvokeInstruction b = make(7, new int[] {4, 5});
+    HashMap<PythonInvokeInstruction, String> map = new HashMap<>();
+    map.put(a, "found");
+    assertEquals("found", map.get(b));
+  }
+}

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ssa/PythonInvokeInstruction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ssa/PythonInvokeInstruction.java
@@ -126,9 +126,18 @@ public class PythonInvokeInstruction extends SSAAbstractInvokeInstruction {
     ((PythonInstructionVisitor) v).visitPythonInvoke(this);
   }
 
+  /**
+   * Hashes purely on {@code iIndex()}. {@link SSAInstruction#equals} is {@code final} and compares
+   * only the instruction index, so any wider hash (the prior {@code getCallSite().hashCode() *
+   * result} included a value number) would let two instances be {@code equals}-equal but hash to
+   * different buckets — breaking the {@code HashMap}/{@code HashSet} invariant. See <a
+   * href="https://github.com/wala/ML/issues/478">wala/ML#478</a>.
+   *
+   * @return a hash code consistent with {@link SSAInstruction#equals}.
+   */
   @Override
   public int hashCode() {
-    return getCallSite().hashCode() * result;
+    return iIndex();
   }
 
   @Override


### PR DESCRIPTION
## Summary

`PythonInvokeInstruction.hashCode` was `getCallSite().hashCode() * result`, but `SSAInstruction.equals` is `final` and compares only `instructionIndex`. Two instances with the same `iIndex` but different `result` (or different `callSite`) were `equals`-equal yet hashed to different buckets—a `HashMap`/`HashSet` invariant violation. CodeQL `java/inconsistent-equals-and-hashcode` flagged it as alert #59 on master commit 3dee0a3c.

The issue body's option-1 (add an `equals` override that includes the Python-specific fields) is **blocked by Java**—`SSAInstruction.equals` is `final`, verified by `javap -p`:

```
public final boolean equals(java.lang.Object);
```

The only consistent fix is to narrow `hashCode` so equal-under-final-equals objects hash equally. `iIndex()` is the field the parent's `equals` actually compares.

## Changes

- `PythonInvokeInstruction.hashCode` → `return iIndex();`, with Javadoc explaining why a wider hash breaks the contract.
- New `TestPythonInvokeInstructionHashCode` with three regression guards:
  - `equals`-equal instances hash equally.
  - `HashSet` correctly dedupes them.
  - `HashMap.get(b)` retrieves the value `HashMap.put(a)` stored.

## Verification

- New tests pass: 3/0/0.
- Full `mvn test` from root: 0 failures, 0 errors across all modules.

Closes wala/ML#478.