### PR TITLE
Drop stale wala/ML#107 uncertainty note in `PythonConstructorTargetSelector`

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -231,8 +231,7 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             // Add a metadata variable that refers to the declaring class.
             // NOTE: Per https://docs.python.org/3/library/functions.html#classmethod, "[i]f a class
             // method is called for a derived class, the derived class object is passed as the
-            // implied first argument." I'm unsure whether `receiver` can refer to the derived
-            // class especially in light of https://github.com/wala/ML/issues/107.
+            // implied first argument."
             int classVar = v++;
             String globalName = getGlobalName(r);
             FieldReference globalRef = makeGlobalRef(receiver.getClassLoader(), globalName);


### PR DESCRIPTION
## Summary

Removes a comment sentence that became stale when ponder-lab/ML#345 (closing wala/ML#107) landed:

> // I'm unsure whether `receiver` can refer to the derived class especially in light of https://github.com/wala/ML/issues/107.

The uncertainty is resolved. ponder-lab/ML#345 made the surrounding loop walk the supertype chain, so `receiver` *does* iterate through derived classes' inherited methods; the per-method stamping block emits a trampoline for each, with `r.getDeclaringClass()` correctly pointing at the declaring (super) class.

## Scope

One-line removal. The classmethod-semantics note above the deleted sentence is still correct Python documentation and stays.

## Cross-references

- ponder-lab/ML#345 — the PR that resolved the uncertainty.
- wala/ML#107 — the underlying issue (now closed).

Note: a separate, larger cleanup remains around `PythonInstanceMethodTrampolineTargetSelector.java:297-319` (the `TODO: Remove this code once wala/ML#118 is completed.` workaround block). wala/ML#118 is also fixed, but the block has independent responsibility for the Keras `call()` vs `__call__()` dispatch quirk (#106), so its removal needs an empirical audit—out of scope for this PR.