### PR TITLE
Handle `IOException` locally in `TensorType.shapeArg`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -62,7 +62,6 @@ import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -751,20 +750,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         op,
         builder,
         (CGNode src, SSAAbstractInvokeInstruction call) -> {
-          try {
-            if (call.getNumberOfUses() > param)
-              targets.put(
-                  builder
-                      .getPropagationSystem()
-                      .findOrCreatePointsToSet(
-                          builder
-                              .getPointerAnalysis()
-                              .getHeapModel()
-                              .getPointerKeyForLocal(src, call.getDef())),
-                  TensorType.shapeArg(src, call.getUse(param)));
-          } catch (IOException e) {
-            throw new RuntimeException("Error while processing shape source call: " + call, e);
-          }
+          if (call.getNumberOfUses() > param)
+            targets.put(
+                builder
+                    .getPropagationSystem()
+                    .findOrCreatePointsToSet(
+                        builder
+                            .getPointerAnalysis()
+                            .getHeapModel()
+                            .getPointerKeyForLocal(src, call.getDef())),
+                TensorType.shapeArg(src, call.getUse(param)));
         });
     return targets;
   }
@@ -856,13 +851,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           }
         }
         if (!receiverEligible) continue;
-        try {
-          targets.put(
-              builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
-              TensorType.shapeArg(caller, call.getUse(1)));
-        } catch (IOException e) {
-          throw new RuntimeException("Error while processing set_shape call: " + call, e);
-        }
+        targets.put(
+            builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
+            TensorType.shapeArg(caller, call.getUse(1)));
       }
     }
     return targets;
@@ -971,12 +962,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
     for (PointsToSetVariable v : sources) init.put(v, getTensorTypes(v, builder));
 
-    Map<PointsToSetVariable, TensorType> placeholders = null;
-    try {
-      placeholders = handleShapeSourceOp(builder, dataflow, placeholder, 2);
-    } catch (IOException e) {
-      throw new RuntimeException("Error while processing placeholder calls.", e);
-    }
+    Map<PointsToSetVariable, TensorType> placeholders =
+        handleShapeSourceOp(builder, dataflow, placeholder, 2);
     LOGGER.fine("Placeholders: " + placeholders);
 
     for (Map.Entry<PointsToSetVariable, TensorType> e : placeholders.entrySet())
@@ -1015,12 +1002,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     }
 
     Map<PointsToSetVariable, TensorType> shapeOps = HashMapFactory.make();
-
-    try {
-      shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
-    } catch (IOException e) {
-      throw new RuntimeException("Error while processing reshape calls.", e);
-    }
+    shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
 
     handlePassThroughOp(builder, dataflow, convert_to_tensor, 1);
 
@@ -1098,8 +1080,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       PropagationCallGraphBuilder builder,
       Graph<PointsToSetVariable> dataflow,
       MethodReference op,
