### PR TITLE
Match Spotless POM self-closing style to `maven-release-plugin` output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <parallel>both</parallel>
     <logging.config.file>./logging.properties</logging.config.file>
     <jacoco-version>0.8.14</jacoco-version>
-    <argLine/>
+    <argLine />
     <junit.4.version>4.13.2</junit.4.version>
   </properties>
   <dependencyManagement>
@@ -228,8 +228,8 @@
                   <exclude>IDE/</exclude>
                   <exclude>jython3/</exclude>
                 </excludes>
-                <trimTrailingWhitespace/>
-                <endWithNewline/>
+                <trimTrailingWhitespace />
+                <endWithNewline />
               </format>
               <format>
                 <includes>
@@ -239,8 +239,8 @@
                 <excludes>
                   <exclude>**/target/</exclude>
                 </excludes>
-                <trimTrailingWhitespace/>
-                <endWithNewline/>
+                <trimTrailingWhitespace />
+                <endWithNewline />
                 <indent>
                   <tabs>true</tabs>
                   <spacesPerTab>4</spacesPerTab>
@@ -251,7 +251,7 @@
                   <include>**/*.xml</include>
                   <include>**/.pydevproject</include>
                 </includes>
-                <toggleOffOn/>
+                <toggleOffOn />
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>**/pom.xml</exclude>
@@ -280,8 +280,8 @@
                   <searchRegex>[ \t]+/&gt;</searchRegex>
                   <replacement>/&gt;</replacement>
                 </replaceRegex>
-                <trimTrailingWhitespace/>
-                <endWithNewline/>
+                <trimTrailingWhitespace />
+                <endWithNewline />
               </format>
             </formats>
             <java>
@@ -289,12 +289,23 @@
                 <version>1.27.0</version>
                 <reflowLongStrings>true</reflowLongStrings>
               </googleJavaFormat>
-              <trimTrailingWhitespace/>
-              <endWithNewline/>
+              <trimTrailingWhitespace />
+              <endWithNewline />
             </java>
             <pom>
               <sortPom>
                 <expandEmptyElements>false</expandEmptyElements>
+                <!-- Emit `<tag />` (space before the self-closing slash) to match
+                  the `maven-release-plugin`'s native POM serialization. Without
+                  this, every `release:prepare` rewrites the POMs to the spaced
+                  form, which `spotless:check` then rejects — failing the tag-push
+                  `build` job and silently skipping the deploy (the root cause of
+                  the 0.47.0 manual-deploy incident). See
+                  https://github.com/wala/ML/issues/566. Only POMs use the spaced
+                  form; the summary XMLs (`tensorflow.xml`, etc.) stay spaceless
+                  via the separate `replaceRegex` step (wala/ML#535), since
+                  nothing rewrites them. -->
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
               </sortPom>
             </pom>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -269,12 +269,15 @@
                   </files>
                 </eclipseWtp>
                 <!-- Normalize self-closing tag spacing to the spaceless form
-                  (`<tag/>`), matching `pom.xml`'s sortpom style, the
-                  `maven-release-plugin`'s native output, and Eclipse WTP's
-                  default. The Eclipse WTP XML formatter above has no pref
-                  that controls this; without explicit enforcement,
-                  `tensorflow.xml` drifts to ~2135 spaced vs 5 spaceless.
-                  See https://github.com/wala/ML/issues/535. -->
+                  (`<tag/>`) for the summary XMLs (this format excludes POMs,
+                  above). The Eclipse WTP XML formatter has no pref that controls
+                  this; without explicit enforcement, `tensorflow.xml` drifts to
+                  ~2135 spaced vs 5 spaceless. See
+                  https://github.com/wala/ML/issues/535. POMs deliberately use
+                  the *spaced* form instead — via sortPom's
+                  `spaceBeforeCloseEmptyElement` — to match the
+                  `maven-release-plugin`'s output; see
+                  https://github.com/wala/ML/issues/566. -->
                 <replaceRegex>
                   <name>Spaceless self-closing tags</name>
                   <searchRegex>[ \t]+/&gt;</searchRegex>


### PR DESCRIPTION
Fixes the release-breaking Spotless conflict that forced 0.47.0 to be deployed manually (wala/ML#566).

## Problem

`maven-release-plugin` re-serializes POMs with the **spaced** self-closing form (`<tag />`) during `release:prepare`, but Spotless's `sortPom` enforced the **spaceless** form (`<tag/>`). So every release commit was Spotless-dirty on the root POM. Pre-wala/ML#349 this was harmless (the `ml-X.Y.Z` tags failed the semver deploy gate and skipped deploy anyway, with post-hoc cleanup like `c3d3d51e`). After #349 pinned plain `X.Y.Z` tags, the tag-push `build` job fails at `spotless:check` and silently skips `release-upload` — `0.47.0` never published via CI and had to be deployed by hand.

Note this is **not** the conflict wala/ML#351 addressed: POMs are already excluded from #351's `replaceRegex`. The POM conflict is `sortPom`'s, and #351's premise that the spaceless form "matches the maven-release-plugin output" was incorrect — the plugin emits the spaced form.

## Fix

Set `sortPom`'s `spaceBeforeCloseEmptyElement=true` so Spotless enforces the same spaced form the release plugin emits. Release commits are now clean from the start. Only POMs adopt the spaced form; the summary XMLs (`tensorflow.xml`, etc.) stay spaceless via the separate `replaceRegex` step (wala/ML#535), since nothing rewrites them.

## Verification

A `release:prepare -DdryRun` produces a tag POM that is **formatting-identical** to the Spotless-clean committed POM — the only differences are the `<version>` and scm `<tag>` values:

```
6c6
<   <version>0.47.1-SNAPSHOT</version>
> <version>0.99.0</version>
22c22
<     <tag>ml-0.45.0</tag>
> <tag>0.99.0</tag>
```

So a real release will pass the tag `build`'s `spotless:check` and deploy without manual intervention.

Fixes wala/ML#566.