### PR TITLE
Resolve inherited method dispatch in the call graph

### DIFF
--- a/com.ibm.wala.cast.python.test/data/test_issue107_118_repro.py
+++ b/com.ibm.wala.cast.python.test/data/test_issue107_118_repro.py
@@ -1,0 +1,16 @@
+# Reproducer for wala/ML#107 (method-inherited-from-parent missing from call graph)
+# and wala/ML#118 (subclass.getSuperclass() returns Object instead of parent).
+
+
+class D:
+    def func(self, x):
+        return x * x
+
+
+class C(D):
+    pass
+
+
+c = C()
+a = c.func(5)
+assert a == 25

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
@@ -2,8 +2,9 @@ package com.ibm.wala.cast.python.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -34,19 +35,14 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
 
     // Look for a CGNode whose method is `D.func` (the inherited method). If wala/ML#107
     // still reproduces, no such node exists.
-    boolean foundInheritedFunc = false;
     for (CGNode n : cg) {
       String name = n.getMethod().toString();
-      if (name.contains("/D/func") || name.contains("/C/func")) {
-        foundInheritedFunc = true;
-        break;
-      }
+      if (name.contains("/D/func") || name.contains("/C/func")) return;
     }
-    assertTrue(
+    fail(
         "wala/ML#107: expected `D.func` (inherited via `class C(D)`) to appear in the call graph;"
             + " saw nodes: "
-            + dumpMethodNames(cg),
-        foundInheritedFunc);
+            + dumpMethodNames(cg));
   }
 
   @Test
@@ -57,8 +53,7 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
     IClass c =
         cha.lookupClass(
             TypeReference.findOrCreate(
-                com.ibm.wala.cast.python.types.PythonTypes.pythonLoader,
-                TypeName.string2TypeName("Lscript " + FIXTURE + "/C")));
+                PythonTypes.pythonLoader, TypeName.string2TypeName("Lscript " + FIXTURE + "/C")));
     assertNotNull("expected to resolve `C` in the loaded class hierarchy", c);
 
     IClass parent = c.getSuperclass();

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
@@ -2,12 +2,10 @@ package com.ibm.wala.cast.python.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.cast.util.test.TestCallGraphShape.GraphAssertion;
 import com.ibm.wala.classLoader.IClass;
-import com.ibm.wala.classLoader.IMethod;
-import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
@@ -15,6 +13,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
+import java.util.List;
 import org.junit.Test;
 
 /**
@@ -28,21 +27,34 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
 
   private static final String FIXTURE = "test_issue107_118_repro.py";
 
+  /**
+   * Asserts the call-graph EDGES from {@code c.func(5)} reach the inherited body. The bug was a
+   * missing edge, not just a missing node; node-existence alone could be satisfied by an unrelated
+   * reachability path.
+   */
+  private static final List<GraphAssertion> assertions =
+      List.of(
+          new GraphAssertion(ROOT, new String[] {"script " + FIXTURE}),
+          // Script-level callees: the `c = C()` constructor call and the `c.func(5)`
+          // trampoline. `D` is declared but never instantiated, so no edge from script to D.
+          // The trampoline edge is the load-bearing assertion for wala/ML#107: pre-fix, this
+          // edge was missing entirely (no `c.func(5)` resolution in the call graph at all).
+          new GraphAssertion(
+              "script " + FIXTURE,
+              new String[] {
+                "script " + FIXTURE + "/C", "$script " + FIXTURE + "/D/func:trampoline2"
+              }),
+          // The trampoline must in turn dispatch to `D.func`'s body. Pre-fix, even if the
+          // trampoline node existed, this resolution edge would not.
+          new GraphAssertion(
+              "$script " + FIXTURE + "/D/func:trampoline2",
+              new String[] {"script " + FIXTURE + "/D/func"}));
+
   @Test
-  public void issue107InheritedMethodAppearsInCallGraph()
+  public void issue107InheritedMethodEdgeReachesParentBody()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     CallGraph cg = this.process(FIXTURE);
-
-    // Look for a CGNode whose method is `D.func` (the inherited method). If wala/ML#107
-    // still reproduces, no such node exists.
-    for (CGNode n : cg) {
-      String name = n.getMethod().toString();
-      if (name.contains("/D/func") || name.contains("/C/func")) return;
-    }
-    fail(
-        "wala/ML#107: expected `D.func` (inherited via `class C(D)`) to appear in the call graph;"
-            + " saw nodes: "
-            + dumpMethodNames(cg));
+    verifyGraphAssertions(cg, assertions);
   }
 
   @Test
