### PR TITLE
Model `np.ones`/`np.zeros` so `tf.constant(...)` preserves their dtype/shape

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -23,9 +23,12 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
 import com.ibm.wala.cast.python.ml.client.BroadcastTo;
+import com.ibm.wala.cast.python.ml.client.Constant;
 import com.ibm.wala.cast.python.ml.client.Linspace;
 import com.ibm.wala.cast.python.ml.client.NonBroadcastableShapesException;
 import com.ibm.wala.cast.python.ml.client.NpArray;
+import com.ibm.wala.cast.python.ml.client.NpOnes;
+import com.ibm.wala.cast.python.ml.client.NpZeros;
 import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
@@ -220,6 +223,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_2_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
+
+  private static final TensorType TENSOR_2_3_FLOAT64 =
+      new TensorType(FLOAT_64, asList(new NumericDim(2), new NumericDim(3)));
+
+  private static final TensorType TENSOR_4_INT64 =
+      new TensorType(INT_64, asList(new NumericDim(4)));
+
+  private static final TensorType TENSOR_100_784_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(100), new NumericDim(784)));
 
   private static final TensorType TENSOR_3_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(3)));
@@ -2200,13 +2212,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code tf.Variable} weights and biases — a different pattern from the {@code Dense}-layer
    * subclass-Model approach already covered by {@code testNeuralNetwork*}.
    *
-   * <p>Empirically, {@code x} is inferred as {@code ⊤ shape / UNKNOWN dtype}. Root cause confirmed
-   * via {@link #testConstantFromNumpy}: the {@code numpy → tf.constant} dtype-loss bug, tracked as
-   * <a href="https://github.com/wala/ML/issues/539">wala/ML#539</a>. The caller's {@code batch_x =
-   * tf.constant(np.ones((100, 784), dtype=np.float32))} loses dtype through the numpy boundary, so
-   * {@code x} arrives with UNKNOWN dtype.
+   * <p>{@code x} is inferred as {@code (100, 784) float32}, flowing from the caller's {@code
+   * batch_x = tf.constant(np.ones((100, 784), dtype=np.float32))}. This relies on the {@code numpy
+   * → tf.constant} dtype/shape bridge fixed in <a
+   * href="https://github.com/wala/ML/issues/539">wala/ML#539</a> (see {@link
+   * #testConstantFromNumpy} for the isolated guard).
    *
-   * <p>TODO: tighten to {@code (100, 784) float32} once wala/ML#539 lands.
+   * <p>The local-tensor count is 16 (up from 14 before wala/ML#539): with {@code x} now typed, two
+   * further {@code tf.matmul}/{@code tf.add} intermediates that consume it are recognized as
+   * tensors.
    */
   @Test
   public void testMultilayerPerceptron()
@@ -2215,8 +2229,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_multilayer_perceptron.py",
         "multilayer_perceptron",
         1,
-        14,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+        16,
+        Map.of(2, Set.of(TENSOR_100_784_FLOAT32)));
   }
 
   /**
@@ -2242,24 +2256,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Isolating regression guard for the {@code numpy → tf.constant} dtype-loss bug (<a
+   * Isolating regression guard for the {@code numpy → tf.constant} dtype/shape bridge (<a
    * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>), surfaced from {@link
    * #testMultilayerPerceptron}. {@code consume(x)} where {@code x = tf.constant(np.ones((2, 3),
-   * dtype=np.float32))} infers {@code ⊤ shape / UNKNOWN dtype} despite the explicit numpy {@code
-   * dtype=np.float32}. Confirms the dtype-loss happens at the {@code numpy → tf.constant} boundary,
-   * independent of any matmul/global-Variable noise.
-   *
-   * <p>TODO: tighten to {@code (2, 3) float32} once wala/ML#539 lands.
+   * dtype=np.float32))} infers {@code (2, 3) float32}: {@code np.ones} is now modeled (see {@link
+   * NpOnes}), so {@link Constant} recovers the numpy producer's shape and dtype through the value
+   * argument rather than falling back to {@code ⊤ shape / UNKNOWN dtype}.
    */
   @Test
   public void testConstantFromNumpy()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_constant_from_numpy.py",
