### PR TITLE
Fix `evalAsInteger` crash on non-constant shape dimensions and add NLPGNN tensor-typing tests

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -96,12 +96,20 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
       PyObject val = ip.eval(expr);
       if (val.isInteger()) {
         return val.asInt();
-      } else
-        throw new IllegalArgumentException(
-            "Python expression: " + expr + " cannot be evaluated to an integer.");
+      } else {
+        // Not a constant integer (e.g., a non-numeric literal). Return null so callers
+        // fall through to their fallback, matching the Python2 implementation and the
+        // nullable-Integer contract documented above.
+        LOGGER.fine(() -> "Python expression cannot be evaluated to an integer: " + expr);
+        return null;
+      }
     } catch (PyException e) {
-      LOGGER.log(Level.SEVERE, "Unable to interpret Python expression: " + expr, e);
-      throw new IllegalArgumentException("Can't interpret Python expression: " + expr + ".", e);
+      // The expression is not a constant the embedded interpreter can evaluate (e.g., a
+      // runtime-shaped value such as `tf.shape(x)[0]` used as a dimension). This is expected
+      // for dynamic shapes, not an error: return null so callers degrade to a symbolic
+      // dimension rather than crashing the analysis, matching the Python2 implementation.
+      LOGGER.log(Level.FINE, e, () -> "Unable to interpret Python expression: " + expr);
+      return null;
     }
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/Python3InterpreterTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/Python3InterpreterTest.java
@@ -1,0 +1,65 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeNotNull;
+
+import com.ibm.wala.cast.python.util.Python3Interpreter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Unit tests for {@link Python3Interpreter}. */
+public class Python3InterpreterTest {
+
+  /**
+   * Points Jython at the {@code jython3} submodule so {@link
+   * org.python.core.PySystemState#initialize()} can find its bootstrap resources ({@code
+   * src/resources/frozen_importlib/}). The analysis engine arranges this implicitly when it builds
+   * a call graph; a standalone interpreter test must set {@code python.home} explicitly, or {@link
+   * Python3Interpreter#getInterp()} fails to initialize and {@link
+   * Python3Interpreter#evalAsInteger(String)} degrades to returning {@code null} for everything.
+   * Locates the submodule by walking up from the working directory, resilient to running from the
+   * test module or the reactor root.
+   */
+  @BeforeClass
+  public static void pointJythonAtSubmodule() {
+    for (Path c = Paths.get(System.getProperty("user.dir")); c != null; c = c.getParent()) {
+      Path jython3 = c.resolve("jython3");
+      if (Files.isDirectory(
+          jython3.resolve("src").resolve("resources").resolve("frozen_importlib"))) {
+        System.setProperty("python.home", jython3.toString());
+        return;
+      }
+    }
+  }
+
+  /**
+   * Verifies that {@link Python3Interpreter#evalAsInteger(String)} returns {@code null} rather than
+   * throwing for expressions that are not constant integers, matching the {@code
+   * Python2Interpreter} sibling and the method's nullable-{@code Integer} contract. Covers both
+   * fallbacks: an expression that evaluates successfully to a non-integer value, and an expression
+   * the embedded interpreter cannot evaluate at all (e.g., a runtime-shaped value such as {@code
+   * tf.shape(x)[0]} used as a shape dimension, which previously crashed the analysis).
+   */
+  @Test
+  public void testEvalAsIntegerReturnsNullForNonInteger() {
+    Python3Interpreter interpreter = new Python3Interpreter();
+
+    // Skip where the embedded Jython interpreter is unavailable despite the setup above (e.g.,
+    // under Tycho-OSGi): the happy-path evaluation returns null there, so guarding on it avoids a
+    // spurious failure.
+    assumeNotNull(interpreter.evalAsInteger("3"));
+
+    // Sanity: a constant integer evaluates to itself.
+    assertEquals(Integer.valueOf(3), interpreter.evalAsInteger("3"));
+
+    // Evaluates successfully, but to a non-integer (a float): null.
+    assertNull(interpreter.evalAsInteger("2.5"));
+
+    // Cannot be evaluated at all (an undefined name, as a runtime-shaped dimension would be): null.
+    assertNull(interpreter.evalAsInteger("undefined_name_xyz[0]"));
+  }
+}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -239,6 +239,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_4_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4)));
 
