### PR TITLE
Model `tf.slice` with a dedicated `Slice` tensor generator

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2346,11 +2346,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Function body mirrors {@code crf_forward} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}
    * for tensor-type inference coverage. {@code crf_forward} is reached only through {@code
    * crf_log_norm} (its sole NLPGNN caller), which passes {@code inputs} and {@code state} from
-   * {@code tf.slice} / {@code tf.squeeze} results. Both now infer as {@code float32} with shape
+   * {@code tf.slice}/{@code tf.squeeze} results. Both now infer as {@code float32} with shape
    * {@code ⊤}: the dedicated {@code Slice} generator forwards the input dtype while leaving the
-   * shape unknown (wala/ML#568); the precise {@code begin}/{@code size} shape is the broader
-   * slice-shape vocabulary tracked by <a
-   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>.
+   * shape unknown (wala/ML#568); computing the precise {@code begin}/{@code size} shape is tracked
+   * by <a href="https://github.com/wala/ML/issues/569">wala/ML#569</a>.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2381,7 +2380,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * base {@code (2, 3, 4)} because these middle-axis subscript slices fall through to the
    * base-shape passthrough; recovering them requires the broader slice vocabulary tracked by <a
    * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Like {@code crf_forward} (reached
-   * via {@code tf.slice} / {@code tf.squeeze}, now dtype-typed with shape {@code ⊤} — wala/ML#568),
+   * via {@code tf.slice}/{@code tf.squeeze}, now dtype-typed with shape {@code ⊤} — wala/ML#568),
    * the subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2285,7 +2285,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_binary_score",
         3,
-        16,
+        26,
         Map.of(
             2, Set.of(TENSOR_2_3_INT32),
             3, Set.of(TENSOR_2_INT32),
@@ -2334,7 +2334,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_log_norm",
         3,
-        6,
+        9,
         Map.of(
             2, Set.of(TENSOR_2_3_4_FLOAT32),
             3, Set.of(TENSOR_2_INT32),
@@ -2346,12 +2346,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Function body mirrors {@code crf_forward} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}
    * for tensor-type inference coverage. {@code crf_forward} is reached only through {@code
    * crf_log_norm} (its sole NLPGNN caller), which passes {@code inputs} and {@code state} from
-   * {@code tf.slice} / {@code tf.squeeze} results. Those two parameters come back {@code ⊤} (only
-   * {@code transition_params} and {@code sequence_lengths}, passed straight through, are
-   * tensor-typed) — i.e., {@code tf.slice} / {@code tf.squeeze} do not propagate tensor types
-   * through to the callee parameter. TODO: Recover {@code inputs} / {@code state} types here once
-   * {@code tf.slice} / {@code tf.squeeze} type propagation lands; tracked by <a
-   * href="https://github.com/wala/ML/issues/568">wala/ML#568</a>.
+   * {@code tf.slice} / {@code tf.squeeze} results. Both now infer as {@code float32} with shape
+   * {@code ⊤}: the dedicated {@code Slice} generator forwards the input dtype while leaving the
+   * shape unknown (wala/ML#568); the precise {@code begin}/{@code size} shape is the broader
+   * slice-shape vocabulary tracked by <a
+   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2364,9 +2363,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test(
         "tf2_test_crf.py",
         "crf_forward",
-        2,
-        9,
+        4,
+        14,
         Map.of(
+            2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32),
+            3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32),
             4, Set.of(TENSOR_4_4_FLOAT32),
             5, Set.of(TENSOR_2_INT32)));
   }
@@ -2379,9 +2380,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * reduce to {@code (2, 2, 4)} and {@code (2, 4)} respectively. They are instead inferred as the
    * base {@code (2, 3, 4)} because these middle-axis subscript slices fall through to the
    * base-shape passthrough; recovering them requires the broader slice vocabulary tracked by <a
-   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Unlike {@code crf_forward}
-   * (reached via {@code tf.slice} / {@code tf.squeeze}, which drop to {@code ⊤} — wala/ML#568), the
-   * subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
+   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Like {@code crf_forward} (reached
+   * via {@code tf.slice} / {@code tf.squeeze}, now dtype-typed with shape {@code ⊤} — wala/ML#568),
+   * the subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2054,8 +2054,8 @@
         </method>
       </class>
       <class name="slice" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/slice. Direct `<new>+<return>` paired with the dedicated `Slice` generator (wala/ML#568): dtype inherits from `input_`; shape is left at ⊤ since `tf.slice` reshapes its input by the runtime `begin`/`size` extents (the broader slice-shape
-          vocabulary is wala/ML#406). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/slice. Direct `<new>+<return>` paired with the dedicated `Slice` generator (wala/ML#568): dtype inherits from `input_`; shape is left at ⊤ since `tf.slice` reshapes its input by the runtime `begin`/`size` extents (computing it from
+          constant `begin`/`size` is wala/ML#569). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_ begin size name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -752,6 +752,10 @@
         <new def="boolean_mask" class="Ltensorflow/functions/boolean_mask"/>
         <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="x" value="boolean_mask"/>
         <putfield class="LRoot" field="boolean_mask" fieldType="LRoot" ref="array_ops" value="boolean_mask"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/slice -->
+        <new def="slice" class="Ltensorflow/functions/slice"/>
+        <putfield class="LRoot" field="slice" fieldType="LRoot" ref="x" value="slice"/>
+        <putfield class="LRoot" field="slice" fieldType="LRoot" ref="array_ops" value="slice"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linspace -->
         <new def="linspace" class="Ltensorflow/functions/linspace"/>
         <putfield class="LRoot" field="linspace" fieldType="LRoot" ref="x" value="linspace"/>
@@ -2045,6 +2049,14 @@
       <class name="boolean_mask" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor mask axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="slice" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/slice. Direct `<new>+<return>` paired with the dedicated `Slice` generator (wala/ML#568): dtype inherits from `input_`; shape is left at ⊤ since `tf.slice` reshapes its input by the runtime `begin`/`size` extents (the broader slice-shape
+          vocabulary is wala/ML#406). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_ begin size name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
@@ -1,0 +1,46 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.slice(input_, begin, size, name=None)}. Output dtype is inherited from
+ * the {@code input_} input. Output shape is left at ⊤ for now: the precise shape is determined by
+ * the {@code begin}/{@code size} extents (where a {@code size[i]} of {@code -1} means "all
+ * remaining elements along axis {@code i}"), which requires the broader slice-shape vocabulary
+ * tracked by <a href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Forwarding only the
+ * dtype already recovers it from ⊤ — see <a
+ * href="https://github.com/wala/ML/issues/568">wala/ML#568</a>.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/slice">tf.slice</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Slice extends PassThroughUnaryTensorGenerator {
+
+  public Slice(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Slice(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "input_";
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
@@ -11,10 +11,9 @@ import java.util.Set;
  * Generator for {@code tf.slice(input_, begin, size, name=None)}. Output dtype is inherited from
  * the {@code input_} input. Output shape is left at ⊤ for now: the precise shape is determined by
  * the {@code begin}/{@code size} extents (where a {@code size[i]} of {@code -1} means "all
- * remaining elements along axis {@code i}"), which requires the broader slice-shape vocabulary
- * tracked by <a href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Forwarding only the
- * dtype already recovers it from ⊤ — see <a
- * href="https://github.com/wala/ML/issues/568">wala/ML#568</a>.
+ * remaining elements along axis {@code i}"), tracked by <a
+ * href="https://github.com/wala/ML/issues/569">wala/ML#569</a>. Forwarding only the dtype already
+ * recovers it from ⊤ — see <a href="https://github.com/wala/ML/issues/568">wala/ML#568</a>.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/slice">tf.slice</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -155,6 +155,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIGN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SINH;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SIZE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SLICE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SLICE_BUILTIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SOFTMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SOFTMAX_CROSS_ENTROPY_WITH_LOGITS;
@@ -1246,6 +1247,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, GATHER_ND.getDeclaringClass())) return new GatherNd(source);
     else if (isType(calledFunction, BOOLEAN_MASK.getDeclaringClass()))
       return new BooleanMask(source);
+    else if (isType(calledFunction, SLICE.getDeclaringClass())) return new Slice(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
     else if (isType(calledFunction, TAN.getDeclaringClass())) return new Tan(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1089,6 +1089,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String BOOLEAN_MASK_SIGNATURE = "tf.boolean_mask()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/slice. */
+  public static final MethodReference SLICE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/slice")),
+          AstMethodReference.fnSelector);
+
+  private static final String SLICE_SIGNATURE = "tf.slice()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/image/extract_patches. */
   public static final MethodReference EXTRACT_PATCHES =
       MethodReference.findOrCreate(
@@ -1875,6 +1884,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(EMBEDDING_LOOKUP.getDeclaringClass(), EMBEDDING_LOOKUP_SIGNATURE),
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
+          Map.entry(SLICE.getDeclaringClass(), SLICE_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
           Map.entry(TAN.getDeclaringClass(), TAN_SIGNATURE),
           Map.entry(ASIN.getDeclaringClass(), ASIN_SIGNATURE),


### PR DESCRIPTION
## Problem

`tf.slice` was unmodeled in `tensorflow.xml`, so its result came back as the top element (no shape, no dtype). In a `tf.slice(...)` → `tf.squeeze(...)` chain, the `⊤` originated at `tf.slice`, and `tf.squeeze` (already `pass_through`) merely forwarded it. The orphaned `SliceOperation` models Python subscript slices (`tensor[..., None]`), not the `tf.slice` API.

## Fix

Add a `<new>+<return>` class block for `tf.slice(input_, begin, size, name=None)` paired with a dedicated `Slice` generator in the `PassThroughUnaryTensorGenerator` family (precedents `GatherNd`, `BooleanMask`):
- forwards the input dtype (the load-bearing axis), and
- leaves the shape at `⊤` rather than over-approximating with the input's shape, since `tf.slice` reshapes by the runtime `begin`/`size` extents.

This follows the `CONTRIBUTING.md` guidance to use a dedicated generator (not blunt `pass_through`) for shape-changing APIs. The precise slice-shape vocabulary is tracked by wala/ML#406. Wired via `TensorGeneratorFactory` dispatch and a `TYPE_REFERENCE_TO_SIGNATURE` entry.

## Test Impact

`crf_*` are the only corpus fixtures using `tf.slice`. Capture-observed updates:
- `crf_forward`'s `inputs`/`state` parameters now infer as `float32` with shape `⊤` (were `⊤` on both axes), so they count as tensor parameters.
- Local tensor-variable counts rise in `crf_binary_score`, `crf_log_norm`, and `crf_forward` as the slice results become tensor-typed.

Full suite green locally: 804 tests, 0 failures, 0 errors (`mvn clean install` then `mvn test`; `mvn clean` required for the XML resource cache).

Closes wala/ML#568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