@@ -63,14 +75,5 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
         "wala/ML#118: `C` should report `D` as its declared superclass, not `Object`",
         "Lscript " + FIXTURE + "/D",
         parentName);
-  }
-
-  private static String dumpMethodNames(CallGraph cg) {
-    StringBuilder sb = new StringBuilder();
-    for (CGNode n : cg) {
-      IMethod m = n.getMethod();
-      sb.append("\n  ").append(m.toString());
-    }
-    return sb.toString();
   }
 }

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
@@ -1,0 +1,81 @@
+package com.ibm.wala.cast.python.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Verification of <a href="https://github.com/wala/ML/issues/107">wala/ML#107</a> (method inherited
+ * from parent class is missing from the call graph) and <a
+ * href="https://github.com/wala/ML/issues/118">wala/ML#118</a> ({@code IClass.getSuperclass()}
+ * returns {@code Object} instead of the declared Python parent) against current master. Both issues
+ * are filed against an older state of the loader; this test pins their current status.
+ */
+public class TestIssue107And118 extends TestJythonCallGraphShape {
+
+  private static final String FIXTURE = "test_issue107_118_repro.py";
+
+  @Test
+  public void issue107InheritedMethodAppearsInCallGraph()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    CallGraph cg = this.process(FIXTURE);
+
+    // Look for a CGNode whose method is `D.func` (the inherited method). If wala/ML#107
+    // still reproduces, no such node exists.
+    boolean foundInheritedFunc = false;
+    for (CGNode n : cg) {
+      String name = n.getMethod().toString();
+      if (name.contains("/D/func") || name.contains("/C/func")) {
+        foundInheritedFunc = true;
+        break;
+      }
+    }
+    assertTrue(
+        "wala/ML#107: expected `D.func` (inherited via `class C(D)`) to appear in the call graph;"
+            + " saw nodes: "
+            + dumpMethodNames(cg),
+        foundInheritedFunc);
+  }
+
+  @Test
+  public void issue118SubclassSuperclassIsParent()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    IClassHierarchy cha = makeEngine(FIXTURE).defaultCallGraphBuilder().getClassHierarchy();
+
+    IClass c =
+        cha.lookupClass(
+            TypeReference.findOrCreate(
+                com.ibm.wala.cast.python.types.PythonTypes.pythonLoader,
+                TypeName.string2TypeName("Lscript " + FIXTURE + "/C")));
+    assertNotNull("expected to resolve `C` in the loaded class hierarchy", c);
+
+    IClass parent = c.getSuperclass();
+    assertNotNull("expected `C` to have a superclass", parent);
+    String parentName = parent.getName().toString();
+    assertEquals(
+        "wala/ML#118: `C` should report `D` as its declared superclass, not `Object`",
+        "Lscript " + FIXTURE + "/D",
+        parentName);
+  }
+
+  private static String dumpMethodNames(CallGraph cg) {
+    StringBuilder sb = new StringBuilder();
+    for (CGNode n : cg) {
+      IMethod m = n.getMethod();
+      sb.append("\n  ").append(m.toString());
+    }
+    return sb.toString();
+  }
+}

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestIssue107And118.java
@@ -50,6 +50,18 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
               "$script " + FIXTURE + "/D/func:trampoline2",
               new String[] {"script " + FIXTURE + "/D/func"}));
 
+  /**
+   * Pins the wala/ML#107 fix: builds the call graph for the reproducer fixture and verifies that
+   * the {@code c.func(5)} call site resolves through the inherited body. The {@link #assertions}
+   * field captures each load-bearing edge; pre-fix, the {@code script → trampoline} edge was
+   * absent, so {@code verifyGraphAssertions} would fail to find the trampoline node as a successor.
+   *
+   * @throws ClassHierarchyException if the {@code PythonAnalysisEngine} cannot build the class
+   *     hierarchy for the fixture.
+   * @throws IllegalArgumentException if a malformed fixture path is rejected by the engine.
+   * @throws CancelException if call-graph construction is cancelled.
+   * @throws IOException if the fixture source cannot be read.
+   */
   @Test
   public void issue107InheritedMethodEdgeReachesParentBody()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -57,6 +69,17 @@ public class TestIssue107And118 extends TestJythonCallGraphShape {
     verifyGraphAssertions(cg, assertions);
   }
 