+  private static final TensorType TENSOR_2_5_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(5)));
+
   private static final TensorType TENSOR_3_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(3)));
 
@@ -2398,6 +2401,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             3, Set.of(TENSOR_2_3_4_FLOAT32),
             4, Set.of(TENSOR_4_4_FLOAT32),
             5, Set.of(TENSOR_2_INT32)));
+  }
+
+  /**
+   * Pins {@code create_attention_mask_from_input_mask(from_tensor, to_mask)}'s parameter types.
+   * Function body mirrors {@code create_attention_mask_from_input_mask} from {@code
+   * kyzhouhzau/NLPGNN/nlpgnn/tools.py}, a real-world function that builds a 3D attention mask from
+   * a 2D input mask, for tensor-type inference coverage. Both parameters infer concretely.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCreateAttentionMaskFromInputMask()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_create_attention_mask.py",
+        "create_attention_mask_from_input_mask",
+        2,
+        6,
+        Map.of(
+            2, Set.of(TENSOR_2_3_4_FLOAT32),
+            3, Set.of(TENSOR_2_5_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -233,6 +233,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_100_784_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(100), new NumericDim(784)));
 
+  private static final TensorType TENSOR_2_3_4_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
+
+  private static final TensorType TENSOR_4_4_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4)));
+
   private static final TensorType TENSOR_3_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(3)));
 
@@ -2231,6 +2237,167 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         16,
         Map.of(2, Set.of(TENSOR_100_784_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code crf_unary_score(tag_indices, sequence_lengths, inputs)}'s parameter types. Function
+   * body mirrors {@code crf_unary_score} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}, a
+   * real-world linear-chain CRF function exercised for tensor-type inference coverage. Its {@code
+   * tf.reshape} with runtime-derived dimensions ({@code tf.shape(inputs)[0]}) previously crashed
+   * the analysis (wala/ML#567).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfUnaryScore()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_unary_score",
+        3,
+        28,
+        Map.of(
+            2, Set.of(TENSOR_2_3_INT32),
+            3, Set.of(TENSOR_2_INT32),
+            4, Set.of(TENSOR_2_3_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code crf_binary_score(tag_indices, sequence_lengths, transition_params)}'s parameter
+   * types. Function body mirrors {@code crf_binary_score} from {@code
+   * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfBinaryScore()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_binary_score",
+        3,
+        16,
+        Map.of(
+            2, Set.of(TENSOR_2_3_INT32),
+            3, Set.of(TENSOR_2_INT32),
+            4, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code crf_sequence_score(inputs, tag_indices, sequence_lengths, transition_params)}'s
+   * parameter types. Function body mirrors {@code crf_sequence_score} from {@code
+   * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfSequenceScore()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_sequence_score",
+        4,
+        6,
+        Map.of(
+            2, Set.of(TENSOR_2_3_4_FLOAT32),
+            3, Set.of(TENSOR_2_3_INT32),
+            4, Set.of(TENSOR_2_INT32),
+            5, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code crf_log_norm(inputs, sequence_lengths, transition_params)}'s parameter types.
+   * Function body mirrors {@code crf_log_norm} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}
+   * for tensor-type inference coverage.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfLogNorm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_log_norm",
+        3,
+        6,
+        Map.of(
+            2, Set.of(TENSOR_2_3_4_FLOAT32),
+            3, Set.of(TENSOR_2_INT32),
+            4, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code crf_forward(inputs, state, transition_params, sequence_lengths)}'s parameter types.
+   * Function body mirrors {@code crf_forward} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}
+   * for tensor-type inference coverage. {@code crf_forward} is reached only through {@code
+   * crf_log_norm} (its sole NLPGNN caller), which passes {@code inputs} and {@code state} from
+   * {@code tf.slice} / {@code tf.squeeze} results. Those two parameters come back {@code ⊤} (only
+   * {@code transition_params} and {@code sequence_lengths}, passed straight through, are
+   * tensor-typed) — i.e., {@code tf.slice} / {@code tf.squeeze} do not propagate tensor types
+   * through to the callee parameter. TODO: Recover {@code inputs} / {@code state} types here once
+   * {@code tf.slice} / {@code tf.squeeze} type propagation lands; tracked by <a
+   * href="https://github.com/wala/ML/issues/568">wala/ML#568</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfForward()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_forward",
+        2,
+        9,
+        Map.of(
+            4, Set.of(TENSOR_4_4_FLOAT32),
+            5, Set.of(TENSOR_2_INT32)));
+  }
+
+  /**
+   * Pins {@code crf_decode_forward(inputs, state, transition_params, sequence_lengths)}'s parameter
+   * types. Function body mirrors {@code crf_decode_forward} from {@code
+   * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage. The caller passes
+   * {@code inputs} from {@code x[:, 1:, :]} and {@code state} from {@code x[:, 0, :]}, which should
+   * reduce to {@code (2, 2, 4)} and {@code (2, 4)} respectively. They are instead inferred as the
+   * base {@code (2, 3, 4)} because these middle-axis subscript slices fall through to the
+   * base-shape passthrough; recovering them requires the broader slice vocabulary tracked by <a
+   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Unlike {@code crf_forward}
+   * (reached via {@code tf.slice} / {@code tf.squeeze}, which drop to {@code ⊤} — wala/ML#568), the
+   * subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCrfDecodeForward()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_crf.py",
+        "crf_decode_forward",
+        4,
+        6,
+        Map.of(
+            2, Set.of(TENSOR_2_3_4_FLOAT32),
+            3, Set.of(TENSOR_2_3_4_FLOAT32),
+            4, Set.of(TENSOR_4_4_FLOAT32),
+            5, Set.of(TENSOR_2_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_create_attention_mask.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_create_attention_mask.py
@@ -1,0 +1,76 @@
+# Fixture mirroring `create_attention_mask_from_input_mask` (and its
+# `assert_rank` / `get_shape_list` helpers) from
+# `kyzhouhzau/NLPGNN/nlpgnn/tools.py`. The function builds a 3D attention mask
+# from a 2D input mask, exercising `tensor.shape.as_list()`, `tf.reshape` with
+# shape-list-derived dimensions, `tf.ones`, and broadcast multiplication. The
+# fixture lets `TestTensorflow2Model` pin the parameter types of `from_tensor`
+# and `to_mask` for tensor-type inference coverage.
+import tensorflow as tf
+
+
+def assert_rank(tensor, expected_rank, name=None):
+    excepted_rank_dict = {}
+    if isinstance(expected_rank, int):
+        excepted_rank_dict[expected_rank] = True
+    else:
+        for x in expected_rank:
+            excepted_rank_dict[x] = True
+    actual_rank = tensor.shape.ndims
+    if actual_rank not in excepted_rank_dict:
+        raise ValueError(
+            "For tensor {} , the actual rank {} is not equal"
+            "to expected rank {}".format(name, actual_rank, str(expected_rank))
+        )
+
+
+def get_shape_list(tensor, expected_rank=None, name=None):
+    if expected_rank is not None:
+        assert_rank(tensor, expected_rank, name)
+
+    shape = tensor.shape.as_list()
+
+    non_static_indexes = []
+    for index, dim in enumerate(shape):
+        if dim is None:
+            non_static_indexes.append(index)
+
+    if not non_static_indexes:
+        return shape
+
+    dyn_shape = tf.shape(tensor)
+    for index in non_static_indexes:
+        shape[index] = dyn_shape[index]
+    return shape
+
+
+def create_attention_mask_from_input_mask(from_tensor, to_mask):
+    assert_rank(from_tensor, [2, 3])
+    from_shape = get_shape_list(from_tensor)
+    batch_size = from_shape[0]
+    from_seq_length = from_shape[1]
+    to_shape = get_shape_list(to_mask)
+    to_seq_length = to_shape[1]
+
+    to_mask = tf.cast(tf.reshape(to_mask, [batch_size, 1, to_seq_length]), tf.float32)
+
+    broadcast_ones = tf.ones(shape=[batch_size, from_seq_length, 1], dtype=tf.float32)
+
+    mask = broadcast_ones * to_mask
+    return mask
+
+
+# Driver: from_tensor [B, F, D] = (2, 3, 4), to_mask [B, T] = (2, 5).
+from_tensor = tf.constant(
+    [
+        [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1.0, 1.1, 1.2]],
+        [[1.3, 1.4, 1.5, 1.6], [1.7, 1.8, 1.9, 2.0], [2.1, 2.2, 2.3, 2.4]],
+    ],
+    dtype=tf.float32,
+)
+to_mask = tf.constant([[1, 1, 1, 0, 0], [1, 1, 0, 0, 0]], dtype=tf.int32)
+
+assert from_tensor.shape == (2, 3, 4) and from_tensor.dtype == tf.float32
+assert to_mask.shape == (2, 5) and to_mask.dtype == tf.int32
+
+mask = create_attention_mask_from_input_mask(from_tensor, to_mask)
+assert mask.shape == (2, 3, 5) and mask.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_crf.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_crf.py
@@ -1,0 +1,190 @@
+# Fixture mirroring the linear-chain CRF functions from
+# `kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py` (`crf_sequence_score`,
+# `crf_unary_score`, `crf_binary_score`, `crf_log_norm`, `crf_forward`,
+# `crf_decode_forward`). These real-world functions exercise CRF-specific
+# tensor ops (`tf.gather`, `tf.sequence_mask`, `tf.scan`, `tf.slice`,
+# `tf.reshape` with runtime-derived dimensions, and a custom RNN cell). The
+# fixture lets `TestTensorflow2Model` pin their parameter types and exercise
+# tensor-type inference on this op mix; see wala/ML#567, wala/ML#568, and
+# wala/ML#406 for gaps it surfaced.
+import tensorflow as tf
+
+
+def crf_sequence_score(inputs, tag_indices, sequence_lengths, transition_params):
+    tag_indices = tf.cast(tag_indices, dtype=tf.int32)
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+    unary_scores = crf_unary_score(tag_indices, sequence_lengths, inputs)
+    binary_scores = crf_binary_score(tag_indices, sequence_lengths, transition_params)
+    sequence_scores = unary_scores + binary_scores
+    return sequence_scores
+
+
+def crf_unary_score(tag_indices, sequence_lengths, inputs):
+    tag_indices = tf.cast(tag_indices, dtype=tf.int32)
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+
+    batch_size = tf.shape(inputs)[0]
+    max_seq_len = tf.shape(inputs)[1]
+    num_tags = tf.shape(inputs)[2]
+
+    flattened_inputs = tf.reshape(inputs, [-1])
+
+    offsets = tf.expand_dims(tf.range(batch_size) * max_seq_len * num_tags, 1)
+    offsets += tf.expand_dims(tf.range(max_seq_len) * num_tags, 0)
+    if tag_indices.dtype == tf.int64:
+        offsets = tf.cast(offsets, tf.int64)
+    flattened_tag_indices = tf.reshape(offsets + tag_indices, [-1])
+
+    unary_scores = tf.reshape(
+        tf.gather(flattened_inputs, flattened_tag_indices),
+        [batch_size, max_seq_len],
+    )
+
+    masks = tf.sequence_mask(
+        sequence_lengths, maxlen=tf.shape(tag_indices)[1], dtype=tf.float32
+    )
+
+    unary_scores = tf.reduce_sum(unary_scores * masks, 1)
+    return unary_scores
+
+
+def crf_binary_score(tag_indices, sequence_lengths, transition_params):
+    tag_indices = tf.cast(tag_indices, dtype=tf.int32)
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+
+    num_tags = tf.shape(transition_params)[0]
+    num_transitions = tf.shape(tag_indices)[1] - 1
+
+    start_tag_indices = tf.slice(tag_indices, [0, 0], [-1, num_transitions])
+    end_tag_indices = tf.slice(tag_indices, [0, 1], [-1, num_transitions])
+
+    flattened_transition_indices = start_tag_indices * num_tags + end_tag_indices
+    flattened_transition_params = tf.reshape(transition_params, [-1])
+
+    binary_scores = tf.gather(flattened_transition_params, flattened_transition_indices)
+    masks = tf.sequence_mask(
+        sequence_lengths, maxlen=tf.shape(tag_indices)[1], dtype=tf.float32
+    )
+    truncated_masks = tf.slice(masks, [0, 1], [-1, -1])
+    binary_scores = tf.reduce_sum(binary_scores * truncated_masks, 1)
+    return binary_scores
+
+
+def crf_log_norm(inputs, sequence_lengths, transition_params):
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+    first_input = tf.slice(inputs, [0, 0, 0], [-1, 1, -1])
+    first_input = tf.squeeze(first_input, [1])
+    rest_of_input = tf.slice(inputs, [0, 1, 0], [-1, -1, -1])
+
+    alphas = crf_forward(
+        rest_of_input, first_input, transition_params, sequence_lengths
+    )
+    log_norm = tf.reduce_logsumexp(alphas, [1])
+
+    return log_norm
+
+
+def crf_forward(inputs, state, transition_params, sequence_lengths):
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+
+    last_index = tf.maximum(
+        tf.constant(0, dtype=sequence_lengths.dtype), sequence_lengths - 1
+    )
+    inputs = tf.transpose(inputs, [1, 0, 2])
+    transition_params = tf.expand_dims(transition_params, 0)
+
+    def _scan_fn(_state, _inputs):
+        _state = tf.expand_dims(_state, 2)
+        transition_scores = _state + transition_params
+        new_alphas = _inputs + tf.reduce_logsumexp(transition_scores, [1])
+        return new_alphas
+
+    all_alphas = tf.transpose(tf.scan(_scan_fn, inputs, state), [1, 0, 2])
+    all_alphas = tf.concat([tf.expand_dims(state, 1), all_alphas], 1)
+
+    idxs = tf.stack([tf.range(tf.shape(last_index)[0]), last_index], axis=1)
+    return tf.gather_nd(all_alphas, idxs)
+
+
+class CrfDecodeForwardRnnCell(tf.keras.layers.AbstractRNNCell):
+    def __init__(self, transition_params, **kwargs):
+        super(CrfDecodeForwardRnnCell, self).__init__(**kwargs)
+        self._transition_params = tf.expand_dims(transition_params, 0)
+        self._num_tags = transition_params.shape[0]
+
+    @property
+    def state_size(self):
+        return self._num_tags
+
+    @property
+    def output_size(self):
+        return self._num_tags
+
+    def build(self, input_shape):
+        super(CrfDecodeForwardRnnCell, self).build(input_shape)
+
+    def call(self, inputs, state):
+        state = tf.expand_dims(state[0], 2)
+        transition_scores = state + self._transition_params
+        new_state = inputs + tf.reduce_max(transition_scores, [1])
+        backpointers = tf.argmax(transition_scores, 1)
+        backpointers = tf.cast(backpointers, dtype=tf.int32)
+        return backpointers, new_state
+
+
+def crf_decode_forward(inputs, state, transition_params, sequence_lengths):
+    sequence_lengths = tf.cast(sequence_lengths, dtype=tf.int32)
+    mask = tf.sequence_mask(sequence_lengths, tf.shape(inputs)[1])
+    crf_fwd_cell = CrfDecodeForwardRnnCell(transition_params)
+    crf_fwd_layer = tf.keras.layers.RNN(
+        crf_fwd_cell, return_sequences=True, return_state=True
+    )
+    return crf_fwd_layer(inputs, state, mask=mask)
+
+
+# Driver: concrete linear-chain CRF inputs (batch=2, seq_len=3, num_tags=4).
+inputs = tf.constant(
+    [
+        [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1.0, 1.1, 1.2]],
+        [[1.3, 1.4, 1.5, 1.6], [1.7, 1.8, 1.9, 2.0], [2.1, 2.2, 2.3, 2.4]],
+    ],
+    dtype=tf.float32,
+)
+tag_indices = tf.constant([[0, 1, 2], [1, 2, 3]], dtype=tf.int32)
+sequence_lengths = tf.constant([3, 2], dtype=tf.int32)
+transition_params = tf.constant(
+    [
+        [0.0, 0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6, 0.7],
+        [0.8, 0.9, 1.0, 1.1],
+        [1.2, 1.3, 1.4, 1.5],
+    ],
+    dtype=tf.float32,
+)
+
+assert inputs.shape == (2, 3, 4) and inputs.dtype == tf.float32
+assert tag_indices.shape == (2, 3) and tag_indices.dtype == tf.int32
+assert sequence_lengths.shape == (2,) and sequence_lengths.dtype == tf.int32
+assert transition_params.shape == (4, 4) and transition_params.dtype == tf.float32
+
+unary = crf_unary_score(tag_indices, sequence_lengths, inputs)
+assert unary.shape == (2,) and unary.dtype == tf.float32
+
+binary = crf_binary_score(tag_indices, sequence_lengths, transition_params)
+assert binary.shape == (2,) and binary.dtype == tf.float32
+
+seq_score = crf_sequence_score(inputs, tag_indices, sequence_lengths, transition_params)
+assert seq_score.shape == (2,) and seq_score.dtype == tf.float32
+
+log_norm = crf_log_norm(inputs, sequence_lengths, transition_params)
+assert log_norm.shape == (2,) and log_norm.dtype == tf.float32
+
+# `crf_forward` is exercised through `crf_log_norm` above (its only caller in
+# NLPGNN), so it is not invoked directly here. `crf_decode_forward` is invoked
+# directly, mirroring its use from `CrfLogLikelihood.crf_decode`.
+first_input = inputs[:, 0, :]
+rest_of_input = inputs[:, 1:, :]
+dec_fwd, _state = crf_decode_forward(
+    rest_of_input, first_input, transition_params, sequence_lengths
+)
+assert dec_fwd.dtype == tf.int32


### PR DESCRIPTION
## What

1. **Fix:** `Python3Interpreter.evalAsInteger` now returns `null` (rather than throwing `IllegalArgumentException`) when a shape-dimension expression is not a constant integer — e.g., `tf.shape(inputs)[0]` used as a `tf.reshape` dimension. Both callers (`TensorType`, `PythonTurtleAnalysisEngine`) already degrade to a symbolic dimension on `null`; only `IOException` was caught before, so the exception aborted the whole analysis. This matches the `Python2Interpreter` sibling and the method's documented nullable contract. Closes wala/ML#567.
2. **Tests:** add tensor-typing tests pinning the parameter types of real-world NLPGNN functions that exercise op mixes nothing else in the suite covers:
   - `tf2_test_crf.py` — the six module-level `crf_*` functions from `nlpgnn/metrics/crf.py` (`tf.gather`, `tf.sequence_mask`, `tf.scan`, `tf.slice`, `tf.squeeze`, `tf.reshape` with runtime-derived dimensions, a custom RNN cell).
   - `tf2_test_create_attention_mask.py` — `create_attention_mask_from_input_mask` and its `assert_rank` / `get_shape_list` helpers from `nlpgnn/tools.py`.
   - `Python3InterpreterTest` — unit coverage for the `evalAsInteger` null fallbacks.

## Results

- `crf_unary_score`, `crf_binary_score`, `crf_sequence_score`, `crf_log_norm`, and `create_attention_mask_from_input_mask`: all parameters inferred concretely.
- `crf_decode_forward`: all four parameters tensor-typed; `inputs`/`state` shape-imprecise (base shape rather than the middle-axis subscript slice) — tracked by wala/ML#406.
- `crf_forward` (reached via `crf_log_norm`): `transition_params`/`sequence_lengths` concrete; `inputs`/`state` come back as the top element because `tf.slice`/`tf.squeeze` do not propagate tensor type to the callee parameter — tracked by wala/ML#568.

Each imprecision-capturing test carries a Javadoc `TODO` pointing at its tracking issue.

## Testing

Full suite green: `Tests run: 804, Failures: 0, Errors: 0, Skipped: 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)