### PR TITLE
Enforce spaceless self-closing XML tag style

### DIFF
--- a/com.ibm.wala.cast.python.jython/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython/data/functools.xml
@@ -5,21 +5,21 @@
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
       <method name="import" static="true" descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools" />
-        <new def="reduce" class="Lfunctools/functions/reduce" />
-        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
-        <return value="x" />
+        <new def="x" class="Lfunctools"/>
+        <new def="reduce" class="Lfunctools/functions/reduce"/>
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="functools/functions">
       <class name="reduce" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-          <constant name="l" type="int" value="0" />
-          <aaload ref="data" def="v1" type="LRoot" index="l" />
-          <constant name="r" type="int" value="1" />
-          <aaload ref="data" def="v2" type="LRoot" index="r" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
-          <return value="v" />
+          <constant name="l" type="int" value="0"/>
+          <aaload ref="data" def="v1" type="LRoot" index="l"/>
+          <constant name="r" type="int" value="1"/>
+          <aaload ref="data" def="v2" type="LRoot" index="r"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython/data/numpy_turtle.xml
@@ -5,9 +5,9 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython/data/pandas.xml
+++ b/com.ibm.wala.cast.python.jython/data/pandas.xml
@@ -5,25 +5,25 @@
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lpandas" />
-        <new def="read_excel" class="Lpandas/functions/read_excel" />
-        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
-        <new def="merge" class="Lpandas/functions/merge" />
-        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
-        <return value="x" />
+        <new def="x" class="Lpandas"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel"/>
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel"/>
+        <new def="merge" class="Lpandas/functions/merge"/>
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="pandas/functions">
       <class name="read_excel" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-          <new def="v" class="Lobject" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="merge" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
-          <return value="left" />
-          <return value="right" />
+          <return value="left"/>
+          <return value="right"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.jython/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython/data/turtles.xml
@@ -5,79 +5,79 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="sklearn" allocatable="true">
       <method name="import" static="true" descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="patsy" allocatable="true">
       <method name="import" static="true" descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="seaborn" allocatable="true">
       <method name="import" static="true" descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="statsmodels" allocatable="true">
       <method name="import" static="true" descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="scipy" allocatable="true">
       <method name="import" static="true" descriptor="()Lscipy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="matplotlib" allocatable="true">
       <method name="import" static="true" descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="IPython" allocatable="true">
       <method name="import" static="true" descriptor="()LIPython;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="mpl_toolkits" allocatable="true">
       <method name="import" static="true" descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
       <method name="import" static="true" descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython3/data/functools.xml
+++ b/com.ibm.wala.cast.python.jython3/data/functools.xml
@@ -5,21 +5,21 @@
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
       <method name="import" static="true" descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools" />
-        <new def="reduce" class="Lfunctools/functions/reduce" />
-        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
-        <return value="x" />
+        <new def="x" class="Lfunctools"/>
+        <new def="reduce" class="Lfunctools/functions/reduce"/>
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="functools/functions">
       <class name="reduce" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-          <constant name="l" type="int" value="0" />
-          <aaload ref="data" def="v1" type="LRoot" index="l" />
-          <constant name="r" type="int" value="1" />
-          <aaload ref="data" def="v2" type="LRoot" index="r" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
-          <return value="v" />
+          <constant name="l" type="int" value="0"/>
+          <aaload ref="data" def="v1" type="LRoot" index="l"/>
+          <constant name="r" type="int" value="1"/>
+          <aaload ref="data" def="v2" type="LRoot" index="r"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python.jython3/data/numpy_turtle.xml
@@ -5,9 +5,9 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.jython3/data/pandas.xml
+++ b/com.ibm.wala.cast.python.jython3/data/pandas.xml
@@ -5,25 +5,25 @@
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lpandas" />
-        <new def="read_excel" class="Lpandas/functions/read_excel" />
-        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
-        <new def="merge" class="Lpandas/functions/merge" />
-        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
-        <return value="x" />
+        <new def="x" class="Lpandas"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel"/>
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel"/>
+        <new def="merge" class="Lpandas/functions/merge"/>
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="pandas/functions">
       <class name="read_excel" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-          <new def="v" class="Lobject" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="merge" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
-          <return value="left" />
-          <return value="right" />
+          <return value="left"/>
+          <return value="right"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.jython3/data/turtles.xml
+++ b/com.ibm.wala.cast.python.jython3/data/turtles.xml
@@ -5,79 +5,79 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="sklearn" allocatable="true">
       <method name="import" static="true" descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="patsy" allocatable="true">
       <method name="import" static="true" descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="seaborn" allocatable="true">
       <method name="import" static="true" descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="statsmodels" allocatable="true">
       <method name="import" static="true" descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="scipy" allocatable="true">
       <method name="import" static="true" descriptor="()Lscipy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="matplotlib" allocatable="true">
       <method name="import" static="true" descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="IPython" allocatable="true">
       <method name="import" static="true" descriptor="()LIPython;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="mpl_toolkits" allocatable="true">
       <method name="import" static="true" descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
       <method name="import" static="true" descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.ml.j2ee/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/com.ibm.wala.cast.python.ml.j2ee/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <runtime name="Apache Tomcat v9.0" />
-  <fixed facet="jst.web" />
-  <fixed facet="java" />
-  <fixed facet="wst.jsdt.web" />
-  <installed facet="java" version="1.8" />
-  <installed facet="jst.web" version="3.1" />
-  <installed facet="wst.jsdt.web" version="1.0" />
+  <runtime name="Apache Tomcat v9.0"/>
+  <fixed facet="jst.web"/>
+  <fixed facet="java"/>
+  <fixed facet="wst.jsdt.web"/>
+  <installed facet="java" version="1.8"/>
+  <installed facet="jst.web" version="3.1"/>
+  <installed facet="wst.jsdt.web" version="1.0"/>
 </faceted-project>

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -4,20 +4,20 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lnumpy" />
-        <new def="float32" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="x" value="float32" />
-        <new def="float64" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64" />
-        <new def="int32" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32" />
-        <new def="int64" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64" />
-        <new def="array_fn" class="Lnumpy/array" />
-        <putfield class="LRoot" field="array" fieldType="LRoot" ref="x" value="array_fn" />
-        <new def="reshape_fn" class="Lnumpy/reshape" />
-        <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape_fn" />
-        <return value="x" />
+        <new def="x" class="Lnumpy"/>
+        <new def="float32" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="x" value="float32"/>
+        <new def="float64" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64"/>
+        <new def="int32" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32"/>
+        <new def="int64" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64"/>
+        <new def="array_fn" class="Lnumpy/array"/>
+        <putfield class="LRoot" field="array" fieldType="LRoot" ref="x" value="array_fn"/>
+        <new def="reshape_fn" class="Lnumpy/reshape"/>
+        <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape_fn"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="numpy">
@@ -25,12 +25,12 @@
       <!-- Modeled as a class-per-function so that `np.array` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray preserves shape from arg 0 and takes dtype from arg 1; see `NpArray`. -->
       <class name="array" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x dtype">
-          <new def="ret" class="Lnumpy/ndarray" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <!-- Must be declared `allocatable="true"` so that `<new class="Lnumpy/ndarray"/>` in the various array-producing `do()` methods (both here and in `tensorflow.xml`) resolves to a concrete `InstanceKey` in the heap model. Without this declaration, `HeapModel.getInstanceKeyForAllocation` returns
@@ -42,12 +42,12 @@
         arg 1 (target shape); dtype is preserved from arg 0 (input tensor); see `NpReshape`. -->
       <class name="reshape" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x shape">
-          <new def="ret" class="Lnumpy/ndarray" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -60,23 +60,23 @@
       <!-- Modeled as a class-per-function (same pattern as `tensorflow/data/shuffle`, etc.) so that attribute access `x.astype` on an ndarray-like value resolves to this class via a field lookup, and the subsequent invocation dispatches to its `do` method. -->
       <class name="astype" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self ndarray dtype">
-          <new def="ret" class="Lnumpy/ndarray" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <!-- https://numpy.org/doc/stable/reference/generated/numpy.ndarray.reshape.html -->
       <class name="reshape" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self ndarray shape">
-          <new def="ret" class="Lnumpy/ndarray" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -52,965 +52,965 @@
   <classloader name="PythonLoader">
     <class name="tensorflow" allocatable="true">
       <method name="import" static="true" descriptor="()Ltensorflow;">
-        <new def="x" class="Ltensorflow" />
-        <new def="train" class="Lobject" />
-        <putfield class="LRoot" field="train" fieldType="LRoot" ref="x" value="train" />
-        <new def="function" class="Ltensorflow/class/function" />
-        <putfield class="LRoot" field="function" fieldType="LRoot" ref="x" value="function" />
-        <new def="AdamOptimizer" class="Ltensorflow/functions/AdamOptimizer" />
-        <putfield class="LRoot" field="AdamOptimizer" fieldType="LRoot" ref="train" value="AdamOptimizer" />
-        <new def="shuffle_batch" class="Ltensorflow/functions/shuffle_batch" />
-        <putfield class="LRoot" field="shuffle_batch" fieldType="LRoot" ref="train" value="shuffle_batch" />
-        <new def="InteractiveSession" class="Ltensorflow/functions/InteractiveSession" />
-        <putfield class="LRoot" field="InteractiveSession" fieldType="LRoot" ref="x" value="InteractiveSession" />
-        <putfield class="LRoot" field="Session" fieldType="LRoot" ref="x" value="InteractiveSession" />
-        <new def="parse_single_example" class="Ltensorflow/functions/parse_single_example" />
-        <putfield class="LRoot" field="parse_single_example" fieldType="LRoot" ref="x" value="parse_single_example" />
-        <new def="FixedLenFeature" class="Ltensorflow/functions/FixedLenFeature" />
-        <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature" />
-        <new def="pass_through" class="Ltensorflow/functions/pass_through" />
-        <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through" />
-        <new def="estimator" class="Lobject" />
-        <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator" />
-        <new def="data" class="Lobject" />
-        <putfield class="LRoot" field="data" fieldType="LRoot" ref="x" value="data" />
-        <new def="distribute" class="Lobject" />
-        <putfield class="LRoot" field="distribute" fieldType="LRoot" ref="x" value="distribute" />
-        <new def="nn" class="Lobject" />
-        <putfield class="LRoot" field="nn" fieldType="LRoot" ref="x" value="nn" />
-        <new def="math" class="Lobject" />
-        <putfield class="LRoot" field="math" fieldType="LRoot" ref="x" value="math" />
-        <new def="random" class="Lobject" />
-        <putfield class="LRoot" field="random" fieldType="LRoot" ref="x" value="random" />
-        <new def="sparse" class="Lobject" />
-        <putfield class="LRoot" field="sparse" fieldType="LRoot" ref="x" value="sparse" />
-        <new def="linalg" class="Lobject" />
-        <putfield class="LRoot" field="linalg" fieldType="LRoot" ref="x" value="linalg" />
-        <new def="keras" class="Lobject" />
-        <putfield class="LRoot" field="keras" fieldType="LRoot" ref="x" value="keras" />
-        <new def="layers" class="Lobject" />
-        <putfield class="LRoot" field="layers" fieldType="LRoot" ref="x" value="layers" />
-        <putfield class="LRoot" field="layers" fieldType="LRoot" ref="keras" value="layers" />
-        <new def="models" class="Lobject" />
-        <putfield class="LRoot" field="models" fieldType="LRoot" ref="keras" value="models" />
-        <new def="preprocessing" class="Lobject" />
-        <putfield class="LRoot" field="preprocessing" fieldType="LRoot" ref="keras" value="preprocessing" />
-        <new def="image" class="Lobject" />
-        <putfield class="LRoot" field="image" fieldType="LRoot" ref="preprocessing" value="image" />
-        <new def="datasets" class="Lobject" />
-        <putfield class="LRoot" field="datasets" fieldType="LRoot" ref="keras" value="datasets" />
-        <new def="keras_mnist" class="Lobject" />
-        <putfield class="LRoot" field="image" fieldType="LRoot" ref="x" value="image" />
-        <new def="io" class="Lobject" />
-        <putfield class="LRoot" field="io" fieldType="LRoot" ref="x" value="io" />
-        <new def="strings" class="Lobject" />
-        <putfield class="LRoot" field="strings" fieldType="LRoot" ref="x" value="strings" />
-        <new def="as_string" class="Ltensorflow/strings/as_string" />
-        <putfield class="LRoot" field="as_string" fieldType="LRoot" ref="strings" value="as_string" />
-        <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="datasets" value="keras_mnist" />
-        <new def="load_data" class="Ltensorflow/keras/datasets/mnist/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_mnist" value="load_data" />
-        <new def="keras_cifar10" class="Lobject" />
-        <putfield class="LRoot" field="cifar10" fieldType="LRoot" ref="datasets" value="keras_cifar10" />
-        <new def="cifar10_load_data" class="Ltensorflow/keras/datasets/cifar10/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar10" value="cifar10_load_data" />
-        <new def="keras_imdb" class="Lobject" />
-        <putfield class="LRoot" field="imdb" fieldType="LRoot" ref="datasets" value="keras_imdb" />
-        <new def="imdb_load_data" class="Ltensorflow/keras/datasets/imdb/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_imdb" value="imdb_load_data" />
-        <new def="keras_fashion_mnist" class="Lobject" />
-        <putfield class="LRoot" field="fashion_mnist" fieldType="LRoot" ref="datasets" value="keras_fashion_mnist" />
-        <new def="fashion_mnist_load_data" class="Ltensorflow/keras/datasets/fashion_mnist/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_fashion_mnist" value="fashion_mnist_load_data" />
-        <new def="keras_cifar100" class="Lobject" />
-        <putfield class="LRoot" field="cifar100" fieldType="LRoot" ref="datasets" value="keras_cifar100" />
-        <new def="cifar100_load_data" class="Ltensorflow/keras/datasets/cifar100/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar100" value="cifar100_load_data" />
-        <new def="keras_reuters" class="Lobject" />
-        <putfield class="LRoot" field="reuters" fieldType="LRoot" ref="datasets" value="keras_reuters" />
-        <new def="reuters_load_data" class="Ltensorflow/keras/datasets/reuters/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_reuters" value="reuters_load_data" />
-        <new def="keras_boston_housing" class="Lobject" />
-        <putfield class="LRoot" field="boston_housing" fieldType="LRoot" ref="datasets" value="keras_boston_housing" />
-        <new def="boston_housing_load_data" class="Ltensorflow/keras/datasets/boston_housing/load_data" />
-        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_boston_housing" value="boston_housing_load_data" />
-        <new def="app" class="Lobject" />
-        <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app" />
-        <new def="run" class="Ltensorflow/app/run" />
-        <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run" />
-        <new def="Estimator" class="Ltensorflow/estimator/Estimator" />
-        <putfield class="LRoot" field="Estimator" fieldType="LRoot" ref="estimator" value="Estimator" />
+        <new def="x" class="Ltensorflow"/>
+        <new def="train" class="Lobject"/>
+        <putfield class="LRoot" field="train" fieldType="LRoot" ref="x" value="train"/>
+        <new def="function" class="Ltensorflow/class/function"/>
+        <putfield class="LRoot" field="function" fieldType="LRoot" ref="x" value="function"/>
+        <new def="AdamOptimizer" class="Ltensorflow/functions/AdamOptimizer"/>
+        <putfield class="LRoot" field="AdamOptimizer" fieldType="LRoot" ref="train" value="AdamOptimizer"/>
+        <new def="shuffle_batch" class="Ltensorflow/functions/shuffle_batch"/>
+        <putfield class="LRoot" field="shuffle_batch" fieldType="LRoot" ref="train" value="shuffle_batch"/>
+        <new def="InteractiveSession" class="Ltensorflow/functions/InteractiveSession"/>
+        <putfield class="LRoot" field="InteractiveSession" fieldType="LRoot" ref="x" value="InteractiveSession"/>
+        <putfield class="LRoot" field="Session" fieldType="LRoot" ref="x" value="InteractiveSession"/>
+        <new def="parse_single_example" class="Ltensorflow/functions/parse_single_example"/>
+        <putfield class="LRoot" field="parse_single_example" fieldType="LRoot" ref="x" value="parse_single_example"/>
+        <new def="FixedLenFeature" class="Ltensorflow/functions/FixedLenFeature"/>
+        <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature"/>
+        <new def="pass_through" class="Ltensorflow/functions/pass_through"/>
+        <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through"/>
+        <new def="estimator" class="Lobject"/>
+        <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator"/>
+        <new def="data" class="Lobject"/>
+        <putfield class="LRoot" field="data" fieldType="LRoot" ref="x" value="data"/>
+        <new def="distribute" class="Lobject"/>
+        <putfield class="LRoot" field="distribute" fieldType="LRoot" ref="x" value="distribute"/>
+        <new def="nn" class="Lobject"/>
+        <putfield class="LRoot" field="nn" fieldType="LRoot" ref="x" value="nn"/>
+        <new def="math" class="Lobject"/>
+        <putfield class="LRoot" field="math" fieldType="LRoot" ref="x" value="math"/>
+        <new def="random" class="Lobject"/>
+        <putfield class="LRoot" field="random" fieldType="LRoot" ref="x" value="random"/>
+        <new def="sparse" class="Lobject"/>
+        <putfield class="LRoot" field="sparse" fieldType="LRoot" ref="x" value="sparse"/>
+        <new def="linalg" class="Lobject"/>
+        <putfield class="LRoot" field="linalg" fieldType="LRoot" ref="x" value="linalg"/>
+        <new def="keras" class="Lobject"/>
+        <putfield class="LRoot" field="keras" fieldType="LRoot" ref="x" value="keras"/>
+        <new def="layers" class="Lobject"/>
+        <putfield class="LRoot" field="layers" fieldType="LRoot" ref="x" value="layers"/>
+        <putfield class="LRoot" field="layers" fieldType="LRoot" ref="keras" value="layers"/>
+        <new def="models" class="Lobject"/>
+        <putfield class="LRoot" field="models" fieldType="LRoot" ref="keras" value="models"/>
+        <new def="preprocessing" class="Lobject"/>
+        <putfield class="LRoot" field="preprocessing" fieldType="LRoot" ref="keras" value="preprocessing"/>
+        <new def="image" class="Lobject"/>
+        <putfield class="LRoot" field="image" fieldType="LRoot" ref="preprocessing" value="image"/>
+        <new def="datasets" class="Lobject"/>
+        <putfield class="LRoot" field="datasets" fieldType="LRoot" ref="keras" value="datasets"/>
+        <new def="keras_mnist" class="Lobject"/>
+        <putfield class="LRoot" field="image" fieldType="LRoot" ref="x" value="image"/>
+        <new def="io" class="Lobject"/>
+        <putfield class="LRoot" field="io" fieldType="LRoot" ref="x" value="io"/>
+        <new def="strings" class="Lobject"/>
+        <putfield class="LRoot" field="strings" fieldType="LRoot" ref="x" value="strings"/>
+        <new def="as_string" class="Ltensorflow/strings/as_string"/>
+        <putfield class="LRoot" field="as_string" fieldType="LRoot" ref="strings" value="as_string"/>
+        <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="datasets" value="keras_mnist"/>
+        <new def="load_data" class="Ltensorflow/keras/datasets/mnist/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_mnist" value="load_data"/>
+        <new def="keras_cifar10" class="Lobject"/>
+        <putfield class="LRoot" field="cifar10" fieldType="LRoot" ref="datasets" value="keras_cifar10"/>
+        <new def="cifar10_load_data" class="Ltensorflow/keras/datasets/cifar10/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar10" value="cifar10_load_data"/>
+        <new def="keras_imdb" class="Lobject"/>
+        <putfield class="LRoot" field="imdb" fieldType="LRoot" ref="datasets" value="keras_imdb"/>
+        <new def="imdb_load_data" class="Ltensorflow/keras/datasets/imdb/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_imdb" value="imdb_load_data"/>
+        <new def="keras_fashion_mnist" class="Lobject"/>
+        <putfield class="LRoot" field="fashion_mnist" fieldType="LRoot" ref="datasets" value="keras_fashion_mnist"/>
+        <new def="fashion_mnist_load_data" class="Ltensorflow/keras/datasets/fashion_mnist/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_fashion_mnist" value="fashion_mnist_load_data"/>
+        <new def="keras_cifar100" class="Lobject"/>
+        <putfield class="LRoot" field="cifar100" fieldType="LRoot" ref="datasets" value="keras_cifar100"/>
+        <new def="cifar100_load_data" class="Ltensorflow/keras/datasets/cifar100/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar100" value="cifar100_load_data"/>
+        <new def="keras_reuters" class="Lobject"/>
+        <putfield class="LRoot" field="reuters" fieldType="LRoot" ref="datasets" value="keras_reuters"/>
+        <new def="reuters_load_data" class="Ltensorflow/keras/datasets/reuters/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_reuters" value="reuters_load_data"/>
+        <new def="keras_boston_housing" class="Lobject"/>
+        <putfield class="LRoot" field="boston_housing" fieldType="LRoot" ref="datasets" value="keras_boston_housing"/>
+        <new def="boston_housing_load_data" class="Ltensorflow/keras/datasets/boston_housing/load_data"/>
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_boston_housing" value="boston_housing_load_data"/>
+        <new def="app" class="Lobject"/>
+        <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app"/>
+        <new def="run" class="Ltensorflow/app/run"/>
+        <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run"/>
+        <new def="Estimator" class="Ltensorflow/estimator/Estimator"/>
+        <putfield class="LRoot" field="Estimator" fieldType="LRoot" ref="estimator" value="Estimator"/>
         <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — return type of model_fn. -->
-        <new def="EstimatorSpec" class="Ltensorflow/estimator/EstimatorSpec" />
-        <putfield class="LRoot" field="EstimatorSpec" fieldType="LRoot" ref="estimator" value="EstimatorSpec" />
-        <new def="GradientTape" class="Ltensorflow/GradientTape" />
-        <putfield class="LRoot" field="GradientTape" fieldType="LRoot" ref="x" value="GradientTape" />
+        <new def="EstimatorSpec" class="Ltensorflow/estimator/EstimatorSpec"/>
+        <putfield class="LRoot" field="EstimatorSpec" fieldType="LRoot" ref="estimator" value="EstimatorSpec"/>
+        <new def="GradientTape" class="Ltensorflow/GradientTape"/>
+        <putfield class="LRoot" field="GradientTape" fieldType="LRoot" ref="x" value="GradientTape"/>
         <!-- https://www.tensorflow.org/api_docs/python/tf#newaxis — at runtime this is `None` (used in subscripts like `x[..., tf.newaxis]` to insert a size-1 dimension). Modeled as an allocation of the sentinel class `Ltensorflow/newaxis` so `NdarraySubscriptOperation.classifyField` can recognize it
           as NEWAXIS, parallel to how the literal `None` produces a `ConstantKey<null>`. -->
