### PR TITLE
Document the release process in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,53 @@ You must install the `jython-dev.jar` to your local maven repository.
 
 Build and install to your local Maven repo: `mvn install`
 
+## Cutting a Release
+
+Releases are published to GitHub Packages (`maven.pkg.github.com/ponder-lab/ML`), including the consumer-facing fat JAR `com.ibm.wala.cast.python.ml-X.Y.Z-fat.jar`. Cutting a release uses `maven-release-plugin`; CI publishes the artifacts automatically when the release tag is pushed, so there is no manual `mvn deploy` step.
+
+### Prerequisites
+
+- The local-dependency installs above (Jython 3 at `0.0.2` and `cast.lsp` at `0.0.1`). `release:prepare` rejects SNAPSHOT dependencies, so these must be present at their release coordinates.
+- Push access to `master`. `release:prepare` pushes two version-bump commits and the tag directly to `master`, bypassing the pull-request requirement via the OrganizationAdmin bypass (sanctioned per [wala/ML#457](https://github.com/wala/ML/issues/457)).
+- A classic PAT is *not* needed for the standard flow: the operator only pushes git commits and a tag; CI does the GitHub Packages deploy. (A classic PAT with `write:packages` is only needed for the manual-deploy fallback below — fine-grained PATs do not authenticate to `maven.pkg.github.com`.)
+
+### Steps
+
+1. From a clean checkout of `master`, run:
+
+	```bash
+	mvn release:clean -B
+	mvn release:prepare -B \
+		-DreleaseVersion=X.Y.Z \
+		-DdevelopmentVersion=X.Y.W-SNAPSHOT
+	```
+
+	For example, to cut `0.48.0` with the next development version `0.48.1-SNAPSHOT`, use `-DreleaseVersion=0.48.0 -DdevelopmentVersion=0.48.1-SNAPSHOT`. No other flags are needed: the tag format is pinned to plain `X.Y.Z` ([wala/ML#560](https://github.com/wala/ML/issues/560)) and the local dependencies are installed at release coordinates (see the install steps above), so `-Dtag`, `-DignoreSnapshots`, and `-DallowTimestampedSnapshots` are unnecessary. `release:prepare` builds and tests the release version, sets it, commits, tags, sets the next development version, commits, and pushes everything to `master`.
+
+1. The tag push triggers CI's deploy gate ([wala/ML#421](https://github.com/wala/ML/issues/421)), which builds the tag and publishes the artifacts to GitHub Packages. The gate requires the tag to be plain semver *and* an ancestor of `master`.
+
+1. Publish the GitHub release. Convention is `--prerelease`, and the notes should reflect the full diff since the previous release (`git log <prev-tag>..X.Y.Z`), not just one change:
+
+	```bash
+	gh release create X.Y.Z --prerelease --title "X.Y.Z" --notes "..."
+	```
+
+1. Confirm the version published:
+
+	```bash
+	gh api "/orgs/ponder-lab/packages/maven/com.ibm.wala.com.ibm.wala.cast.python.ml/versions" --jq '.[].name' | head
+	```
+
+### Troubleshooting
+
+- **The tag pushed but the deploy did not fire** (rare — e.g., the tag's commit predates a workflow fix). Re-trigger the tag-push event: `git push --delete origin X.Y.Z && git push origin X.Y.Z`. ([wala/ML#454](https://github.com/wala/ML/issues/454) tracks a `workflow_dispatch` recovery for this.)
+- **The pre-commit hook rejects `release:prepare`'s commit** ("files were modified by this hook"). This was a Spotless / `maven-release-plugin` self-closing-tag conflict, fixed in [wala/ML#566](https://github.com/wala/ML/issues/566) (`sortPom`'s `spaceBeforeCloseEmptyElement`). If it ever recurs, run the release with git hooks disabled: `git config core.hooksPath "$(mktemp -d)"`, run `release:prepare`, then `git config --unset core.hooksPath`.
+- **Manual-deploy fallback.** If CI cannot deploy a tag at all, deploy from a clean local build: check out the release commit, `mvn spotless:apply` (working tree only), then `mvn clean deploy -DskipTests -B` using a `~/.m2/settings.xml` `github` server with a classic `write:packages` PAT.
+
+### One-Click Releases (Planned)
+
+[wala/ML#455](https://github.com/wala/ML/issues/455) tracks moving this to a `workflow_dispatch` GitHub Action so a release can be cut from the Actions UI with no local toolchain or credentials.
+
 ## Commit Messages
 
 - End commit messages with a period.


### PR DESCRIPTION
Adds a "Cutting a Release" section to `CONTRIBUTING.md`. The repo previously documented only the dependency-coordinate prerequisite — there was no runbook for actually cutting a release, which made today's 0.47.0 cut a reconstruct-from-scratch exercise.

## Contents

- **Prerequisites** — the local dep installs, push access to `master` (the OrganizationAdmin bypass, wala/ML#457), and the clarification that no `write:packages` PAT is needed for the standard flow (CI deploys).
- **Steps** — `release:clean` / `release:prepare` with the *current minimal* flag set (no `-Dtag`, `-DignoreSnapshots`, or `-DallowTimestampedSnapshots`, now unnecessary after the tag-format pin for wala/ML#560 and the release-coordinate dep installs), CI tag-deploy (wala/ML#421), `gh release create --prerelease`, and registry verification.
- **Troubleshooting** — deploy-did-not-fire tag re-push (wala/ML#454), the pre-commit-hook conflict fixed in wala/ML#566 (with the hooks-disabled workaround if it recurs), and the manual-deploy fallback.
- **One-click releases (planned)** — points at wala/ML#455.

Doc-only; no behavior change.