-      int shapeSrcOperand)
-      throws IOException {
+      int shapeSrcOperand) {
     Map<PointsToSetVariable, TensorType> reshapeTypes =
         getShapeSourceCalls(op, builder, shapeSrcOperand);
     for (PointsToSetVariable to : reshapeTypes.keySet()) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -627,24 +627,34 @@ public class TensorType implements Iterable<Dimension<?>> {
         logger.fine("value: " + v);
         dims.put(index, v >= 0 ? new NumericDim((Integer) v) : new SymbolicDim("?"));
       } else {
-        if (du.getDef(val) != null && node.getMethod() instanceof AstMethod) {
+        // Guard `iIndex() >= 0`: synthetic defs have a negative instruction index,
+        // for which `getInstructionPosition` has no valid position (same guard as
+        // `PythonTurtleAnalysisEngine`).
+        if (du.getDef(val) != null
+            && node.getMethod() instanceof AstMethod
+            && du.getDef(val).iIndex() >= 0) {
           Position p =
               ((AstMethod) node.getMethod())
                   .debugInfo()
                   .getInstructionPosition(du.getDef(val).iIndex());
-          // `SourceBuffer(Position)` reads the underlying source file. If the file
-          // is unavailable (synthetic / detached position), fall through to the
-          // symbolic-dim fallback below rather than propagating the I/O failure.
-          try {
-            SourceBuffer b = new SourceBuffer(p);
-            String expr = b.toString();
-            Integer ival = PythonInterpreter.interpretAsInt(expr);
-            if (ival != null) {
-              dims.put(index, new NumericDim(ival));
-              continue;
+          // `SourceBuffer(Position)` reads the underlying source file. If the
+          // position is absent (detached def) or the file is unavailable
+          // (synthetic position), fall through to the symbolic-dim fallback below
+          // rather than crashing the analysis. The `p != null` guard prevents a
+          // `SourceBuffer(null)` NPE, which the `IOException` catch would not
+          // handle.
+          if (p != null) {
+            try {
+              SourceBuffer b = new SourceBuffer(p);
+              String expr = b.toString();
+              Integer ival = PythonInterpreter.interpretAsInt(expr);
+              if (ival != null) {
+                dims.put(index, new NumericDim(ival));
+                continue;
+              }
+            } catch (IOException e) {
+              logger.fine(() -> "Could not read source for shape-arg position " + p + ": " + e);
             }
-          } catch (IOException e) {
-            logger.fine(() -> "Could not read source for shape-arg position " + p + ": " + e);
           }
         }
         dims.put(index, new SymbolicDim("?"));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -572,7 +572,7 @@ public class TensorType implements Iterable<Dimension<?>> {
     return new TensorType(FLOAT32.name().toLowerCase(Locale.ROOT), Arrays.asList(batch, vec));
   }
 
-  public static TensorType shapeArg(CGNode node, int literalVn) throws IOException {
+  public static TensorType shapeArg(CGNode node, int literalVn) {
     logger.fine(() -> node.getIR().toString());
     Map<Integer, Dimension<?>> dims = new TreeMap<>();
     DefUse du = node.getDU();
@@ -632,14 +632,19 @@ public class TensorType implements Iterable<Dimension<?>> {
               ((AstMethod) node.getMethod())
                   .debugInfo()
                   .getInstructionPosition(du.getDef(val).iIndex());
-          System.err.println(p);
-          SourceBuffer b = new SourceBuffer(p);
-          String expr = b.toString();
-          System.err.println(expr);
-          Integer ival = PythonInterpreter.interpretAsInt(expr);
-          if (ival != null) {
-            dims.put(index, new NumericDim(ival));
-            continue;
+          // `SourceBuffer(Position)` reads the underlying source file. If the file
+          // is unavailable (synthetic / detached position), fall through to the
+          // symbolic-dim fallback below rather than propagating the I/O failure.
+          try {
+            SourceBuffer b = new SourceBuffer(p);
+            String expr = b.toString();
+            Integer ival = PythonInterpreter.interpretAsInt(expr);
+            if (ival != null) {
+              dims.put(index, new NumericDim(ival));
+              continue;
+            }
+          } catch (IOException e) {
+            logger.fine(() -> "Could not read source for shape-arg position " + p + ": " + e);
           }
         }
         dims.put(index, new SymbolicDim("?"));


### PR DESCRIPTION
## Summary

`TensorType.shapeArg` declared `throws IOException` because `new SourceBuffer(p)` inside the body reads the source file at the SSA-instruction's `Position` (and can fail when the position is synthetic or the source file isn't available). The issue's premise that "no I/O happens" was incomplete — I/O does happen via `SourceBuffer`. But the conclusion (drop the throws clause) was right: the analysis has a symbolic-dim fallback already and can degrade gracefully on I/O failure instead of bubbling up as `RuntimeException` and crashing.

This PR:

- Catches `IOException` inside `shapeArg` (around the `SourceBuffer` block), logs at `FINE`, and falls through to the existing symbolic-dim fallback.
- Drops the `throws IOException` clauses on `shapeArg` and `handleShapeSourceOp`.
- Removes the four `try/catch (IOException) { throw new RuntimeException(...); }` wrappers in `getShapeSourceCalls`, `getSetShapeCallsSyntactic`, and the two `handleShapeSourceOp` call sites.
- Drops two `System.err.println` debug prints in the `shapeArg` source-buffer block (they should never have been there; one short-line cleanup since the surrounding block was being rewritten anyway).

## Test Plan

- [ ] Full mvn test passes in CI.
- [ ] Locally `mvn clean install -DskipTests` passes (Java `-Xlint -failOnWarning` would catch unused-import / dead-throws).
- [ ] No callers were missed (verified via `grep -rn 'shapeArg\|handleShapeSourceOp'`).

Fixes https://github.com/wala/ML/issues/555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)