### PR TITLE
Install `jython3` and `cast.lsp` at release coordinates (no `-SNAPSHOT`)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,14 +62,15 @@ jobs:
         pushd jython3
         ant
         pushd dist
-        mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.2-SNAPSHOT" -Dpackaging="jar" -DgeneratePom=true -B
+        mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.2" -Dpackaging="jar" -DgeneratePom=true -B
         popd
         popd
       shell: bash
     - name: Install IDE
       run: |
         pushd IDE/com.ibm.wala.cast.lsp
-        mvn install -B -q -DskipTests
+        mvn package -B -q -DskipTests
+        mvn install:install-file -Dfile=target/com.ibm.wala.cast.lsp-0.0.1-SNAPSHOT.jar -DgroupId="com.ibm.wala" -DartifactId="com.ibm.wala.cast.lsp" -Dversion="0.0.1" -Dpackaging="jar" -DgeneratePom=true -B
         popd
     - name: Build with Maven
       run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ You must install the `jython-dev.jar` to your local maven repository.
 	```
 ### Installing IDE
 
-1. Change directory to `com.ibm.wala.cast.lsp`: `cd com.ibm.wala.cast.lsp`
+1. Change directory to `IDE/com.ibm.wala.cast.lsp` (the IDE code lives in a Git submodule at `IDE/`, per `.gitmodules`): `cd IDE/com.ibm.wala.cast.lsp`
 1. Build (without installing): `mvn package -DskipTests`
 1. Install at the non-SNAPSHOT coordinate `0.0.1` (the `cast.lsp` POM declares `0.0.1-SNAPSHOT`, but the release-plugin rejects SNAPSHOT deps; we install under a release coordinate locally so Ariadne's `release:prepare` runs in batch mode without `-DignoreSnapshots`):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,25 @@ You must install the `jython-dev.jar` to your local maven repository.
 	-Dfile=./jython-dev.jar \
 	-DgroupId="org.python" \
 	-DartifactId="jython3" \
-	-Dversion="0.0.2-SNAPSHOT" \
+	-Dversion="0.0.2" \
 	-Dpackaging="jar" \
 	-DgeneratePom=true
 	```
 ### Installing IDE
 
 1. Change directory to `com.ibm.wala.cast.lsp`: `cd com.ibm.wala.cast.lsp`
-1. Build and install to your local Maven repo: `mvn install`
+1. Build (without installing): `mvn package -DskipTests`
+1. Install at the non-SNAPSHOT coordinate `0.0.1` (the `cast.lsp` POM declares `0.0.1-SNAPSHOT`, but the release-plugin rejects SNAPSHOT deps; we install under a release coordinate locally so Ariadne's `release:prepare` runs in batch mode without `-DignoreSnapshots`):
+
+	```bash
+	mvn install:install-file \
+	-Dfile=target/com.ibm.wala.cast.lsp-0.0.1-SNAPSHOT.jar \
+	-DgroupId="com.ibm.wala" \
+	-DartifactId="com.ibm.wala.cast.lsp" \
+	-Dversion="0.0.1" \
+	-Dpackaging="jar" \
+	-DgeneratePom=true
+	```
 
 ### Building WALA/ML
 

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.ibm.wala</groupId>
       <artifactId>com.ibm.wala.cast.lsp</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>0.0.1</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -56,7 +56,7 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <!-- `jython3` references `jnr/constants/Constant` (and other `jnr/...`)
-      from its `org.python.modules.posix.PosixModule`. The `0.0.2-SNAPSHOT`
+      from its `org.python.modules.posix.PosixModule`. The `0.0.2`
       `jython-dev.jar` is registered via `mvn install:install-file
       -DgeneratePom=true` (see `CONTRIBUTING.md` and the CI workflow),
       which synthesizes a minimal POM that declares zero dependencies — so

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>org.python</groupId>
         <artifactId>jython3</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.python</groupId>


### PR DESCRIPTION
## Summary

`mvn release:prepare -B` rejects projects with `-SNAPSHOT` dependencies. Both `org.python:jython3` (locally installed from the `jython3/` submodule) and `com.ibm.wala:com.ibm.wala.cast.lsp` (locally installed from the `IDE/` submodule) are SNAPSHOT-coordinated even though we never publish them to a remote SNAPSHOT repository.

Two paths considered, this PR takes the second:

1. **Override the check with `-DignoreSnapshots=true`** at release time. One-flag fix. Works mechanically. But the flag name conflates "bypass the safety check" with "treat the deps as resolved", which is misleading for anyone reading the release recipe later.
2. **Install the artifacts at release coordinates locally.** No flag needed. The release-plugin sees no SNAPSHOT deps and proceeds in batch mode. Trade: more files touched, downstream consumers update their install commands to match.

This PR takes (2).

## Changes

- `pom.xml`: jython3 dep `0.0.2-SNAPSHOT` → `0.0.2`.
- `com.ibm.wala.cast.python.ml/pom.xml`: cast.lsp dep `0.0.1-SNAPSHOT` → `0.0.1`; jython3-mention comment text update.
- `CONTRIBUTING.md`: jython3 install command version + new cast.lsp `install:install-file` step (replacing plain `mvn install`).
- `.github/workflows/continuous-integration.yml`: same CI updates.

For `cast.lsp`, the upstream `IDE/com.ibm.wala.cast.lsp/pom.xml` still declares `0.0.1-SNAPSHOT`. We don't touch that file. Instead, we build with `mvn package` and install at coordinate `0.0.1` via `install:install-file`. An upstream `wala/IDE` PR to bump the version is the cleaner long-term fix; this is the local workaround.

## Verification

- Local: jython3 installed at `0.0.2`, cast.lsp at `0.0.1`.
- `mvn clean install -DskipTests` from repo root: green across all 10 modules.
- `mvn release:prepare -B -DdryRun=true -DreleaseVersion=0.46.0 ...` (no `-DignoreSnapshots`): BUILD SUCCESS.

## Downstream

Hybridize and other consumers update their install commands when they bump to the next Ariadne release. This is a one-time coordinate change; subsequent releases just work.