### PR TITLE
Fix release-upload glob so fat JAR actually attaches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -179,9 +179,18 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         name: fat-jar
+    # `actions/download-artifact@v8` with only `name:` extracts to the workspace
+    # root (single-artifact archives flatten away their source path). The
+    # `build` job's `upload-artifact` step uploaded the JAR from
+    # `com.ibm.wala.cast.python.ml/target/`, but only the filename survives the
+    # round-trip — so the `files:` glob below must match the bare filename, not
+    # the original on-disk path. `fail_on_unmatched_files: true` makes a future
+    # glob drift fail loudly instead of silently producing an assetless
+    # release. See https://github.com/wala/ML/issues/561.
     - name: Attach fat JAR to GitHub Release
       uses: softprops/action-gh-release@v3
       with:
-        files: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
+        files: com.ibm.wala.cast.python.ml-*-fat.jar
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`actions/download-artifact@v8` with only `name:` extracts to the workspace root — the source on-disk path `com.ibm.wala.cast.python.ml/target/...` does not survive the artifact round-trip. The previous `files:` glob looked at the vanished path, matched zero files, and `softprops/action-gh-release@v3` silently produced an assetless release.

Symptom: the 0.46.1 GitHub Release had `assets: []` despite the `release-upload` job reporting success.

## Test Plan

- [ ] Next semver tag-push produces a Release with the fat JAR attached automatically.
- [ ] If the glob ever stops matching, `fail_on_unmatched_files: true` makes the step fail instead of producing an assetless release.

Fixes https://github.com/wala/ML/issues/561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)