### PR TITLE
Return `DType.UNKNOWN` instead of `emptySet` for `from_generator` dtype fallback

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -480,7 +480,10 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       }
     }
 
-    // Default: No dtype information found.
-    return Collections.emptySet();
+    // Default: dtype unknown. `tf.data.Dataset.from_generator` always produces a tensor
+    // iterable; the dtype just isn't statically resolvable here. Per the dtype lattice,
+    // return `DType.UNKNOWN` (⊤) rather than `emptySet()` (⊥/not-a-tensor), so downstream
+    // analysis preserves the "this is a tensor source" signal. See wala/ML#408.
+    return EnumSet.of(DType.UNKNOWN);
   }
 }


### PR DESCRIPTION
## Summary

`DatasetFromGeneratorGenerator.getDefaultDTypes` (line 484) returned `Collections.emptySet()` when both `output_signature` and `output_types` resolution failed. Per the dtype lattice in `CONTRIBUTING.md > Tensor Type Generators`, `emptySet()` means ⊥ (not a tensor); the semantically correct return for "tensor source whose dtype isn't statically known" is `EnumSet.of(DType.UNKNOWN)` (⊤).

`tf.data.Dataset.from_generator(...)` always produces a tensor iterable, so collapsing the dtype to ⊥ erased the "is a tensor" signal for downstream analysis.

## How this matches the lattice

`CONTRIBUTING.md`'s dtype table for `getDefaultDTypes`:

| Return value | Meaning |
|---|---|
| `EnumSet.of(DType.UNKNOWN)` | ⊤ — generator produces a tensor, but its dtype cannot be determined. |
| empty set | ⊥ — the variable is provably not a tensor. |
| non-empty set of concrete `DType`s | The set of possible dtypes. |

The default branch of `getDefaultDTypes` is reached when neither `output_signature` nor `output_types` resolves. The control state at that line is "tensor source confirmed (`from_generator` structurally produces a `Dataset`), dtype not statically resolvable" — that's the documented ⊤ cell, not ⊥. The pre-fix `emptySet()` claimed the wrong cell, silently dropping the "is a tensor" signal downstream. The fix is contract-matching against the documented lattice, not coverage-driven.

## Context

Surfaced during a https://github.com/wala/ML/issues/408 direction-2 audit of `Collections.emptySet()` and `EnumSet.noneOf(DType.class)` returns across `TensorGenerator` subclasses. The audit flagged four candidate sites; three turned out to be false positives in `getDatasetSizes` (which uses a different lattice — empty means "no concrete sizes known, fall back to symbolic" at the consumer side, per `DatasetBatchGenerator.java:152`). This was the only real bug.

## Note on https://github.com/wala/ML/issues/408

This fix doesn't close #408. #408's motivating example (chain-collapse through `Conv2D`→`Flatten`→`Dense`→`Dropout` in `convolutional_network.py`) is from `Flatten`/`Dropout` having **no generator at all**, not from per-generator `emptySet` returns. That lever is a different #408 direction; see issue body's options 1 and 3.
