### PR TITLE
Lead the release runbook with the one-click workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,17 +62,30 @@ Build and install to your local Maven repo: `mvn install`
 
 ## Cutting a Release
 
-Releases are published to GitHub Packages (`maven.pkg.github.com/ponder-lab/ML`), including the consumer-facing fat JAR `com.ibm.wala.cast.python.ml-X.Y.Z-fat.jar`. Cutting a release uses `maven-release-plugin`; CI publishes the artifacts automatically when the release tag is pushed, so there is no manual `mvn deploy` step.
+Releases are published to GitHub Packages (`maven.pkg.github.com/ponder-lab/ML`), including the consumer-facing fat JAR `com.ibm.wala.cast.python.ml-X.Y.Z-fat.jar`. The mechanism is `maven-release-plugin`: it pushes two version-bump commits and a plain-semver tag to `master`, and the tag push drives CI's deploy gate (publish to GitHub Packages) and `release-upload` job (create the prerelease with generated notes and attach the fat JAR). There is no manual `mvn deploy` or `gh release create` step.
 
-### Prerequisites
+### One-Click Release (Preferred)
 
-- The local-dependency installs above (Jython 3 at `0.0.2` and `cast.lsp` at `0.0.1`). `release:prepare` rejects SNAPSHOT dependencies, so these must be present at their release coordinates.
-- Push access to `master`. `release:prepare` pushes two version-bump commits and the tag directly to `master`, bypassing the pull-request requirement via the OrganizationAdmin bypass (sanctioned per [wala/ML#457](https://github.com/wala/ML/issues/457)).
-- A classic PAT is *not* needed for the standard flow: the operator only pushes git commits and a tag; CI does the GitHub Packages deploy. (A classic PAT with `write:packages` is only needed for the manual-deploy fallback below — fine-grained PATs do not authenticate to `maven.pkg.github.com`.)
+Dispatch the **Cut release** workflow (`.github/workflows/release.yml`), which runs `maven-release-plugin` on a runner — no local toolchain, flags, or credentials. From the Actions UI: **Actions → Cut release → Run workflow**, select branch `master`, and enter the versions. Or from the CLI:
 
-### Steps
+```bash
+gh workflow run release.yml --repo ponder-lab/ML --ref master \
+	-f releaseVersion=0.48.0 -f developmentVersion=0.48.1-SNAPSHOT
+```
 
-1. From a clean checkout of `master`, run:
+`releaseVersion` is plain semver (`X.Y.Z`); `developmentVersion` is the next snapshot (`X.Y.W-SNAPSHOT`). The workflow validates the inputs, tests the release version before tagging, pushes the commits and tag, and the tag-push CI then deploys and creates the prerelease. Confirm the published version afterward:
+
+```bash
+gh api "/orgs/ponder-lab/packages/maven/com.ibm.wala.com.ibm.wala.cast.python.ml/versions" --jq '.[].name' | head
+```
+
+**One-time setup:** the workflow needs a `RELEASE_PAT` repository secret — a *classic* PAT (fine-grained PATs do not authenticate to `maven.pkg.github.com`) with `repo` scope, owned by an OrganizationAdmin so its push bypasses the `master` branch protection (`github-actions[bot]` is not a bypass actor; the default `GITHUB_TOKEN` push would be rejected).
+
+### Manual Release (Fallback)
+
+If you need to cut a release locally, the prerequisites are the local-dependency installs above (Jython 3 at `0.0.2`, `cast.lsp` at `0.0.1`; `release:prepare` rejects SNAPSHOT dependencies) and push access to `master` (the version-bump commits push directly, bypassing the pull-request requirement via the OrganizationAdmin bypass, sanctioned per [wala/ML#457](https://github.com/wala/ML/issues/457)).
+
+1. From a clean checkout of `master`:
 
 	```bash
 	mvn release:clean -B
@@ -81,31 +94,15 @@ Releases are published to GitHub Packages (`maven.pkg.github.com/ponder-lab/ML`)
 		-DdevelopmentVersion=X.Y.W-SNAPSHOT
 	```
 
-	For example, to cut `0.48.0` with the next development version `0.48.1-SNAPSHOT`, use `-DreleaseVersion=0.48.0 -DdevelopmentVersion=0.48.1-SNAPSHOT`. No other flags are needed: the tag format is pinned to plain `X.Y.Z` ([wala/ML#560](https://github.com/wala/ML/issues/560)) and the local dependencies are installed at release coordinates (see the install steps above), so `-Dtag`, `-DignoreSnapshots`, and `-DallowTimestampedSnapshots` are unnecessary. `release:prepare` builds and tests the release version, sets it, commits, tags, sets the next development version, commits, and pushes everything to `master`.
+	No other flags are needed: the tag format is pinned to plain `X.Y.Z` ([wala/ML#560](https://github.com/wala/ML/issues/560)) and the local dependencies are installed at release coordinates, so `-Dtag`, `-DignoreSnapshots`, and `-DallowTimestampedSnapshots` are unnecessary. `release:prepare` builds and tests the release version, sets it, commits, tags, sets the next development version, commits, and pushes everything to `master`.
 
-1. The tag push triggers CI's deploy gate ([wala/ML#421](https://github.com/wala/ML/issues/421)), which builds the tag and publishes the artifacts to GitHub Packages. The gate requires the tag to be plain semver *and* an ancestor of `master`.
-
-1. Publish the GitHub release. Convention is `--prerelease`, and the notes should reflect the full diff since the previous release (`git log <prev-tag>..X.Y.Z`), not just one change:
-
-	```bash
-	gh release create X.Y.Z --prerelease --title "X.Y.Z" --notes "..."
-	```
-
-1. Confirm the version published:
-
-	```bash
-	gh api "/orgs/ponder-lab/packages/maven/com.ibm.wala.com.ibm.wala.cast.python.ml/versions" --jq '.[].name' | head
-	```
+1. The tag push triggers CI's deploy gate ([wala/ML#421](https://github.com/wala/ML/issues/421)) — which requires the tag to be plain semver *and* an ancestor of `master` — publishing the artifacts and creating the prerelease, exactly as in the one-click flow. Confirm with the `gh api` command above.
 
 ### Troubleshooting
 
 - **The tag pushed but the deploy did not fire** (rare — e.g., the tag's commit predates a workflow fix). Re-trigger the tag-push event: `git push --delete origin X.Y.Z && git push origin X.Y.Z`. ([wala/ML#454](https://github.com/wala/ML/issues/454) tracks a `workflow_dispatch` recovery for this.)
-- **The pre-commit hook rejects `release:prepare`'s commit** ("files were modified by this hook"). This was a Spotless / `maven-release-plugin` self-closing-tag conflict, fixed in [wala/ML#566](https://github.com/wala/ML/issues/566) (`sortPom`'s `spaceBeforeCloseEmptyElement`). If it ever recurs, run the release with git hooks disabled: `git config core.hooksPath "$(mktemp -d)"`, run `release:prepare`, then `git config --unset core.hooksPath`.
+- **The pre-commit hook rejects `release:prepare`'s commit** ("files were modified by this hook"), in the manual flow only — the workflow runner has no hook. This was a Spotless / `maven-release-plugin` self-closing-tag conflict, fixed in [wala/ML#566](https://github.com/wala/ML/issues/566) (`sortPom`'s `spaceBeforeCloseEmptyElement`). If it ever recurs, run the release with git hooks disabled: `git config core.hooksPath "$(mktemp -d)"`, run `release:prepare`, then `git config --unset core.hooksPath`.
 - **Manual-deploy fallback.** If CI cannot deploy a tag at all, deploy from a clean local build: check out the release commit, `mvn spotless:apply` (working tree only), then `mvn clean deploy -DskipTests -B` using a `~/.m2/settings.xml` `github` server with a classic `write:packages` PAT.
-
-### One-Click Releases (Planned)
-
-[wala/ML#455](https://github.com/wala/ML/issues/455) tracks moving this to a `workflow_dispatch` GitHub Action so a release can be cut from the Actions UI with no local toolchain or credentials.
 
 ## Commit Messages
 


### PR DESCRIPTION
Follow-up to ponder-lab/ML#358 (now merged): the `CONTRIBUTING.md` "Cutting a Release" section (added in #357) still documented only the manual `release:prepare` flow. Restructure it now that the `Cut release` workflow exists on master.

## Changes

- **One-Click Release (Preferred)** is now the lead: dispatch the `Cut release` workflow (UI or `gh workflow run`), with the `RELEASE_PAT` one-time setup noted.
- **Manual Release (Fallback)** keeps the local `release:prepare` steps for when you need to cut locally.
- Both flows now rely on the tag-push `release-upload` job to create the prerelease (per #358), so neither documents a `gh release create` step anymore.
- Drops the now-implemented "One-Click Releases (Planned)" stub.

Doc-only; no behavior change.