### PR TITLE
Demote per-call FINE logs to FINER

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -66,8 +66,8 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
   @Override
   public IMethod getCalleeTarget(CGNode caller, CallSiteReference site, IClass receiver) {
     if (receiver != null) {
-      LOGGER.fine("Getting callee target for receiver: " + receiver);
-      LOGGER.fine("Calling method name is: " + caller.getMethod().getName());
+      LOGGER.finer("Getting callee target for receiver: " + receiver);
+      LOGGER.finer("Calling method name is: " + caller.getMethod().getName());
 
       IClassHierarchy cha = receiver.getClassHierarchy();
       if (cha.isSubclassOf(receiver, cha.lookupClass(PythonTypes.object))

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -82,7 +82,7 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
     // TODO: Callable detection may need to be moved. See https://github.com/wala/ML/issues/207. If
     // it stays here, we should further document the receiver swapping process.
     if (isCallable(receiver)) {
-      LOGGER.fine("Encountered callable.");
+      LOGGER.finer("Encountered callable.");
 
       PythonInvokeInstruction call = this.getCall(caller, site);
       if (call == null) return super.getCalleeTarget(caller, site, receiver);
@@ -91,7 +91,7 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
       receiver = getCallable(caller, receiver.getClassHierarchy(), call);
 
       if (receiver == null) return null; // not found.
-      else LOGGER.fine("Substituting the receiver with one derived from a callable.");
+      else LOGGER.finer("Substituting the receiver with one derived from a callable.");
     }
 
     return super.getCalleeTarget(caller, site, receiver);
@@ -298,7 +298,7 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
         if (callable == null) {
           // try the workaround for https://github.com/wala/ML/issues/106. NOTE: We cannot verify
           // that the super class is tf.keras.Model due to https://github.com/wala/ML/issues/118.
-          LOGGER.fine("Attempting callable workaround for https://github.com/wala/ML/issues/118.");
+          LOGGER.finer("Attempting callable workaround for https://github.com/wala/ML/issues/118.");
 
           callable =
               cha.lookupClass(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -978,7 +978,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     ((CAstControlFlowRecorder) cfg).map(call, call);
 
     if (cfg.getTargetLabels(call).isEmpty()) {
-      LOGGER.fine(() -> "no exceptions for " + CAstPrinter.print(call));
+      LOGGER.finer(() -> "no exceptions for " + CAstPrinter.print(call));
       context.cfg().addPreEdgeToExit(call, true);
     } else {
       cfg.getTargetLabels(call)


### PR DESCRIPTION
## Summary

`.level=FINE` is the project's local default for diagnostic logging. The highest-volume FINE sites — `PythonCAstToIRTranslator`'s `"no exceptions for"` per-call note, `PythonInstanceMethodTrampolineTargetSelector` & `PythonConstructorTargetSelector`'s per-receiver dispatch traces — are per-call detail, not human-meaningful flow events. Demoting them to FINER preserves the existing FINE-as-default flow-event view while moving per-call detail out of the default `mvn test` Surefire XML.

Per the issue's volume breakdown, the bulk of the Surefire XML's ~467k FINE lines comes from these sites.

## Test Plan

- [ ] CI green (no semantic change; logs only).
- [ ] A follow-up local `mvn test` run measures the Surefire XML size delta (out of scope for CI but worth confirming once landed).

Partially addresses https://github.com/wala/ML/issues/496. The front-end `LOGGER.info` sweep and per-package volume audit remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)