### PR TITLE
Pin `maven-release-plugin` tag format to plain `X.Y.Z`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <version>3.3.1</version>
+          <configuration>
+            <!-- Override the default `@{project.artifactId}-@{project.version}`
+              format (which produces `ml-X.Y.Z`). The CI deploy gate's tag-check
+              regex matches plain semver `X.Y.Z` only, and historical tags
+              `0.40.0`–`0.45.0` are all plain semver. See wala/ML#535. -->
+            <tagNameFormat>@{project.version}</tagNameFormat>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,10 +150,10 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>3.3.1</version>
           <configuration>
-            <!-- Override the default `@{project.artifactId}-@{project.version}`
-              format (which produces `ml-X.Y.Z`). The CI deploy gate's tag-check
-              regex matches plain semver `X.Y.Z` only, and historical tags
-              `0.40.0`–`0.45.0` are all plain semver. See wala/ML#535. -->
+            <!-- Override the default `@{project.artifactId}-@{project.version}`.
+              The CI deploy gate's tag-check regex matches plain semver
+              `X.Y.Z` only, and historical release tags are plain semver.
+              See https://github.com/wala/ML/issues/535. -->
             <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>
         </plugin>


### PR DESCRIPTION
## Summary

The default `tagNameFormat` is `@{project.artifactId}-@{project.version}`, which for our root pom (`artifactId=ml`) expands to `ml-X.Y.Z`. The CI deploy gate in `continuous-integration.yml` matches plain semver `X.Y.Z` only — that's why the `ml-0.46.0` and `ml-0.46.1` tag-pushes silently skipped their deploy step. Historical release tags `0.40.0`–`0.45.0` are all plain semver, presumably created manually alongside the `ml-`-prefixed ones.

## Test Plan

- [ ] After this PR lands, the next `mvn release:prepare` should produce a plain `X.Y.Z` tag.
- [ ] That tag's push triggers the CI deploy gate (semver regex match + `git merge-base --is-ancestor` succeeds with `--depth=50` from #340).

Fixes https://github.com/wala/ML/issues/560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)