+  /**
+   * Regression guard for wala/ML#118: pins that {@code C.getSuperclass()} returns the declared
+   * Python parent {@code D}, not {@code Object}. wala/ML#118 is already fixed on master; the test
+   * exists to catch a future regression and to document the precondition that {@link
+   * #issue107InheritedMethodEdgeReachesParentBody} depends on.
+   *
+   * @throws ClassHierarchyException if the loader cannot build the class hierarchy.
+   * @throws IllegalArgumentException if a malformed fixture path is rejected.
+   * @throws CancelException if hierarchy construction is cancelled.
+   * @throws IOException if the fixture source cannot be read.
+   */
   @Test
   public void issue118SubclassSuperclassIsParent()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -137,7 +137,27 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
           if (receiver instanceof IPythonClass) {
             IPythonClass x = (IPythonClass) receiver;
             innerReferences = x.getInnerReferences();
-            methodReferences = x.getMethodReferences();
+            // Collect own methods first; they take precedence over inherited methods of the same
+            // name (Python override semantics).
+            java.util.Set<Atom> seenMethodNames = new java.util.HashSet<>();
+            for (MethodReference m : x.getMethodReferences()) {
+              methodReferences.add(m);
+              seenMethodNames.add(m.getName());
+            }
+            // wala/ML#107: also stamp methods inherited from supertypes onto the instance, so a
+            // call like `c.func(...)` where `class C(D)` and `D` declares `func` resolves through
+            // the constructor's per-method trampoline instead of silently dropping the edge.
+            // Multiple-supertype iteration is left-first (matching Python's MRO depth-first rule);
+            // the `seenMethodNames` set dedupes when supertypes contribute the same name.
+            for (IClass parent = receiver.getSuperclass();
+                parent instanceof IPythonClass;
+                parent = parent.getSuperclass()) {
+              for (MethodReference m : ((IPythonClass) parent).getMethodReferences()) {
+                if (seenMethodNames.add(m.getName())) {
+                  methodReferences.add(m);
+                }
+              }
+            }
           } else {
             for (IMethod m : receiver.getDeclaredMethods()) {
               if (!m.isInit() && !m.isClinit()) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -45,7 +45,9 @@ import com.ibm.wala.util.collections.Pair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 public class PythonConstructorTargetSelector implements MethodTargetSelector {
@@ -139,24 +141,26 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             innerReferences = x.getInnerReferences();
             // Collect own methods first; they take precedence over inherited methods of the same
             // name (Python override semantics).
-            java.util.Set<Atom> seenMethodNames = new java.util.HashSet<>();
+            Set<Atom> seenMethodNames = new HashSet<>();
             for (MethodReference m : x.getMethodReferences()) {
               methodReferences.add(m);
               seenMethodNames.add(m.getName());
             }
-            // wala/ML#107: also stamp methods inherited from supertypes onto the instance, so a
-            // call like `c.func(...)` where `class C(D)` and `D` declares `func` resolves through
-            // the constructor's per-method trampoline instead of silently dropping the edge.
-            // Multiple-supertype iteration is left-first (matching Python's MRO depth-first rule);
-            // the `seenMethodNames` set dedupes when supertypes contribute the same name.
+            // Also stamp methods inherited from supertypes onto the instance, so a call like
+            // `c.func(...)` where `class C(D)` and `D` declares `func` resolves through the
+            // constructor's per-method trampoline instead of silently dropping the edge. Walks
+            // the single supertype chain via `getSuperclass()`; the `seenMethodNames` set keeps
+            // own methods winning on name collision, and the IClass model collapses Python
+            // multi-inheritance to one `superName` per `PythonClass`, so a true left-first MRO
+            // walk isn't representable here without extending the loader. See
+            // https://github.com/wala/ML/issues/107.
             for (IClass parent = receiver.getSuperclass();
                 parent instanceof IPythonClass;
                 parent = parent.getSuperclass()) {
-              for (MethodReference m : ((IPythonClass) parent).getMethodReferences()) {
-                if (seenMethodNames.add(m.getName())) {
-                  methodReferences.add(m);
-                }
-              }
+              ((IPythonClass) parent)
+                  .getMethodReferences().stream()
+                      .filter(m -> seenMethodNames.add(m.getName()))
+                      .forEach(methodReferences::add);
             }
           } else {
             for (IMethod m : receiver.getDeclaredMethods()) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -88,12 +88,14 @@ public class PythonCAstToIRTranslator extends AstTranslator {
 
   /**
    * For each class's WALA {@link TypeName}, the user-source names of the members emitted as {@code
-   * putfield}s on that class's class object during {@link #leaveTypeEntity}. Used to propagate
-   * inherited members onto subclass class objects (wala/ML#107): a property read like {@code
+   * putfield}s on that class's class object during {@link #leaveTypeEntity}. The list accumulates
+   * both own and inherited members as propagation runs, so a subclass's entry contains everything
+   * descendants need to inherit. Used to propagate inherited members onto subclass class objects
+   * (<a href="https://github.com/wala/ML/issues/107">wala/ML#107</a>): a property read like {@code
    * c.func} on an instance of {@code class C(D)} where {@code func} is declared on {@code D} would
    * otherwise miss because {@code C}'s class-object catalog has no {@code func} entry.
    */
-  private final Map<TypeName, List<String>> classOwnMemberNames = HashMapFactory.make();
+  private final Map<TypeName, List<String>> classEmittedMemberNames = HashMapFactory.make();
 
   private final Set<Pair<Scope, String>> globalDeclSet = new HashSet<>();
   private static boolean singleFileAnalysis = true;
@@ -790,7 +792,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     }
     this.entity2ExposedNames.get(context.top()).add(fnName);
 
-    List<String> ownMemberNames = new ArrayList<>();
+    List<String> emittedMemberNames = new ArrayList<>();
     for (CAstEntity field : n.getAllScopedEntities().get(null)) {
       FieldReference fr =
           FieldReference.findOrCreate(
@@ -818,28 +820,28 @@ public class PythonCAstToIRTranslator extends AstTranslator {
           .addInstruction(
               Python.instructionFactory()
                   .PutInstruction(code.cfg().getCurrentInstruction(), v, val, fr));
-      ownMemberNames.add(field.getName());
+      emittedMemberNames.add(field.getName());
     }
-    classOwnMemberNames.put(cls.getName(), ownMemberNames);
+    classEmittedMemberNames.put(cls.getName(), emittedMemberNames);
 
-    // wala/ML#107: propagate members from non-missing supertypes onto this class's class
-    // object so that property reads (e.g., `c.func` where `class C(D)` and `D` declares
-    // `func`) find inherited members via the catalog. Without this pass, the IR for
-    // `class C(D): pass` emits `new C` with no `putfield` statements, and any read of an
-    // inherited attribute on a `C` instance yields an empty PTS — silently dropping the
-    // call-graph edge for `c.func(...)`. Each inherited member is emitted as a
-    // `getfield <super>.<name>` followed by a `putfield <this>.<name>`, so the runtime
-    // shape mirrors the per-class loop above. Members already defined on this class take
-    // precedence (Python override semantics); the seen-set also dedupes when multiple
-    // supertypes contribute the same name (left-first wins, matching Python's MRO).
-    Set<String> propagated = new HashSet<>(ownMemberNames);
+    // Propagate members from non-missing supertypes onto this class's class object so that
+    // property reads (e.g., `c.func` where `class C(D)` and `D` declares `func`) find inherited
+    // members via the catalog. Without this pass, the IR for `class C(D): pass` emits `new C`
+    // with no `putfield` statements, and any read of an inherited attribute on a `C` instance
+    // yields an empty PTS — silently dropping the call-graph edge for `c.func(...)`. Each
+    // inherited member is emitted as a `getfield <super>.<name>` followed by a
+    // `putfield <this>.<name>`, so the runtime shape mirrors the per-class loop above. Members
+    // already defined on this class take precedence (Python override semantics); the seen-set
+    // also dedupes when multiple supertypes contribute the same name (left-first wins, matching
+    // Python's MRO). See https://github.com/wala/ML/issues/107.
+    Set<String> propagated = new HashSet<>(emittedMemberNames);
     for (CAstType superType : n.getType().getSupertypes()) {
       if (superType instanceof MissingType) continue;
       TypeName superTypeName = walaTypeNames.get(superType);
       if (superTypeName == null) continue;
       IClass superClass = loader.lookupClass(superTypeName);
       if (superClass == null) continue;
-      List<String> superMembers = classOwnMemberNames.get(superTypeName);
+      List<String> superMembers = classEmittedMemberNames.get(superTypeName);
       if (superMembers == null || superMembers.isEmpty()) continue;
 
       int superClassObject = doLocalRead(code, superType.getName(), superClass.getReference());
@@ -867,7 +869,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
             .addInstruction(
                 Python.instructionFactory()
                     .PutInstruction(code.cfg().getCurrentInstruction(), v, inheritedVal, thisFr));
-        ownMemberNames.add(memberName);
+        emittedMemberNames.add(memberName);
       }
     }
 

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -85,6 +85,16 @@ public class PythonCAstToIRTranslator extends AstTranslator {
   private static final Logger LOGGER = Logger.getLogger(PythonCAstToIRTranslator.class.getName());
 
   private final Map<CAstType, TypeName> walaTypeNames = HashMapFactory.make();
+
+  /**
+   * For each class's WALA {@link TypeName}, the user-source names of the members emitted as {@code
+   * putfield}s on that class's class object during {@link #leaveTypeEntity}. Used to propagate
+   * inherited members onto subclass class objects (wala/ML#107): a property read like {@code
+   * c.func} on an instance of {@code class C(D)} where {@code func} is declared on {@code D} would
+   * otherwise miss because {@code C}'s class-object catalog has no {@code func} entry.
+   */
+  private final Map<TypeName, List<String>> classOwnMemberNames = HashMapFactory.make();
+
   private final Set<Pair<Scope, String>> globalDeclSet = new HashSet<>();
   private static boolean singleFileAnalysis = true;
 
@@ -780,6 +790,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     }
     this.entity2ExposedNames.get(context.top()).add(fnName);
 
+    List<String> ownMemberNames = new ArrayList<>();
     for (CAstEntity field : n.getAllScopedEntities().get(null)) {
       FieldReference fr =
           FieldReference.findOrCreate(
@@ -807,6 +818,57 @@ public class PythonCAstToIRTranslator extends AstTranslator {
           .addInstruction(
               Python.instructionFactory()
                   .PutInstruction(code.cfg().getCurrentInstruction(), v, val, fr));
+      ownMemberNames.add(field.getName());
+    }
+    classOwnMemberNames.put(cls.getName(), ownMemberNames);
+
+    // wala/ML#107: propagate members from non-missing supertypes onto this class's class
+    // object so that property reads (e.g., `c.func` where `class C(D)` and `D` declares
+    // `func`) find inherited members via the catalog. Without this pass, the IR for
+    // `class C(D): pass` emits `new C` with no `putfield` statements, and any read of an
+    // inherited attribute on a `C` instance yields an empty PTS — silently dropping the
+    // call-graph edge for `c.func(...)`. Each inherited member is emitted as a
+    // `getfield <super>.<name>` followed by a `putfield <this>.<name>`, so the runtime
+    // shape mirrors the per-class loop above. Members already defined on this class take
+    // precedence (Python override semantics); the seen-set also dedupes when multiple
+    // supertypes contribute the same name (left-first wins, matching Python's MRO).
+    Set<String> propagated = new HashSet<>(ownMemberNames);
+    for (CAstType superType : n.getType().getSupertypes()) {
+      if (superType instanceof MissingType) continue;
+      TypeName superTypeName = walaTypeNames.get(superType);
+      if (superTypeName == null) continue;
+      IClass superClass = loader.lookupClass(superTypeName);
+      if (superClass == null) continue;
+      List<String> superMembers = classOwnMemberNames.get(superTypeName);
+      if (superMembers == null || superMembers.isEmpty()) continue;
+
+      int superClassObject = doLocalRead(code, superType.getName(), superClass.getReference());
+
+      for (String memberName : superMembers) {
+        if (!propagated.add(memberName)) continue;
+        int inheritedVal = code.currentScope().allocateTempValue();
+        FieldReference superFr =
+            FieldReference.findOrCreate(
+                superClass.getReference(),
+                Atom.findOrCreateUnicodeAtom(memberName),
+                PythonTypes.Root);
+        code.cfg()
+            .addInstruction(
+                Python.instructionFactory()
+                    .GetInstruction(
+                        code.cfg().getCurrentInstruction(),
+                        inheritedVal,
+                        superClassObject,
+                        superFr));
+        FieldReference thisFr =
+            FieldReference.findOrCreate(
+                type, Atom.findOrCreateUnicodeAtom(memberName), PythonTypes.Root);
+        code.cfg()
+            .addInstruction(
+                Python.instructionFactory()
+                    .PutInstruction(code.cfg().getCurrentInstruction(), v, inheritedVal, thisFr));
+        ownMemberNames.add(memberName);
+      }
     }
 
     if (cls instanceof PythonClass) {


### PR DESCRIPTION
## Summary

Fixes wala/ML#107. When `class C(D): pass` and `D` declared `func`, a call `c.func(5)` was silently dropped from the call graph—no edge to `D.func` (or a trampoline) appeared, so any downstream analysis ignored the call.

Verified state before this change:
- wala/ML#118 (`C.getSuperclass()` returning `Object`) is already fixed on master.
- wala/ML#107 still reproduced on master with the issue body's exact case-2 fixture.

So the bug surface is just the dispatch pieces that didn't honor the working class hierarchy.

## What the Fix Changes

Two pieces, both required (verified by toggling each off in isolation):

### 1. `PythonCAstToIRTranslator.leaveTypeEntity`

Emits one `putfield` per own member onto a class's class object. For an inheriting class with no own members (`class C(D): pass`), it emitted nothing—so `C`'s class-object catalog had no `func` field. The constructor's `getfield receiver.<name>` (step 3 of the per-method stamping block, see section 2 below) then read an empty PTS even when `func` existed on `D`.

Now the loop records the names it emits, then walks `n.getType().getSupertypes()` and emits one `getfield <super>.<name>; putfield <this>.<name>` pair per inherited member. Own members take precedence on name collision (Python override semantics); multiple supertypes are iterated left-first (Python MRO depth-first); transitive ancestors propagate because each class's recorded emitted-member list also accumulates its inherited entries.

### 2. `PythonConstructorTargetSelector.getCalleeTarget`

Synthesizes the per-class constructor that stamps a per-method trampoline onto each freshly-allocated instance. Its iteration over `methodReferences` used `IPythonClass.getMethodReferences()`, which is declared-only. The existing block already had a comment flagging this exact gap:

https://github.com/ponder-lab/ML/blob/64f6002180861907039b1bff04b5fa3d4387b9f8/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java#L208-L211

The iteration now collects own methods first, then walks `receiver.getSuperclass()` to pick up inherited methods with the same dedupe rules. The existing stamping block then emits trampolines for inherited methods using `r.getDeclaringClass()` for the trampoline's host class, and the receiver's `getfield <name>` (now correctly populated by piece #1) for the `$function` metadata.

## Verification

`TestIssue107And118` pins both fixes:
- `issue107InheritedMethodAppearsInCallGraph`—asserts a CGNode for the inherited `func` (`D.func` or `C.func`'s trampoline) shows up. Reproducer matches the issue body's case-2 exactly.
- `issue118SubclassSuperclassIsParent`—asserts `C.getSuperclass()` returns `D`, not `Object`. Regression guard since wala/ML#118 is already fixed but was uncovered.

## Downstream

This is the root-cause fix that, per the https://github.com/wala/ML/issues/408 discussion, also unlocks Direction 3 for that issue. The existing per-subclass `__call__` declarations in `tensorflow.xml`—for example, on `tf.keras.models.Model`:

https://github.com/ponder-lab/ML/blob/64f6002180861907039b1bff04b5fa3d4387b9f8/com.ibm.wala.cast.python.ml/data/tensorflow.xml#L2297-L2301

now propagate to user-defined subclasses (`class MyModel(tf.keras.Model)`) via inheritance, since `MyModel.do()`'s synthesized body iterates inherited methods. Follow-up work on #408 can extend this pattern to `tf.keras.layers.Layer` without per-subclass duplication.

Closes wala/ML#107.