-        "consume",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+    test("tf2_test_constant_from_numpy.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   /**
@@ -9873,6 +9880,47 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_60000_28_28_FLOAT32)));
+  }
+
+  /**
+   * Pins {@link NpOnes} directly (isolated from the {@code tf.constant} bridge of {@link
+   * #testConstantFromNumpy}): {@code consume_ones(x)} where {@code x = np.ones((2, 3),
+   * dtype=np.float32)} should yield {@code (2, 3) float32} &mdash; shape from the shape-tuple
+   * argument, dtype from the explicit {@code dtype} argument. Positive regression guard for
+   * wala/ML#539.
+   */
+  @Test
+  public void testNpOnes()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_ones_zeros.py", "consume_ones", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * Pins {@link NpZeros} directly: {@code consume_zeros(x)} where {@code x = np.zeros((4,),
+   * dtype=np.int64)} should yield {@code (4,) int64}. Companion to {@link #testNpOnes}; positive
+   * regression guard for wala/ML#539.
+   */
+  @Test
+  public void testNpZeros()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_ones_zeros.py", "consume_zeros", 1, 1, Map.of(2, Set.of(TENSOR_4_INT64)));
+  }
+
+  /**
+   * Pins {@link NpOnes}'s default dtype: {@code consume_ones_default(x)} where {@code x =
+   * np.ones((2, 3))} (no {@code dtype} argument) should yield {@code (2, 3) float64}, since NumPy
+   * defaults to {@code float64} (unlike {@code tf.ones}, which defaults to {@code float32}). Guards
+   * the {@code float64} default override in {@link NpOnes#getDefaultDTypes} for wala/ML#539.
+   */
+  @Test
+  public void testNpOnesDefaultDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_ones_zeros.py",
+        "consume_ones_default",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT64)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2270,6 +2270,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Companion to {@link #testConstantFromNumpy} for the {@code np.zeros → tf.constant} bridge:
+   * {@code consume(x)} where {@code x = tf.constant(np.zeros((2, 3), dtype=np.int32))} infers
+   * {@code (2, 3) int32}. Exercises {@link NpZeros} via the {@code createManualGenerator} recovery
+   * path (symmetric to the {@code np.ones} bridge in {@link #testMultilayerPerceptron}, but with a
+   * non-float dtype). Positive regression guard for wala/ML#539.
+   */
+  @Test
+  public void testConstantFromNpZeros()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_constant_from_np_zeros.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_INT32)));
+  }
+
+  /**
    * {@code MyModel.call(self, x)} receives {@code x} from {@code model(images)} calls inside {@code
    * train_step} and {@code test_step}. {@code images} comes from iterating {@code train_ds}, {@code
    * valid_ds}, or {@code test_ds} &mdash; all created from mnist data via {@code

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -15,6 +15,10 @@
         <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64"/>
         <new def="array_fn" class="Lnumpy/array"/>
         <putfield class="LRoot" field="array" fieldType="LRoot" ref="x" value="array_fn"/>
+        <new def="ones_fn" class="Lnumpy/ones"/>
+        <putfield class="LRoot" field="ones" fieldType="LRoot" ref="x" value="ones_fn"/>
+        <new def="zeros_fn" class="Lnumpy/zeros"/>
+        <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros_fn"/>
         <new def="reshape_fn" class="Lnumpy/reshape"/>
         <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape_fn"/>
         <return value="x"/>
@@ -25,6 +29,32 @@
       <!-- Modeled as a class-per-function so that `np.array` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray preserves shape from arg 0 and takes dtype from arg 1; see `NpArray`. -->
       <class name="array" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x dtype">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.ones.html -->
+      <!-- Modeled as a class-per-function (same pattern as `array`) so that `np.ones` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray takes its shape from arg 0 (a shape tuple) and its dtype from the `dtype` argument;
+        see `NpOnes`. -->
+      <class name="ones" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self shape dtype">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.zeros.html -->
+      <!-- Modeled as a class-per-function (same pattern as `array`) so that `np.zeros` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray takes its shape from arg 0 (a shape tuple) and its dtype from the `dtype` argument;
+        see `NpZeros`. -->
+      <class name="zeros" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self shape dtype">
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
@@ -1,0 +1,58 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * A generator for ndarrays created by NumPy's {@code ones()} function.
+ *
+ * <p>Structurally identical to {@link Ones} (the shape comes from the mandatory shape-tuple
+ * argument and the dtype from the {@code dtype} argument), differing only in the default dtype:
+ * NumPy defaults to {@code float64} whereas TensorFlow's {@code tf.ones} defaults to {@code
+ * float32}.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/generated/numpy.ones.html">numpy.ones()
+ *     API</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpOnes extends Ones {
+
+  private static final Logger LOGGER = getLogger(NpOnes.class.getName());
+
+  public NpOnes(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpOnes(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>NumPy defaults to {@code float64} when no {@code dtype} argument is supplied.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} for the analysis.
+   * @return A singleton set containing the default NumPy dtype, {@code float64}.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    LOGGER.fine(
+        () ->
+            "No dtype specified for source: "
+                + source
+                + ". Using NumPy default dtype of: "
+                + FLOAT64
+                + ".");
+
+    return EnumSet.of(FLOAT64);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpZeros.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpZeros.java
@@ -1,0 +1,26 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * A generator for ndarrays created by NumPy's {@code zeros()} function.
+ *
+ * <p>Shares all shape and dtype logic with {@link NpOnes} (shape from the mandatory shape-tuple
+ * argument, dtype from the {@code dtype} argument with a {@code float64} default), mirroring how
+ * {@link Zeros} extends {@link Ones} on the TensorFlow side.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/generated/numpy.zeros.html">numpy.zeros()
+ *     API</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpZeros extends NpOnes {
+
+  public NpZeros(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpZeros(CGNode node) {
+    super(node);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2030,9 +2030,11 @@ public abstract class TensorGenerator {
   }
 
   /**
-   * Returns the TensorFlow function signature represented by this generator.
+   * Returns the TensorFlow or NumPy function signature represented by this generator.
    *
-   * @return The TensorFlow function signature represented by this generator.
+   * @return The TensorFlow or NumPy function signature represented by this generator, or {@code
+   *     <unmapped:...>} if the function has no mapped signature in either {@link TensorFlowTypes}
+   *     or {@link NumpyTypes}.
    */
   protected String getSignature() {
     TypeReference function;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2041,7 +2041,10 @@ public abstract class TensorGenerator {
     } else {
       function = getFunction(this.getSource());
     }
-    String signature = TYPE_REFERENCE_TO_SIGNATURE.get(function);
+    // TensorFlow signatures live in TensorFlowTypes; numpy signatures in NumpyTypes. Consult both.
+    String signature =
+        TYPE_REFERENCE_TO_SIGNATURE.getOrDefault(
+            function, NumpyTypes.TYPE_REFERENCE_TO_SIGNATURE.get(function));
     if (signature == null) {
       return "<unmapped:" + function + ">";
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2824,6 +2824,10 @@ public abstract class TensorGenerator {
       return new Ones(node);
     } else if (type.equals(TensorFlowTypes.ZEROS.getDeclaringClass())) {
       return new Zeros(node);
+    } else if (type.equals(NumpyTypes.ONES.getDeclaringClass())) {
+      return new NpOnes(node);
+    } else if (type.equals(NumpyTypes.ZEROS.getDeclaringClass())) {
+      return new NpZeros(node);
     } else if (type.equals(TensorFlowTypes.SPARSE_EYE.getDeclaringClass())) {
       return new SparseEye(node);
     } else if (type.equals(TensorFlowTypes.EYE.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1102,6 +1102,9 @@ public class TensorGeneratorFactory {
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);
     else if (isType(calledFunction, NumpyTypes.ARRAY.getDeclaringClass()))
       return new NpArray(source);
+    else if (isType(calledFunction, NumpyTypes.ONES.getDeclaringClass())) return new NpOnes(source);
+    else if (isType(calledFunction, NumpyTypes.ZEROS.getDeclaringClass()))
+      return new NpZeros(source);
     else if (isType(calledFunction, NumpyTypes.RESHAPE.getDeclaringClass()))
       return new NpReshape(source);
     else if (isType(calledFunction, DATASET_FROM_TENSOR_SLICES_TYPE))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -122,8 +122,6 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NEGATIVE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NORMAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NORMAL_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NOT_EQUAL;
-import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NUMPY_ARRAY;
-import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.NUMPY_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ONES;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ONE_HOT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.PLACEHOLDER;
@@ -195,6 +193,7 @@ import static java.util.Map.entry;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
+import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -1101,8 +1100,9 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);
     else if (isType(calledFunction, TENSOR.getDeclaringClass())
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);
-    else if (isType(calledFunction, NUMPY_ARRAY.getDeclaringClass())) return new NpArray(source);
-    else if (isType(calledFunction, NUMPY_RESHAPE.getDeclaringClass()))
+    else if (isType(calledFunction, NumpyTypes.ARRAY.getDeclaringClass()))
+      return new NpArray(source);
+    else if (isType(calledFunction, NumpyTypes.RESHAPE.getDeclaringClass()))
       return new NpReshape(source);
     else if (isType(calledFunction, DATASET_FROM_TENSOR_SLICES_TYPE))
       return new DatasetFromTensorSlicesGenerator(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -61,7 +61,7 @@ public class NumpyTypes extends PythonTypes {
   public static final MethodReference ARRAY =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/core/multiarray/array")),
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/array")),
           AstMethodReference.fnSelector);
 
   private static final String ARRAY_SIGNATURE = "numpy.array()";
@@ -70,7 +70,7 @@ public class NumpyTypes extends PythonTypes {
   public static final MethodReference ZEROS =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/core/numeric/zeros")),
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/zeros")),
           AstMethodReference.fnSelector);
 
   private static final String ZEROS_SIGNATURE = "numpy.zeros()";
@@ -79,7 +79,7 @@ public class NumpyTypes extends PythonTypes {
   public static final MethodReference ONES =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/core/numeric/ones")),
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/ones")),
           AstMethodReference.fnSelector);
 
   private static final String ONES_SIGNATURE = "numpy.ones()";
@@ -88,8 +88,7 @@ public class NumpyTypes extends PythonTypes {
   public static final MethodReference RESHAPE =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
-              PythonTypes.pythonLoader,
-              TypeName.string2TypeName("Lnumpy/core/fromnumeric/reshape")),
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/reshape")),
           AstMethodReference.fnSelector);
 
   private static final String RESHAPE_SIGNATURE = "numpy.reshape()";

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -796,22 +796,6 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String NDARRAY_SIGNATURE = "tf.ndarray()";
 
-  public static final MethodReference NUMPY_ARRAY =
-      MethodReference.findOrCreate(
-          TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/array")),
-          AstMethodReference.fnSelector);
-
-  private static final String NUMPY_ARRAY_SIGNATURE = "numpy.array()";
-
-  public static final MethodReference NUMPY_RESHAPE =
-      MethodReference.findOrCreate(
-          TypeReference.findOrCreate(
-              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/reshape")),
-          AstMethodReference.fnSelector);
-
-  private static final String NUMPY_RESHAPE_SIGNATURE = "numpy.reshape()";
-
   public static final MethodReference READ_DATA_SETS =
       MethodReference.findOrCreate(
           TypeReference.findOrCreate(
@@ -1851,8 +1835,6 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(MODEL_CALL.getDeclaringClass(), MODEL_CALL_SIGNATURE),
           Map.entry(TENSOR.getDeclaringClass(), TENSOR_SIGNATURE),
           Map.entry(NDARRAY.getDeclaringClass(), NDARRAY_SIGNATURE),
-          Map.entry(NUMPY_ARRAY.getDeclaringClass(), NUMPY_ARRAY_SIGNATURE),
-          Map.entry(NUMPY_RESHAPE.getDeclaringClass(), NUMPY_RESHAPE_SIGNATURE),
           Map.entry(READ_DATA_SETS.getDeclaringClass(), READ_DATA_SETS_SIGNATURE),
           Map.entry(MNIST_X_TRAIN, MNIST_X_TRAIN_SIGNATURE),
           Map.entry(MNIST_Y_TRAIN, MNIST_Y_TRAIN_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_np_zeros.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_constant_from_np_zeros.py
@@ -1,0 +1,17 @@
+# Companion to `tf2_test_constant_from_numpy.py` for the `np.zeros → tf.constant`
+# bridge (wala/ML#539). Exercises the `NpZeros` manual-generator recovery path
+# (`createManualGenerator`) — symmetric to the `np.ones` bridge but with a
+# non-float dtype — so the `tf.constant` result is `(2, 3) int32` rather than ⊤.
+import numpy as np
+import tensorflow as tf
+
+
+def consume(x):
+    """Sink function — pins the dtype/shape of whatever flows in as `x`."""
+    return x
+
+
+arr_from_np = tf.constant(np.zeros((2, 3), dtype=np.int32))
+assert arr_from_np.shape == (2, 3)
+assert arr_from_np.dtype == tf.int32
+consume(arr_from_np)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_ones_zeros.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_ones_zeros.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 import numpy as np
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_ones_zeros.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_ones_zeros.py
@@ -1,0 +1,37 @@
+import tensorflow as tf
+import numpy as np
+
+
+def consume_ones(tensor):
+    pass
+
+
+def consume_zeros(tensor):
+    pass
+
+
+def consume_ones_default(tensor):
+    pass
+
+
+# `np.ones(shape, dtype)`: the shape comes from the shape tuple (arg 0) and the
+# dtype from the explicit `dtype` argument. Isolated from `tf.constant` so this
+# pins the `NpOnes` generator directly (wala/ML#539).
+a = np.ones((2, 3), dtype=np.float32)
+assert a.shape == (2, 3)
+assert a.dtype == np.float32
+consume_ones(a)
+
+# `np.zeros(shape, dtype)`: same shape-from-tuple / dtype-from-arg contract via
+# `NpZeros`.
+b = np.zeros((4,), dtype=np.int64)
+assert b.shape == (4,)
+assert b.dtype == np.int64
+consume_zeros(b)
+
+# `np.ones(shape)` without an explicit dtype: NumPy defaults to `float64` (unlike
+# TensorFlow's `tf.ones`, which defaults to `float32`).
+c = np.ones((2, 3))
+assert c.shape == (2, 3)
+assert c.dtype == np.float64
+consume_ones_default(c)


### PR DESCRIPTION
Fixes `tf.constant(np.ones((2, 3), dtype=np.float32))` inferring `⊤ shape/UNKNOWN dtype` instead of `(2, 3) float32`. `np.ones`/`np.zeros` were unmodeled, so the call returned an untyped synthetic result that dropped the value from downstream analysis. This is a contributory blocker for input-signature inference on the perf-eval corpus (e.g. `multilayer_perceptron(x)`, whose caller passes `tf.constant(np.ones((100, 784), dtype=np.float32))`).

### Two Commits

1. **Consolidate numpy method references into `NumpyTypes`** (refactor, behavior-preserving)—the live numpy dispatch refs lived in `TensorFlowTypes` (`NUMPY_ARRAY`/`NUMPY_RESHAPE`) while `NumpyTypes` carried a dead parallel set with wrong deep-internal type strings feeding an unconsumed signature map. Makes `NumpyTypes` the single source of truth: corrects its `ARRAY`/`RESHAPE`/`ONES`/`ZEROS` type strings, drops the `TensorFlowTypes` copies, and has `TensorGenerator.getCalledFunctionSignature` consult both signature maps.
2. **Model `np.ones`/`np.zeros`** (the fix)—models both as class-per-function `do(self, shape, dtype)` methods returning a fresh `Lnumpy/ndarray` (mirroring `np.array`); adds `NpOnes`/`NpZeros` generators (thin subclasses of the TensorFlow `Ones`/`Zeros`, overriding only the default dtype to `float64`, NumPy's default). The `tf.constant` bridge recovers a value argument's producer via `createManualGenerator`, which had cases for the TensorFlow `Ones`/`Zeros` `do` methods but none for numpy—so `tf.constant` of any numpy producer fell back to `⊤`. Adding the `NumpyTypes.ONES`/`ZEROS` cases there fixes the bridge (and, via the shared path, `np.array` through `tf.constant`).

### Tests

- Flips the two waiting regression guards: `testConstantFromNumpy` (now `(2, 3) float32`) and `testMultilayerPerceptron` (now `(100, 784) float32`; local-tensor count 16, up from 14 as two `tf.matmul`/`tf.add` intermediates that consume the now-typed parameter become tensors).
- Adds `tf2_test_np_ones_zeros.py` with `testNpOnes`/`testNpZeros`/`testNpOnesDefaultDtype`, pinning the generators in isolation from the `tf.constant` bridge, including NumPy's `float64` default.

Full suite green locally (795 tests, 0 failures).

Follow-up filed: wala/ML#563 (reconcile the two parallel `DType` enums, deliberately untouched here).

Closes wala/ML#539.
