### PR TITLE
Bind `spotless:check` to the `verify` lifecycle phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,31 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <!-- Bind `spotless:check` to `verify` so formatting is enforced by the build
+        itself, not only by the standalone CI step and the pre-commit hook. This
+        closes the gap where `mvn release:prepare`'s default `clean verify` did not
+        run Spotless, so a formatting violation could be committed, tagged, and
+        pushed before the tag-push deploy failed on it. `inherited=false` keeps it a
+        single root-level pass over the whole tree — the Spotless `<format>`s use
+        repo-root-relative `**/*` globs, so running it per-module would re-check the
+        root's subtree from each child. The plugin config (formats, sortPom, ...)
+        is inherited from `<pluginManagement>` above. -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
   <reporting>
     <plugins>


### PR DESCRIPTION
Answers "should Spotless be in the lifecycle?"—yes. Spotless was configured only in `<pluginManagement>`, so it ran solely as a standalone CI step and the pre-commit hook, never during `mvn verify`/`install`.

## Why

That gap is a root cause behind the release fragility: `mvn release:prepare`'s default `clean verify` did **not** run Spotless, so a formatting violation could be committed, tagged, and pushed, only to fail at the tag-push deploy (one of the things that broke the 0.47.0 cut). Binding the check to `verify` closes it at the source—complementing wala/ML#566 (which made the version-bumped POMs Spotless-clean in the first place).

## What

- Bind `spotless:check` to `verify`, `inherited=false` so it runs **once at the root** over the whole tree. The `<format>`s use repo-root `**/*` globs, so a per-module (inherited) binding would re-check the root subtree from every child.
- Config (formats, sortPom, ...) is inherited from `<pluginManagement>`; this only adds the execution.

Now `release:prepare`, `mvn verify`, and `mvn install` all enforce formatting. The tradeoff: a local `mvn verify`/`install` fails on a formatting violation in the working tree—mitigated by the pre-commit hook, which keeps committed code clean, so it only bites uncommitted WIP.

## Verification

Tested locally on the root module (`pom` packaging, fast):
- Clean tree: `spotless:check` runs at `verify`, `BUILD SUCCESS`.
- Deliberate violation (stray trailing newlines): `BUILD FAILURE` at `spotless:check`.

It even caught the initial unformatted `<execution>` block in this very change.

## Follow-Ups

- CI keeps its standalone `spotless:check` step for fast-fail before the slower build (a few-second redundancy; preserves quick formatting feedback).
- The release workflow's pre-flight Spotless check (ponder-lab/ML#358) becomes redundant once both land and can be trimmed; its `black --check` pre-flight stays (Black is not a Maven goal).