-        <new def="newaxis" class="Ltensorflow/newaxis" />
-        <putfield class="LRoot" field="newaxis" fieldType="LRoot" ref="x" value="newaxis" />
-        <new def="initializers" class="Lobject" />
-        <putfield class="LRoot" field="initializers" fieldType="LRoot" ref="x" value="initializers" />
-        <new def="RandomNormal" class="Ltensorflow/initializers/class/RandomNormal" />
-        <putfield class="LRoot" field="RandomNormal" fieldType="LRoot" ref="initializers" value="RandomNormal" />
-        <new def="Dataset" class="Ltensorflow/data/Dataset" />
-        <putfield class="LRoot" field="Dataset" fieldType="LRoot" ref="data" value="Dataset" />
+        <new def="newaxis" class="Ltensorflow/newaxis"/>
+        <putfield class="LRoot" field="newaxis" fieldType="LRoot" ref="x" value="newaxis"/>
+        <new def="initializers" class="Lobject"/>
+        <putfield class="LRoot" field="initializers" fieldType="LRoot" ref="x" value="initializers"/>
+        <new def="RandomNormal" class="Ltensorflow/initializers/class/RandomNormal"/>
+        <putfield class="LRoot" field="RandomNormal" fieldType="LRoot" ref="initializers" value="RandomNormal"/>
+        <new def="Dataset" class="Ltensorflow/data/Dataset"/>
+        <putfield class="LRoot" field="Dataset" fieldType="LRoot" ref="data" value="Dataset"/>
         <!--https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TextLineDataset -->
         <!-- Distinct class type so the factory can dispatch to `TextLineDatasetGenerator` and seed iteration elements as 0-D string tensors (wala/ML#452). -->
-        <new def="TextLineDataset" class="Ltensorflow/data/TextLineDataset" />
-        <putfield class="LRoot" field="TextLineDataset" fieldType="LRoot" ref="data" value="TextLineDataset" />
+        <new def="TextLineDataset" class="Ltensorflow/data/TextLineDataset"/>
+        <putfield class="LRoot" field="TextLineDataset" fieldType="LRoot" ref="data" value="TextLineDataset"/>
         <!--https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset -->
-        <new def="TFRecordDataset" class="Ltensorflow/data/Dataset" /> <!-- FIXME: Should *extend* `Dataset` -->
-        <putfield class="LRoot" field="TFRecordDataset" fieldType="LRoot" ref="data" value="TFRecordDataset" />
-        <new def="MirroredStrategy" class="Ltensorflow/distribute/MirroredStrategy" />
-        <putfield class="LRoot" field="MirroredStrategy" fieldType="LRoot" ref="distribute" value="MirroredStrategy" />
-        <new def="TPUStrategy" class="Ltensorflow/distribute/TPUStrategy" />
-        <putfield class="LRoot" field="TPUStrategy" fieldType="LRoot" ref="distribute" value="TPUStrategy" />
-        <new def="OneDeviceStrategy" class="Ltensorflow/distribute/OneDeviceStrategy" />
-        <putfield class="LRoot" field="OneDeviceStrategy" fieldType="LRoot" ref="distribute" value="OneDeviceStrategy" />
-        <new def="inputs" class="Lobject" />
-        <putfield class="LRoot" field="inputs" fieldType="LRoot" ref="estimator" value="inputs" />
-        <new def="numpy_input_fn" class="Ltensorflow/estimator/numpy_input_fn" />
-        <putfield class="LRoot" field="numpy_input_fn" fieldType="LRoot" ref="inputs" value="numpy_input_fn" />
-        <new def="from_tensor_slices" class="Ltensorflow/data/Dataset/from_tensor_slices" />
-        <putfield class="LRoot" field="from_tensor_slices" fieldType="LRoot" ref="Dataset" value="from_tensor_slices" />
-        <new def="sample_from_datasets" class="Ltensorflow/data/Dataset/sample_from_datasets" />
-        <putfield class="LRoot" field="sample_from_datasets" fieldType="LRoot" ref="Dataset" value="sample_from_datasets" />
-        <new def="list_files" class="Ltensorflow/data/Dataset/list_files" />
-        <putfield class="LRoot" field="list_files" fieldType="LRoot" ref="Dataset" value="list_files" />
-        <new def="choose_from_datasets" class="Ltensorflow/data/Dataset/choose_from_datasets" />
-        <putfield class="LRoot" field="choose_from_datasets" fieldType="LRoot" ref="Dataset" value="choose_from_datasets" />
-        <new def="from_generator" class="Ltensorflow/data/Dataset/from_generator" />
-        <putfield class="LRoot" field="from_generator" fieldType="LRoot" ref="Dataset" value="from_generator" />
-        <new def="zip" class="Ltensorflow/data/Dataset/zip" />
-        <putfield class="LRoot" field="zip" fieldType="LRoot" ref="Dataset" value="zip" />
-        <new def="dsrange" class="Ltensorflow/data/Dataset/range" />
-        <putfield class="LRoot" field="range" fieldType="LRoot" ref="Dataset" value="dsrange" />
-        <new def="dsrandom" class="Ltensorflow/data/Dataset/random" />
-        <putfield class="LRoot" field="random" fieldType="LRoot" ref="Dataset" value="dsrandom" />
-        <new def="from_tensors" class="Ltensorflow/data/Dataset/from_tensors" />
-        <putfield class="LRoot" field="from_tensors" fieldType="LRoot" ref="Dataset" value="from_tensors" />
-        <new def="TensorSpec" class="Ltensorflow/framework/TensorSpec" />
-        <putfield class="LRoot" field="TensorSpec" fieldType="LRoot" ref="x" value="TensorSpec" />
-        <new def="RaggedTensorSpec" class="Ltensorflow/framework/RaggedTensorSpec" />
-        <putfield class="LRoot" field="RaggedTensorSpec" fieldType="LRoot" ref="x" value="RaggedTensorSpec" />
+        <new def="TFRecordDataset" class="Ltensorflow/data/Dataset"/> <!-- FIXME: Should *extend* `Dataset` -->
+        <putfield class="LRoot" field="TFRecordDataset" fieldType="LRoot" ref="data" value="TFRecordDataset"/>
+        <new def="MirroredStrategy" class="Ltensorflow/distribute/MirroredStrategy"/>
+        <putfield class="LRoot" field="MirroredStrategy" fieldType="LRoot" ref="distribute" value="MirroredStrategy"/>
+        <new def="TPUStrategy" class="Ltensorflow/distribute/TPUStrategy"/>
+        <putfield class="LRoot" field="TPUStrategy" fieldType="LRoot" ref="distribute" value="TPUStrategy"/>
+        <new def="OneDeviceStrategy" class="Ltensorflow/distribute/OneDeviceStrategy"/>
+        <putfield class="LRoot" field="OneDeviceStrategy" fieldType="LRoot" ref="distribute" value="OneDeviceStrategy"/>
+        <new def="inputs" class="Lobject"/>
+        <putfield class="LRoot" field="inputs" fieldType="LRoot" ref="estimator" value="inputs"/>
+        <new def="numpy_input_fn" class="Ltensorflow/estimator/numpy_input_fn"/>
+        <putfield class="LRoot" field="numpy_input_fn" fieldType="LRoot" ref="inputs" value="numpy_input_fn"/>
+        <new def="from_tensor_slices" class="Ltensorflow/data/Dataset/from_tensor_slices"/>
+        <putfield class="LRoot" field="from_tensor_slices" fieldType="LRoot" ref="Dataset" value="from_tensor_slices"/>
+        <new def="sample_from_datasets" class="Ltensorflow/data/Dataset/sample_from_datasets"/>
+        <putfield class="LRoot" field="sample_from_datasets" fieldType="LRoot" ref="Dataset" value="sample_from_datasets"/>
+        <new def="list_files" class="Ltensorflow/data/Dataset/list_files"/>
+        <putfield class="LRoot" field="list_files" fieldType="LRoot" ref="Dataset" value="list_files"/>
+        <new def="choose_from_datasets" class="Ltensorflow/data/Dataset/choose_from_datasets"/>
+        <putfield class="LRoot" field="choose_from_datasets" fieldType="LRoot" ref="Dataset" value="choose_from_datasets"/>
+        <new def="from_generator" class="Ltensorflow/data/Dataset/from_generator"/>
+        <putfield class="LRoot" field="from_generator" fieldType="LRoot" ref="Dataset" value="from_generator"/>
+        <new def="zip" class="Ltensorflow/data/Dataset/zip"/>
+        <putfield class="LRoot" field="zip" fieldType="LRoot" ref="Dataset" value="zip"/>
+        <new def="dsrange" class="Ltensorflow/data/Dataset/range"/>
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="Dataset" value="dsrange"/>
+        <new def="dsrandom" class="Ltensorflow/data/Dataset/random"/>
+        <putfield class="LRoot" field="random" fieldType="LRoot" ref="Dataset" value="dsrandom"/>
+        <new def="from_tensors" class="Ltensorflow/data/Dataset/from_tensors"/>
+        <putfield class="LRoot" field="from_tensors" fieldType="LRoot" ref="Dataset" value="from_tensors"/>
+        <new def="TensorSpec" class="Ltensorflow/framework/TensorSpec"/>
+        <putfield class="LRoot" field="TensorSpec" fieldType="LRoot" ref="x" value="TensorSpec"/>
+        <new def="RaggedTensorSpec" class="Ltensorflow/framework/RaggedTensorSpec"/>
+        <putfield class="LRoot" field="RaggedTensorSpec" fieldType="LRoot" ref="x" value="RaggedTensorSpec"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reshape -->
-        <new def="reshape" class="Ltensorflow/functions/reshape" />
-        <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape" />
-        <new def="conv2d" class="Ltensorflow/functions/conv2d" />
-        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="x" value="conv2d" />
-        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="nn" value="conv2d" />
-        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="layers" value="conv2d" />
-        <new def="conv3d" class="Ltensorflow/functions/conv3d" />
-        <putfield class="LRoot" field="conv3d" fieldType="LRoot" ref="nn" value="conv3d" />
-        <new def="softmax" class="Ltensorflow/functions/softmax" />
-        <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax" />
+        <new def="reshape" class="Ltensorflow/functions/reshape"/>
+        <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape"/>
+        <new def="conv2d" class="Ltensorflow/functions/conv2d"/>
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="x" value="conv2d"/>
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="nn" value="conv2d"/>
+        <putfield class="LRoot" field="conv2d" fieldType="LRoot" ref="layers" value="conv2d"/>
+        <new def="conv3d" class="Ltensorflow/functions/conv3d"/>
+        <putfield class="LRoot" field="conv3d" fieldType="LRoot" ref="nn" value="conv3d"/>
+        <new def="softmax" class="Ltensorflow/functions/softmax"/>
+        <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
-        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="pass_through" />
-        <new def="sparse_softmax_cross_entropy_with_logits" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits" />
-        <putfield class="LRoot" field="sparse_softmax_cross_entropy_with_logits" fieldType="LRoot" ref="nn" value="sparse_softmax_cross_entropy_with_logits" />
-        <new def="sigmoid" class="Ltensorflow/math/sigmoid" />
-        <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="nn" value="sigmoid" />
-        <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="math" value="sigmoid" />
-        <new def="math_ops" class="Lobject" />
+        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="pass_through"/>
+        <new def="sparse_softmax_cross_entropy_with_logits" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits"/>
+        <putfield class="LRoot" field="sparse_softmax_cross_entropy_with_logits" fieldType="LRoot" ref="nn" value="sparse_softmax_cross_entropy_with_logits"/>
+        <new def="sigmoid" class="Ltensorflow/math/sigmoid"/>
+        <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="nn" value="sigmoid"/>
+        <putfield class="LRoot" field="sigmoid" fieldType="LRoot" ref="math" value="sigmoid"/>
+        <new def="math_ops" class="Lobject"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/add -->
-        <new def="add" class="Ltensorflow/math/add" />
-        <putfield class="LRoot" field="add" fieldType="LRoot" ref="x" value="add" />
-        <putfield class="LRoot" field="add" fieldType="LRoot" ref="math" value="add" />
-        <putfield class="LRoot" field="add" fieldType="LRoot" ref="math_ops" value="add" />
-        <new def="multiply" class="Ltensorflow/math/multiply" />
-        <putfield class="LRoot" field="multiply" fieldType="LRoot" ref="x" value="multiply" />
-        <putfield class="LRoot" field="multiply" fieldType="LRoot" ref="math" value="multiply" />
+        <new def="add" class="Ltensorflow/math/add"/>
+        <putfield class="LRoot" field="add" fieldType="LRoot" ref="x" value="add"/>
+        <putfield class="LRoot" field="add" fieldType="LRoot" ref="math" value="add"/>
+        <putfield class="LRoot" field="add" fieldType="LRoot" ref="math_ops" value="add"/>
+        <new def="multiply" class="Ltensorflow/math/multiply"/>
+        <putfield class="LRoot" field="multiply" fieldType="LRoot" ref="x" value="multiply"/>
+        <putfield class="LRoot" field="multiply" fieldType="LRoot" ref="math" value="multiply"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/matmul -->
-        <new def="matmul" class="Ltensorflow/functions/matmul" />
-        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="x" value="matmul" />
-        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="math" value="matmul" />
-        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="linalg" value="matmul" />
-        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="math_ops" value="matmul" />
-        <new def="reduce_mean" class="Ltensorflow/math/reduce_mean" />
-        <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="x" value="reduce_mean" />
-        <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="math" value="reduce_mean" />
+        <new def="matmul" class="Ltensorflow/functions/matmul"/>
+        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="x" value="matmul"/>
+        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="math" value="matmul"/>
+        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="linalg" value="matmul"/>
+        <putfield class="LRoot" field="matmul" fieldType="LRoot" ref="math_ops" value="matmul"/>
+        <new def="reduce_mean" class="Ltensorflow/math/reduce_mean"/>
+        <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="x" value="reduce_mean"/>
+        <putfield class="LRoot" field="reduce_mean" fieldType="LRoot" ref="math" value="reduce_mean"/>
         <!-- `tf.argmax` is an alias for `tf.math.argmax` in real TensorFlow. Expose the same `tensorflow/math/argmax` class under both the top-level `tensorflow` namespace and `tensorflow.math` so attribute lookups on either path resolve. See wala/ML#386. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/argmax -->
-        <new def="argmax" class="Ltensorflow/math/argmax" />
-        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="x" value="argmax" />
-        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math" value="argmax" />
-        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math_ops" value="argmax" />
+        <new def="argmax" class="Ltensorflow/math/argmax"/>
+        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="x" value="argmax"/>
+        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math" value="argmax"/>
+        <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math_ops" value="argmax"/>
         <!-- Same aliasing for `tf.argmin` / `tf.math.argmin`. -->
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin -->
-        <new def="argmin" class="Ltensorflow/math/argmin" />
-        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="x" value="argmin" />
-        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math" value="argmin" />
-        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math_ops" value="argmin" />
+        <new def="argmin" class="Ltensorflow/math/argmin"/>
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="x" value="argmin"/>
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math" value="argmin"/>
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math_ops" value="argmin"/>
         <!-- Same aliasing for `tf.equal` / `tf.math.equal`. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/equal -->
-        <new def="equal" class="Ltensorflow/math/equal" />
-        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="x" value="equal" />
-        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="math" value="equal" />
-        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="math_ops" value="equal" />
-        <new def="placeholder" class="Ltensorflow/functions/placeholder" />
-        <putfield class="LRoot" field="placeholder" fieldType="LRoot" ref="x" value="placeholder" />
-        <new def="examples" class="Lobject" />
-        <putfield class="LRoot" field="examples" fieldType="LRoot" ref="x" value="examples" />
-        <new def="tutorials" class="Lobject" />
-        <putfield class="LRoot" field="tutorials" fieldType="LRoot" ref="examples" value="tutorials" />
-        <new def="mnist" class="Lobject" />
-        <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="tutorials" value="mnist" />
-        <new def="id" class="Ltensorflow/examples/tutorials/mnist/input_data" />
-        <putfield class="LRoot" field="input_data" fieldType="LRoot" ref="mnist" value="id" />
-        <new def="rds" class="Ltensorflow/examples/tutorials/mnist/read_data_sets" />
-        <putfield class="LRoot" field="read_data_sets" fieldType="LRoot" ref="id" value="rds" />
-        <new def="python" class="Lobject" />
-        <putfield class="LRoot" field="python" fieldType="LRoot" ref="x" value="python" />
-        <new def="framework" class="Lobject" />
-        <putfield class="LRoot" field="framework" fieldType="LRoot" ref="python" value="framework" />
-        <new def="ops" class="Lobject" />
-        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="python" value="ops" />
-        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="framework" value="ops" />
-        <new def="ragged" class="Lobject" />
-        <putfield class="LRoot" field="ragged" fieldType="LRoot" ref="x" value="ragged" />
-        <putfield class="LRoot" field="ragged" fieldType="LRoot" ref="ops" value="ragged" />
-        <new def="experimental" class="Lobject" />
-        <putfield class="LRoot" field="experimental" fieldType="LRoot" ref="x" value="experimental" />
-        <new def="numpy" class="Lobject" />
-        <putfield class="LRoot" field="numpy" fieldType="LRoot" ref="experimental" value="numpy" />
-        <new def="array_ops" class="Lobject" />
-        <putfield class="LRoot" field="array_ops" fieldType="LRoot" ref="ops" value="array_ops" />
-        <new def="nn_impl" class="Lobject" />
-        <putfield class="LRoot" field="nn_impl" fieldType="LRoot" ref="ops" value="nn_impl" />
-        <new def="gen_array_ops" class="Lobject" />
-        <putfield class="LRoot" field="gen_array_ops" fieldType="LRoot" ref="ops" value="gen_array_ops" />
-        <new def="gen_linalg_ops" class="Lobject" />
-        <putfield class="LRoot" field="gen_linalg_ops" fieldType="LRoot" ref="ops" value="gen_linalg_ops" />
-        <new def="gen_image_ops" class="Lobject" />
-        <putfield class="LRoot" field="gen_image_ops" fieldType="LRoot" ref="ops" value="gen_image_ops" />
-        <new def="control_flow_ops" class="Lobject" />
-        <putfield class="LRoot" field="control_flow_ops" fieldType="LRoot" ref="ops" value="control_flow_ops" />
-        <new def="clip_ops" class="Lobject" />
-        <putfield class="LRoot" field="clip_ops" fieldType="LRoot" ref="ops" value="clip_ops" />
-        <new def="random_ops" class="Lobject" />
-        <putfield class="LRoot" field="random_ops" fieldType="LRoot" ref="ops" value="random_ops" />
-        <new def="sort_ops" class="Lobject" />
-        <putfield class="LRoot" field="sort_ops" fieldType="LRoot" ref="ops" value="sort_ops" />
-        <putfield class="LRoot" field="math_ops" fieldType="LRoot" ref="ops" value="math_ops" />
-        <new def="gen_math_ops" class="Lobject" />
-        <putfield class="LRoot" field="gen_math_ops" fieldType="LRoot" ref="ops" value="gen_math_ops" />
-        <new def="nn_ops" class="Lobject" />
-        <putfield class="LRoot" field="nn_ops" fieldType="LRoot" ref="ops" value="nn_ops" />
-        <new def="special_math_ops" class="Lobject" />
-        <putfield class="LRoot" field="special_math_ops" fieldType="LRoot" ref="ops" value="special_math_ops" />
-        <new def="gen_data_flow_ops" class="Lobject" />
-        <putfield class="LRoot" field="gen_data_flow_ops" fieldType="LRoot" ref="ops" value="gen_data_flow_ops" />
-        <new def="embedding_ops" class="Lobject" />
-        <putfield class="LRoot" field="embedding_ops" fieldType="LRoot" ref="ops" value="embedding_ops" />
+        <new def="equal" class="Ltensorflow/math/equal"/>
+        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="x" value="equal"/>
+        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="math" value="equal"/>
+        <putfield class="LRoot" field="equal" fieldType="LRoot" ref="math_ops" value="equal"/>
+        <new def="placeholder" class="Ltensorflow/functions/placeholder"/>
+        <putfield class="LRoot" field="placeholder" fieldType="LRoot" ref="x" value="placeholder"/>
+        <new def="examples" class="Lobject"/>
+        <putfield class="LRoot" field="examples" fieldType="LRoot" ref="x" value="examples"/>
+        <new def="tutorials" class="Lobject"/>
+        <putfield class="LRoot" field="tutorials" fieldType="LRoot" ref="examples" value="tutorials"/>
+        <new def="mnist" class="Lobject"/>
+        <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="tutorials" value="mnist"/>
+        <new def="id" class="Ltensorflow/examples/tutorials/mnist/input_data"/>
+        <putfield class="LRoot" field="input_data" fieldType="LRoot" ref="mnist" value="id"/>
+        <new def="rds" class="Ltensorflow/examples/tutorials/mnist/read_data_sets"/>
+        <putfield class="LRoot" field="read_data_sets" fieldType="LRoot" ref="id" value="rds"/>
+        <new def="python" class="Lobject"/>
+        <putfield class="LRoot" field="python" fieldType="LRoot" ref="x" value="python"/>
+        <new def="framework" class="Lobject"/>
+        <putfield class="LRoot" field="framework" fieldType="LRoot" ref="python" value="framework"/>
+        <new def="ops" class="Lobject"/>
+        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="python" value="ops"/>
+        <putfield class="LRoot" field="ops" fieldType="LRoot" ref="framework" value="ops"/>
+        <new def="ragged" class="Lobject"/>
+        <putfield class="LRoot" field="ragged" fieldType="LRoot" ref="x" value="ragged"/>
+        <putfield class="LRoot" field="ragged" fieldType="LRoot" ref="ops" value="ragged"/>
+        <new def="experimental" class="Lobject"/>
+        <putfield class="LRoot" field="experimental" fieldType="LRoot" ref="x" value="experimental"/>
+        <new def="numpy" class="Lobject"/>
+        <putfield class="LRoot" field="numpy" fieldType="LRoot" ref="experimental" value="numpy"/>
+        <new def="array_ops" class="Lobject"/>
+        <putfield class="LRoot" field="array_ops" fieldType="LRoot" ref="ops" value="array_ops"/>
+        <new def="nn_impl" class="Lobject"/>
+        <putfield class="LRoot" field="nn_impl" fieldType="LRoot" ref="ops" value="nn_impl"/>
+        <new def="gen_array_ops" class="Lobject"/>
+        <putfield class="LRoot" field="gen_array_ops" fieldType="LRoot" ref="ops" value="gen_array_ops"/>
+        <new def="gen_linalg_ops" class="Lobject"/>
+        <putfield class="LRoot" field="gen_linalg_ops" fieldType="LRoot" ref="ops" value="gen_linalg_ops"/>
+        <new def="gen_image_ops" class="Lobject"/>
+        <putfield class="LRoot" field="gen_image_ops" fieldType="LRoot" ref="ops" value="gen_image_ops"/>
+        <new def="control_flow_ops" class="Lobject"/>
+        <putfield class="LRoot" field="control_flow_ops" fieldType="LRoot" ref="ops" value="control_flow_ops"/>
+        <new def="clip_ops" class="Lobject"/>
+        <putfield class="LRoot" field="clip_ops" fieldType="LRoot" ref="ops" value="clip_ops"/>
+        <new def="random_ops" class="Lobject"/>
+        <putfield class="LRoot" field="random_ops" fieldType="LRoot" ref="ops" value="random_ops"/>
+        <new def="sort_ops" class="Lobject"/>
+        <putfield class="LRoot" field="sort_ops" fieldType="LRoot" ref="ops" value="sort_ops"/>
+        <putfield class="LRoot" field="math_ops" fieldType="LRoot" ref="ops" value="math_ops"/>
+        <new def="gen_math_ops" class="Lobject"/>
+        <putfield class="LRoot" field="gen_math_ops" fieldType="LRoot" ref="ops" value="gen_math_ops"/>
+        <new def="nn_ops" class="Lobject"/>
+        <putfield class="LRoot" field="nn_ops" fieldType="LRoot" ref="ops" value="nn_ops"/>
+        <new def="special_math_ops" class="Lobject"/>
+        <putfield class="LRoot" field="special_math_ops" fieldType="LRoot" ref="ops" value="special_math_ops"/>
+        <new def="gen_data_flow_ops" class="Lobject"/>
+        <putfield class="LRoot" field="gen_data_flow_ops" fieldType="LRoot" ref="ops" value="gen_data_flow_ops"/>
+        <new def="embedding_ops" class="Lobject"/>
+        <putfield class="LRoot" field="embedding_ops" fieldType="LRoot" ref="ops" value="embedding_ops"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup -->
-        <new def="embedding_lookup" class="Ltensorflow/functions/embedding_lookup" />
-        <putfield class="LRoot" field="embedding_lookup" fieldType="LRoot" ref="nn" value="embedding_lookup" />
-        <putfield class="LRoot" field="embedding_lookup" fieldType="LRoot" ref="embedding_ops" value="embedding_lookup" />
+        <new def="embedding_lookup" class="Ltensorflow/functions/embedding_lookup"/>
+        <putfield class="LRoot" field="embedding_lookup" fieldType="LRoot" ref="nn" value="embedding_lookup"/>
+        <putfield class="LRoot" field="embedding_lookup" fieldType="LRoot" ref="embedding_ops" value="embedding_lookup"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/add_n -->
-        <new def="add_n" class="Ltensorflow/math/add_n" />
-        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="x" value="add_n" />
-        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="math" value="add_n" />
-        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="math_ops" value="add_n" />
+        <new def="add_n" class="Ltensorflow/math/add_n"/>
+        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="x" value="add_n"/>
+        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="math" value="add_n"/>
+        <putfield class="LRoot" field="add_n" fieldType="LRoot" ref="math_ops" value="add_n"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/exp -->
-        <new def="exp" class="Ltensorflow/math/exp" />
-        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="x" value="exp" />
-        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="math" value="exp" />
-        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="math_ops" value="exp" />
+        <new def="exp" class="Ltensorflow/math/exp"/>
+        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="x" value="exp"/>
+        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="math" value="exp"/>
+        <putfield class="LRoot" field="exp" fieldType="LRoot" ref="math_ops" value="exp"/>
         <!-- `tf.not_equal` is the elementwise inverse of `tf.equal`; same alias structure. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/not_equal -->
-        <new def="not_equal" class="Ltensorflow/math/not_equal" />
-        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="x" value="not_equal" />
-        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math" value="not_equal" />
-        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math_ops" value="not_equal" />
+        <new def="not_equal" class="Ltensorflow/math/not_equal"/>
+        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="x" value="not_equal"/>
+        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math" value="not_equal"/>
+        <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math_ops" value="not_equal"/>
         <!-- The four ordering comparison ops (`tf.less`, `tf.less_equal`, `tf.greater`, `tf.greater_equal`) round out the comparison family started by `equal`/`not_equal`; same alias structure (top-level `tf.X`, `tf.math.X`, `tf.math_ops.X`). Each routes to `ComparisonOperation` and emits `bool` per
           wala/ML#427. -->
-        <new def="less" class="Ltensorflow/math/less" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="less" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="less" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math_ops" value="less" />
-        <new def="less_equal" class="Ltensorflow/math/less_equal" />
-        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="x" value="less_equal" />
-        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math" value="less_equal" />
-        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math_ops" value="less_equal" />
-        <new def="greater" class="Ltensorflow/math/greater" />
-        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="x" value="greater" />
-        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math" value="greater" />
-        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math_ops" value="greater" />
-        <new def="greater_equal" class="Ltensorflow/math/greater_equal" />
-        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="x" value="greater_equal" />
-        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math" value="greater_equal" />
-        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math_ops" value="greater_equal" />
+        <new def="less" class="Ltensorflow/math/less"/>
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="less"/>
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="less"/>
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math_ops" value="less"/>
+        <new def="less_equal" class="Ltensorflow/math/less_equal"/>
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="x" value="less_equal"/>
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math" value="less_equal"/>
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math_ops" value="less_equal"/>
+        <new def="greater" class="Ltensorflow/math/greater"/>
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="x" value="greater"/>
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math" value="greater"/>
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math_ops" value="greater"/>
+        <new def="greater_equal" class="Ltensorflow/math/greater_equal"/>
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="x" value="greater_equal"/>
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math" value="greater_equal"/>
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math_ops" value="greater_equal"/>
         <!-- `tf.{sqrt,log,sin,cos}` and their aliases (`tf.math.*`, `tf.gen_math_ops.{log,sin,cos}`, `tf.math_ops.sqrt`) now route through dedicated `<class>` blocks defined later in this file (search for `class name="sqrt"`, etc.). -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/lgamma -->
-        <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
+        <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="math" value="pass_through"/>
+        <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="gen_math_ops" value="pass_through"/>
         <!-- `tf.{math,gen_math_ops}.{reciprocal,erf}` and `tf.square` (plus its `tf.{math,gen_math_ops}.square` aliases) now route through dedicated `<class>` blocks defined later in this file (search for `class name="reciprocal"`, etc.). `tf.reciprocal` and `tf.erf` are not real TF 2 top-level names,
           so no `ref="x"` putfield is needed for those. -->
         <!-- `tf.{maximum,minimum}` and `tf.{math,gen_math_ops}.{maximum,minimum}` now route through dedicated `<class>` blocks dispatched to `ElementWiseOperation` (broadcast shape, unified dtype). -->
         <!-- `tf.less`'s legacy `pass_through` aliasing was removed: the modern `<class name="less">` block + `ComparisonOperation` dispatch (wala/ML#427) now handle bool dtype directly. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/tanh -->
-        <new def="tanh" class="Ltensorflow/math/tanh" />
-        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="x" value="tanh" />
-        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="math" value="tanh" />
-        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="gen_math_ops" value="tanh" />
+        <new def="tanh" class="Ltensorflow/math/tanh"/>
+        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="x" value="tanh"/>
+        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="math" value="tanh"/>
+        <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="gen_math_ops" value="tanh"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/log_softmax -->
-        <new def="log_softmax" class="Ltensorflow/math/log_softmax" />
-        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="nn" value="log_softmax" />
-        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="math" value="log_softmax" />
-        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="nn_ops" value="log_softmax" />
+        <new def="log_softmax" class="Ltensorflow/math/log_softmax"/>
+        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="nn" value="log_softmax"/>
+        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="math" value="log_softmax"/>
+        <putfield class="LRoot" field="log_softmax" fieldType="LRoot" ref="nn_ops" value="log_softmax"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/bias_add -->
-        <new def="bias_add" class="Ltensorflow/functions/bias_add" />
-        <putfield class="LRoot" field="bias_add" fieldType="LRoot" ref="nn" value="bias_add" />
-        <putfield class="LRoot" field="bias_add" fieldType="LRoot" ref="nn_ops" value="bias_add" />
+        <new def="bias_add" class="Ltensorflow/functions/bias_add"/>
+        <putfield class="LRoot" field="bias_add" fieldType="LRoot" ref="nn" value="bias_add"/>
+        <putfield class="LRoot" field="bias_add" fieldType="LRoot" ref="nn_ops" value="bias_add"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k -->
-        <new def="top_k" class="Ltensorflow/math/top_k" />
-        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="nn" value="top_k" />
-        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="math" value="top_k" />
-        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="nn_ops" value="top_k" />
+        <new def="top_k" class="Ltensorflow/math/top_k"/>
+        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="nn" value="top_k"/>
+        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="math" value="top_k"/>
+        <putfield class="LRoot" field="top_k" fieldType="LRoot" ref="nn_ops" value="top_k"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/l2_normalize -->
-        <new def="l2_normalize" class="Ltensorflow/math/l2_normalize" />
-        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="linalg" value="l2_normalize" />
-        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="math" value="l2_normalize" />
-        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn" value="l2_normalize" />
-        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn_impl" value="l2_normalize" />
+        <new def="l2_normalize" class="Ltensorflow/math/l2_normalize"/>
+        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="linalg" value="l2_normalize"/>
+        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="math" value="l2_normalize"/>
+        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn" value="l2_normalize"/>
+        <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn_impl" value="l2_normalize"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow -->
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pass_through" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pass_through"/>
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_sum -->
-        <new def="reduce_sum" class="Ltensorflow/math/reduce_sum" />
-        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="x" value="reduce_sum" />
-        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="math" value="reduce_sum" />
-        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="math_ops" value="reduce_sum" />
+        <new def="reduce_sum" class="Ltensorflow/math/reduce_sum"/>
+        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="x" value="reduce_sum"/>
+        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="math" value="reduce_sum"/>
+        <putfield class="LRoot" field="reduce_sum" fieldType="LRoot" ref="math_ops" value="reduce_sum"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_max -->
-        <new def="reduce_max" class="Ltensorflow/math/reduce_max" />
-        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="x" value="reduce_max" />
-        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math" value="reduce_max" />
-        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math_ops" value="reduce_max" />
+        <new def="reduce_max" class="Ltensorflow/math/reduce_max"/>
+        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="x" value="reduce_max"/>
+        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math" value="reduce_max"/>
+        <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math_ops" value="reduce_max"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/rsqrt -->
-        <new def="rsqrt" class="Ltensorflow/math/rsqrt" />
-        <putfield class="LRoot" field="rsqrt" fieldType="LRoot" ref="math" value="rsqrt" />
-        <putfield class="LRoot" field="rsqrt" fieldType="LRoot" ref="math_ops" value="rsqrt" />
-        <new def="linalg_ops" class="Lobject" />
-        <putfield class="LRoot" field="linalg_ops" fieldType="LRoot" ref="ops" value="linalg_ops" />
-        <new def="linalg_impl" class="Lobject" />
-        <putfield class="LRoot" field="linalg_impl" fieldType="LRoot" ref="linalg" value="linalg_impl" />
-        <new def="linear_operator" class="Lobject" />
-        <putfield class="LRoot" field="linear_operator" fieldType="LRoot" ref="linalg" value="linear_operator" />
-        <new def="sparse_ops" class="Lobject" />
-        <putfield class="LRoot" field="sparse_ops" fieldType="LRoot" ref="ops" value="sparse_ops" />
-        <new def="variables" class="Lobject" />
-        <putfield class="LRoot" field="variables" fieldType="LRoot" ref="ops" value="variables" />
-        <new def="sparse_tensor" class="Lobject" />
-        <putfield class="LRoot" field="sparse_tensor" fieldType="LRoot" ref="framework" value="sparse_tensor" />
-        <new def="constant_op" class="Lobject" />
-        <putfield class="LRoot" field="constant_op" fieldType="LRoot" ref="framework" value="constant_op" />
+        <new def="rsqrt" class="Ltensorflow/math/rsqrt"/>
+        <putfield class="LRoot" field="rsqrt" fieldType="LRoot" ref="math" value="rsqrt"/>
+        <putfield class="LRoot" field="rsqrt" fieldType="LRoot" ref="math_ops" value="rsqrt"/>
+        <new def="linalg_ops" class="Lobject"/>
+        <putfield class="LRoot" field="linalg_ops" fieldType="LRoot" ref="ops" value="linalg_ops"/>
+        <new def="linalg_impl" class="Lobject"/>
+        <putfield class="LRoot" field="linalg_impl" fieldType="LRoot" ref="linalg" value="linalg_impl"/>
+        <new def="linear_operator" class="Lobject"/>
+        <putfield class="LRoot" field="linear_operator" fieldType="LRoot" ref="linalg" value="linear_operator"/>
+        <new def="sparse_ops" class="Lobject"/>
+        <putfield class="LRoot" field="sparse_ops" fieldType="LRoot" ref="ops" value="sparse_ops"/>
+        <new def="variables" class="Lobject"/>
+        <putfield class="LRoot" field="variables" fieldType="LRoot" ref="ops" value="variables"/>
+        <new def="sparse_tensor" class="Lobject"/>
+        <putfield class="LRoot" field="sparse_tensor" fieldType="LRoot" ref="framework" value="sparse_tensor"/>
+        <new def="constant_op" class="Lobject"/>
+        <putfield class="LRoot" field="constant_op" fieldType="LRoot" ref="framework" value="constant_op"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes -->
-        <new def="dtypes" class="Lobject" />
-        <putfield class="LRoot" field="dtypes" fieldType="LRoot" ref="framework" value="dtypes" />
-        <new def="ragged_factory_ops" class="Lobject" />
-        <putfield class="LRoot" field="ragged_factory_ops" fieldType="LRoot" ref="ragged" value="ragged_factory_ops" />
-        <new def="ragged_math_ops" class="Lobject" />
-        <putfield class="LRoot" field="ragged_math_ops" fieldType="LRoot" ref="ragged" value="ragged_math_ops" />
-        <new def="ragged_tensor" class="Lobject" />
-        <putfield class="LRoot" field="ragged_tensor" fieldType="LRoot" ref="ragged" value="ragged_tensor" />
-        <new def="ndarray" class="Ltensorflow/functions/ndarray" />
-        <putfield class="LRoot" field="ndarray" fieldType="LRoot" ref="numpy" value="ndarray" />
-        <new def="Input" class="Ltensorflow/keras/layers/Input" />
-        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="keras" value="Input" />
-        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="layers" value="Input" />
-        <new def="Dense" class="Ltensorflow/keras/layers/class/Dense" />
-        <putfield class="LRoot" field="Dense" fieldType="LRoot" ref="layers" value="Dense" />
-        <new def="FlattenLayerCls" class="Ltensorflow/keras/layers/class/Flatten" />
-        <putfield class="LRoot" field="Flatten" fieldType="LRoot" ref="layers" value="FlattenLayerCls" />
-        <new def="DropoutLayerCls" class="Ltensorflow/keras/layers/class/Dropout" />
-        <putfield class="LRoot" field="Dropout" fieldType="LRoot" ref="layers" value="DropoutLayerCls" />
-        <new def="Model" class="Ltensorflow/keras/models/class/Model" />
-        <putfield class="LRoot" field="Model" fieldType="LRoot" ref="keras" value="Model" />
-        <putfield class="LRoot" field="Model" fieldType="LRoot" ref="models" value="Model" />
-        <new def="ImageDataGenerator" class="Ltensorflow/keras/preprocessing/image/ImageDataGenerator" />
-        <putfield class="LRoot" field="ImageDataGenerator" fieldType="LRoot" ref="image" value="ImageDataGenerator" />
-        <new def="Variable" class="Ltensorflow/functions/Variable" />
-        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="x" value="Variable" />
-        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="variables" value="Variable" />
-        <new def="ones" class="Ltensorflow/functions/ones" />
-        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="x" value="ones" />
-        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="array_ops" value="ones" />
+        <new def="dtypes" class="Lobject"/>
+        <putfield class="LRoot" field="dtypes" fieldType="LRoot" ref="framework" value="dtypes"/>
+        <new def="ragged_factory_ops" class="Lobject"/>
+        <putfield class="LRoot" field="ragged_factory_ops" fieldType="LRoot" ref="ragged" value="ragged_factory_ops"/>
+        <new def="ragged_math_ops" class="Lobject"/>
+        <putfield class="LRoot" field="ragged_math_ops" fieldType="LRoot" ref="ragged" value="ragged_math_ops"/>
+        <new def="ragged_tensor" class="Lobject"/>
+        <putfield class="LRoot" field="ragged_tensor" fieldType="LRoot" ref="ragged" value="ragged_tensor"/>
+        <new def="ndarray" class="Ltensorflow/functions/ndarray"/>
+        <putfield class="LRoot" field="ndarray" fieldType="LRoot" ref="numpy" value="ndarray"/>
+        <new def="Input" class="Ltensorflow/keras/layers/Input"/>
+        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="keras" value="Input"/>
+        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="layers" value="Input"/>
+        <new def="Dense" class="Ltensorflow/keras/layers/class/Dense"/>
+        <putfield class="LRoot" field="Dense" fieldType="LRoot" ref="layers" value="Dense"/>
+        <new def="FlattenLayerCls" class="Ltensorflow/keras/layers/class/Flatten"/>
+        <putfield class="LRoot" field="Flatten" fieldType="LRoot" ref="layers" value="FlattenLayerCls"/>
+        <new def="DropoutLayerCls" class="Ltensorflow/keras/layers/class/Dropout"/>
+        <putfield class="LRoot" field="Dropout" fieldType="LRoot" ref="layers" value="DropoutLayerCls"/>
+        <new def="Model" class="Ltensorflow/keras/models/class/Model"/>
+        <putfield class="LRoot" field="Model" fieldType="LRoot" ref="keras" value="Model"/>
+        <putfield class="LRoot" field="Model" fieldType="LRoot" ref="models" value="Model"/>
+        <new def="ImageDataGenerator" class="Ltensorflow/keras/preprocessing/image/ImageDataGenerator"/>
+        <putfield class="LRoot" field="ImageDataGenerator" fieldType="LRoot" ref="image" value="ImageDataGenerator"/>
+        <new def="Variable" class="Ltensorflow/functions/Variable"/>
+        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="x" value="Variable"/>
+        <putfield class="LRoot" field="Variable" fieldType="LRoot" ref="variables" value="Variable"/>
+        <new def="ones" class="Ltensorflow/functions/ones"/>
+        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="x" value="ones"/>
+        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="array_ops" value="ones"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat -->
-        <new def="concat" class="Ltensorflow/functions/concat" />
-        <putfield class="LRoot" field="concat" fieldType="LRoot" ref="x" value="concat" />
-        <putfield class="LRoot" field="concat" fieldType="LRoot" ref="array_ops" value="concat" />
+        <new def="concat" class="Ltensorflow/functions/concat"/>
+        <putfield class="LRoot" field="concat" fieldType="LRoot" ref="x" value="concat"/>
+        <putfield class="LRoot" field="concat" fieldType="LRoot" ref="array_ops" value="concat"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask -->
-        <new def="sequence_mask" class="Ltensorflow/functions/sequence_mask" />
-        <putfield class="LRoot" field="sequence_mask" fieldType="LRoot" ref="x" value="sequence_mask" />
-        <putfield class="LRoot" field="sequence_mask" fieldType="LRoot" ref="array_ops" value="sequence_mask" />
+        <new def="sequence_mask" class="Ltensorflow/functions/sequence_mask"/>
+        <putfield class="LRoot" field="sequence_mask" fieldType="LRoot" ref="x" value="sequence_mask"/>
+        <putfield class="LRoot" field="sequence_mask" fieldType="LRoot" ref="array_ops" value="sequence_mask"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stop_gradient -->
-        <new def="stop_gradient" class="Ltensorflow/functions/stop_gradient" />
-        <putfield class="LRoot" field="stop_gradient" fieldType="LRoot" ref="x" value="stop_gradient" />
-        <putfield class="LRoot" field="stop_gradient" fieldType="LRoot" ref="array_ops" value="stop_gradient" />
+        <new def="stop_gradient" class="Ltensorflow/functions/stop_gradient"/>
+        <putfield class="LRoot" field="stop_gradient" fieldType="LRoot" ref="x" value="stop_gradient"/>
+        <putfield class="LRoot" field="stop_gradient" fieldType="LRoot" ref="array_ops" value="stop_gradient"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/ones_like -->
-        <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — at runtime allocates a fresh 1-D int32 tensor whose values are `input`'s shape. The model here is partial: `<new>+<return>` allocates a `Ltensorflow/python/framework/ops/Tensor` of unknown dtype and unknown rank/shape (no
           dedicated generator yet wired to encode int32 dtype or the statically-1 rank). That's enough to fix wala/ML#489's specific symptom &mdash; the dedicated allocation breaks the prior `pass_through` aliasing that caused `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape
           spec. Tightening the result to int32 dtype / rank-1 shape is tracked at wala/ML#473. -->
-        <new def="shape" class="Ltensorflow/math/shape" />
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape" />
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape" />
+        <new def="shape" class="Ltensorflow/math/shape"/>
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape"/>
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->
-        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- `tf.clip_by_value` and `clip_ops.clip_by_value` now route through the dedicated `<class name="clip_by_value">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
-        <new def="clip_by_global_norm" class="Ltensorflow/functions/clip_by_global_norm" />
-        <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="x" value="clip_by_global_norm" />
-        <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="clip_ops" value="clip_by_global_norm" />
-        <new def="image_ops_impl" class="Lobject" />
-        <putfield class="LRoot" field="image_ops_impl" fieldType="LRoot" ref="ops" value="image_ops_impl" />
+        <new def="clip_by_global_norm" class="Ltensorflow/functions/clip_by_global_norm"/>
+        <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="x" value="clip_by_global_norm"/>
+        <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="clip_ops" value="clip_by_global_norm"/>
+        <new def="image_ops_impl" class="Lobject"/>
+        <putfield class="LRoot" field="image_ops_impl" fieldType="LRoot" ref="ops" value="image_ops_impl"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/resize -->
-        <putfield class="LRoot" field="resize" fieldType="LRoot" ref="image" value="pass_through" />
-        <putfield class="LRoot" field="resize" fieldType="LRoot" ref="image_ops_impl" value="pass_through" />
+        <putfield class="LRoot" field="resize" fieldType="LRoot" ref="image" value="pass_through"/>
+        <putfield class="LRoot" field="resize" fieldType="LRoot" ref="image_ops_impl" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/ssim -->
-        <putfield class="LRoot" field="ssim" fieldType="LRoot" ref="image" value="pass_through" />
-        <putfield class="LRoot" field="ssim" fieldType="LRoot" ref="image_ops_impl" value="pass_through" />
+        <putfield class="LRoot" field="ssim" fieldType="LRoot" ref="image" value="pass_through"/>
+        <putfield class="LRoot" field="ssim" fieldType="LRoot" ref="image_ops_impl" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/total_variation -->
-        <putfield class="LRoot" field="total_variation" fieldType="LRoot" ref="image" value="pass_through" />
-        <putfield class="LRoot" field="total_variation" fieldType="LRoot" ref="image_ops_impl" value="pass_through" />
+        <putfield class="LRoot" field="total_variation" fieldType="LRoot" ref="image" value="pass_through"/>
+        <putfield class="LRoot" field="total_variation" fieldType="LRoot" ref="image_ops_impl" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches -->
-        <new def="extract_patches" class="Ltensorflow/functions/image/extract_patches" />
-        <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="image" value="extract_patches" />
-        <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="array_ops" value="extract_patches" />
-        <new def="zeros" class="Ltensorflow/functions/zeros" />
-        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros" />
-        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="array_ops" value="zeros" />
-        <new def="fill" class="Ltensorflow/functions/fill" />
-        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="x" value="fill" />
-        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="array_ops" value="fill" />
-        <new def="zeros_like" class="Ltensorflow/functions/zeros_like" />
-        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="x" value="zeros_like" />
-        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="array_ops" value="zeros_like" />
-        <new def="one_hot" class="Ltensorflow/functions/one_hot" />
-        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="x" value="one_hot" />
-        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="array_ops" value="one_hot" />
-        <new def="uniform" class="Ltensorflow/functions/uniform" />
-        <putfield class="LRoot" field="uniform" fieldType="LRoot" ref="random" value="uniform" />
-        <putfield class="LRoot" field="random_uniform" fieldType="LRoot" ref="random_ops" value="uniform" />
-        <new def="gamma" class="Ltensorflow/functions/gamma" />
-        <putfield class="LRoot" field="gamma" fieldType="LRoot" ref="random" value="gamma" />
-        <putfield class="LRoot" field="random_gamma" fieldType="LRoot" ref="random_ops" value="gamma" />
-        <new def="normal" class="Ltensorflow/functions/normal" />
-        <putfield class="LRoot" field="normal" fieldType="LRoot" ref="random" value="normal" />
-        <putfield class="LRoot" field="random_normal" fieldType="LRoot" ref="random_ops" value="normal" />
-        <new def="poisson" class="Ltensorflow/functions/poisson" />
-        <putfield class="LRoot" field="poisson" fieldType="LRoot" ref="random" value="poisson" />
-        <putfield class="LRoot" field="random_poisson_v2" fieldType="LRoot" ref="random_ops" value="poisson" />
-        <new def="truncated_normal" class="Ltensorflow/functions/truncated_normal" />
-        <putfield class="LRoot" field="truncated_normal" fieldType="LRoot" ref="random" value="truncated_normal" />
-        <putfield class="LRoot" field="truncated_normal" fieldType="LRoot" ref="random_ops" value="truncated_normal" />
+        <new def="extract_patches" class="Ltensorflow/functions/image/extract_patches"/>
+        <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="image" value="extract_patches"/>
+        <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="array_ops" value="extract_patches"/>
+        <new def="zeros" class="Ltensorflow/functions/zeros"/>
+        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros"/>
+        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="array_ops" value="zeros"/>
+        <new def="fill" class="Ltensorflow/functions/fill"/>
+        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="x" value="fill"/>
+        <putfield class="LRoot" field="fill" fieldType="LRoot" ref="array_ops" value="fill"/>
+        <new def="zeros_like" class="Ltensorflow/functions/zeros_like"/>
+        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="x" value="zeros_like"/>
+        <putfield class="LRoot" field="zeros_like" fieldType="LRoot" ref="array_ops" value="zeros_like"/>
+        <new def="one_hot" class="Ltensorflow/functions/one_hot"/>
+        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="x" value="one_hot"/>
+        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="array_ops" value="one_hot"/>
+        <new def="uniform" class="Ltensorflow/functions/uniform"/>
+        <putfield class="LRoot" field="uniform" fieldType="LRoot" ref="random" value="uniform"/>
+        <putfield class="LRoot" field="random_uniform" fieldType="LRoot" ref="random_ops" value="uniform"/>
+        <new def="gamma" class="Ltensorflow/functions/gamma"/>
+        <putfield class="LRoot" field="gamma" fieldType="LRoot" ref="random" value="gamma"/>
+        <putfield class="LRoot" field="random_gamma" fieldType="LRoot" ref="random_ops" value="gamma"/>
+        <new def="normal" class="Ltensorflow/functions/normal"/>
+        <putfield class="LRoot" field="normal" fieldType="LRoot" ref="random" value="normal"/>
+        <putfield class="LRoot" field="random_normal" fieldType="LRoot" ref="random_ops" value="normal"/>
+        <new def="poisson" class="Ltensorflow/functions/poisson"/>
+        <putfield class="LRoot" field="poisson" fieldType="LRoot" ref="random" value="poisson"/>
+        <putfield class="LRoot" field="random_poisson_v2" fieldType="LRoot" ref="random_ops" value="poisson"/>
+        <new def="truncated_normal" class="Ltensorflow/functions/truncated_normal"/>
+        <putfield class="LRoot" field="truncated_normal" fieldType="LRoot" ref="random" value="truncated_normal"/>
+        <putfield class="LRoot" field="truncated_normal" fieldType="LRoot" ref="random_ops" value="truncated_normal"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/random/categorical -->
-        <putfield class="LRoot" field="categorical" fieldType="LRoot" ref="random" value="pass_through" />
-        <putfield class="LRoot" field="categorical" fieldType="LRoot" ref="random_ops" value="pass_through" />
+        <putfield class="LRoot" field="categorical" fieldType="LRoot" ref="random" value="pass_through"/>
+        <putfield class="LRoot" field="categorical" fieldType="LRoot" ref="random_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/random/shuffle -->
-        <new def="shuffle" class="Ltensorflow/functions/shuffle" />
-        <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="random" value="shuffle" />
-        <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="random_ops" value="shuffle" />
+        <new def="shuffle" class="Ltensorflow/functions/shuffle"/>
+        <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="random" value="shuffle"/>
+        <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="random_ops" value="shuffle"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sort -->
-        <new def="sort" class="Ltensorflow/functions/sort" />
-        <putfield class="LRoot" field="sort" fieldType="LRoot" ref="x" value="sort" />
-        <putfield class="LRoot" field="sort" fieldType="LRoot" ref="sort_ops" value="sort" />
-        <new def="range" class="Ltensorflow/functions/range" />
-        <putfield class="LRoot" field="range" fieldType="LRoot" ref="x" value="range" />
-        <putfield class="LRoot" field="range" fieldType="LRoot" ref="math_ops" value="range" />
+        <new def="sort" class="Ltensorflow/functions/sort"/>
+        <putfield class="LRoot" field="sort" fieldType="LRoot" ref="x" value="sort"/>
+        <putfield class="LRoot" field="sort" fieldType="LRoot" ref="sort_ops" value="sort"/>
+        <new def="range" class="Ltensorflow/functions/range"/>
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="x" value="range"/>
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="math_ops" value="range"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag -->
-        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag_part -->
-        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/set_diag -->
-        <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/matrix_transpose -->
-        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/band_part -->
-        <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
+        <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="gen_array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/cholesky -->
-        <putfield class="LRoot" field="cholesky" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="cholesky" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="cholesky" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="cholesky" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/inv -->
-        <putfield class="LRoot" field="inv" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="inv" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="inv" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="inv" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/solve -->
-        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — fresh allocation routed to the dedicated `BroadcastTo` generator (wala/ML#449 Tier 7). Pre-fix used `value="pass_through"` aliasing, which routed the result through `PassThrough`'s identity semantics rather than computing the actual
           broadcast shape from the `shape` argument. -->
-        <new def="broadcast_to" class="Ltensorflow/functions/broadcast_to" />
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to" />
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="broadcast_to" />
+        <new def="broadcast_to" class="Ltensorflow/functions/broadcast_to"/>
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to"/>
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="broadcast_to"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile -->
-        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
+        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through"/>
         <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd -->
-        <new def="gather_nd" class="Ltensorflow/functions/gather_nd" />
-        <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="x" value="gather_nd" />
-        <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="array_ops" value="gather_nd" />
+        <new def="gather_nd" class="Ltensorflow/functions/gather_nd"/>
+        <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="x" value="gather_nd"/>
+        <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="array_ops" value="gather_nd"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/squeeze -->
-        <putfield class="LRoot" field="squeeze" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="squeeze" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <putfield class="LRoot" field="squeeze" fieldType="LRoot" ref="x" value="pass_through"/>
+        <putfield class="LRoot" field="squeeze" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/io/decode_png -->
         <!-- TODO: Return a dtype other than the input -->
-        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="image" value="pass_through" />
-        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="io" value="pass_through" />
-        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="gen_image_ops" value="pass_through" />
+        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="image" value="pass_through"/>
+        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="io" value="pass_through"/>
+        <putfield class="LRoot" field="decode_png" fieldType="LRoot" ref="gen_image_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/identity -->
-        <new def="identity" class="Ltensorflow/functions/identity" />
-        <putfield class="LRoot" field="identity" fieldType="LRoot" ref="x" value="identity" />
-        <putfield class="LRoot" field="identity" fieldType="LRoot" ref="array_ops" value="identity" />
+        <new def="identity" class="Ltensorflow/functions/identity"/>
+        <putfield class="LRoot" field="identity" fieldType="LRoot" ref="x" value="identity"/>
+        <putfield class="LRoot" field="identity" fieldType="LRoot" ref="array_ops" value="identity"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where -->
-        <new def="where" class="Ltensorflow/functions/where" />
-        <putfield class="LRoot" field="where" fieldType="LRoot" ref="x" value="where" />
-        <putfield class="LRoot" field="where" fieldType="LRoot" ref="array_ops" value="where" />
+        <new def="where" class="Ltensorflow/functions/where"/>
+        <putfield class="LRoot" field="where" fieldType="LRoot" ref="x" value="where"/>
+        <putfield class="LRoot" field="where" fieldType="LRoot" ref="array_ops" value="where"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid -->
-        <new def="meshgrid" class="Ltensorflow/functions/meshgrid" />
-        <putfield class="LRoot" field="meshgrid" fieldType="LRoot" ref="x" value="meshgrid" />
-        <putfield class="LRoot" field="meshgrid" fieldType="LRoot" ref="array_ops" value="meshgrid" />
+        <new def="meshgrid" class="Ltensorflow/functions/meshgrid"/>
+        <putfield class="LRoot" field="meshgrid" fieldType="LRoot" ref="x" value="meshgrid"/>
+        <putfield class="LRoot" field="meshgrid" fieldType="LRoot" ref="array_ops" value="meshgrid"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_partition -->
-        <new def="dynamic_partition" class="Ltensorflow/functions/dynamic_partition" />
-        <putfield class="LRoot" field="dynamic_partition" fieldType="LRoot" ref="x" value="dynamic_partition" />
-        <putfield class="LRoot" field="dynamic_partition" fieldType="LRoot" ref="gen_data_flow_ops" value="dynamic_partition" />
+        <new def="dynamic_partition" class="Ltensorflow/functions/dynamic_partition"/>
+        <putfield class="LRoot" field="dynamic_partition" fieldType="LRoot" ref="x" value="dynamic_partition"/>
+        <putfield class="LRoot" field="dynamic_partition" fieldType="LRoot" ref="gen_data_flow_ops" value="dynamic_partition"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_stitch -->
-        <new def="dynamic_stitch" class="Ltensorflow/functions/dynamic_stitch" />
-        <putfield class="LRoot" field="dynamic_stitch" fieldType="LRoot" ref="x" value="dynamic_stitch" />
-        <putfield class="LRoot" field="dynamic_stitch" fieldType="LRoot" ref="gen_data_flow_ops" value="dynamic_stitch" />
+        <new def="dynamic_stitch" class="Ltensorflow/functions/dynamic_stitch"/>
+        <putfield class="LRoot" field="dynamic_stitch" fieldType="LRoot" ref="x" value="dynamic_stitch"/>
+        <putfield class="LRoot" field="dynamic_stitch" fieldType="LRoot" ref="gen_data_flow_ops" value="dynamic_stitch"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split -->
-        <new def="split" class="Ltensorflow/functions/split" />
-        <putfield class="LRoot" field="split" fieldType="LRoot" ref="x" value="split" />
-        <putfield class="LRoot" field="split" fieldType="LRoot" ref="array_ops" value="split" />
+        <new def="split" class="Ltensorflow/functions/split"/>
+        <putfield class="LRoot" field="split" fieldType="LRoot" ref="x" value="split"/>
+        <putfield class="LRoot" field="split" fieldType="LRoot" ref="array_ops" value="split"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/rank -->
-        <new def="rank" class="Ltensorflow/functions/rank" />
-        <putfield class="LRoot" field="rank" fieldType="LRoot" ref="x" value="rank" />
-        <putfield class="LRoot" field="rank" fieldType="LRoot" ref="array_ops" value="rank" />
+        <new def="rank" class="Ltensorflow/functions/rank"/>
+        <putfield class="LRoot" field="rank" fieldType="LRoot" ref="x" value="rank"/>
+        <putfield class="LRoot" field="rank" fieldType="LRoot" ref="array_ops" value="rank"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/size -->
-        <new def="size" class="Ltensorflow/functions/size" />
-        <putfield class="LRoot" field="size" fieldType="LRoot" ref="x" value="size" />
-        <putfield class="LRoot" field="size" fieldType="LRoot" ref="array_ops" value="size" />
+        <new def="size" class="Ltensorflow/functions/size"/>
+        <putfield class="LRoot" field="size" fieldType="LRoot" ref="x" value="size"/>
+        <putfield class="LRoot" field="size" fieldType="LRoot" ref="array_ops" value="size"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update -->
-        <new def="tensor_scatter_nd_update" class="Ltensorflow/functions/tensor_scatter_nd_update" />
-        <putfield class="LRoot" field="tensor_scatter_nd_update" fieldType="LRoot" ref="x" value="tensor_scatter_nd_update" />
-        <putfield class="LRoot" field="tensor_scatter_nd_update" fieldType="LRoot" ref="array_ops" value="tensor_scatter_nd_update" />
+        <new def="tensor_scatter_nd_update" class="Ltensorflow/functions/tensor_scatter_nd_update"/>
+        <putfield class="LRoot" field="tensor_scatter_nd_update" fieldType="LRoot" ref="x" value="tensor_scatter_nd_update"/>
+        <putfield class="LRoot" field="tensor_scatter_nd_update" fieldType="LRoot" ref="array_ops" value="tensor_scatter_nd_update"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/abs -->
-        <new def="abs" class="Ltensorflow/math/abs" />
-        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="x" value="abs" />
-        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="math" value="abs" />
-        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="math_ops" value="abs" />
+        <new def="abs" class="Ltensorflow/math/abs"/>
+        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="x" value="abs"/>
+        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="math" value="abs"/>
+        <putfield class="LRoot" field="abs" fieldType="LRoot" ref="math_ops" value="abs"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_all -->
-        <new def="reduce_all" class="Ltensorflow/math/reduce_all" />
-        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="x" value="reduce_all" />
-        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="math" value="reduce_all" />
-        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="math_ops" value="reduce_all" />
+        <new def="reduce_all" class="Ltensorflow/math/reduce_all"/>
+        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="x" value="reduce_all"/>
+        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="math" value="reduce_all"/>
+        <putfield class="LRoot" field="reduce_all" fieldType="LRoot" ref="math_ops" value="reduce_all"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_prod -->
-        <new def="reduce_prod" class="Ltensorflow/math/reduce_prod" />
-        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="x" value="reduce_prod" />
-        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="math" value="reduce_prod" />
-        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="math_ops" value="reduce_prod" />
+        <new def="reduce_prod" class="Ltensorflow/math/reduce_prod"/>
+        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="x" value="reduce_prod"/>
+        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="math" value="reduce_prod"/>
+        <putfield class="LRoot" field="reduce_prod" fieldType="LRoot" ref="math_ops" value="reduce_prod"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_logsumexp -->
-        <new def="reduce_logsumexp" class="Ltensorflow/math/reduce_logsumexp" />
-        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="x" value="reduce_logsumexp" />
-        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math" value="reduce_logsumexp" />
-        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math_ops" value="reduce_logsumexp" />
+        <new def="reduce_logsumexp" class="Ltensorflow/math/reduce_logsumexp"/>
+        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="x" value="reduce_logsumexp"/>
+        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math" value="reduce_logsumexp"/>
+        <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math_ops" value="reduce_logsumexp"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/acos -->
-        <new def="acos" class="Ltensorflow/math/acos" />
-        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="x" value="acos" />
-        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="math" value="acos" />
-        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="math_ops" value="acos" />
-        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="gen_math_ops" value="acos" />
-        <new def="ragged_range" class="Ltensorflow/functions/ragged_range" />
-        <putfield class="LRoot" field="range" fieldType="LRoot" ref="ragged" value="ragged_range" />
-        <putfield class="LRoot" field="range" fieldType="LRoot" ref="ragged_math_ops" value="ragged_range" />
-        <new def="eye" class="Ltensorflow/functions/eye" />
-        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="x" value="eye" />
-        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg" value="eye" />
-        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg_ops" value="eye" />
+        <new def="acos" class="Ltensorflow/math/acos"/>
+        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="x" value="acos"/>
+        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="math" value="acos"/>
+        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="math_ops" value="acos"/>
+        <putfield class="LRoot" field="acos" fieldType="LRoot" ref="gen_math_ops" value="acos"/>
+        <new def="ragged_range" class="Ltensorflow/functions/ragged_range"/>
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="ragged" value="ragged_range"/>
+        <putfield class="LRoot" field="range" fieldType="LRoot" ref="ragged_math_ops" value="ragged_range"/>
+        <new def="eye" class="Ltensorflow/functions/eye"/>
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="x" value="eye"/>
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg" value="eye"/>
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg_ops" value="eye"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/cholesky_solve -->
-        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/eigh -->
-        <new def="eigh" class="Ltensorflow/functions/eigh" />
-        <putfield class="LRoot" field="eigh" fieldType="LRoot" ref="linalg" value="eigh" />
-        <putfield class="LRoot" field="eigh" fieldType="LRoot" ref="linalg_ops" value="eigh" />
+        <new def="eigh" class="Ltensorflow/functions/eigh"/>
+        <putfield class="LRoot" field="eigh" fieldType="LRoot" ref="linalg" value="eigh"/>
+        <putfield class="LRoot" field="eigh" fieldType="LRoot" ref="linalg_ops" value="eigh"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot -->
-        <new def="tensordot" class="Ltensorflow/math/tensordot" />
-        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="x" value="tensordot" />
-        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="linalg" value="tensordot" />
-        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="math_ops" value="tensordot" />
+        <new def="tensordot" class="Ltensorflow/math/tensordot"/>
+        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="x" value="tensordot"/>
+        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="linalg" value="tensordot"/>
+        <putfield class="LRoot" field="tensordot" fieldType="LRoot" ref="math_ops" value="tensordot"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace -->
-        <new def="trace" class="Ltensorflow/math/trace" />
-        <putfield class="LRoot" field="trace" fieldType="LRoot" ref="linalg" value="trace" />
-        <putfield class="LRoot" field="trace" fieldType="LRoot" ref="math_ops" value="trace" />
+        <new def="trace" class="Ltensorflow/math/trace"/>
+        <putfield class="LRoot" field="trace" fieldType="LRoot" ref="linalg" value="trace"/>
+        <putfield class="LRoot" field="trace" fieldType="LRoot" ref="math_ops" value="trace"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum -->
-        <new def="einsum" class="Ltensorflow/math/einsum" />
-        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="x" value="einsum" />
-        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="linalg" value="einsum" />
-        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="special_math_ops" value="einsum" />
+        <new def="einsum" class="Ltensorflow/math/einsum"/>
+        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="x" value="einsum"/>
+        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="linalg" value="einsum"/>
+        <putfield class="LRoot" field="einsum" fieldType="LRoot" ref="special_math_ops" value="einsum"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/eigvalsh -->
-        <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/triangular_solve -->
-        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through" />
+        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/adjoint -->
-        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg_impl" value="pass_through" />
+        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg_impl" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/logdet -->
-        <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg_impl" value="pass_through" />
+        <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg_impl" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/log_abs_determinant -->
-        <putfield class="LRoot" field="log_abs_determinant" fieldType="LRoot" ref="linalg" value="pass_through" />
-        <putfield class="LRoot" field="log_abs_determinant" fieldType="LRoot" ref="linear_operator" value="pass_through" />
+        <putfield class="LRoot" field="log_abs_determinant" fieldType="LRoot" ref="linalg" value="pass_through"/>
+        <putfield class="LRoot" field="log_abs_determinant" fieldType="LRoot" ref="linear_operator" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/map_fn -->
-        <new def="map_fn" class="Ltensorflow/functions/map_fn" />
-        <putfield class="LRoot" field="map_fn" fieldType="LRoot" ref="x" value="map_fn" />
+        <new def="map_fn" class="Ltensorflow/functions/map_fn"/>
+        <putfield class="LRoot" field="map_fn" fieldType="LRoot" ref="x" value="map_fn"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function -->
-        <new def="py_function" class="Ltensorflow/functions/py_function" />
-        <putfield class="LRoot" field="py_function" fieldType="LRoot" ref="x" value="py_function" />
-        <new def="constant" class="Ltensorflow/functions/constant" />
-        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="x" value="constant" />
-        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="constant_op" value="constant" />
+        <new def="py_function" class="Ltensorflow/functions/py_function"/>
+        <putfield class="LRoot" field="py_function" fieldType="LRoot" ref="x" value="py_function"/>
+        <new def="constant" class="Ltensorflow/functions/constant"/>
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="x" value="constant"/>
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="constant_op" value="constant"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#float32 -->
-        <new def="float32" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="x" value="float32" />
-        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="dtypes" value="float32" />
+        <new def="float32" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="x" value="float32"/>
+        <putfield class="LRoot" field="float32" fieldType="LRoot" ref="dtypes" value="float32"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#float64 -->
-        <new def="float64" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64" />
-        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="dtypes" value="float64" />
+        <new def="float64" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64"/>
+        <putfield class="LRoot" field="float64" fieldType="LRoot" ref="dtypes" value="float64"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#int32 -->
-        <new def="int32" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32" />
-        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="dtypes" value="int32" />
+        <new def="int32" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32"/>
+        <putfield class="LRoot" field="int32" fieldType="LRoot" ref="dtypes" value="int32"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#int64 -->
-        <new def="int64" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64" />
-        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="dtypes" value="int64" />
+        <new def="int64" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64"/>
+        <putfield class="LRoot" field="int64" fieldType="LRoot" ref="dtypes" value="int64"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#string -->
-        <new def="string" class="Ltensorflow/dtypes/DType" />
-        <putfield class="LRoot" field="string" fieldType="LRoot" ref="x" value="string" />
-        <putfield class="LRoot" field="string" fieldType="LRoot" ref="dtypes" value="string" />
-        <new def="ragged_constant" class="Ltensorflow/functions/ragged_constant" />
-        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged" value="ragged_constant" />
-        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged_factory_ops" value="ragged_constant" />
-        <new def="SparseTensor" class="Ltensorflow/functions/SparseTensor" />
-        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="x" value="SparseTensor" />
-        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="sparse" value="SparseTensor" />
-        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="sparse_tensor" value="SparseTensor" />
-        <new def="sparse_eye" class="Ltensorflow/functions/sparse_eye" />
-        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="sparse" value="sparse_eye" />
-        <putfield class="LRoot" field="sparse_eye" fieldType="LRoot" ref="sparse_ops" value="sparse_eye" />
-        <new def="sparse_add" class="Ltensorflow/functions/sparse_add" />
-        <putfield class="LRoot" field="add" fieldType="LRoot" ref="sparse" value="sparse_add" />
-        <putfield class="LRoot" field="sparse_add" fieldType="LRoot" ref="sparse_ops" value="sparse_add" />
-        <new def="sparse_from_dense" class="Ltensorflow/functions/sparse_from_dense" />
-        <putfield class="LRoot" field="from_dense" fieldType="LRoot" ref="sparse" value="sparse_from_dense" />
-        <putfield class="LRoot" field="sparse_from_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_from_dense" />
-        <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor" />
-        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor" />
-        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops" value="convert_to_tensor" />
-        <new def="Tensor" class="Ltensorflow/functions/Tensor" />
-        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="x" value="Tensor" />
-        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="ops" value="Tensor" />
-        <new def="Graph" class="Ltensorflow/functions/Graph" />
-        <putfield class="LRoot" field="Graph" fieldType="LRoot" ref="x" value="Graph" />
-        <putfield class="LRoot" field="Graph" fieldType="LRoot" ref="ops" value="Graph" />
-        <new def="RaggedTensor" class="Lobject" />
-        <putfield class="LRoot" field="RaggedTensor" fieldType="LRoot" ref="x" value="RaggedTensor" />
-        <putfield class="LRoot" field="RaggedTensor" fieldType="LRoot" ref="ragged_tensor" value="RaggedTensor" />
-        <new def="from_nested_row_lengths" class="Ltensorflow/functions/from_nested_row_lengths" />
-        <putfield class="LRoot" field="from_nested_row_lengths" fieldType="LRoot" ref="RaggedTensor" value="from_nested_row_lengths" />
-        <new def="from_nested_row_splits" class="Ltensorflow/functions/from_nested_row_splits" />
-        <putfield class="LRoot" field="from_nested_row_splits" fieldType="LRoot" ref="RaggedTensor" value="from_nested_row_splits" />
-        <new def="from_nested_value_rowids" class="Ltensorflow/functions/from_nested_value_rowids" />
-        <putfield class="LRoot" field="from_nested_value_rowids" fieldType="LRoot" ref="RaggedTensor" value="from_nested_value_rowids" />
-        <new def="from_row_lengths" class="Ltensorflow/functions/from_row_lengths" />
-        <putfield class="LRoot" field="from_row_lengths" fieldType="LRoot" ref="RaggedTensor" value="from_row_lengths" />
-        <new def="from_row_limits" class="Ltensorflow/functions/from_row_limits" />
-        <putfield class="LRoot" field="from_row_limits" fieldType="LRoot" ref="RaggedTensor" value="from_row_limits" />
-        <new def="from_row_splits" class="Ltensorflow/functions/from_row_splits" />
-        <putfield class="LRoot" field="from_row_splits" fieldType="LRoot" ref="RaggedTensor" value="from_row_splits" />
-        <new def="from_row_starts" class="Ltensorflow/functions/from_row_starts" />
-        <putfield class="LRoot" field="from_row_starts" fieldType="LRoot" ref="RaggedTensor" value="from_row_starts" />
-        <new def="from_value_rowids" class="Ltensorflow/functions/from_value_rowids" />
-        <putfield class="LRoot" field="from_value_rowids" fieldType="LRoot" ref="RaggedTensor" value="from_value_rowids" />
+        <new def="string" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="string" fieldType="LRoot" ref="x" value="string"/>
+        <putfield class="LRoot" field="string" fieldType="LRoot" ref="dtypes" value="string"/>
+        <new def="ragged_constant" class="Ltensorflow/functions/ragged_constant"/>
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged" value="ragged_constant"/>
+        <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged_factory_ops" value="ragged_constant"/>
+        <new def="SparseTensor" class="Ltensorflow/functions/SparseTensor"/>
+        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="x" value="SparseTensor"/>
+        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="sparse" value="SparseTensor"/>
+        <putfield class="LRoot" field="SparseTensor" fieldType="LRoot" ref="sparse_tensor" value="SparseTensor"/>
+        <new def="sparse_eye" class="Ltensorflow/functions/sparse_eye"/>
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="sparse" value="sparse_eye"/>
+        <putfield class="LRoot" field="sparse_eye" fieldType="LRoot" ref="sparse_ops" value="sparse_eye"/>
+        <new def="sparse_add" class="Ltensorflow/functions/sparse_add"/>
+        <putfield class="LRoot" field="add" fieldType="LRoot" ref="sparse" value="sparse_add"/>
+        <putfield class="LRoot" field="sparse_add" fieldType="LRoot" ref="sparse_ops" value="sparse_add"/>
+        <new def="sparse_from_dense" class="Ltensorflow/functions/sparse_from_dense"/>
+        <putfield class="LRoot" field="from_dense" fieldType="LRoot" ref="sparse" value="sparse_from_dense"/>
+        <putfield class="LRoot" field="sparse_from_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_from_dense"/>
+        <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor"/>
+        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor"/>
+        <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops" value="convert_to_tensor"/>
+        <new def="Tensor" class="Ltensorflow/functions/Tensor"/>
+        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="x" value="Tensor"/>
+        <putfield class="LRoot" field="Tensor" fieldType="LRoot" ref="ops" value="Tensor"/>
+        <new def="Graph" class="Ltensorflow/functions/Graph"/>
+        <putfield class="LRoot" field="Graph" fieldType="LRoot" ref="x" value="Graph"/>
+        <putfield class="LRoot" field="Graph" fieldType="LRoot" ref="ops" value="Graph"/>
+        <new def="RaggedTensor" class="Lobject"/>
+        <putfield class="LRoot" field="RaggedTensor" fieldType="LRoot" ref="x" value="RaggedTensor"/>
+        <putfield class="LRoot" field="RaggedTensor" fieldType="LRoot" ref="ragged_tensor" value="RaggedTensor"/>
+        <new def="from_nested_row_lengths" class="Ltensorflow/functions/from_nested_row_lengths"/>
+        <putfield class="LRoot" field="from_nested_row_lengths" fieldType="LRoot" ref="RaggedTensor" value="from_nested_row_lengths"/>
+        <new def="from_nested_row_splits" class="Ltensorflow/functions/from_nested_row_splits"/>
+        <putfield class="LRoot" field="from_nested_row_splits" fieldType="LRoot" ref="RaggedTensor" value="from_nested_row_splits"/>
+        <new def="from_nested_value_rowids" class="Ltensorflow/functions/from_nested_value_rowids"/>
+        <putfield class="LRoot" field="from_nested_value_rowids" fieldType="LRoot" ref="RaggedTensor" value="from_nested_value_rowids"/>
+        <new def="from_row_lengths" class="Ltensorflow/functions/from_row_lengths"/>
+        <putfield class="LRoot" field="from_row_lengths" fieldType="LRoot" ref="RaggedTensor" value="from_row_lengths"/>
+        <new def="from_row_limits" class="Ltensorflow/functions/from_row_limits"/>
+        <putfield class="LRoot" field="from_row_limits" fieldType="LRoot" ref="RaggedTensor" value="from_row_limits"/>
+        <new def="from_row_splits" class="Ltensorflow/functions/from_row_splits"/>
+        <putfield class="LRoot" field="from_row_splits" fieldType="LRoot" ref="RaggedTensor" value="from_row_splits"/>
+        <new def="from_row_starts" class="Ltensorflow/functions/from_row_starts"/>
+        <putfield class="LRoot" field="from_row_starts" fieldType="LRoot" ref="RaggedTensor" value="from_row_starts"/>
+        <new def="from_value_rowids" class="Ltensorflow/functions/from_value_rowids"/>
+        <putfield class="LRoot" field="from_value_rowids" fieldType="LRoot" ref="RaggedTensor" value="from_value_rowids"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask -->
-        <new def="boolean_mask" class="Ltensorflow/functions/boolean_mask" />
-        <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="x" value="boolean_mask" />
-        <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="array_ops" value="boolean_mask" />
+        <new def="boolean_mask" class="Ltensorflow/functions/boolean_mask"/>
+        <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="x" value="boolean_mask"/>
+        <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="array_ops" value="boolean_mask"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linspace -->
-        <new def="linspace" class="Ltensorflow/functions/linspace" />
-        <putfield class="LRoot" field="linspace" fieldType="LRoot" ref="x" value="linspace" />
-        <putfield class="LRoot" field="linspace" fieldType="LRoot" ref="math_ops" value="linspace" />
-        <new def="autograph" class="Lobject" />
+        <new def="linspace" class="Ltensorflow/functions/linspace"/>
+        <putfield class="LRoot" field="linspace" fieldType="LRoot" ref="x" value="linspace"/>
+        <putfield class="LRoot" field="linspace" fieldType="LRoot" ref="math_ops" value="linspace"/>
+        <new def="autograph" class="Lobject"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack -->
-        <new def="stack" class="Ltensorflow/functions/stack" />
-        <putfield class="LRoot" field="stack" fieldType="LRoot" ref="x" value="stack" />
-        <putfield class="LRoot" field="stack" fieldType="LRoot" ref="array_ops" value="stack" />
+        <new def="stack" class="Ltensorflow/functions/stack"/>
+        <putfield class="LRoot" field="stack" fieldType="LRoot" ref="x" value="stack"/>
+        <putfield class="LRoot" field="stack" fieldType="LRoot" ref="array_ops" value="stack"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack -->
-        <new def="unstack" class="Ltensorflow/functions/unstack" />
-        <putfield class="LRoot" field="unstack" fieldType="LRoot" ref="x" value="unstack" />
-        <putfield class="LRoot" field="unstack" fieldType="LRoot" ref="array_ops" value="unstack" />
+        <new def="unstack" class="Ltensorflow/functions/unstack"/>
+        <putfield class="LRoot" field="unstack" fieldType="LRoot" ref="x" value="unstack"/>
+        <putfield class="LRoot" field="unstack" fieldType="LRoot" ref="array_ops" value="unstack"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cond -->
-        <new def="cond" class="Ltensorflow/functions/cond" />
-        <putfield class="LRoot" field="cond" fieldType="LRoot" ref="x" value="cond" />
-        <putfield class="LRoot" field="cond" fieldType="LRoot" ref="control_flow_ops" value="cond" />
+        <new def="cond" class="Ltensorflow/functions/cond"/>
+        <putfield class="LRoot" field="cond" fieldType="LRoot" ref="x" value="cond"/>
+        <putfield class="LRoot" field="cond" fieldType="LRoot" ref="control_flow_ops" value="cond"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/while_loop -->
-        <new def="while_loop" class="Ltensorflow/functions/while_loop" />
-        <putfield class="LRoot" field="while_loop" fieldType="LRoot" ref="x" value="while_loop" />
-        <putfield class="LRoot" field="while_loop" fieldType="LRoot" ref="control_flow_ops" value="while_loop" />
-        <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="x" value="autograph" />
-        <putfield class="LRoot" field="experimental" fieldType="LRoot" ref="autograph" value="experimental" />
+        <new def="while_loop" class="Ltensorflow/functions/while_loop"/>
+        <putfield class="LRoot" field="while_loop" fieldType="LRoot" ref="x" value="while_loop"/>
+        <putfield class="LRoot" field="while_loop" fieldType="LRoot" ref="control_flow_ops" value="while_loop"/>
+        <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="x" value="autograph"/>
+        <putfield class="LRoot" field="experimental" fieldType="LRoot" ref="autograph" value="experimental"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/autograph/experimental/do_not_convert -->
-        <new def="do_not_convert" class="Ltensorflow/class/do_not_convert" />
-        <putfield class="LRoot" field="do_not_convert" fieldType="LRoot" ref="experimental" value="do_not_convert" />
+        <new def="do_not_convert" class="Ltensorflow/class/do_not_convert"/>
+        <putfield class="LRoot" field="do_not_convert" fieldType="LRoot" ref="experimental" value="do_not_convert"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/custom_gradient -->
-        <new def="custom_gradient" class="Ltensorflow/class/custom_gradient" />
-        <putfield class="LRoot" field="custom_gradient" fieldType="LRoot" ref="x" value="custom_gradient" />
+        <new def="custom_gradient" class="Ltensorflow/class/custom_gradient"/>
+        <putfield class="LRoot" field="custom_gradient" fieldType="LRoot" ref="x" value="custom_gradient"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
-        <new def="relu" class="Ltensorflow/functions/relu" />
-        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="relu" />
+        <new def="relu" class="Ltensorflow/functions/relu"/>
+        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="relu"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast -->
-        <new def="cast" class="Ltensorflow/functions/cast" />
-        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="cast" />
-        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="dtypes" value="cast" />
+        <new def="cast" class="Ltensorflow/functions/cast"/>
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="cast"/>
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="dtypes" value="cast"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
-        <new def="expand_dims" class="Ltensorflow/functions/expand_dims" />
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="expand_dims" />
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="expand_dims" />
+        <new def="expand_dims" class="Ltensorflow/functions/expand_dims"/>
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="expand_dims"/>
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="expand_dims"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
-        <new def="clip_by_value" class="Ltensorflow/functions/clip_by_value" />
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="clip_by_value" />
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="clip_by_value" />
+        <new def="clip_by_value" class="Ltensorflow/functions/clip_by_value"/>
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="clip_by_value"/>
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="clip_by_value"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu -->
-        <new def="leaky_relu" class="Ltensorflow/functions/leaky_relu" />
-        <putfield class="LRoot" field="leaky_relu" fieldType="LRoot" ref="nn" value="leaky_relu" />
+        <new def="leaky_relu" class="Ltensorflow/functions/leaky_relu"/>
+        <putfield class="LRoot" field="leaky_relu" fieldType="LRoot" ref="nn" value="leaky_relu"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min -->
-        <new def="reduce_min" class="Ltensorflow/math/reduce_min" />
-        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="x" value="reduce_min" />
-        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math" value="reduce_min" />
-        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math_ops" value="reduce_min" />
+        <new def="reduce_min" class="Ltensorflow/math/reduce_min"/>
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="x" value="reduce_min"/>
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math" value="reduce_min"/>
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math_ops" value="reduce_min"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow -->
-        <new def="pow" class="Ltensorflow/math/pow" />
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pow" />
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pow" />
-        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pow" />
+        <new def="pow" class="Ltensorflow/math/pow"/>
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pow"/>
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pow"/>
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pow"/>
         <!-- Tier-A pure-passthrough math ops (wala/ML#422). Each modeled with direct `<new>+<return>` and a per-op Java generator extending `PassThroughUnaryTensorGenerator`; output shape and dtype both inherit from `x`. Pre-this-PR, several of these ops (sqrt, log, sin, cos) were earlier-bound to a
           generic `pass_through` field-write that aliases the result to the input rather than allocating a fresh tensor &mdash; the result was reachable via the receiver's modeling but had no per-op precision. The per-op `<new>+<return>` here replaces that for `tf` / `tf.math` callers, and the `gen_math_ops` /
           `math_ops` aliases below restore the precision under those internal modules too (`sqrt` had `math_ops`; `log`/`sin`/`cos` had `gen_math_ops` in the prior model). -->
-        <new def="sqrt" class="Ltensorflow/math/sqrt" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="x" value="sqrt" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math" value="sqrt" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math_ops" value="sqrt" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="gen_math_ops" value="sqrt" />
-        <new def="log" class="Ltensorflow/math/log" />
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="x" value="log" />
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math" value="log" />
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="gen_math_ops" value="log" />
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math_ops" value="log" />
-        <new def="negative" class="Ltensorflow/math/negative" />
-        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="x" value="negative" />
-        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="math" value="negative" />
-        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="math_ops" value="negative" />
+        <new def="sqrt" class="Ltensorflow/math/sqrt"/>
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="x" value="sqrt"/>
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math" value="sqrt"/>
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math_ops" value="sqrt"/>
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="gen_math_ops" value="sqrt"/>
+        <new def="log" class="Ltensorflow/math/log"/>
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="x" value="log"/>
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math" value="log"/>
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="gen_math_ops" value="log"/>
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math_ops" value="log"/>
+        <new def="negative" class="Ltensorflow/math/negative"/>
+        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="x" value="negative"/>
+        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="math" value="negative"/>
+        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="math_ops" value="negative"/>
         <!-- `gen_math_ops` wraps the C++ `Neg` op as `neg` (not `negative`); bind that field so `tensorflow.python.ops.gen_math_ops.neg(...)` routes to the `Negative` generator. -->
-        <putfield class="LRoot" field="neg" fieldType="LRoot" ref="gen_math_ops" value="negative" />
-        <new def="sin" class="Ltensorflow/math/sin" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="x" value="sin" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math" value="sin" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="gen_math_ops" value="sin" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math_ops" value="sin" />
-        <new def="cos" class="Ltensorflow/math/cos" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="x" value="cos" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math" value="cos" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="gen_math_ops" value="cos" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math_ops" value="cos" />
-        <new def="floor" class="Ltensorflow/math/floor" />
-        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="x" value="floor" />
-        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="math" value="floor" />
-        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="math_ops" value="floor" />
-        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="gen_math_ops" value="floor" />
-        <new def="ceil" class="Ltensorflow/math/ceil" />
-        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="x" value="ceil" />
-        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="math" value="ceil" />
-        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="math_ops" value="ceil" />
-        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="gen_math_ops" value="ceil" />
-        <new def="sign" class="Ltensorflow/math/sign" />
-        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="x" value="sign" />
-        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="math" value="sign" />
+        <putfield class="LRoot" field="neg" fieldType="LRoot" ref="gen_math_ops" value="negative"/>
+        <new def="sin" class="Ltensorflow/math/sin"/>
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="x" value="sin"/>
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math" value="sin"/>
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="gen_math_ops" value="sin"/>
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math_ops" value="sin"/>
+        <new def="cos" class="Ltensorflow/math/cos"/>
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="x" value="cos"/>
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math" value="cos"/>
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="gen_math_ops" value="cos"/>
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math_ops" value="cos"/>
+        <new def="floor" class="Ltensorflow/math/floor"/>
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="x" value="floor"/>
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="math" value="floor"/>
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="math_ops" value="floor"/>
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="gen_math_ops" value="floor"/>
+        <new def="ceil" class="Ltensorflow/math/ceil"/>
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="x" value="ceil"/>
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="math" value="ceil"/>
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="math_ops" value="ceil"/>
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="gen_math_ops" value="ceil"/>
+        <new def="sign" class="Ltensorflow/math/sign"/>
+        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="x" value="sign"/>
+        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="math" value="sign"/>
         <!-- Tier-A math ops (continued, wala/ML#422). Most are shape and dtype passthrough on their primary tensor argument (named `x` for the unary ops; `features` for `softplus` / `softsign`). The binary ops `atan2` / `maximum` / `minimum` later in this block are the exception &mdash; they're routed
           through `ElementWiseOperation`, which derives dtype from the `x` parameter at position 0 and computes broadcast shape from both operands. -->
-        <new def="tan" class="Ltensorflow/math/tan" />
-        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="x" value="tan" />
-        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="math" value="tan" />
-        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="gen_math_ops" value="tan" />
-        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="math_ops" value="tan" />
-        <new def="asin" class="Ltensorflow/math/asin" />
-        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="x" value="asin" />
-        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="math" value="asin" />
-        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="gen_math_ops" value="asin" />
-        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="math_ops" value="asin" />
-        <new def="atan" class="Ltensorflow/math/atan" />
-        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="x" value="atan" />
-        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="math" value="atan" />
-        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="gen_math_ops" value="atan" />
-        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="math_ops" value="atan" />
-        <new def="sinh" class="Ltensorflow/math/sinh" />
-        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="x" value="sinh" />
-        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="math" value="sinh" />
-        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="gen_math_ops" value="sinh" />
-        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="math_ops" value="sinh" />
-        <new def="cosh" class="Ltensorflow/math/cosh" />
-        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="x" value="cosh" />
-        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="math" value="cosh" />
-        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="math_ops" value="cosh" />
-        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="gen_math_ops" value="cosh" />
-        <new def="asinh" class="Ltensorflow/math/asinh" />
-        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="x" value="asinh" />
-        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="math" value="asinh" />
-        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="math_ops" value="asinh" />
-        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="gen_math_ops" value="asinh" />
-        <new def="acosh" class="Ltensorflow/math/acosh" />
-        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="x" value="acosh" />
-        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="math" value="acosh" />
-        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="math_ops" value="acosh" />
-        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="gen_math_ops" value="acosh" />
-        <new def="atanh" class="Ltensorflow/math/atanh" />
-        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="x" value="atanh" />
-        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="math" value="atanh" />
-        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="math_ops" value="atanh" />
-        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="gen_math_ops" value="atanh" />
-        <new def="log1p" class="Ltensorflow/math/log1p" />
-        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="x" value="log1p" />
-        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="math" value="log1p" />
-        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="math_ops" value="log1p" />
-        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="gen_math_ops" value="log1p" />
-        <new def="expm1" class="Ltensorflow/math/expm1" />
-        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="x" value="expm1" />
-        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="math" value="expm1" />
-        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="math_ops" value="expm1" />
-        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="gen_math_ops" value="expm1" />
-        <new def="round" class="Ltensorflow/math/round" />
-        <putfield class="LRoot" field="round" fieldType="LRoot" ref="x" value="round" />
-        <putfield class="LRoot" field="round" fieldType="LRoot" ref="math" value="round" />
-        <putfield class="LRoot" field="round" fieldType="LRoot" ref="math_ops" value="round" />
-        <putfield class="LRoot" field="round" fieldType="LRoot" ref="gen_math_ops" value="round" />
-        <new def="reciprocal" class="Ltensorflow/math/reciprocal" />
-        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math" value="reciprocal" />
-        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="gen_math_ops" value="reciprocal" />
-        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math_ops" value="reciprocal" />
-        <new def="softplus" class="Ltensorflow/math/softplus" />
-        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="math" value="softplus" />
-        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="nn" value="softplus" />
-        <new def="softsign" class="Ltensorflow/math/softsign" />
-        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="math" value="softsign" />
-        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="nn" value="softsign" />
-        <new def="square" class="Ltensorflow/math/square" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="x" value="square" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math" value="square" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math_ops" value="square" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="gen_math_ops" value="square" />
-        <new def="erf" class="Ltensorflow/math/erf" />
-        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math" value="erf" />
-        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="gen_math_ops" value="erf" />
-        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math_ops" value="erf" />
-        <new def="erfc" class="Ltensorflow/math/erfc" />
-        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="math" value="erfc" />
-        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="math_ops" value="erfc" />
-        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="gen_math_ops" value="erfc" />
+        <new def="tan" class="Ltensorflow/math/tan"/>
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="x" value="tan"/>
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="math" value="tan"/>
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="gen_math_ops" value="tan"/>
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="math_ops" value="tan"/>
+        <new def="asin" class="Ltensorflow/math/asin"/>
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="x" value="asin"/>
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="math" value="asin"/>
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="gen_math_ops" value="asin"/>
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="math_ops" value="asin"/>
+        <new def="atan" class="Ltensorflow/math/atan"/>
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="x" value="atan"/>
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="math" value="atan"/>
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="gen_math_ops" value="atan"/>
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="math_ops" value="atan"/>
+        <new def="sinh" class="Ltensorflow/math/sinh"/>
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="x" value="sinh"/>
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="math" value="sinh"/>
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="gen_math_ops" value="sinh"/>
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="math_ops" value="sinh"/>
+        <new def="cosh" class="Ltensorflow/math/cosh"/>
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="x" value="cosh"/>
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="math" value="cosh"/>
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="math_ops" value="cosh"/>
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="gen_math_ops" value="cosh"/>
+        <new def="asinh" class="Ltensorflow/math/asinh"/>
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="x" value="asinh"/>
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="math" value="asinh"/>
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="math_ops" value="asinh"/>
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="gen_math_ops" value="asinh"/>
+        <new def="acosh" class="Ltensorflow/math/acosh"/>
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="x" value="acosh"/>
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="math" value="acosh"/>
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="math_ops" value="acosh"/>
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="gen_math_ops" value="acosh"/>
+        <new def="atanh" class="Ltensorflow/math/atanh"/>
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="x" value="atanh"/>
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="math" value="atanh"/>
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="math_ops" value="atanh"/>
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="gen_math_ops" value="atanh"/>
+        <new def="log1p" class="Ltensorflow/math/log1p"/>
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="x" value="log1p"/>
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="math" value="log1p"/>
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="math_ops" value="log1p"/>
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="gen_math_ops" value="log1p"/>
+        <new def="expm1" class="Ltensorflow/math/expm1"/>
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="x" value="expm1"/>
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="math" value="expm1"/>
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="math_ops" value="expm1"/>
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="gen_math_ops" value="expm1"/>
+        <new def="round" class="Ltensorflow/math/round"/>
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="x" value="round"/>
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="math" value="round"/>
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="math_ops" value="round"/>
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="gen_math_ops" value="round"/>
+        <new def="reciprocal" class="Ltensorflow/math/reciprocal"/>
+        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math" value="reciprocal"/>
+        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="gen_math_ops" value="reciprocal"/>
+        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math_ops" value="reciprocal"/>
+        <new def="softplus" class="Ltensorflow/math/softplus"/>
+        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="math" value="softplus"/>
+        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="nn" value="softplus"/>
+        <new def="softsign" class="Ltensorflow/math/softsign"/>
+        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="math" value="softsign"/>
+        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="nn" value="softsign"/>
+        <new def="square" class="Ltensorflow/math/square"/>
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="x" value="square"/>
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math" value="square"/>
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math_ops" value="square"/>
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="gen_math_ops" value="square"/>
+        <new def="erf" class="Ltensorflow/math/erf"/>
+        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math" value="erf"/>
+        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="gen_math_ops" value="erf"/>
+        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math_ops" value="erf"/>
+        <new def="erfc" class="Ltensorflow/math/erfc"/>
+        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="math" value="erfc"/>
+        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="math_ops" value="erfc"/>
+        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="gen_math_ops" value="erfc"/>
         <!-- Element-wise binary ops (broadcast shape, unified dtype) — routed through ElementWiseOperation. -->
-        <new def="atan2" class="Ltensorflow/math/atan2" />
-        <putfield class="LRoot" field="atan2" fieldType="LRoot" ref="math" value="atan2" />
-        <new def="maximum" class="Ltensorflow/math/maximum" />
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="x" value="maximum" />
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="math" value="maximum" />
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="gen_math_ops" value="maximum" />
-        <new def="minimum" class="Ltensorflow/math/minimum" />
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="x" value="minimum" />
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="math" value="minimum" />
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="gen_math_ops" value="minimum" />
-        <return value="x" />
+        <new def="atan2" class="Ltensorflow/math/atan2"/>
+        <putfield class="LRoot" field="atan2" fieldType="LRoot" ref="math" value="atan2"/>
+        <new def="maximum" class="Ltensorflow/math/maximum"/>
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="x" value="maximum"/>
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="math" value="maximum"/>
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="gen_math_ops" value="maximum"/>
+        <new def="minimum" class="Ltensorflow/math/minimum"/>
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="x" value="minimum"/>
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="math" value="minimum"/>
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="gen_math_ops" value="minimum"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="keras" allocatable="true">
       <method name="import" static="true" descriptor="()Lkeras;">
-        <new def="x" class="Lkeras" />
-        <new def="engine" class="Lobject" />
-        <putfield class="LRoot" field="engine" fieldType="LRoot" ref="x" value="engine" />
-        <new def="input_layer" class="Lobject" />
-        <putfield class="LRoot" field="input_layer" fieldType="LRoot" ref="engine" value="input_layer" />
-        <new def="Input" class="Ltensorflow/keras/layers/Input" />
-        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="input_layer" value="Input" />
-        <return value="x" />
+        <new def="x" class="Lkeras"/>
+        <new def="engine" class="Lobject"/>
+        <putfield class="LRoot" field="engine" fieldType="LRoot" ref="x" value="engine"/>
+        <new def="input_layer" class="Lobject"/>
+        <putfield class="LRoot" field="input_layer" fieldType="LRoot" ref="engine" value="input_layer"/>
+        <new def="Input" class="Ltensorflow/keras/layers/Input"/>
+        <putfield class="LRoot" field="Input" fieldType="LRoot" ref="input_layer" value="Input"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="tensorflow/class">
       <class name="Function" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="function" allocatable="true">
         <!-- These parameters are from TensorFlow v.2.9 https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function -->
         <method name="do" descriptor="()LRoot;" numArgs="11" paramNames="self func input_signature autograph jit_compile reduce_retracing experimental_implements experimental_autograph_options experimental_relax_shapes experimental_compile experimental_follow_type_hints">
-          <new def="params" class="Ltensorflow/class/Function" />
-          <putfield class="LRoot" field="func" fieldType="LRoot" ref="params" value="func" />
-          <putfield class="LRoot" field="input_signature" fieldType="LRoot" ref="params" value="input_signature" />
-          <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="params" value="autograph" />
-          <putfield class="LRoot" field="jit_compile" fieldType="LRoot" ref="params" value="jit_compile" />
-          <putfield class="LRoot" field="reduce_retracing" fieldType="LRoot" ref="params" value="reduce_retracing" />
-          <putfield class="LRoot" field="experimental_implements" fieldType="LRoot" ref="params" value="experimental_implements" />
-          <putfield class="LRoot" field="experimental_autograph_options" fieldType="LRoot" ref="params" value="experimental_autograph_options" />
-          <putfield class="LRoot" field="experimental_relax_shapes" fieldType="LRoot" ref="params" value="experimental_relax_shapes" />
-          <putfield class="LRoot" field="experimental_compile" fieldType="LRoot" ref="params" value="experimental_compile" />
-          <putfield class="LRoot" field="experimental_follow_type_hints" fieldType="LRoot" ref="params" value="experimental_follow_type_hints" />
-          <return value="params" />
+          <new def="params" class="Ltensorflow/class/Function"/>
+          <putfield class="LRoot" field="func" fieldType="LRoot" ref="params" value="func"/>
+          <putfield class="LRoot" field="input_signature" fieldType="LRoot" ref="params" value="input_signature"/>
+          <putfield class="LRoot" field="autograph" fieldType="LRoot" ref="params" value="autograph"/>
+          <putfield class="LRoot" field="jit_compile" fieldType="LRoot" ref="params" value="jit_compile"/>
+          <putfield class="LRoot" field="reduce_retracing" fieldType="LRoot" ref="params" value="reduce_retracing"/>
+          <putfield class="LRoot" field="experimental_implements" fieldType="LRoot" ref="params" value="experimental_implements"/>
+          <putfield class="LRoot" field="experimental_autograph_options" fieldType="LRoot" ref="params" value="experimental_autograph_options"/>
+          <putfield class="LRoot" field="experimental_relax_shapes" fieldType="LRoot" ref="params" value="experimental_relax_shapes"/>
+          <putfield class="LRoot" field="experimental_compile" fieldType="LRoot" ref="params" value="experimental_compile"/>
+          <putfield class="LRoot" field="experimental_follow_type_hints" fieldType="LRoot" ref="params" value="experimental_follow_type_hints"/>
+          <return value="params"/>
         </method>
       </class>
       <class name="Custom_gradient" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="custom_gradient" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/custom_gradient -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Ltensorflow/class/Custom_gradient" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Ltensorflow/class/Custom_gradient"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
       <class name="Do_not_convert" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="do_not_convert" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/autograph/experimental/do_not_convert -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Ltensorflow/class/Do_not_convert" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Ltensorflow/class/Do_not_convert"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
     </package>
@@ -1018,46 +1018,46 @@
       <class name="DType" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes/DType -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self type_enum handle_data">
-          <new def="obj" class="Ltensorflow/dtypes/DType" />
-          <putfield class="LRoot" field="type_enum" fieldType="LRoot" ref="obj" value="type_enum" />
-          <putfield class="LRoot" field="handle_data" fieldType="LRoot" ref="obj" value="handle_data" />
-          <return value="obj" />
+          <new def="obj" class="Ltensorflow/dtypes/DType"/>
+          <putfield class="LRoot" field="type_enum" fieldType="LRoot" ref="obj" value="type_enum"/>
+          <putfield class="LRoot" field="handle_data" fieldType="LRoot" ref="obj" value="handle_data"/>
+          <return value="obj"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/framework">
       <class name="TensorSpec" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self shape dtype name">
-          <new def="spec" class="Ltensorflow/framework/TensorSpec" />
-          <putfield class="LRoot" field="shape" fieldType="LRoot" ref="spec" value="shape" />
-          <putfield class="LRoot" field="dtype" fieldType="LRoot" ref="spec" value="dtype" />
-          <return value="spec" />
+          <new def="spec" class="Ltensorflow/framework/TensorSpec"/>
+          <putfield class="LRoot" field="shape" fieldType="LRoot" ref="spec" value="shape"/>
+          <putfield class="LRoot" field="dtype" fieldType="LRoot" ref="spec" value="dtype"/>
+          <return value="spec"/>
         </method>
       </class>
       <class name="RaggedTensorSpec" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self shape dtype ragged_rank row_splits_dtype flat_values_spec">
-          <new def="spec" class="Ltensorflow/framework/RaggedTensorSpec" />
-          <putfield class="LRoot" field="shape" fieldType="LRoot" ref="spec" value="shape" />
-          <putfield class="LRoot" field="dtype" fieldType="LRoot" ref="spec" value="dtype" />
-          <return value="spec" />
+          <new def="spec" class="Ltensorflow/framework/RaggedTensorSpec"/>
+          <putfield class="LRoot" field="shape" fieldType="LRoot" ref="spec" value="shape"/>
+          <putfield class="LRoot" field="dtype" fieldType="LRoot" ref="spec" value="dtype"/>
+          <return value="spec"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/objects">
-      <class name="feature" allocatable="true" />
+      <class name="feature" allocatable="true"/>
     </package>
     <package name="keras/objects">
-      <class name="feature" allocatable="true" />
+      <class name="feature" allocatable="true"/>
     </package>
     <package name="tensorflow/python/framework/sparse_tensor">
       <class name="SparseTensor" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self indices values dense_shape">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
       <class name="sparse_eye" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self num_rows num_columns dtype name">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
     </package>
@@ -1066,156 +1066,156 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — returns a 1-D int32 tensor whose values are `input`'s runtime shape. Modeled as `<new>+<return>` (fresh allocation, not pass-through) so `getShapesFromShapeArgument` doesn't conflate the shape-tensor with `input`'s data
           structure (wala/ML#489). The result is a tensor whose rank is statically 1 but whose dim depends on `input`'s rank, which static analysis can't compute in general — left at ⊤ (no per-op generator wired up here). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input out_type name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sigmoid" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sigmoid. Modeled as `<new>+<return>` (fresh allocation, not pass-through) to match add/matmul and reflect actual TF semantics: sigmoid returns a new tensor with the same shape/dtype as its input, not the input object itself.
           Shape/dtype inference lives in the `Sigmoid` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="add" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/add -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <!-- Even though tf.add() isn't a tensor "generator," it can convert its non-tensor arguments to tensors. -->
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="multiply" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/multiply -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <!-- Even though tf.multiply() isn't a tensor "generator," it can convert its non-tensor arguments to tensors. -->
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reduce_mean" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_mean -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reduce_sum" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_sum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="argmax" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator reads the `output_type` argument when explicitly passed (e.g. `output_type=tf.int32`) and falls back to the TF default of `int64` otherwise; output shape
           is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for `axis`) is retained in `paramNames` for back-compat. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="argmin" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same direct `<new>+<return>` per wala/ML#380, same `output_type`-overrideable output dtype via the dedicated `Argmin` generator). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="equal" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Return a Tensor whose dtype is bool (see wala/ML#427). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="rsqrt" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/rsqrt. Modeled as `<new>+<return>` (fresh allocation, not `read_data` pass-through) so the factory can dispatch to the dedicated `Rsqrt` generator (wala/ML#449 Tier 2). Shape/dtype inference reads the `x` argument's PTS via
           `PassThroughUnaryTensorGenerator`. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="log_softmax" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/log_softmax. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 2. Note the parameter name `logits` (vs. `x` for the other Tier-2 unary math ops). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self logits axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="exp" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/exp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 2. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="tensordot" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self a b axes name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="trace" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="einsum" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self equation *inputs **kwargs">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="add_n" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/add_n -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self inputs name">
-          <getfield class="Llist" field="0" fieldType="LRoot" ref="inputs" def="x" />
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <getfield class="Llist" field="0" fieldType="LRoot" ref="inputs" def="x"/>
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="not_equal" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/not_equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="less" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/less — elementwise `x < y`. Direct `<new>+<return>` per wala/ML#380's preference (no `read_data` materialization chain). Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="less_equal" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/less_equal — elementwise `x <= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="greater" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater — elementwise `x > y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="greater_equal" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater_equal — elementwise `x >= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="top_k" allocatable="true">
@@ -1223,261 +1223,261 @@
           (in addition to the numeric `0`/`1` fields) handle the NamedTuple attribute-access pattern: `result.values` reads field `"values"` (a string property name) and the alias makes that resolve to the same `xx` alloc as field `0`. Without the alias, `result.values` reads an empty field-PTS and falls through
           to ⊤, even though `values, indices = result` (numeric destructuring) worked fine. See wala/ML#480 for the full diagnosis. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input k sorted name">
-          <new def="x" class="Ltuple" />
-          <new def="xx" class="Ltensorflow/python/framework/ops/Tensor" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="xx" />
-          <new def="yy" class="Ltensorflow/python/framework/ops/Tensor" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy" />
-          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="yy" />
-          <return value="x" />
+          <new def="x" class="Ltuple"/>
+          <new def="xx" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="xx"/>
+          <new def="yy" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy"/>
+          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="yy"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="abs" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/abs -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="reduce_all" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_all. Modeled as `<new>+<return>` so the factory dispatches to the dedicated `ReduceAll` generator (wala/ML#449 Tier 3); the `convert_to_tensor` chain preserved input's shape, but reductions collapse dims along `axis`.
           Shape logic lives in `ReduceMean`'s axis/keepdims handling, which `ReduceAll` reuses by inheritance; dtype is always `BOOL`. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reduce_prod" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_prod. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="tanh" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tanh -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="l2_normalize" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/l2_normalize -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self x axis epsilon name dim">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="reduce_max" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_max. Modeled as `<new>+<return>` for the same reason as `reduce_all`/`reduce_prod` — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reduce_min" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min. Mirrors reduce_max — same axis-collapse / keepdims shape semantics, dtype inherited from input. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="pow" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow. Element-wise binary op (`x ** y`); routed through `ElementWiseOperation` for broadcast shape and dtype-from-`x` (TF requires `x`/`y` to share dtype, so this is sound). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <!-- Tier-A pure-passthrough math ops (wala/ML#422). Each is shape and dtype passthrough on `x`. -->
       <class name="sqrt" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="log" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="negative" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sin" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="cos" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="floor" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="ceil" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sign" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <!-- Tier-A pure-passthrough math ops (continued, wala/ML#422). Each is shape and dtype passthrough on `x`. -->
       <class name="tan" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="asin" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="atan" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sinh" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="cosh" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="asinh" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="acosh" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="atanh" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="log1p" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="expm1" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="round" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reciprocal" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="softplus" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="softsign" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="square" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="erf" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="erfc" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <!-- Element-wise binary ops — routed through ElementWiseOperation for shape (broadcast) and dtype (unified). -->
       <class name="atan2" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self y x name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="maximum" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="minimum" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="reduce_logsumexp" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_logsumexp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (`reduce_logsumexp` requires float input at runtime; static analysis just preserves whatever the input
           dtype was). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="acos" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/acos -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
     </package>
@@ -1486,99 +1486,99 @@
       </class>
       <class name="Tensor" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="convert_to_tensor" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="ndarray" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/ndarray" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/ndarray"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/python/framework/constant_op">
       <class name="constant" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <return value="arg0" />
+          <return value="arg0"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/python/ops/array_ops">
       <class name="zeros" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="zeros_like" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="fill" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="reshape" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self tensor shape name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="one_hot" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/python/ops/linalg_ops">
       <class name="eye" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/python/ops/random_ops">
       <class name="uniform" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="gamma" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="normal" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="poisson" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="truncated_normal" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
@@ -1602,161 +1602,161 @@
     <package name="tensorflow/functions">
       <class name="from_nested_value_rowids" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self flat_values nested_value_rowids nested_nrows name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="matmul" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/matmul -->
         <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="self a b transpose_a transpose_b adjoint_a adjoint_b a_is_sparse b_is_sparse name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <new def="op" class="Ltensorflow/python/framework/ops/Operation" />
-          <putfield class="Ltensorflow/python/framework/ops/Tensor" field="op" fieldType="LRoot" ref="res" value="op" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <new def="op" class="Ltensorflow/python/framework/ops/Operation"/>
+          <putfield class="Ltensorflow/python/framework/ops/Tensor" field="op" fieldType="LRoot" ref="res" value="op"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="AdamOptimizer" allocatable="true">
         <method name="do" descriptor="()LRoot;">
-          <new def="opt" class="Lobject" />
-          <new def="minimize" class="Ltensorflow/functions/minimize" />
-          <putfield class="LRoot" field="minimize" fieldType="LRoot" ref="opt" value="minimize" />
-          <return value="opt" />
+          <new def="opt" class="Lobject"/>
+          <new def="minimize" class="Ltensorflow/functions/minimize"/>
+          <putfield class="LRoot" field="minimize" fieldType="LRoot" ref="opt" value="minimize"/>
+          <return value="opt"/>
         </method>
       </class>
       <class name="minimize" allocatable="true">
         <method name="do" descriptor="()LRoot;">
-          <new def="v" class="Lobject" />
-          <new def="f" class="Ltensorflow/functions/Runner" />
-          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <new def="f" class="Ltensorflow/functions/Runner"/>
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="shuffle_batch" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self data">
-          <return value="data" />
+          <return value="data"/>
         </method>
       </class>
       <class name="InteractiveSession" allocatable="true">
         <method name="do" descriptor="()LRoot;">
-          <new def="v" class="Lobject" />
-          <new def="f" class="Ltensorflow/functions/Runner" />
-          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <new def="f" class="Ltensorflow/functions/Runner"/>
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="v" value="f"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="Runner" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self graph feed_dict">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
       <class name="set_shape" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self shape">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
       <class name="reshape" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reshape -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input shape name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="ones" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self shape dtype name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="concat" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat. Direct `<new>+<return>` paired with the dedicated `Concat` generator (wala/ML#449 Tier 5): the generator computes the precise output shape by walking every entry in the `values` list, summing each input's dim along the resolved
           `axis`, and inheriting the rest of the shape from the first input. Pre-fix the XML routed through `convert_to_tensor` which inherited the first input's shape verbatim — sound on dtype but unsound on shape (missed the per-input axis-dim sum). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="Variable" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="13" paramNames="self initial_value trainable validate_shape caching_device name variable_def dtype import_scope constraint synchronization aggregation shape">
-          <new def="res" class="Ltensorflow/python/ops/variables/Variable" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/ops/variables/Variable"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="constant" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value dtype shape name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <!-- The `value` putfield was removed (wala/ML#451 reopen): binding the user-supplied value to the alloc's `value` field caused Hybridize's `Function.containsPrimitive` to traverse fields of the alloc and find a `ConstantKey<Integer>`/`ConstantKey<Float>` for `tf.constant(N)`-style calls, classifying
             parameters that receive the result (e.g. `recursive_fn(tf.constant(5))`'s `n`) as having primitive parameters. The Ariadne-side `Constant` generator reads dtype/shape directly from the call's `value` argument PTS via `getArgumentPointsToSet`, so dtype/shape inference is unaffected. The Java-side `TensorGenerator.getShapesFromShapeArgument`'s
             `CONSTANT_OP_CONSTANT` branch falls back to walking back to the allocating call's value arg when the field is empty. -->
-          <putfield class="Ltensorflow/python/framework/constant_op/constant" field="dtype" fieldType="LRoot" ref="res" value="dtype" />
-          <return value="res" />
+          <putfield class="Ltensorflow/python/framework/constant_op/constant" field="dtype" fieldType="LRoot" ref="res" value="dtype"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="zeros" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self shape dtype name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="SparseTensor" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor"/>
+          <return value="x"/>
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self indices values dense_shape">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x" />
-          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="indices" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="values" />
-          <putfield class="LRoot" field="dense_shape" fieldType="LRoot" ref="x" value="dense_shape" />
-          <return value="x" />
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x"/>
+          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="indices"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="values"/>
+          <putfield class="LRoot" field="dense_shape" fieldType="LRoot" ref="x" value="dense_shape"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="sparse_eye" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self num_rows num_columns dtype name">
-          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor" />
-          <new def="shape" class="Llist" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="shape" value="num_rows" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="shape" value="num_columns" />
-          <putfield class="LRoot" field="dense_shape" fieldType="LRoot" ref="x" value="shape" />
-          <new def="val_list" class="Llist" />
-          <constant name="one" type="float" value="1.0" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="val_list" value="one" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="val_list" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor"/>
+          <new def="shape" class="Llist"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="shape" value="num_rows"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="shape" value="num_columns"/>
+          <putfield class="LRoot" field="dense_shape" fieldType="LRoot" ref="x" value="shape"/>
+          <new def="val_list" class="Llist"/>
+          <constant name="one" type="float" value="1.0"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="val_list" value="one"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="val_list"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="sparse_add" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/add. Fresh allocation, not pass-through; shape / dtype inference lives in the `SparseAdd` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self a b threshold name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sparse_from_dense" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/from_dense. Fresh allocation, not pass-through; shape and dtype inheritance from the `tensor` argument lives in the `SparseFromDense` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="fill" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self dims value name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="broadcast_to" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — direct `<new>+<return>` per wala/ML#380's preferred pattern. Routes to `BroadcastTo` for shape-from-`shape` and dtype-from-`input` (wala/ML#449 Tier 7). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input shape name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sequence_mask" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self lengths maxlen dtype name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="stop_gradient" allocatable="true">
@@ -1764,443 +1764,443 @@
           inference reads the `input` argument's PTS via `StopGradient.shapesOfArg` / `dtypesOfArg`. The alloc class matches this `<class>`'s declared type (`Ltensorflow/functions/stop_gradient`) so the heap model can resolve the `<new>` to a concrete InstanceKey — a separate undeclared `Ltensorflow/python/ops/array_ops/stop_gradient`
           would silently fail PA propagation (see `project_synthetic_method_implicit_pts` note). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="zeros_like" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input dtype name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="embedding_lookup" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params ids max_norm name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="one_hot" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="8" paramNames="self indices depth on_value off_value axis dtype name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="convert_to_tensor" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value dtype dtype_hint name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="identity" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/identity. Modeled as `<new>+<return>` (fresh allocation, not pass-through) to match `sigmoid`/`softmax` and enable factory dispatch to the dedicated `Identity` generator (wala/ML#449 Tier 1). Shape/dtype inference reads the `input`
           argument's PTS via `Identity.shapesOfArg` / `dtypesOfArg`. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="where" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self condition x y name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="meshgrid" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
-          <new def="x" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="split" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
-          <new def="x" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="rank" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/rank. Modeled as `<new>+<return>` so the factory dispatches to the dedicated `Rank` generator (wala/ML#449 Tier 4); pre-fix routed through the `read_data → constant.do(z, 1)` materialization chain which gave ⊤ via `ReadDataFallback`.
           Output is intrinsic to the API (scalar int32 = number of dims of `input`); shape/dtype are hardcoded in the generator rather than read from any arg. Param shape `self input name` matches `sigmoid`. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="size" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/size. Modeled as `<new>+<return>` for the same reason as `rank` — wala/ML#449 Tier 4. Output is intrinsic (scalar = total number of elements). Default dtype is int32; the `out_type` arg can override to int64 (the analysis' DType
           lattice models int32, int64, and a handful of others — uint32/uint64 from the runtime API aren't in the lattice). The generator currently hardcodes int32 — extending to honor `out_type` is a clean follow-up if a fixture surfaces the need. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input out_type name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="tensor_scatter_nd_update" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a constant-materialized tensor. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor indices updates name">
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
-          <return value="x" />
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="range" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start limit delta dtype name">
-          <new def="x" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <constant name="p" type="int" value="1" /> <!-- FIXME: The type may actually depend on the arguments passed to `tf.range()`. It may not necessarily be `int`. -->
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="p" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <constant name="p" type="int" value="1"/> <!-- FIXME: The type may actually depend on the arguments passed to `tf.range()`. It may not necessarily be `int`. -->
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="p" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="Tensor" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self op value_index dtype name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="ndarray" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self op value_index dtype">
-          <new def="x" class="Ltensorflow/python/framework/ops/ndarray" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/ndarray"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="ragged_range" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self starts limits deltas dtype name row_splits_dtype">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="ragged_constant" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self pylist dtype ragged_rank inner_shape name row_splits_dtype">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <putfield class="Ltensorflow/python/ops/ragged/ragged_factory_ops/constant" field="value" fieldType="LRoot" ref="x" value="pylist" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <putfield class="Ltensorflow/python/ops/ragged/ragged_factory_ops/constant" field="value" fieldType="LRoot" ref="x" value="pylist"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="eye" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self num_rows num_columns batch_shape dtype name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="eigh" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/eigh -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
-          <new def="x" class="Ltuple" />
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="tensor" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Ltuple"/>
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="tensor" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="clip_by_global_norm" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self t_list clip_norm use_norm name">
-          <new def="x" class="Ltuple" />
-          <new def="y" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yy" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="y" value="yy" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yyy" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yyy" />
-          <return value="x" />
+          <new def="x" class="Ltuple"/>
+          <new def="y" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yy"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="y" value="yy"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yyy"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yyy"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="map_fn" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/map_fn -->
         <!-- TODO: Call `map_fn()` on each of the elements of `elems`. -->
         <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="self fn elems dtype parallel_iterations back_prop swap_memory infer_shape name fn_output_signature">
-          <return value="elems" />
+          <return value="elems"/>
         </method>
       </class>
       <class name="py_function" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Call `func` per https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function#returns -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self func inp Tout name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="uniform" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape minval maxval dtype seed name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="gamma" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape alpha beta dtype seed name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="normal" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape mean stddev dtype seed name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="poisson" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self shape lam dtype seed name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="gather_nd" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params indices batch_dims name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="truncated_normal" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape mean stddev dtype seed name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="shuffle" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/random/shuffle -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self value seed name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="sort" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sort -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values axis direction name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="values" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="values" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="Input" allocatable="true">
         <!-- Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). Mirrors `tensorflow/keras/layers/Input` below. -->
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_nested_row_lengths" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self flat_values nested_row_lengths name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_nested_row_splits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self flat_values nested_row_splits name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_row_lengths" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_lengths name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_row_limits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_limits name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_row_splits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_splits name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_row_starts" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_starts name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="from_value_rowids" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self values value_rowids nrows name validate">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="boolean_mask" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor mask axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="linspace" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/linspace — direct `<new>+<return>` per wala/ML#380's preferred pattern (was `read_data`). Routes to `Linspace` for shape-from-`num` and dtype-from-`start` (wala/ML#449 Tier 7). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start stop num name axis">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="stack" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack. Direct `<new>+<return>` paired with the dedicated `Stack` generator (wala/ML#449 Tier 5): the generator computes the precise output shape `t.shape[:axis] + (len(values),) + t.shape[axis:]` from the `values` list's PTS-derived
           length and the first element's shape, and inherits the dtype from the first element. Pre-fix the XML routed through `convert_to_tensor` which inherited the first element's shape verbatim — sound on dtype but unsound on shape (missed the new axis). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="unstack" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value num axis name">
-          <new def="x" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="dynamic_partition" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_partition -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data partitions num_partitions name">
-          <new def="x" class="Llist" />
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Llist"/>
+          <new def="z" class="Ltensorflow/functions/constant"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="dynamic_stitch" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_stitch -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self indices data name">
-          <getfield class="Llist" field="0" fieldType="LRoot" ref="data" def="x" />
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
-          <return value="y" />
+          <getfield class="Llist" field="0" fieldType="LRoot" ref="data" def="x"/>
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="cond" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cond -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self pred true_fn false_fn name">
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="true_fn" def="v" />
-          <return value="v" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="true_fn" def="v"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="while_loop" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/while_loop -->
         <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="self cond body loop_vars shape_invariants parallel_iterations back_prop swap_memory maximum_iterations name">
-          <return value="loop_vars" />
+          <return value="loop_vars"/>
         </method>
       </class>
       <class name="placeholder" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self dtype shape name">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="pass_through" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data features">
-          <return value="data" />
+          <return value="data"/>
         </method>
       </class>
       <class name="parse_single_example" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data features">
-          <return value="features" />
+          <return value="features"/>
         </method>
       </class>
       <class name="FixedLenFeature" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self dims type">
-          <new def="x" class="Ltensorflow/objects/feature" />
-          <new def="y" class="Ltensorflow/functions/set_shape" />
-          <putfield class="LRoot" field="set_shape" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/objects/feature"/>
+          <new def="y" class="Ltensorflow/functions/set_shape"/>
+          <putfield class="LRoot" field="set_shape" fieldType="LRoot" ref="x" value="y"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="conv2d" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x y">
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
       </class>
       <class name="conv3d" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x y">
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
       </class>
       <class name="softmax" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/softmax. Fresh allocation (not pass-through); shape / dtype inferred from `logits` by the `Softmax` generator. See the rationale on `sigmoid.do()` in this file. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self logits axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="sparse_softmax_cross_entropy_with_logits" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits -->
         <!-- Returns a fresh loss tensor of shape `logits.shape[:-1]` and dtype float32 — does NOT return `labels`. `SoftmaxCrossEntropy` computes the output type. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self labels logits name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="bias_add" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/bias_add -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value bias data_format name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="z" class="Ltensorflow/functions/convert_to_tensor"/>
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y"/>
+          <return value="y"/>
         </method>
       </class>
       <class name="relu" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu. Direct `<new>+<return>` intended to be paired with the dedicated `Relu` generator (full-passthrough on shape and dtype). CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.nn.relu` `pass_through` alias (kept
           because removing it risks breaking chained consumers; same integration shape as `cast`, see wala/ML#509). Tracked together with wala/ML#481. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="cast" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast. Direct `<new>+<return>` paired with the dedicated `Cast` generator: shape inherits from `x`; dtype intended to be the explicit `dtype` argument. CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.cast` `pass_through`
           alias (kept because removing it breaks chained consumers; see wala/ML#509), so the analyzer reports the input dtype today. Tracked by wala/ML#481. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x dtype name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="expand_dims" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims. Direct `<new>+<return>` paired with the dedicated `ExpandDims` generator: dtype inherits from `input`; shape is `input.shape` with a length-1 dim inserted at `axis` (currently emitted as ⊤ pending the axis-aware shape
           composer). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input axis name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="clip_by_value" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value. Direct `<new>+<return>` paired with the dedicated `ClipByValue` generator (full-passthrough on shape and dtype of `t`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self t clip_value_min clip_value_max name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="leaky_relu" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu. Direct `<new>+<return>` paired with the dedicated `LeakyRelu` generator (full-passthrough on shape and dtype of `features`). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self features alpha name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
@@ -2208,41 +2208,41 @@
       <class name="extract_patches" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self images sizes strides rates padding name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/estimator">
       <class name="Estimator" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self model">
-          <new def="x" class="Ltensorflow/estimator/train/train" />
-          <putfield class="LRoot" field="train" fieldType="LRoot" ref="self" value="x" />
-          <putfield class="LRoot" field="evaluate" fieldType="LRoot" ref="self" value="x" />
-          <putfield class="LRoot" field="$callback" fieldType="LRoot" ref="x" value="model" />
-          <return value="arg0" />
+          <new def="x" class="Ltensorflow/estimator/train/train"/>
+          <putfield class="LRoot" field="train" fieldType="LRoot" ref="self" value="x"/>
+          <putfield class="LRoot" field="evaluate" fieldType="LRoot" ref="self" value="x"/>
+          <putfield class="LRoot" field="$callback" fieldType="LRoot" ref="x" value="model"/>
+          <return value="arg0"/>
         </method>
       </class>
       <class name="EstimatorSpec" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — fresh allocation (not pass-through) so the resulting spec is a distinct object from any input. Each named parameter is stored as a field on the result, mirroring the namedtuple shape of the real API. Allocated as `Ltensorflow/estimator/EstimatorSpec`
           (the proper class type that's already registered for the estimator-namespace binding), not as a `Tensor` — `EstimatorSpec` is a namedtuple-like spec object, not a tensor. See wala/ML#429 (binding + body) and wala/ML#523 (allocation-class fix). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self mode predictions loss train_op eval_metric_ops export_outputs">
-          <new def="res" class="Ltensorflow/estimator/EstimatorSpec" />
-          <putfield class="LRoot" field="mode" fieldType="LRoot" ref="res" value="mode" />
-          <putfield class="LRoot" field="predictions" fieldType="LRoot" ref="res" value="predictions" />
-          <putfield class="LRoot" field="loss" fieldType="LRoot" ref="res" value="loss" />
-          <putfield class="LRoot" field="train_op" fieldType="LRoot" ref="res" value="train_op" />
-          <putfield class="LRoot" field="eval_metric_ops" fieldType="LRoot" ref="res" value="eval_metric_ops" />
-          <putfield class="LRoot" field="export_outputs" fieldType="LRoot" ref="res" value="export_outputs" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/estimator/EstimatorSpec"/>
+          <putfield class="LRoot" field="mode" fieldType="LRoot" ref="res" value="mode"/>
+          <putfield class="LRoot" field="predictions" fieldType="LRoot" ref="res" value="predictions"/>
+          <putfield class="LRoot" field="loss" fieldType="LRoot" ref="res" value="loss"/>
+          <putfield class="LRoot" field="train_op" fieldType="LRoot" ref="res" value="train_op"/>
+          <putfield class="LRoot" field="eval_metric_ops" fieldType="LRoot" ref="res" value="eval_metric_ops"/>
+          <putfield class="LRoot" field="export_outputs" fieldType="LRoot" ref="res" value="export_outputs"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="numpy_input_fn" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self x y batch_size shuffle">
-          <new def="xx" class="Lobject" />
-          <putfield class="LRoot" field="data" fieldType="LRoot" ref="xx" value="2" />
-          <putfield class="LRoot" field="labels" fieldType="LRoot" ref="xx" value="3" />
-          <return value="xx" />
+          <new def="xx" class="Lobject"/>
+          <putfield class="LRoot" field="data" fieldType="LRoot" ref="xx" value="2"/>
+          <putfield class="LRoot" field="labels" fieldType="LRoot" ref="xx" value="3"/>
+          <return value="xx"/>
         </method>
       </class>
     </package>
@@ -2251,38 +2251,38 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/preprocessing/image/ImageDataGenerator -->
         <method name="do" descriptor="()LRoot;" numArgs="24"
           paramNames="self featurewise_center samplewise_center featurewise_std_normalization samplewise_std_normalization zca_whitening zca_epsilon rotation_range width_shift_range height_shift_range brightness_range shear_range zoom_range channel_shift_range fill_mode cval horizontal_flip vertical_flip rescale preprocessing_function data_format validation_split interpolation_order dtype">
-          <new def="flow_from_directory" class="Ltensorflow/keras/preprocessing/image/flow_from_directory" />
-          <putfield class="LRoot" field="flow_from_directory" fieldType="LRoot" ref="arg0" value="flow_from_directory" />
-          <return value="arg0" />
+          <new def="flow_from_directory" class="Ltensorflow/keras/preprocessing/image/flow_from_directory"/>
+          <putfield class="LRoot" field="flow_from_directory" fieldType="LRoot" ref="arg0" value="flow_from_directory"/>
+          <return value="arg0"/>
         </method>
       </class>
       <class name="flow_from_directory" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/preprocessing/image/ImageDataGenerator#flow_from_directory -->
         <method name="do" descriptor="()LRoot;" numArgs="16" paramNames="self directory target_size color_mode classes class_mode batch_size shuffle seed save_to_dir save_prefix save_format follow_links subset interpolation keep_aspect_ratio">
-          <new def="x" class="Ltensorflow/keras/preprocessing/image/flow_from_directory" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/keras/preprocessing/image/flow_from_directory"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/keras/models/class">
       <class name="Model" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/keras/Model/attribute" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/keras/Model/attribute"/>
+          <return value="x"/>
         </method>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/models/Model -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self inputs outputs name">
-          <new def="res" class="Ltensorflow/keras/models/Model" />
-          <new def="x" class="Llist" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="res" numArgs="1" def="xx" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
+          <new def="res" class="Ltensorflow/keras/models/Model"/>
+          <new def="x" class="Llist"/>
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="res" numArgs="1" def="xx"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx"/>
           <!-- https://www.tensorflow.org/guide/keras/transfer_learning#freezing_layers_understanding_the_trainable_attribute -->
-          <putfield class="LRoot" field="trainable_weights" fieldType="LRoot" ref="res" value="x" />
-          <putfield class="LRoot" field="weights" fieldType="LRoot" ref="res" value="x" />
-          <putfield class="LRoot" field="non_trainable_weights" fieldType="LRoot" ref="res" value="x" />
-          <putfield class="LRoot" field="inputs" fieldType="LRoot" ref="res" value="inputs" />
-          <putfield class="LRoot" field="outputs" fieldType="LRoot" ref="res" value="outputs" />
-          <return value="res" />
+          <putfield class="LRoot" field="trainable_weights" fieldType="LRoot" ref="res" value="x"/>
+          <putfield class="LRoot" field="weights" fieldType="LRoot" ref="res" value="x"/>
+          <putfield class="LRoot" field="non_trainable_weights" fieldType="LRoot" ref="res" value="x"/>
+          <putfield class="LRoot" field="inputs" fieldType="LRoot" ref="res" value="inputs"/>
+          <putfield class="LRoot" field="outputs" fieldType="LRoot" ref="res" value="outputs"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
@@ -2296,14 +2296,14 @@
       <class name="Model" allocatable="true">
         <method name="__call__" descriptor="()LRoot;" numArgs="5" paramNames="func self inputs training mask">
           <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/Model#call -->
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
         <!-- FIXME: Workaround for https://github.com/wala/ML/issues/106. -->
         <method name="call" descriptor="()LRoot;" numArgs="5" paramNames="func self inputs training mask">
           <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/Model#call -->
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
       </class>
     </package>
@@ -2311,63 +2311,63 @@
       <class name="Dense" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/Dense -->
         <method name="do" descriptor="()LRoot;" numArgs="11" paramNames="self units activation use_bias kernel_initializer bias_initializer kernel_regularizer bias_regularizer activity_regularizer kernel_constraint bias_constraint">
-          <new def="res" class="Ltensorflow/keras/layers/Dense" />
-          <putfield class="LRoot" field="units" fieldType="LRoot" ref="res" value="units" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/keras/layers/Dense"/>
+          <putfield class="LRoot" field="units" fieldType="LRoot" ref="res" value="units"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="Flatten" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Flatten -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data_format input_shape">
-          <new def="res" class="Ltensorflow/keras/layers/Flatten" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/keras/layers/Flatten"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="Dropout" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dropout -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self rate noise_shape seed">
-          <new def="res" class="Ltensorflow/keras/layers/Dropout" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/keras/layers/Dropout"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/keras/layers">
       <class name="Input" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="Dense" allocatable="true">
         <!-- https://github.com/keras-team/keras/blob/07e13740fd181fc3ddec7d9a594d8a08666645f6/keras/layers/core/dense.py#L166-L240 -->
         <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
         <!-- FIXME: Workaround for https://github.com/wala/ML/issues/106. -->
         <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
           <!-- https://github.com/keras-team/keras/blob/07e13740fd181fc3ddec7d9a594d8a08666645f6/keras/layers/core/dense.py#L166-L240 -->
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
       </class>
       <class name="Flatten" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Flatten#__call__ -->
         <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
         <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
-          <new def="out" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
         </method>
       </class>
       <class name="Dropout" allocatable="true">
         <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
-          <return value="inputs" />
+          <return value="inputs"/>
         </method>
         <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
-          <return value="inputs" />
+          <return value="inputs"/>
         </method>
       </class>
     </package>
@@ -2375,8 +2375,8 @@
       <class name="RandomNormal" allocatable="true">
         <!-- Constructor for `tf.initializers.RandomNormal(mean, stddev, seed)`. Returns the callable initializer instance (modeled as `Ltensorflow/initializers/RandomNormal`, whose `__call__` is in the sibling package below). https://www.tensorflow.org/api_docs/python/tf/keras/initializers/RandomNormal -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self mean stddev seed">
-          <new def="res" class="Ltensorflow/initializers/RandomNormal" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/initializers/RandomNormal"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
@@ -2385,28 +2385,28 @@
         <!-- Instance `__call__` for `tf.initializers.RandomNormal`: `instance(shape, dtype=None)` returns a tensor of the requested shape drawn from the normal distribution. Allocates a `random_ops/normal` result so the factory dispatches to the existing `Normal`-family generator (via `RandomNormalCall`,
           which handles the extra `self` offset). https://www.tensorflow.org/api_docs/python/tf/keras/initializers/RandomNormal#__call__ -->
         <method name="__call__" descriptor="()LRoot;" numArgs="4" paramNames="func self shape dtype">
-          <new def="out" class="Ltensorflow/python/ops/random_ops/normal" />
-          <return value="out" />
+          <new def="out" class="Ltensorflow/python/ops/random_ops/normal"/>
+          <return value="out"/>
         </method>
       </class>
     </package>
     <package name="tensorflow">
       <!-- Sentinel class for `tf.newaxis` (aliased as `None` at runtime) so the allocation emitted during the tensorflow import (see the `new Ltensorflow/newaxis` above) registers as an allocatable type. `NdarraySubscriptOperation.classifyField` pattern-matches on `TensorFlowTypes.NEWAXIS` (= `Ltensorflow/newaxis`)
         to distinguish it from other non-constant subscript elements. -->
-      <class name="newaxis" allocatable="true" />
+      <class name="newaxis" allocatable="true"/>
       <class name="GradientTape" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self persistent watch_accessed_variables">
-          <new def="gradient" class="Ltensorflow/gradient" />
-          <putfield class="LRoot" field="gradient" fieldType="LRoot" ref="arg0" value="gradient" />
-          <return value="arg0" />
+          <new def="gradient" class="Ltensorflow/gradient"/>
+          <putfield class="LRoot" field="gradient" fieldType="LRoot" ref="arg0" value="gradient"/>
+          <return value="arg0"/>
         </method>
       </class>
       <class name="gradient" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient — fresh allocation (not pass-through of `sources`). The dedicated `Gradient` generator inherits shape and dtype from the `sources` argument. See wala/ML#430. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self target sources output_gradients unconnected_gradients">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
     </package>
@@ -2414,26 +2414,26 @@
       <class name="Dataset" allocatable="true">
         <!-- "read_dataset" means that this function reads a tensor iterable. -->
         <method name="read_dataset" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <return value="self" />
+          <return value="self"/>
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self variant_tensor">
-          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x" />
-          <return value="x" />
+          <call class="LRoot" name="read_dataset" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x"/>
+          <return value="x"/>
         </method>
         <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="it" class="Ltensorflow/data/iterator" />
-          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self" />
-          <return value="it" />
+          <new def="it" class="Ltensorflow/data/iterator"/>
+          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self"/>
+          <return value="it"/>
         </method>
       </class>
       <class name="iterator" allocatable="true">
         <method name="__next__" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <getfield class="LRoot" field="dataset" fieldType="LRoot" ref="self" def="ds" />
-          <return value="ds" />
+          <getfield class="LRoot" field="dataset" fieldType="LRoot" ref="self" def="ds"/>
+          <return value="ds"/>
         </method>
         <method name="next" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <getfield class="LRoot" field="dataset" fieldType="LRoot" ref="self" def="ds" />
-          <return value="ds" />
+          <getfield class="LRoot" field="dataset" fieldType="LRoot" ref="self" def="ds"/>
+          <return value="ds"/>
         </method>
       </class>
       <!-- Distinct type for `tf.data.TextLineDataset` so the factory dispatches to `TextLineDatasetGenerator` (intrinsic 0-D string element type). `do` allocates a fresh `TextLineDataset` per call site (parallel to the per-endpoint allocation pattern in `shuffle`/`batch`/etc.) so 1-CFA context preserves
@@ -2441,373 +2441,373 @@
         See wala/ML#452. -->
       <class name="TextLineDataset" allocatable="true">
         <method name="read_dataset" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <return value="self" />
+          <return value="self"/>
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self filenames compression_type">
-          <new def="x" class="Ltensorflow/data/TextLineDataset" />
+          <new def="x" class="Ltensorflow/data/TextLineDataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. See shuffle/do() for rationale. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
         <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="it" class="Ltensorflow/data/iterator" />
-          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self" />
-          <return value="it" />
+          <new def="it" class="Ltensorflow/data/iterator"/>
+          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self"/>
+          <return value="it"/>
         </method>
       </class>
       <class name="shuffle" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#shuffle -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self buffer_size seed reshuffle_each_iteration name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="batch" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#batch -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self batch_size drop_remainder num_parallel_calls deterministic name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="repeat" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#repeat -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self count name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. See shuffle/do() for rationale. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="prefetch" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#prefetch -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self buffer_size name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="with_options" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#with_options -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self options name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="take" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#take -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self count name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="map" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#map -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self map_func num_parallel_calls deterministic name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="filter" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#filter -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self predicate name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="concatenate" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#concatenate -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self predicate name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="reduce" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#reduce. `Dataset.reduce(initial_state, reduce_func, name)` returns the *final state* — a tensor (or structure of tensors) with the same shape/dtype as `initial_state`, not a Dataset. Pre-fix this was modeled as `read_data(arg0)`
           virtually on the receiver, but the `reduce` class doesn't define `read_data` — the call couldn't resolve and the result was ⊤. Pass `initial_state` through directly so its tensor type flows to the caller. See wala/ML#456. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self initial_state reduce_func name">
-          <return value="initial_state" />
+          <return value="initial_state"/>
         </method>
       </class>
       <class name="enumerate" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#enumerate -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self predicate name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
@@ -2816,361 +2816,361 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_tensors -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensors name">
           <!-- FIXME: We should encode the tensors argument here. See https://github.com/wala/ML/issues/164. -->
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="from_tensor_slices" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_tensor_slices -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensors name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="sample_from_datasets" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#sample_from_datasets -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self datasets weights seed stop_on_empty_dataset">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="list_files" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#list_files -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self file_pattern shuffle seed name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="choose_from_datasets" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#choose_from_datasets -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self datasets choice_dataset stop_on_empty_dataset">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="from_generator" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_generator -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self generator output_types output_shapes args output_signature name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="zip" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#zip -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self datasets name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
           <!-- FIXME: This could return tuples of tensors. See https://github.com/wala/ML/issues/165. -->
-          <return value="x" />
+          <return value="x"/>
         </method>
       </class>
       <class name="range" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#range -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start stop step output_type name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
       <class name="random" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#random -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self seed name">
-          <new def="x" class="Ltensorflow/data/Dataset" />
+          <new def="x" class="Ltensorflow/data/Dataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance*
             via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>`
             allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF
             setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
-          <new def="rd_shuffle" class="Ltensorflow/data/shuffle" />
-          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle" />
-          <new def="rd_batch" class="Ltensorflow/data/batch" />
-          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch" />
-          <new def="rd_repeat" class="Ltensorflow/data/repeat" />
-          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat" />
-          <new def="rd_prefetch" class="Ltensorflow/data/prefetch" />
-          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch" />
-          <new def="rd_with_options" class="Ltensorflow/data/with_options" />
-          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options" />
-          <new def="rd_take" class="Ltensorflow/data/take" />
-          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take" />
-          <new def="rd_map" class="Ltensorflow/data/map" />
-          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map" />
-          <new def="rd_filter" class="Ltensorflow/data/filter" />
-          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter" />
-          <new def="rd_concatenate" class="Ltensorflow/data/concatenate" />
-          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate" />
-          <new def="rd_reduce" class="Ltensorflow/data/reduce" />
-          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce" />
-          <new def="rd_enumerate" class="Ltensorflow/data/enumerate" />
-          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate" />
-          <return value="x" />
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/estimator/train">
       <class name="train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3">
-          <getfield class="LRoot" field="$callback" fieldType="LRoot" ref="arg0" def="xx" />
-          <getfield class="LRoot" field="data" fieldType="LRoot" ref="arg1" def="data" />
-          <getfield class="LRoot" field="labels" fieldType="LRoot" ref="arg1" def="labels" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="xx" arg1="data" arg2="labels" numArgs="3" def="v" />
-          <return value="v" />
+          <getfield class="LRoot" field="$callback" fieldType="LRoot" ref="arg0" def="xx"/>
+          <getfield class="LRoot" field="data" fieldType="LRoot" ref="arg1" def="data"/>
+          <getfield class="LRoot" field="labels" fieldType="LRoot" ref="arg1" def="labels"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="xx" arg1="data" arg2="labels" numArgs="3" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/distribute">
       <class name="MirroredStrategy" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self devices cross_device_ops">
-          <new def="x" class="Ltensorflow/distribute/run/run" />
-          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
-          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
-          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
-          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <return value="arg0" />
+          <new def="x" class="Ltensorflow/distribute/run/run"/>
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x"/>
+          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x"/>
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <return value="arg0"/>
         </method>
       </class>
       <class name="TPUStrategy" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self devices cross_device_ops">
-          <new def="x" class="Ltensorflow/distribute/run/run" />
-          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
-          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
-          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
-          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <return value="arg0" />
+          <new def="x" class="Ltensorflow/distribute/run/run"/>
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x"/>
+          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x"/>
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <return value="arg0"/>
         </method>
       </class>
       <class name="OneDeviceStrategy" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self device">
-          <new def="x" class="Ltensorflow/distribute/run/run" />
-          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
-          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
-          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
-          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
-          <return value="arg0" />
+          <new def="x" class="Ltensorflow/distribute/run/run"/>
+          <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x"/>
+          <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x"/>
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <return value="arg0"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/distribute/run">
       <class name="run" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3">
-          <getfield class="LRoot" field="0" fieldType="LRoot" ref="arg2" def="x" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="x" numArgs="2" def="v" />
-          <return value="v" />
+          <getfield class="LRoot" field="0" fieldType="LRoot" ref="arg2" def="x"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="x" numArgs="2" def="v"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="experimental_run_v2" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3">
-          <getfield class="LRoot" field="0" fieldType="LRoot" ref="arg2" def="x" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="x" numArgs="2" def="v" />
-          <return value="v" />
+          <getfield class="LRoot" field="0" fieldType="LRoot" ref="arg2" def="x"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="x" numArgs="2" def="v"/>
+          <return value="v"/>
         </method>
       </class>
       <!-- https://www.tensorflow.org/api_docs/python/tf/distribute/Strategy#distribute_datasets_from_function — at runtime `strategy.distribute_datasets_from_function(dataset_fn)` invokes `dataset_fn(input_context)` once per replica and wraps the results in a distributed-dataset object. This synthetic-method
@@ -3179,15 +3179,15 @@
         the wrapper as an opaque object, not as a typed dataset. The deprecated alias `experimental_distribute_datasets_from_function` is wired to the same class on each strategy. -->
       <class name="distribute_datasets_from_function" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self dataset_fn">
-          <new def="ctx" class="Ltensorflow/distribute/InputContext" />
-          <constant name="num_pipelines" type="int" value="1" />
-          <constant name="pipeline_id" type="int" value="0" />
-          <putfield class="LRoot" field="num_input_pipelines" fieldType="LRoot" ref="ctx" value="num_pipelines" />
-          <putfield class="LRoot" field="input_pipeline_id" fieldType="LRoot" ref="ctx" value="pipeline_id" />
-          <new def="batch_fn" class="Ltensorflow/distribute/InputContext/get_per_replica_batch_size" />
-          <putfield class="LRoot" field="get_per_replica_batch_size" fieldType="LRoot" ref="ctx" value="batch_fn" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="ctx" numArgs="2" def="v" />
-          <return value="v" />
+          <new def="ctx" class="Ltensorflow/distribute/InputContext"/>
+          <constant name="num_pipelines" type="int" value="1"/>
+          <constant name="pipeline_id" type="int" value="0"/>
+          <putfield class="LRoot" field="num_input_pipelines" fieldType="LRoot" ref="ctx" value="num_pipelines"/>
+          <putfield class="LRoot" field="input_pipeline_id" fieldType="LRoot" ref="ctx" value="pipeline_id"/>
+          <new def="batch_fn" class="Ltensorflow/distribute/InputContext/get_per_replica_batch_size"/>
+          <putfield class="LRoot" field="get_per_replica_batch_size" fieldType="LRoot" ref="ctx" value="batch_fn"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="ctx" numArgs="2" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
@@ -3204,35 +3204,35 @@
         <!-- `input_context.get_per_replica_batch_size(global_batch_size)` returns `global_batch_size / num_replicas` at runtime. This synthetic body returns `global_batch_size` unchanged &mdash; an upper bound, used because we don't track replica counts statically and the caller's typing on the returned
           int doesn't depend on the precise division (only that it's an int). -->
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self global_batch_size">
-          <return value="arg1" />
+          <return value="arg1"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/app">
       <class name="run" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self main argv">
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="" def="v" />
-          <return value="v" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/examples/tutorials/mnist">
       <class name="read_data_sets" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="x"/>
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self train_dir fake_data one_hot dtype reshape validation_size seed source_url">
-          <new def="test" class="Ldict" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x" />
-          <putfield class="LRoot" field="images" fieldType="LRoot" ref="test" value="x" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="y" />
-          <new def="training" class="Ldict" />
-          <putfield class="LRoot" field="images" fieldType="LRoot" ref="training" value="y" />
-          <new def="data" class="Ldict" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="data" value="test" />
-          <putfield class="LRoot" field="train" fieldType="LRoot" ref="data" value="training" />
-          <return value="data" />
+          <new def="test" class="Ldict"/>
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x"/>
+          <putfield class="LRoot" field="images" fieldType="LRoot" ref="test" value="x"/>
+          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="y"/>
+          <new def="training" class="Ldict"/>
+          <putfield class="LRoot" field="images" fieldType="LRoot" ref="training" value="y"/>
+          <new def="data" class="Ldict"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="data" value="test"/>
+          <putfield class="LRoot" field="train" fieldType="LRoot" ref="data" value="training"/>
+          <return value="data"/>
         </method>
       </class>
       <class name="input_data" allocatable="true">
@@ -3243,27 +3243,27 @@
     <package name="tensorflow/examples/tutorials">
       <class name="mnist" allocatable="true">
         <method name="import" static="true" descriptor="()Ltensorflow/examples/tutorials/mnist;">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist" />
-          <call name="__init__" class="Ltensorflow/examples/tutorials/mnist" descriptor="()V" type="virtual" arg0="x" numArgs="1" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist"/>
+          <call name="__init__" class="Ltensorflow/examples/tutorials/mnist" descriptor="()V" type="virtual" arg0="x" numArgs="1"/>
+          <return value="x"/>
         </method>
         <method name="__init__" descriptor="()V">
-          <new def="x" class="Ltensorflow/examples/tutorials/mnist/input_data" />
-          <new def="y" class="Ltensorflow/examples/tutorials/mnist/read_data_sets" />
-          <putfield class="Ltensorflow/examples/tutorials/mnist" field="input_data" fieldType="LRoot" ref="arg0" value="x" />
-          <putfield class="Ltensorflow/examples/tutorials/mnist/input_data" field="read_data_sets" fieldType="LRoot" ref="x" value="y" />
+          <new def="x" class="Ltensorflow/examples/tutorials/mnist/input_data"/>
+          <new def="y" class="Ltensorflow/examples/tutorials/mnist/read_data_sets"/>
+          <putfield class="Ltensorflow/examples/tutorials/mnist" field="input_data" fieldType="LRoot" ref="arg0" value="x"/>
+          <putfield class="Ltensorflow/examples/tutorials/mnist/input_data" field="read_data_sets" fieldType="LRoot" ref="x" value="y"/>
         </method>
       </class>
     </package>
     <package name="tensorflow/functions">
       <class name="Graph" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Graph" />
-          <new def="get_ops" class="Ltensorflow/python/framework/ops/Graph_get_operations" />
-          <putfield class="Ltensorflow/python/framework/ops/Graph" field="get_operations" fieldType="LRoot" ref="x" value="get_ops" />
-          <new def="as_def" class="Ltensorflow/python/framework/ops/Graph_as_default" />
-          <putfield class="Ltensorflow/python/framework/ops/Graph" field="as_default" fieldType="LRoot" ref="x" value="as_def" />
-          <return value="x" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Graph"/>
+          <new def="get_ops" class="Ltensorflow/python/framework/ops/Graph_get_operations"/>
+          <putfield class="Ltensorflow/python/framework/ops/Graph" field="get_operations" fieldType="LRoot" ref="x" value="get_ops"/>
+          <new def="as_def" class="Ltensorflow/python/framework/ops/Graph_as_default"/>
+          <putfield class="Ltensorflow/python/framework/ops/Graph" field="as_default" fieldType="LRoot" ref="x" value="as_def"/>
+          <return value="x"/>
         </method>
       </class>
     </package>
@@ -3272,29 +3272,29 @@
       </class>
       <class name="Graph_get_operations" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1">
-          <new def="ops" class="Llist" />
-          <new def="const_func" class="Ltensorflow/functions/constant" />
-          <constant name="val" type="float" value="0.0" />
-          <constant name="dtype" type="string" value="float" />
-          <constant name="shape" type="int" value="0" />
-          <constant name="name" type="string" value="dummy" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="const_func" arg1="val" arg2="dtype" arg3="shape" arg4="name" numArgs="5" def="c" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ops" value="c" />
-          <return value="ops" />
+          <new def="ops" class="Llist"/>
+          <new def="const_func" class="Ltensorflow/functions/constant"/>
+          <constant name="val" type="float" value="0.0"/>
+          <constant name="dtype" type="string" value="float"/>
+          <constant name="shape" type="int" value="0"/>
+          <constant name="name" type="string" value="dummy"/>
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="const_func" arg1="val" arg2="dtype" arg3="shape" arg4="name" numArgs="5" def="c"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ops" value="c"/>
+          <return value="ops"/>
         </method>
       </class>
       <class name="Graph_as_default" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1">
-          <new def="cm" class="Ltensorflow/python/framework/ops/GraphContextManager" />
-          <return value="cm" />
+          <new def="cm" class="Ltensorflow/python/framework/ops/GraphContextManager"/>
+          <return value="cm"/>
         </method>
       </class>
       <class name="GraphContextManager" allocatable="true">
         <method name="__begin__" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <return value="self" />
+          <return value="self"/>
         </method>
         <method name="__end__" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
     </package>
@@ -3302,65 +3302,65 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/mnist/load_data -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/mnist/x_train" />
+          <new def="ret" class="Ltensorflow/keras/datasets/mnist/x_train"/>
           <!-- Populate ndarray method fields so `x_train.astype(...)` / `x_train.reshape(...)` calls resolve via class-type dispatch (mirrors the Dataset-method pattern). -->
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/mnist/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/mnist/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/mnist/x_train" />
-          <call class="Ltensorflow/keras/datasets/mnist/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/mnist/y_train" />
-          <call class="Ltensorflow/keras/datasets/mnist/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/mnist/x_test" />
-          <call class="Ltensorflow/keras/datasets/mnist/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/mnist/y_test" />
-          <call class="Ltensorflow/keras/datasets/mnist/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/mnist/x_train"/>
+          <call class="Ltensorflow/keras/datasets/mnist/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/mnist/y_train"/>
+          <call class="Ltensorflow/keras/datasets/mnist/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/mnist/x_test"/>
+          <call class="Ltensorflow/keras/datasets/mnist/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/mnist/y_test"/>
+          <call class="Ltensorflow/keras/datasets/mnist/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3368,65 +3368,65 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/cifar10/load_data -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/x_train" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/x_train"/>
           <!-- Populate ndarray method fields so `x_train.astype(...)` / `x_train.reshape(...)` calls resolve via class-type dispatch (mirrors the mnist/Dataset-method pattern). -->
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/cifar10/x_train" />
-          <call class="Ltensorflow/keras/datasets/cifar10/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/cifar10/y_train" />
-          <call class="Ltensorflow/keras/datasets/cifar10/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/cifar10/x_test" />
-          <call class="Ltensorflow/keras/datasets/cifar10/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/cifar10/y_test" />
-          <call class="Ltensorflow/keras/datasets/cifar10/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/cifar10/x_train"/>
+          <call class="Ltensorflow/keras/datasets/cifar10/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/cifar10/y_train"/>
+          <call class="Ltensorflow/keras/datasets/cifar10/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/cifar10/x_test"/>
+          <call class="Ltensorflow/keras/datasets/cifar10/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/cifar10/y_test"/>
+          <call class="Ltensorflow/keras/datasets/cifar10/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3434,64 +3434,64 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb/load_data -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/imdb/x_train" />
-          <call class="Ltensorflow/keras/datasets/imdb/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/imdb/y_train" />
-          <call class="Ltensorflow/keras/datasets/imdb/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/imdb/x_test" />
-          <call class="Ltensorflow/keras/datasets/imdb/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/imdb/y_test" />
-          <call class="Ltensorflow/keras/datasets/imdb/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/imdb/x_train"/>
+          <call class="Ltensorflow/keras/datasets/imdb/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/imdb/y_train"/>
+          <call class="Ltensorflow/keras/datasets/imdb/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/imdb/x_test"/>
+          <call class="Ltensorflow/keras/datasets/imdb/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/imdb/y_test"/>
+          <call class="Ltensorflow/keras/datasets/imdb/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3499,64 +3499,64 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/fashion_mnist/load_data — same shapes and dtype as `mnist.load_data()`. -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_train" />
-          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_train" />
-          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_test" />
-          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_test" />
-          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_train"/>
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_train"/>
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_test"/>
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_test"/>
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3565,64 +3565,64 @@
         the analyzer doesn't yet capture, see wala/ML#487. -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/cifar100/x_train" />
-          <call class="Ltensorflow/keras/datasets/cifar100/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/cifar100/y_train" />
-          <call class="Ltensorflow/keras/datasets/cifar100/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/cifar100/x_test" />
-          <call class="Ltensorflow/keras/datasets/cifar100/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/cifar100/y_test" />
-          <call class="Ltensorflow/keras/datasets/cifar100/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/cifar100/x_train"/>
+          <call class="Ltensorflow/keras/datasets/cifar100/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/cifar100/y_train"/>
+          <call class="Ltensorflow/keras/datasets/cifar100/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/cifar100/x_test"/>
+          <call class="Ltensorflow/keras/datasets/cifar100/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/cifar100/y_test"/>
+          <call class="Ltensorflow/keras/datasets/cifar100/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3630,64 +3630,64 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/reuters/load_data — newswire-classification corpus, variable-length integer-encoded sequences. -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/reuters/x_train" />
-          <call class="Ltensorflow/keras/datasets/reuters/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/reuters/y_train" />
-          <call class="Ltensorflow/keras/datasets/reuters/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/reuters/x_test" />
-          <call class="Ltensorflow/keras/datasets/reuters/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/reuters/y_test" />
-          <call class="Ltensorflow/keras/datasets/reuters/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/reuters/x_train"/>
+          <call class="Ltensorflow/keras/datasets/reuters/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/reuters/y_train"/>
+          <call class="Ltensorflow/keras/datasets/reuters/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/reuters/x_test"/>
+          <call class="Ltensorflow/keras/datasets/reuters/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/reuters/y_test"/>
+          <call class="Ltensorflow/keras/datasets/reuters/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3695,64 +3695,64 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/boston_housing/load_data — small numeric regression dataset, all float64. -->
       <class name="x_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_train" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_train" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_train"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="x_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="y_test" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_test" />
-          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
-          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
-          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
-          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
-          <return value="ret" />
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_test"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
         </method>
       </class>
       <class name="load_data" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="x_train_fn" class="Ltensorflow/keras/datasets/boston_housing/x_train" />
-          <call class="Ltensorflow/keras/datasets/boston_housing/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
-          <new def="y_train_fn" class="Ltensorflow/keras/datasets/boston_housing/y_train" />
-          <call class="Ltensorflow/keras/datasets/boston_housing/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
-          <new def="train" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
-          <new def="x_test_fn" class="Ltensorflow/keras/datasets/boston_housing/x_test" />
-          <call class="Ltensorflow/keras/datasets/boston_housing/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
-          <new def="y_test_fn" class="Ltensorflow/keras/datasets/boston_housing/y_test" />
-          <call class="Ltensorflow/keras/datasets/boston_housing/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
-          <new def="test" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
-          <new def="ret" class="Ltuple" />
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
-          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
-          <return value="ret" />
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/boston_housing/x_train"/>
+          <call class="Ltensorflow/keras/datasets/boston_housing/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1"/>
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/boston_housing/y_train"/>
+          <call class="Ltensorflow/keras/datasets/boston_housing/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1"/>
+          <new def="train" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train"/>
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/boston_housing/x_test"/>
+          <call class="Ltensorflow/keras/datasets/boston_housing/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1"/>
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/boston_housing/y_test"/>
+          <call class="Ltensorflow/keras/datasets/boston_housing/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1"/>
+          <new def="test" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test"/>
+          <return value="ret"/>
         </method>
       </class>
     </package>
@@ -3760,8 +3760,8 @@
       <!-- https://www.tensorflow.org/api_docs/python/tf/strings/as_string. Shape passthrough on `input`; output dtype is fixed to `string`. -->
       <class name="as_string" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="8" paramNames="self input precision scientific shortest width fill name">
-          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="res" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.test/data/issue127.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127.xml
@@ -5,24 +5,24 @@
   <classloader name="PythonLoader">
     <class name="issue127" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127;">
-        <new def="x" class="Lissue127" />
-        <new def="c_class" class="Lissue127/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127"/>
+        <new def="c_class" class="Lissue127/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127/class">
       <class name="C" allocatable="true">
         <!-- The constructor -->
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="c" class="Lissue127/C" />
-          <return value="c" />
+          <new def="c" class="Lissue127/C"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127/C" allocatable="true">
       <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self x">
-        <return value="x" />
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127b.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127b.xml
@@ -4,23 +4,23 @@
   <classloader name="PythonLoader">
     <class name="issue127b" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127b;">
-        <new def="x" class="Lissue127b" />
-        <new def="c_class" class="Lissue127b/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127b"/>
+        <new def="c_class" class="Lissue127b/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127b/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="c" class="Lissue127b/C" />
-          <return value="c" />
+          <new def="c" class="Lissue127b/C"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127b/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="2" paramNames="self x">
-        <return value="x" />
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127c.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127c.xml
@@ -4,23 +4,23 @@
   <classloader name="PythonLoader">
     <class name="issue127c" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127c;">
-        <new def="x" class="Lissue127c" />
-        <new def="c_class" class="Lissue127c/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127c"/>
+        <new def="c_class" class="Lissue127c/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127c/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="c" class="Lissue127c/C" />
-          <return value="c" />
+          <new def="c" class="Lissue127c/C"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127c/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="2" paramNames="self x">
-        <return value="self" />
+        <return value="self"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127d.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127d.xml
@@ -4,23 +4,23 @@
   <classloader name="PythonLoader">
     <class name="issue127d" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127d;">
-        <new def="x" class="Lissue127d" />
-        <new def="c_class" class="Lissue127d/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127d"/>
+        <new def="c_class" class="Lissue127d/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127d/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="c" class="Lissue127d/C" />
-          <return value="c" />
+          <new def="c" class="Lissue127d/C"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127d/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="2" paramNames="self x">
-        <return value="self" />
+        <return value="self"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127e.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127e.xml
@@ -4,25 +4,25 @@
   <classloader name="PythonLoader">
     <class name="issue127e" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127e;">
-        <new def="x" class="Lissue127e" />
-        <new def="c_class" class="Lissue127e/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127e"/>
+        <new def="c_class" class="Lissue127e/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127e/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val">
-          <new def="c" class="Lissue127e/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val" />
-          <return value="c" />
+          <new def="c" class="Lissue127e/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127e/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="2" paramNames="func self">
-        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self" />
-        <return value="res" />
+        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
+        <return value="res"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127f.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127f.xml
@@ -4,26 +4,26 @@
   <classloader name="PythonLoader">
     <class name="issue127f" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127f;">
-        <new def="x" class="Lissue127f" />
-        <new def="c_class" class="Lissue127f/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127f"/>
+        <new def="c_class" class="Lissue127f/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127f/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val1">
-          <new def="c" class="Lissue127f/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1" />
-          <return value="c" />
+          <new def="c" class="Lissue127f/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127f/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="3" paramNames="func self val2">
-        <getfield def="f_val" class="LRoot" field="f" fieldType="LRoot" ref="self" />
+        <getfield def="f_val" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
         <!-- We return val2 but the test will also inspect f_val via pointer analysis -->
-        <return value="val2" />
+        <return value="val2"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127g.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127g.xml
@@ -4,23 +4,23 @@
   <classloader name="PythonLoader">
     <class name="issue127g" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127g;">
-        <new def="x" class="Lissue127g" />
-        <new def="c_class" class="Lissue127g/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127g"/>
+        <new def="c_class" class="Lissue127g/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127g/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="func">
-          <new def="c" class="Lissue127g/C" />
-          <return value="c" />
+          <new def="c" class="Lissue127g/C"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127g/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="3" paramNames="func self val">
-        <return value="val" />
+        <return value="val"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127h.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127h.xml
@@ -4,25 +4,25 @@
   <classloader name="PythonLoader">
     <class name="issue127h" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127h;">
-        <new def="x" class="Lissue127h" />
-        <new def="c_class" class="Lissue127h/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127h"/>
+        <new def="c_class" class="Lissue127h/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127h/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val1">
-          <new def="c" class="Lissue127h/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1" />
-          <return value="c" />
+          <new def="c" class="Lissue127h/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127h/C" allocatable="true">
       <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self val2">
-        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self" />
-        <return value="val2" />
+        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
+        <return value="val2"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127i.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127i.xml
@@ -4,25 +4,25 @@
   <classloader name="PythonLoader">
     <class name="issue127i" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127i;">
-        <new def="x" class="Lissue127i" />
-        <new def="c_class" class="Lissue127i/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127i"/>
+        <new def="c_class" class="Lissue127i/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127i/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val1">
-          <new def="c" class="Lissue127i/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1" />
-          <return value="c" />
+          <new def="c" class="Lissue127i/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127i/C" allocatable="true">
       <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self val2">
-        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self" />
-        <return value="val2" />
+        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
+        <return value="val2"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127j.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127j.xml
@@ -4,25 +4,25 @@
   <classloader name="PythonLoader">
     <class name="issue127j" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127j;">
-        <new def="x" class="Lissue127j" />
-        <new def="c_class" class="Lissue127j/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127j"/>
+        <new def="c_class" class="Lissue127j/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127j/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val1">
-          <new def="c" class="Lissue127j/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1" />
-          <return value="c" />
+          <new def="c" class="Lissue127j/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127j/C" allocatable="true">
       <method name="foo" descriptor="()LRoot;" numArgs="3" paramNames="func self val2">
-        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self" />
-        <return value="val2" />
+        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
+        <return value="val2"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python.test/data/issue127k.xml
+++ b/com.ibm.wala.cast.python.test/data/issue127k.xml
@@ -4,25 +4,25 @@
   <classloader name="PythonLoader">
     <class name="issue127k" allocatable="true">
       <method name="import" static="true" descriptor="()Lissue127k;">
-        <new def="x" class="Lissue127k" />
-        <new def="c_class" class="Lissue127k/class/C" />
-        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class" />
-        <return value="x" />
+        <new def="x" class="Lissue127k"/>
+        <new def="c_class" class="Lissue127k/class/C"/>
+        <putfield class="LRoot" field="C" fieldType="LRoot" ref="x" value="c_class"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="issue127k/class">
       <class name="C" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="func val1">
-          <new def="c" class="Lissue127k/C" />
-          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1" />
-          <return value="c" />
+          <new def="c" class="Lissue127k/C"/>
+          <putfield class="LRoot" field="f" fieldType="LRoot" ref="c" value="val1"/>
+          <return value="c"/>
         </method>
       </class>
     </package>
     <class name="issue127k/C" allocatable="true">
       <method name="__call__" descriptor="()LRoot;" numArgs="2" paramNames="func self">
-        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self" />
-        <return value="res" />
+        <getfield def="res" class="LRoot" field="f" fieldType="LRoot" ref="self"/>
+        <return value="res"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python/data/abseil.xml
+++ b/com.ibm.wala.cast.python/data/abseil.xml
@@ -5,45 +5,45 @@
   <classloader name="PythonLoader">
     <class name="absl" allocatable="true">
       <method name="import" static="true" descriptor="()Labsl;">
-        <new def="x" class="Labsl" />
+        <new def="x" class="Labsl"/>
         <!-- https://abseil.io/docs/python/guides/app -->
-        <new def="app" class="Lobject" />
-        <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app" />
-        <new def="run" class="Labsl/run" />
-        <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run" />
+        <new def="app" class="Lobject"/>
+        <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app"/>
+        <new def="run" class="Labsl/run"/>
+        <putfield class="LRoot" field="run" fieldType="LRoot" ref="app" value="run"/>
         <!-- https://abseil.io/docs/python/guides/testing -->
-        <new def="testing" class="Lobject" />
-        <putfield class="LRoot" field="testing" fieldType="LRoot" ref="x" value="testing" />
-        <new def="parameterized" class="Lobject" />
-        <putfield class="LRoot" field="parameterized" fieldType="LRoot" ref="testing" value="parameterized" />
-        <new def="named_parameters" class="Labsl/class/named_parameters" />
-        <putfield class="LRoot" field="named_parameters" fieldType="LRoot" ref="parameterized" value="named_parameters" />
-        <return value="x" />
+        <new def="testing" class="Lobject"/>
+        <putfield class="LRoot" field="testing" fieldType="LRoot" ref="x" value="testing"/>
+        <new def="parameterized" class="Lobject"/>
+        <putfield class="LRoot" field="parameterized" fieldType="LRoot" ref="testing" value="parameterized"/>
+        <new def="named_parameters" class="Labsl/class/named_parameters"/>
+        <putfield class="LRoot" field="named_parameters" fieldType="LRoot" ref="parameterized" value="named_parameters"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="absl">
       <class name="run" allocatable="true">
         <!-- https://abseil.io/docs/python/guides/app -->
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self func">
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="func" def="v" />
-          <return value="v" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="func" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
     <package name="absl/class">
       <class name="NamedParameters" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="named_parameters" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Labsl/class/NamedParameters" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Labsl/class/NamedParameters"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/click.xml
+++ b/com.ibm.wala.cast.python/data/click.xml
@@ -5,48 +5,48 @@
   <classloader name="PythonLoader">
     <class name="click" allocatable="true">
       <method name="import" static="true" descriptor="()Lclick;">
-        <new def="x" class="Lclick" />
+        <new def="x" class="Lclick"/>
         <!-- https://click.palletsprojects.com/en/8.1.x/api/#click.command -->
-        <new def="command" class="Lclick/class/command" />
-        <putfield class="LRoot" field="command" fieldType="LRoot" ref="x" value="command" />
+        <new def="command" class="Lclick/class/command"/>
+        <putfield class="LRoot" field="command" fieldType="LRoot" ref="x" value="command"/>
         <!-- https://click.palletsprojects.com/en/8.1.x/api/#click.option -->
-        <new def="option" class="Lclick/class/option" />
-        <putfield class="LRoot" field="option" fieldType="LRoot" ref="x" value="option" />
-        <return value="x" />
+        <new def="option" class="Lclick/class/option"/>
+        <putfield class="LRoot" field="option" fieldType="LRoot" ref="x" value="option"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="click/class">
       <class name="Command" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self func">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="func" value="self" />
-          <return value="func" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="func" value="self"/>
+          <return value="func"/>
         </method>
       </class>
       <class name="command" allocatable="true">
         <!-- https://click.palletsprojects.com/en/8.1.x/api/#click.command -->
         <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <new def="closure" class="Lclick/class/Command" />
-          <putfield class="LRoot" field="func" fieldType="LRoot" ref="closure" value="self" />
-          <return value="closure" />
+          <new def="closure" class="Lclick/class/Command"/>
+          <putfield class="LRoot" field="func" fieldType="LRoot" ref="closure" value="self"/>
+          <return value="closure"/>
         </method>
       </class>
       <class name="Option" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self func">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="func" value="self" />
-          <return value="func" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="func" value="self"/>
+          <return value="func"/>
         </method>
       </class>
       <class name="option" allocatable="true">
         <!-- https://click.palletsprojects.com/en/8.1.x/api/#click.option -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self param_decls type default show_default help">
-          <new def="closure" class="Lclick/class/Option" />
-          <putfield class="LRoot" field="func" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="param_decls" fieldType="LRoot" ref="closure" value="param_decls" />
-          <putfield class="LRoot" field="type" fieldType="LRoot" ref="closure" value="type" />
-          <putfield class="LRoot" field="default" fieldType="LRoot" ref="closure" value="default" />
-          <putfield class="LRoot" field="show_default" fieldType="LRoot" ref="closure" value="show_default" />
-          <putfield class="LRoot" field="help" fieldType="LRoot" ref="closure" value="help" />
-          <return value="closure" />
+          <new def="closure" class="Lclick/class/Option"/>
+          <putfield class="LRoot" field="func" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="param_decls" fieldType="LRoot" ref="closure" value="param_decls"/>
+          <putfield class="LRoot" field="type" fieldType="LRoot" ref="closure" value="type"/>
+          <putfield class="LRoot" field="default" fieldType="LRoot" ref="closure" value="default"/>
+          <putfield class="LRoot" field="show_default" fieldType="LRoot" ref="closure" value="show_default"/>
+          <putfield class="LRoot" field="help" fieldType="LRoot" ref="closure" value="help"/>
+          <return value="closure"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/flask.xml
+++ b/com.ibm.wala.cast.python/data/flask.xml
@@ -5,52 +5,52 @@
   <classloader name="PythonLoader">
     <class name="flask" allocatable="true">
       <method name="import" static="true" descriptor="()Lflask;">
-        <new def="x" class="Lflask" />
-        <new def="flask" class="Lflask/class/Flask" />
-        <putfield class="LRoot" field="Flask" fieldType="LRoot" ref="x" value="flask" />
-        <new def="request" class="Lobject" />
-        <putfield class="LRoot" field="request" fieldType="LRoot" ref="x" value="request" />
-        <new def="form" class="Lobject" />
-        <putfield class="LRoot" field="form" fieldType="LRoot" ref="request" value="form" />
-        <return value="x" />
+        <new def="x" class="Lflask"/>
+        <new def="flask" class="Lflask/class/Flask"/>
+        <putfield class="LRoot" field="Flask" fieldType="LRoot" ref="x" value="flask"/>
+        <new def="request" class="Lobject"/>
+        <putfield class="LRoot" field="request" fieldType="LRoot" ref="x" value="request"/>
+        <new def="form" class="Lobject"/>
+        <putfield class="LRoot" field="form" fieldType="LRoot" ref="request" value="form"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="subprocess" allocatable="true">
       <method name="import" static="true" descriptor="()Lsubprocess;">
-        <new def="x" class="Lsubprocess" />
-        <new def="call" class="Lsubprocess/function/call" />
-        <putfield class="LRoot" field="call" fieldType="LRoot" ref="x" value="call" />
-        <return value="x" />
+        <new def="x" class="Lsubprocess"/>
+        <new def="call" class="Lsubprocess/function/call"/>
+        <putfield class="LRoot" field="call" fieldType="LRoot" ref="x" value="call"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="flask/class">
       <class name="Flask" allocatable="true">
         <method name="do" descriptor="()LRoot;">
-          <new def="v" class="Lobject" />
-          <new def="route" class="Lflask/function/route" />
-          <putfield class="LRoot" field="route" fieldType="LRoot" ref="v" value="route" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <new def="route" class="Lflask/function/route"/>
+          <putfield class="LRoot" field="route" fieldType="LRoot" ref="v" value="route"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
     <package name="flask/function">
       <class name="route" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
-          <new def="v" class="Lflask/function/callback" />
-          <return value="v" />
+          <new def="v" class="Lflask/function/callback"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="callback" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self entry">
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="entry" def="v" />
-          <return value="v" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="entry" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>
     <package name="subprocess/function">
       <class name="call" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self value shell">
-          <return value="self" />
+          <return value="self"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/functools.xml
+++ b/com.ibm.wala.cast.python/data/functools.xml
@@ -5,21 +5,21 @@
   <classloader name="PythonLoader">
     <class name="functools" allocatable="true">
       <method name="import" static="true" descriptor="()Lfunctools;">
-        <new def="x" class="Lfunctools" />
-        <new def="reduce" class="Lfunctools/functions/reduce" />
-        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce" />
-        <return value="x" />
+        <new def="x" class="Lfunctools"/>
+        <new def="reduce" class="Lfunctools/functions/reduce"/>
+        <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="reduce"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="functools/functions">
       <class name="reduce" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self lambda data">
-          <constant name="l" type="int" value="0" />
-          <aaload ref="data" def="v1" type="LRoot" index="l" />
-          <constant name="r" type="int" value="1" />
-          <aaload ref="data" def="v2" type="LRoot" index="r" />
-          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v" />
-          <return value="v" />
+          <constant name="l" type="int" value="0"/>
+          <aaload ref="data" def="v1" type="LRoot" index="l"/>
+          <constant name="r" type="int" value="1"/>
+          <aaload ref="data" def="v2" type="LRoot" index="r"/>
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="lambda" arg1="v1" arg2="v2" numArgs="3" def="v"/>
+          <return value="v"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/numpy_turtle.xml
+++ b/com.ibm.wala.cast.python/data/numpy_turtle.xml
@@ -5,9 +5,9 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.cast.python/data/pandas.xml
+++ b/com.ibm.wala.cast.python/data/pandas.xml
@@ -5,25 +5,25 @@
   <classloader name="PythonLoader">
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lpandas" />
-        <new def="read_excel" class="Lpandas/functions/read_excel" />
-        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel" />
-        <new def="merge" class="Lpandas/functions/merge" />
-        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge" />
-        <return value="x" />
+        <new def="x" class="Lpandas"/>
+        <new def="read_excel" class="Lpandas/functions/read_excel"/>
+        <putfield class="LRoot" field="read_excel" fieldType="LRoot" ref="x" value="read_excel"/>
+        <new def="merge" class="Lpandas/functions/merge"/>
+        <putfield class="LRoot" field="merge" fieldType="LRoot" ref="x" value="merge"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="pandas/functions">
       <class name="read_excel" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self file sheet">
-          <new def="v" class="Lobject" />
-          <return value="v" />
+          <new def="v" class="Lobject"/>
+          <return value="v"/>
         </method>
       </class>
       <class name="merge" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self left right on how">
-          <return value="left" />
-          <return value="right" />
+          <return value="left"/>
+          <return value="right"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/pytest.xml
+++ b/com.ibm.wala.cast.python/data/pytest.xml
@@ -5,64 +5,64 @@
   <classloader name="PythonLoader">
     <class name="pytest" allocatable="true">
       <method name="import" static="true" descriptor="()Lpytest;">
-        <new def="x" class="Lpytest" />
-        <new def="mark" class="Lobject" />
-        <putfield class="LRoot" field="mark" fieldType="LRoot" ref="x" value="mark" />
-        <new def="parametrize" class="Lpytest/class/parametrize" />
-        <putfield class="LRoot" field="parametrize" fieldType="LRoot" ref="mark" value="parametrize" />
-        <new def="skip" class="Lpytest/class/skip" />
-        <putfield class="LRoot" field="skip" fieldType="LRoot" ref="mark" value="skip" />
-        <new def="skipif" class="Lpytest/class/skipif" />
-        <putfield class="LRoot" field="skipif" fieldType="LRoot" ref="mark" value="skipif" />
-        <return value="x" />
+        <new def="x" class="Lpytest"/>
+        <new def="mark" class="Lobject"/>
+        <putfield class="LRoot" field="mark" fieldType="LRoot" ref="x" value="mark"/>
+        <new def="parametrize" class="Lpytest/class/parametrize"/>
+        <putfield class="LRoot" field="parametrize" fieldType="LRoot" ref="mark" value="parametrize"/>
+        <new def="skip" class="Lpytest/class/skip"/>
+        <putfield class="LRoot" field="skip" fieldType="LRoot" ref="mark" value="skip"/>
+        <new def="skipif" class="Lpytest/class/skipif"/>
+        <putfield class="LRoot" field="skipif" fieldType="LRoot" ref="mark" value="skipif"/>
+        <return value="x"/>
       </method>
     </class>
     <package name="pytest/class">
       <class name="Parametrize" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="parametrize" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Lpytest/class/Parametrize" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Lpytest/class/Parametrize"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
       <class name="Skip" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="skip" allocatable="true">
         <!-- https://docs.pytest.org/en/8.2.x/reference/reference.html#pytest.mark.skip -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Lpytest/class/Skip" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Lpytest/class/Skip"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
       <class name="Skipif" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self test">
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self" />
-          <return value="test" />
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="test" value="self"/>
+          <return value="test"/>
         </method>
       </class>
       <class name="skipif" allocatable="true">
         <!-- https://docs.pytest.org/en/8.2.x/reference/reference.html#pytest.mark.skipif -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self params values extra">
-          <new def="closure" class="Lpytest/class/Skipif" />
-          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self" />
-          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params" />
-          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values" />
-          <return value="closure" />
+          <new def="closure" class="Lpytest/class/Skipif"/>
+          <putfield class="LRoot" field="test" fieldType="LRoot" ref="closure" value="self"/>
+          <putfield class="LRoot" field="params" fieldType="LRoot" ref="closure" value="params"/>
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="closure" value="values"/>
+          <return value="closure"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python/data/turtles.xml
+++ b/com.ibm.wala.cast.python/data/turtles.xml
@@ -5,79 +5,79 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="sklearn" allocatable="true">
       <method name="import" static="true" descriptor="()Lsklearn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="pandas" allocatable="true">
       <method name="import" static="true" descriptor="()Lpandas;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="patsy" allocatable="true">
       <method name="import" static="true" descriptor="()Lpatsy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="seaborn" allocatable="true">
       <method name="import" static="true" descriptor="()Lseaborn;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="statsmodels" allocatable="true">
       <method name="import" static="true" descriptor="()Lstatsmodels;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="scipy" allocatable="true">
       <method name="import" static="true" descriptor="()Lscipy;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="matplotlib" allocatable="true">
       <method name="import" static="true" descriptor="()Lmatplotlib;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="IPython" allocatable="true">
       <method name="import" static="true" descriptor="()LIPython;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="mpl_toolkits" allocatable="true">
       <method name="import" static="true" descriptor="()Lmpl_toolkits;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
     <class name="tensorflow" allocatable="true">
       <method name="import" static="true" descriptor="()Ltensorflow;">
-        <new def="x" class="Lturtle" />
-        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
-        <return value="x" />
+        <new def="x" class="Lturtle"/>
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x"/>
+        <return value="x"/>
       </method>
     </class>
   </classloader>

--- a/com.ibm.wala.ide.pycharm/.idea/misc.xml
+++ b/com.ibm.wala.ide.pycharm/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ExternalStorageConfigurationManager" enabled="true"/>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" project-jdk-name="9" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/out" />
+    <output url="file://$PROJECT_DIR$/out"/>
   </component>
 </project>

--- a/com.ibm.wala.ide.pycharm/.idea/workspace.xml
+++ b/com.ibm.wala.ide.pycharm/.idea/workspace.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="82996a5c-124b-494d-8f8d-24db1dda1a86" name="Default" comment="" />
-    <ignored path="$PROJECT_DIR$/.gradle/" />
-    <ignored path="$PROJECT_DIR$/build/" />
-    <ignored path="$PROJECT_DIR$/out/" />
-    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
-    <option name="TRACKING_ENABLED" value="true" />
-    <option name="SHOW_DIALOG" value="false" />
-    <option name="HIGHLIGHT_CONFLICTS" value="true" />
-    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
-    <option name="LAST_RESOLUTION" value="IGNORE" />
+    <list default="true" id="82996a5c-124b-494d-8f8d-24db1dda1a86" name="Default" comment=""/>
+    <ignored path="$PROJECT_DIR$/.gradle/"/>
+    <ignored path="$PROJECT_DIR$/build/"/>
+    <ignored path="$PROJECT_DIR$/out/"/>
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true"/>
+    <option name="TRACKING_ENABLED" value="true"/>
+    <option name="SHOW_DIALOG" value="false"/>
+    <option name="HIGHLIGHT_CONFLICTS" value="true"/>
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false"/>
+    <option name="LAST_RESOLUTION" value="IGNORE"/>
   </component>
   <component name="ExternalProjectsData">
     <projectState path="$PROJECT_DIR$">
-      <ProjectState />
+      <ProjectState/>
     </projectState>
   </component>
   <component name="ExternalProjectsManager">
     <system id="GRADLE">
       <state>
         <task path="$PROJECT_DIR$">
-          <activation />
+          <activation/>
         </task>
         <projects_view>
           <tree_state>
             <expand>
               <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode" />
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode"/>
+                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode"/>
               </path>
               <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode" />
-                <item name="Source Sets" type="e897c970:GradleViewContributor$SourceSetsNode" />
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode"/>
+                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode"/>
+                <item name="Source Sets" type="e897c970:GradleViewContributor$SourceSetsNode"/>
               </path>
               <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode" />
-                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode"/>
+                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode"/>
+                <item name="Tasks" type="e4a08cd1:TasksNode"/>
               </path>
               <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode" />
-                <item name="Tasks" type="e4a08cd1:TasksNode" />
-                <item name="intellij" type="c8890929:TasksNode$1" />
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode"/>
+                <item name="com.ibm.wala.ide.pycharm" type="f1a62948:ProjectNode"/>
+                <item name="Tasks" type="e4a08cd1:TasksNode"/>
+                <item name="intellij" type="c8890929:TasksNode$1"/>
               </path>
             </expand>
-            <select />
+            <select/>
           </tree_state>
         </projects_view>
       </state>
@@ -59,7 +59,7 @@
         <entry file="file://$PROJECT_DIR$/build.gradle">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="435">
-              <caret line="29" selection-start-line="29" selection-end-line="29" />
+              <caret line="29" selection-start-line="29" selection-end-line="29"/>
             </state>
           </provider>
         </entry>
@@ -68,7 +68,7 @@
         <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/AnalysisAction.java">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="570">
-              <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7" />
+              <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7"/>
             </state>
           </provider>
         </entry>
@@ -77,7 +77,7 @@
         <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/WALAClient.java">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="148">
-              <caret line="39" column="42" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42" />
+              <caret line="39" column="42" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42"/>
             </state>
           </provider>
         </entry>
@@ -95,12 +95,12 @@
   <component name="GradleLocalSettings">
     <option name="myGradleHomes">
       <map>
-        <entry key="$PROJECT_DIR$" value="/usr/local/Cellar/gradle/4.7/libexec" />
+        <entry key="$PROJECT_DIR$" value="/usr/local/Cellar/gradle/4.7/libexec"/>
       </map>
     </option>
     <option name="myGradleVersions">
       <map>
-        <entry key="$PROJECT_DIR$" value="4.7" />
+        <entry key="$PROJECT_DIR$" value="4.7"/>
       </map>
     </option>
     <option name="availableProjects">
@@ -108,15 +108,15 @@
         <entry>
           <key>
             <ExternalProjectPojo>
-              <option name="name" value="com.ibm.wala.ide.pycharm" />
-              <option name="path" value="$PROJECT_DIR$" />
+              <option name="name" value="com.ibm.wala.ide.pycharm"/>
+              <option name="path" value="$PROJECT_DIR$"/>
             </ExternalProjectPojo>
           </key>
           <value>
             <list>
               <ExternalProjectPojo>
-                <option name="name" value="com.ibm.wala.ide.pycharm" />
-                <option name="path" value="$PROJECT_DIR$" />
+                <option name="name" value="com.ibm.wala.ide.pycharm"/>
+                <option name="path" value="$PROJECT_DIR$"/>
               </ExternalProjectPojo>
             </list>
           </value>
@@ -129,190 +129,190 @@
           <value>
             <list>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the components produced by root project 'com.ibm.wala.ide.pycharm'. [incubating]" />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="components" />
+                <option name="description" value="Displays the components produced by root project 'com.ibm.wala.ide.pycharm'. [incubating]"/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="components"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles and tests this project and all projects that depend on it." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="buildDependents" />
+                <option name="description" value="Assembles and tests this project and all projects that depend on it."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="buildDependents"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the sub-projects of root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="projects" />
+                <option name="description" value="Displays the sub-projects of root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="projects"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles main classes." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="classes" />
+                <option name="description" value="Assembles main classes."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="classes"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the dependent components of components in root project 'com.ibm.wala.ide.pycharm'. [incubating]" />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="dependentComponents" />
+                <option name="description" value="Displays the dependent components of components in root project 'com.ibm.wala.ide.pycharm'. [incubating]"/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="dependentComponents"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Bundles the project as a distribution." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="buildPlugin" />
+                <option name="description" value="Bundles the project as a distribution."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="buildPlugin"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays all buildscript dependencies declared in root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="buildEnvironment" />
+                <option name="description" value="Displays all buildscript dependencies declared in root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="buildEnvironment"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Generates Gradle wrapper files." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="wrapper" />
+                <option name="description" value="Generates Gradle wrapper files."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="wrapper"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles test classes." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="testClasses" />
+                <option name="description" value="Assembles test classes."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="testClasses"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Generates Javadoc API documentation for the main source code." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="javadoc" />
+                <option name="description" value="Generates Javadoc API documentation for the main source code."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="javadoc"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Prepare sandbox directory with installed plugin and its dependencies." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="prepareSandbox" />
+                <option name="description" value="Prepare sandbox directory with installed plugin and its dependencies."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="prepareSandbox"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles a jar archive containing the main classes." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="jar" />
+                <option name="description" value="Assembles a jar archive containing the main classes."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="jar"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the configuration model of root project 'com.ibm.wala.ide.pycharm'. [incubating]" />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="model" />
+                <option name="description" value="Displays the configuration model of root project 'com.ibm.wala.ide.pycharm'. [incubating]"/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="model"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Publish plugin distribution on plugins.jetbrains.com." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="publishPlugin" />
+                <option name="description" value="Publish plugin distribution on plugins.jetbrains.com."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="publishPlugin"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Processes main resources." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="processResources" />
+                <option name="description" value="Processes main resources."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="processResources"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the tasks runnable from root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="tasks" />
+                <option name="description" value="Displays the tasks runnable from root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="tasks"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Initializes a new Gradle build." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="init" />
+                <option name="description" value="Initializes a new Gradle build."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="init"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Runs the unit tests." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="test" />
+                <option name="description" value="Runs the unit tests."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="test"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Prepare sandbox directory with installed plugin and its dependencies." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="prepareTestingSandbox" />
+                <option name="description" value="Prepare sandbox directory with installed plugin and its dependencies."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="prepareTestingSandbox"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Compiles main Java source." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="compileJava" />
+                <option name="description" value="Compiles main Java source."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="compileJava"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the insight into a specific dependency in root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="dependencyInsight" />
+                <option name="description" value="Displays the insight into a specific dependency in root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="dependencyInsight"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Runs all checks." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="check" />
+                <option name="description" value="Runs all checks."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="check"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles the outputs of this project." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="assemble" />
+                <option name="description" value="Assembles the outputs of this project."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="assemble"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Deletes the build directory." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="clean" />
+                <option name="description" value="Deletes the build directory."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="clean"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Compiles test Java source." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="compileTestJava" />
+                <option name="description" value="Compiles test Java source."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="compileTestJava"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays all dependencies declared in root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="dependencies" />
+                <option name="description" value="Displays all dependencies declared in root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="dependencies"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="instrumentCode" />
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="instrumentCode"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Patch plugin xml files with corresponding since/until build numbers and version attributes" />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="patchPluginXml" />
+                <option name="description" value="Patch plugin xml files with corresponding since/until build numbers and version attributes"/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="patchPluginXml"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Processes test resources." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="processTestResources" />
+                <option name="description" value="Processes test resources."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="processTestResources"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays a help message." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="help" />
+                <option name="description" value="Displays a help message."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="help"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Runs Intellij IDEA with installed plugin." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="runIde" />
+                <option name="description" value="Runs Intellij IDEA with installed plugin."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="runIde"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="instrumentTestCode" />
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="instrumentTestCode"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="postInstrumentTestCode" />
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="postInstrumentTestCode"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles and tests this project." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="build" />
+                <option name="description" value="Assembles and tests this project."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="build"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Assembles and tests this project and all projects it depends on." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="buildNeeded" />
+                <option name="description" value="Assembles and tests this project and all projects it depends on."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="buildNeeded"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="postInstrumentCode" />
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="postInstrumentCode"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Runs Intellij IDEA with installed plugin." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="runIdea" />
+                <option name="description" value="Runs Intellij IDEA with installed plugin."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="runIdea"/>
               </ExternalTaskPojo>
               <ExternalTaskPojo>
-                <option name="description" value="Displays the properties of root project 'com.ibm.wala.ide.pycharm'." />
-                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$" />
-                <option name="name" value="properties" />
+                <option name="description" value="Displays the properties of root project 'com.ibm.wala.ide.pycharm'."/>
+                <option name="linkedExternalProjectPath" value="$PROJECT_DIR$"/>
+                <option name="name" value="properties"/>
               </ExternalTaskPojo>
             </list>
           </value>
@@ -321,9 +321,9 @@
     </option>
     <option name="modificationStamps">
       <map>
-        <entry key="$PROJECT_DIR$" value="3051791590000" />
-        <entry key="$PROJECT_DIR$/.gradle" value="0" />
-        <entry key="$PROJECT_DIR$/build.gradle" value="175793273" />
+        <entry key="$PROJECT_DIR$" value="3051791590000"/>
+        <entry key="$PROJECT_DIR$/.gradle" value="0"/>
+        <entry key="$PROJECT_DIR$/build.gradle" value="175793273"/>
       </map>
     </option>
     <option name="projectBuildClasspath">
@@ -338,130 +338,130 @@
                       <ExternalModuleBuildClasspathPojo>
                         <option name="entries">
                           <list>
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/gradle.plugin.org.jetbrains.intellij.plugins/gradle-intellij-plugin/0.2.18/59cd30937f2be8bed4ed7e92f539f8e203ede3cb/gradle-intellij-plugin-0.2.18-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/gradle.plugin.org.jetbrains.intellij.plugins/gradle-intellij-plugin/0.2.18/b138c3b2b009b73795e8c63a54dfe4723a7dce10/gradle-intellij-plugin-0.2.18.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/5991ca87ef1fb5544943d9abc5a9a37583fabe03/annotations-13.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/919f0dfe192fb4e063e7dacadee7f8bb9a2672a9/annotations-13.0.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij/plugin-repository-rest-client/0.3.21/cab97091a70b6a4fcbed414043d76f8c1180feb1/plugin-repository-rest-client-0.3.21-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij/plugin-repository-rest-client/0.3.21/8a78ebb5e57e5fe81be4740e5d206179319988cc/plugin-repository-rest-client-0.3.21.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij.plugins/intellij-plugin-structure/1.37/5d64de629888e9ebeb91a31c5b1db61f19f59c80/intellij-plugin-structure-1.37-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij.plugins/intellij-plugin-structure/1.37/b13f256ce9bf2594e2a0e1c8d20c2f6a1a1c358a/intellij-plugin-structure-1.37.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.0.0/3a8a73d14b5fdda2425b40b440bb0ce71cb627fc/kotlin-stdlib-1.0.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.0.0/2db5ac6eb2746708e77e4c439625f9331c25e766/kotlin-stdlib-1.0.0.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.21/f285ac123f201fb4b028bac556928d7cf527ef48/slf4j-api-1.7.21-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.21/139535a69a4239db087de9bab0bee568bf8e0b70/slf4j-api-1.7.21.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.retrofit/retrofit/1.9.0/f3908d76273ad2498add8bb89d7fb787f3061b1d/retrofit-1.9.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.retrofit/retrofit/1.9.0/a681c044244d9fc375198588297a39ba78028423/retrofit-1.9.0.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jdom/jdom/2.0.2/2c0614e33230394e42f5cfe55c20d5ae8949c108/jdom-2.0.2-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jdom/jdom/2.0.2/d06c71e0df0ac4b94deb737718580ccce22d92e8/jdom-2.0.2.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/19.0/91a4d115400e904f22b03a78deb355e9ea803cd4/guava-19.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/19.0/6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9/guava-19.0.jar" />
-                            <option value="$MAVEN_REPOSITORY$/commons-io/commons-io/2.5/commons-io-2.5.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.intellij/annotations/12.0/4943118f12f706a8820f73529fcb8f5853bc0fed/annotations-12.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.intellij/annotations/12.0/bbcf6448f6d40abe506e2c83b70a3e8bfd2b4539/annotations-12.0.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-all/5.0.4/112ff54474f1f04ccf1384c92e39fdc566f0bb5e/asm-all-5.0.4-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-all/5.0.4/e6244859997b3d4237a552669279780876228909/asm-all-5.0.4.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jsoup/jsoup/1.9.2/97441f4a0f6bb4c2d9f1e19321f4a45c9ffd0e2c/jsoup-1.9.2-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jsoup/jsoup/1.9.2/5e3bda828a80c7a21dfbe2308d1755759c2fd7b4/jsoup-1.9.2.jar" />
-                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-archiver/2.3/plexus-archiver-2.3.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/1.0.0/d0c738e20f1658e1705ce166caa1768267bf4262/kotlin-runtime-1.0.0-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/1.0.0/8739b3cd3bf98584cf2d1cabf59b55dbd5f7349d/kotlin-runtime-1.0.0.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.3.1/563dcb685903c96ce8abbd03adf7fa49e19aa8b4/gson-2.3.1-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.3.1/ecb6e1f8e4b0e84c4b886c2f14a1500caf309757/gson-2.3.1.jar" />
-                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.plexus/plexus-utils/3.0.10/51816cf410d9320e4e6c9ab4acce95ff873be8ea/plexus-utils-3.0.10-sources.jar" />
-                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.plexus/plexus-utils/3.0.10/65e6460a49460d2ca038f8644ff9ae6d878733b8/plexus-utils-3.0.10.jar" />
-                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-io/2.0.6/plexus-io-2.0.6.jar" />
-                            <option value="$MAVEN_REPOSITORY$/junit/junit/3.8.1/junit-3.8.1.jar" />
-                            <option value="$MAVEN_REPOSITORY$/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar" />
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/gradle.plugin.org.jetbrains.intellij.plugins/gradle-intellij-plugin/0.2.18/59cd30937f2be8bed4ed7e92f539f8e203ede3cb/gradle-intellij-plugin-0.2.18-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/gradle.plugin.org.jetbrains.intellij.plugins/gradle-intellij-plugin/0.2.18/b138c3b2b009b73795e8c63a54dfe4723a7dce10/gradle-intellij-plugin-0.2.18.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/5991ca87ef1fb5544943d9abc5a9a37583fabe03/annotations-13.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/13.0/919f0dfe192fb4e063e7dacadee7f8bb9a2672a9/annotations-13.0.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij/plugin-repository-rest-client/0.3.21/cab97091a70b6a4fcbed414043d76f8c1180feb1/plugin-repository-rest-client-0.3.21-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij/plugin-repository-rest-client/0.3.21/8a78ebb5e57e5fe81be4740e5d206179319988cc/plugin-repository-rest-client-0.3.21.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij.plugins/intellij-plugin-structure/1.37/5d64de629888e9ebeb91a31c5b1db61f19f59c80/intellij-plugin-structure-1.37-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.intellij.plugins/intellij-plugin-structure/1.37/b13f256ce9bf2594e2a0e1c8d20c2f6a1a1c358a/intellij-plugin-structure-1.37.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.0.0/3a8a73d14b5fdda2425b40b440bb0ce71cb627fc/kotlin-stdlib-1.0.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.0.0/2db5ac6eb2746708e77e4c439625f9331c25e766/kotlin-stdlib-1.0.0.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.21/f285ac123f201fb4b028bac556928d7cf527ef48/slf4j-api-1.7.21-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.21/139535a69a4239db087de9bab0bee568bf8e0b70/slf4j-api-1.7.21.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.retrofit/retrofit/1.9.0/f3908d76273ad2498add8bb89d7fb787f3061b1d/retrofit-1.9.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup.retrofit/retrofit/1.9.0/a681c044244d9fc375198588297a39ba78028423/retrofit-1.9.0.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jdom/jdom/2.0.2/2c0614e33230394e42f5cfe55c20d5ae8949c108/jdom-2.0.2-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jdom/jdom/2.0.2/d06c71e0df0ac4b94deb737718580ccce22d92e8/jdom-2.0.2.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/19.0/91a4d115400e904f22b03a78deb355e9ea803cd4/guava-19.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/19.0/6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9/guava-19.0.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/commons-io/commons-io/2.5/commons-io-2.5.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.intellij/annotations/12.0/4943118f12f706a8820f73529fcb8f5853bc0fed/annotations-12.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.intellij/annotations/12.0/bbcf6448f6d40abe506e2c83b70a3e8bfd2b4539/annotations-12.0.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-all/5.0.4/112ff54474f1f04ccf1384c92e39fdc566f0bb5e/asm-all-5.0.4-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.ow2.asm/asm-all/5.0.4/e6244859997b3d4237a552669279780876228909/asm-all-5.0.4.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jsoup/jsoup/1.9.2/97441f4a0f6bb4c2d9f1e19321f4a45c9ffd0e2c/jsoup-1.9.2-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jsoup/jsoup/1.9.2/5e3bda828a80c7a21dfbe2308d1755759c2fd7b4/jsoup-1.9.2.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-archiver/2.3/plexus-archiver-2.3.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/1.0.0/d0c738e20f1658e1705ce166caa1768267bf4262/kotlin-runtime-1.0.0-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-runtime/1.0.0/8739b3cd3bf98584cf2d1cabf59b55dbd5f7349d/kotlin-runtime-1.0.0.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.3.1/563dcb685903c96ce8abbd03adf7fa49e19aa8b4/gson-2.3.1-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.3.1/ecb6e1f8e4b0e84c4b886c2f14a1500caf309757/gson-2.3.1.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.plexus/plexus-utils/3.0.10/51816cf410d9320e4e6c9ab4acce95ff873be8ea/plexus-utils-3.0.10-sources.jar"/>
+                            <option value="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.plexus/plexus-utils/3.0.10/65e6460a49460d2ca038f8644ff9ae6d878733b8/plexus-utils-3.0.10.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/org/codehaus/plexus/plexus-io/2.0.6/plexus-io-2.0.6.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/junit/junit/3.8.1/junit-3.8.1.jar"/>
+                            <option value="$MAVEN_REPOSITORY$/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar"/>
                           </list>
                         </option>
-                        <option name="path" value="$PROJECT_DIR$" />
+                        <option name="path" value="$PROJECT_DIR$"/>
                       </ExternalModuleBuildClasspathPojo>
                     </value>
                   </entry>
                 </map>
               </option>
-              <option name="name" value="com.ibm.wala.ide.pycharm" />
+              <option name="name" value="com.ibm.wala.ide.pycharm"/>
               <option name="projectBuildClasspath">
                 <list>
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-logging-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-wrapper-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-runtime-api-info-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-native-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-process-services-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-tooling-builders-0.16.3.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-build-cache-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-core-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/groovy-all-2.4.12.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-model-core-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-base-services-groovy-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/ant-launcher-1.9.9.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-installation-beacon-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/ant-1.9.9.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-launcher-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-jvm-services-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-messaging-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-build-option-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-base-services-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-persistent-cache-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-docs-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-cli-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-tooling-api-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-tooling-models-0.16.3.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-core-api-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-model-groovy-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-resources-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-0.16.3.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugin-use-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-announce-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-tooling-api-builders-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-play-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-scala-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-javascript-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-version-control-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-native-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-comparison-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugins-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-jacoco-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-native-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-native-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-diagnostics-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugin-development-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-workers-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-cache-http-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-native-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-dependency-management-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-composite-builds-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-junit-platform-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-publish-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ear-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-jvm-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-base-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-gcs-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-play-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-http-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-scala-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-java-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-groovy-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-osgi-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-reporting-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-antlr-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-code-quality-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-s3-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-signing-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-sftp-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ivy-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-test-kit-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-init-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-jvm-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-base-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-jvm-4.7.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/ivy-2.2.0.jar" />
-                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-maven-4.7.jar" />
-                  <option value="$PROJECT_DIR$/buildSrc/src/main/java" />
-                  <option value="$PROJECT_DIR$/buildSrc/src/main/groovy" />
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-logging-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-wrapper-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-runtime-api-info-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-native-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-process-services-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-tooling-builders-0.16.3.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-build-cache-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-core-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/groovy-all-2.4.12.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-model-core-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-base-services-groovy-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/ant-launcher-1.9.9.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-installation-beacon-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/ant-1.9.9.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-launcher-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-jvm-services-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-messaging-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-build-option-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-base-services-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-persistent-cache-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-docs-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-cli-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-tooling-api-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-tooling-models-0.16.3.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-core-api-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-model-groovy-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-resources-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/gradle-kotlin-dsl-0.16.3.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugin-use-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-announce-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-tooling-api-builders-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-play-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-scala-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-javascript-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-version-control-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-native-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-comparison-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugins-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-jacoco-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-native-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-native-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-diagnostics-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-plugin-development-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-workers-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-cache-http-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-native-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-dependency-management-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-composite-builds-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-junit-platform-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-publish-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ear-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-jvm-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-base-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-gcs-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ide-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-play-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-http-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-scala-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-java-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-language-groovy-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-osgi-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-reporting-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-antlr-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-code-quality-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-s3-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-signing-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-resources-sftp-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-ivy-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-test-kit-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-build-init-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-jvm-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-testing-base-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-platform-jvm-4.7.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/ivy-2.2.0.jar"/>
+                  <option value="/usr/local/Cellar/gradle/4.7/libexec/lib/plugins/gradle-maven-4.7.jar"/>
+                  <option value="$PROJECT_DIR$/buildSrc/src/main/java"/>
+                  <option value="$PROJECT_DIR$/buildSrc/src/main/groovy"/>
                 </list>
               </option>
             </ExternalProjectBuildClasspathPojo>
@@ -471,269 +471,269 @@
     </option>
     <option name="projectSyncType">
       <map>
-        <entry key="$PROJECT_DIR$/../../Ariadne" value="PREVIEW" />
-        <entry key="$PROJECT_DIR$/../../IDE" value="PREVIEW" />
-        <entry key="$PROJECT_DIR$" value="RE_IMPORT" />
-        <entry key="$PROJECT_DIR$/../../intellij-lsp/intellij-lsp" value="PREVIEW" />
+        <entry key="$PROJECT_DIR$/../../Ariadne" value="PREVIEW"/>
+        <entry key="$PROJECT_DIR$/../../IDE" value="PREVIEW"/>
+        <entry key="$PROJECT_DIR$" value="RE_IMPORT"/>
+        <entry key="$PROJECT_DIR$/../../intellij-lsp/intellij-lsp" value="PREVIEW"/>
       </map>
     </option>
   </component>
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/build.gradle" />
+        <option value="$PROJECT_DIR$/build.gradle"/>
       </list>
     </option>
   </component>
   <component name="ProjectFrameBounds">
-    <option name="x" value="40" />
-    <option name="y" value="29" />
-    <option name="width" value="1355" />
-    <option name="height" value="802" />
+    <option name="x" value="40"/>
+    <option name="y" value="29"/>
+    <option name="width" value="1355"/>
+    <option name="height" value="802"/>
   </component>
   <component name="ProjectView">
     <navigator proportions="" version="1">
-      <foldersAlwaysOnTop value="true" />
+      <foldersAlwaysOnTop value="true"/>
     </navigator>
     <panes>
-      <pane id="AndroidView" />
+      <pane id="AndroidView"/>
       <pane id="ProjectPane">
         <subPane>
           <expand>
             <path>
-              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode" />
-              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
+              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode"/>
+              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
             </path>
             <path>
-              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode" />
-              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode"/>
+              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="src" type="462c0819:PsiDirectoryNode"/>
             </path>
             <path>
-              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode" />
-              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
+              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode"/>
+              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="src" type="462c0819:PsiDirectoryNode"/>
+              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
             </path>
             <path>
-              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode" />
-              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="java" type="462c0819:PsiDirectoryNode" />
+              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode"/>
+              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="src" type="462c0819:PsiDirectoryNode"/>
+              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="java" type="462c0819:PsiDirectoryNode"/>
             </path>
             <path>
-              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode" />
-              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode" />
-              <item name="java" type="462c0819:PsiDirectoryNode" />
-              <item name="pycharm" type="462c0819:PsiDirectoryNode" />
+              <item name="com.ibm.wala.ide.pycharm" type="b2602c69:ProjectViewProjectNode"/>
+              <item name="com.ibm.wala.ide.pycharm" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="src" type="462c0819:PsiDirectoryNode"/>
+              <item name="main" type="8a07ba80:GradleTreeStructureProvider$GradleModuleDirectoryNode"/>
+              <item name="java" type="462c0819:PsiDirectoryNode"/>
+              <item name="pycharm" type="462c0819:PsiDirectoryNode"/>
             </path>
           </expand>
-          <select />
+          <select/>
         </subPane>
       </pane>
-      <pane id="Scope" />
-      <pane id="PackagesPane" />
+      <pane id="Scope"/>
+      <pane id="PackagesPane"/>
     </panes>
   </component>
   <component name="PropertiesComponent">
-    <property name="settings.editor.selected.configurable" value="preferences.pluginManager" />
+    <property name="settings.editor.selected.configurable" value="preferences.pluginManager"/>
   </component>
   <component name="RunDashboard">
     <option name="ruleStates">
       <list>
         <RuleState>
-          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule"/>
         </RuleState>
         <RuleState>
-          <option name="name" value="StatusDashboardGroupingRule" />
+          <option name="name" value="StatusDashboardGroupingRule"/>
         </RuleState>
       </list>
     </option>
   </component>
   <component name="RunManager">
     <configuration default="true" type="Application" factoryName="Application">
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$"/>
     </configuration>
     <configuration name="com.ibm.wala.ide.pycharm [runIde]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" />
+        <option name="executionName"/>
+        <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+        <option name="externalSystemIdString" value="GRADLE"/>
+        <option name="scriptParameters"/>
         <option name="taskDescriptions">
-          <list />
+          <list/>
         </option>
         <option name="taskNames">
           <list>
-            <option value="runIde" />
+            <option value="runIde"/>
           </list>
         </option>
-        <option name="vmOptions" />
+        <option name="vmOptions"/>
       </ExternalSystemSettings>
     </configuration>
     <configuration default="true" type="JUnit" factoryName="JUnit">
-      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-      <option name="ALTERNATIVE_JRE_PATH" />
-      <option name="PACKAGE_NAME" />
-      <option name="MAIN_CLASS_NAME" />
-      <option name="METHOD_NAME" />
-      <option name="TEST_OBJECT" value="class" />
-      <option name="VM_PARAMETERS" value="-ea" />
-      <option name="PARAMETERS" />
-      <option name="WORKING_DIRECTORY" value="%MODULE_WORKING_DIR%" />
-      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
+      <option name="ALTERNATIVE_JRE_PATH"/>
+      <option name="PACKAGE_NAME"/>
+      <option name="MAIN_CLASS_NAME"/>
+      <option name="METHOD_NAME"/>
+      <option name="TEST_OBJECT" value="class"/>
+      <option name="VM_PARAMETERS" value="-ea"/>
+      <option name="PARAMETERS"/>
+      <option name="WORKING_DIRECTORY" value="%MODULE_WORKING_DIR%"/>
+      <option name="PASS_PARENT_ENVS" value="true"/>
       <option name="TEST_SEARCH_SCOPE">
-        <value defaultName="singleModule" />
+        <value defaultName="singleModule"/>
       </option>
-      <patterns />
+      <patterns/>
     </configuration>
     <configuration default="true" type="TestNG" factoryName="TestNG">
-      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-      <option name="ALTERNATIVE_JRE_PATH" />
-      <option name="SUITE_NAME" />
-      <option name="PACKAGE_NAME" />
-      <option name="MAIN_CLASS_NAME" />
-      <option name="METHOD_NAME" />
-      <option name="GROUP_NAME" />
-      <option name="TEST_OBJECT" value="CLASS" />
-      <option name="VM_PARAMETERS" value="-ea" />
-      <option name="PARAMETERS" />
-      <option name="WORKING_DIRECTORY" value="%MODULE_WORKING_DIR%" />
-      <option name="OUTPUT_DIRECTORY" />
-      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false"/>
+      <option name="ALTERNATIVE_JRE_PATH"/>
+      <option name="SUITE_NAME"/>
+      <option name="PACKAGE_NAME"/>
+      <option name="MAIN_CLASS_NAME"/>
+      <option name="METHOD_NAME"/>
+      <option name="GROUP_NAME"/>
+      <option name="TEST_OBJECT" value="CLASS"/>
+      <option name="VM_PARAMETERS" value="-ea"/>
+      <option name="PARAMETERS"/>
+      <option name="WORKING_DIRECTORY" value="%MODULE_WORKING_DIR%"/>
+      <option name="OUTPUT_DIRECTORY"/>
+      <option name="PASS_PARENT_ENVS" value="true"/>
       <option name="TEST_SEARCH_SCOPE">
-        <value defaultName="singleModule" />
+        <value defaultName="singleModule"/>
       </option>
-      <option name="USE_DEFAULT_REPORTERS" value="false" />
-      <option name="PROPERTIES_FILE" />
-      <properties />
-      <listeners />
+      <option name="USE_DEFAULT_REPORTERS" value="false"/>
+      <option name="PROPERTIES_FILE"/>
+      <properties/>
+      <listeners/>
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Gradle.com.ibm.wala.ide.pycharm [runIde]" />
+        <item itemvalue="Gradle.com.ibm.wala.ide.pycharm [runIde]"/>
       </list>
     </recent_temporary>
   </component>
   <component name="SvnConfiguration">
-    <configuration />
+    <configuration/>
   </component>
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
-      <changelist id="82996a5c-124b-494d-8f8d-24db1dda1a86" name="Default" comment="" />
+      <changelist id="82996a5c-124b-494d-8f8d-24db1dda1a86" name="Default" comment=""/>
       <created>1525895592359</created>
-      <option name="number" value="Default" />
-      <option name="presentableId" value="Default" />
+      <option name="number" value="Default"/>
+      <option name="presentableId" value="Default"/>
       <updated>1525895592359</updated>
     </task>
-    <servers />
+    <servers/>
   </component>
   <component name="ToolWindowManager">
-    <frame x="40" y="29" width="1355" height="802" extended-state="0" />
+    <frame x="40" y="29" width="1355" height="802" extended-state="0"/>
     <layout>
-      <window_info anchor="right" id="Palette" order="3" />
-      <window_info anchor="bottom" id="TODO" order="6" />
-      <window_info anchor="right" id="Palette&#9;" order="3" />
-      <window_info id="Image Layers" order="2" />
-      <window_info anchor="right" id="Capture Analysis" order="3" />
-      <window_info anchor="bottom" id="Event Log" order="7" side_tool="true" />
-      <window_info anchor="right" id="Maven Projects" order="3" />
-      <window_info anchor="bottom" id="Run" order="2" weight="0.6468085" />
-      <window_info anchor="bottom" id="Version Control" order="7" show_stripe_button="false" />
-      <window_info anchor="bottom" id="Terminal" order="7" />
-      <window_info id="Capture Tool" order="2" />
-      <window_info id="Designer" order="2" />
-      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.2612338" />
-      <window_info id="Learn" order="2" />
-      <window_info anchor="right" id="Gradle" order="3" visible="true" weight="0.17288652" />
-      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
-      <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
-      <window_info id="UI Designer" order="2" />
-      <window_info anchor="right" id="Theme Preview" order="3" />
-      <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
-      <window_info id="Favorites" order="2" side_tool="true" />
-      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
-      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
-      <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
-      <window_info anchor="bottom" id="Message" order="0" />
-      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
-      <window_info anchor="bottom" id="Build" order="7" weight="0.24822696" />
-      <window_info anchor="bottom" id="Find" order="1" />
+      <window_info anchor="right" id="Palette" order="3"/>
+      <window_info anchor="bottom" id="TODO" order="6"/>
+      <window_info anchor="right" id="Palette&#9;" order="3"/>
+      <window_info id="Image Layers" order="2"/>
+      <window_info anchor="right" id="Capture Analysis" order="3"/>
+      <window_info anchor="bottom" id="Event Log" order="7" side_tool="true"/>
+      <window_info anchor="right" id="Maven Projects" order="3"/>
+      <window_info anchor="bottom" id="Run" order="2" weight="0.6468085"/>
+      <window_info anchor="bottom" id="Version Control" order="7" show_stripe_button="false"/>
+      <window_info anchor="bottom" id="Terminal" order="7"/>
+      <window_info id="Capture Tool" order="2"/>
+      <window_info id="Designer" order="2"/>
+      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.2612338"/>
+      <window_info id="Learn" order="2"/>
+      <window_info anchor="right" id="Gradle" order="3" visible="true" weight="0.17288652"/>
+      <window_info id="Structure" order="1" side_tool="true" weight="0.25"/>
+      <window_info anchor="right" id="Ant Build" order="1" weight="0.25"/>
+      <window_info id="UI Designer" order="2"/>
+      <window_info anchor="right" id="Theme Preview" order="3"/>
+      <window_info anchor="bottom" id="Debug" order="3" weight="0.4"/>
+      <window_info id="Favorites" order="2" side_tool="true"/>
+      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25"/>
+      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4"/>
+      <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4"/>
+      <window_info anchor="bottom" id="Message" order="0"/>
+      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25"/>
+      <window_info anchor="bottom" id="Build" order="7" weight="0.24822696"/>
+      <window_info anchor="bottom" id="Find" order="1"/>
     </layout>
   </component>
   <component name="VcsContentAnnotationSettings">
-    <option name="myLimit" value="2678400000" />
+    <option name="myLimit" value="2678400000"/>
   </component>
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/build.gradle">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="435">
-          <caret line="29" selection-start-line="29" selection-end-line="29" />
+          <caret line="29" selection-start-line="29" selection-end-line="29"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/AnalysisAction.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="570">
-          <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7" />
+          <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/WALAClient.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="360">
-          <caret line="39" column="42" lean-forward="true" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42" />
+          <caret line="39" column="42" lean-forward="true" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/build.gradle">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="435">
-          <caret line="29" selection-start-line="29" selection-end-line="29" />
+          <caret line="29" selection-start-line="29" selection-end-line="29"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/AnalysisAction.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="1095">
-          <caret line="73" column="7" selection-start-line="73" selection-start-column="7" selection-end-line="73" selection-end-column="7" />
+          <caret line="73" column="7" selection-start-line="73" selection-start-column="7" selection-end-line="73" selection-end-column="7"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/WALAClient.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="285">
-          <caret line="34" column="25" selection-start-line="34" selection-start-column="25" selection-end-line="34" selection-end-column="25" />
+          <caret line="34" column="25" selection-start-line="34" selection-start-column="25" selection-end-line="34" selection-end-column="25"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/build.gradle">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="435">
-          <caret line="29" selection-start-line="29" selection-end-line="29" />
+          <caret line="29" selection-start-line="29" selection-end-line="29"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/AnalysisAction.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="570">
-          <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7" />
+          <caret line="72" column="7" selection-start-line="72" selection-start-column="7" selection-end-line="72" selection-end-column="7"/>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/main/java/com/ibm/wala/ide/pycharm/WALAClient.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="148">
-          <caret line="39" column="42" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42" />
+          <caret line="39" column="42" selection-start-line="39" selection-start-column="42" selection-end-line="39" selection-end-column="42"/>
         </state>
       </provider>
     </entry>
   </component>
   <component name="gradleExecuteTaskHistory">
-    <option value="" />
+    <option value=""/>
   </component>
   <component name="masterDetails">
     <states>
@@ -743,7 +743,7 @@
           <splitter-proportions>
             <option name="proportions">
               <list>
-                <option value="0.2" />
+                <option value="0.2"/>
               </list>
             </option>
           </splitter-proportions>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
             <!-- Override the default `@{project.artifactId}-@{project.version}`.
               The CI deploy gate's tag-check regex matches plain semver
               `X.Y.Z` only, and historical release tags are plain semver.
-              See https://github.com/wala/ML/issues/535. -->
+              See https://github.com/wala/ML/issues/560. -->
             <tagNameFormat>@{project.version}</tagNameFormat>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,18 @@
                     <file>${maven.multiModuleProjectDirectory}/spotless.xml.prefs</file>
                   </files>
                 </eclipseWtp>
+                <!-- Normalize self-closing tag spacing to the spaceless form
+                  (`<tag/>`), matching `pom.xml`'s sortpom style, the
+                  `maven-release-plugin`'s native output, and Eclipse WTP's
+                  default. The Eclipse WTP XML formatter above has no pref
+                  that controls this; without explicit enforcement,
+                  `tensorflow.xml` drifts to ~2135 spaced vs 5 spaceless.
+                  See https://github.com/wala/ML/issues/535. -->
+                <replaceRegex>
+                  <name>Spaceless self-closing tags</name>
+                  <searchRegex>[ \t]+/&gt;</searchRegex>
+                  <replacement>/&gt;</replacement>
+                </replaceRegex>
                 <trimTrailingWhitespace/>
                 <endWithNewline/>
               </format>


### PR DESCRIPTION
## Summary

The general-XML Spotless formatter uses Eclipse WTP, which has no preference for self-closing tag spacing. The result was silent drift: `tensorflow.xml` had 2135 spaced (`<tag />`) and 5 spaceless (`<tag/>`) self-closing tags, with similar mixes across the other summary XMLs.

Pin the spaceless form via a Spotless `replaceRegex` step. This matches `pom.xml`'s sortpom style (already enforced — every release-plugin pom rewrite then re-conflicts with the spaced-XML formatter, biting releases 0.46.0 and 0.46.1), the `maven-release-plugin`'s native output, and Eclipse WTP's default.

The first commit on this branch corrects a stale issue ref in the `tagNameFormat` comment landed by ponder-lab/ML#349 (it referenced #535 but should have referenced #560). The second commit is the actual enforcement plus the one-time normalization across 33 files (~2900 lines, purely whitespace inside self-closing tags).

## Test Plan

- [ ] `mvn spotless:check` passes (verified locally; idempotent).
- [ ] CI green — XML diff is whitespace-only, semantically identical for any XML parser.
- [ ] Future drift caught by `mvn spotless:check` in CI.

Fixes https://github.com/wala/ML/issues/535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)