### PR TITLE
Recover `tf.keras.Model` call output shape instead of mis-propagating the input shape

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -189,9 +189,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_NONE_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(2)));
 
-  private static final TensorType TENSOR_NONE_100_FLOAT32 =
-      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(100)));
-
   private static final TensorType TENSOR_NONE_NONE_STRING =
       new TensorType(STRING, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE));
 
@@ -2142,17 +2139,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code discriminator(generated_images, ...)}; runtime shape is {@code (batch, 1) float32} since
    * the discriminator ends with a {@code Dense(1)} layer.
    *
-   * <p>Empirically, {@code fake_output} is inferred as {@code (None, 100) float32}. The dtype is
-   * concrete, which confirms the layer-output-parameter pattern works on the dtype axis. The shape
-   * is mis-propagated: {@code 100} is the generator's noise input dim (from {@code
-   * tf.keras.Input((100,))} in {@code make_generator_model}), not the discriminator's {@code
-   * Dense(1)} output dim. The mis-routing is shape-only and orthogonal to dtype-axis precision.
+   * <p>Inferred as {@code float32} with shape {@code ⊤} (unknown). The dtype is concrete and sound.
+   * The shape is unknown rather than wrong: previously {@code ModelCall.getDefaultShapes} fell back
+   * to the call's <em>input</em> shape when no output generator resolved, emitting the unsound
+   * {@code (None, 100)} ({@code 100} is the generator's noise input dim from {@code
+   * tf.keras.Input((100,))}, not the discriminator's {@code Dense(1)} output dim). A {@code
+   * tf.keras.Model} generally transforms its input shape, so that fallback is removed
+   * (wala/ML#537): the input shape now only refines a recovered output shape's batch dim, never
+   * substitutes for it.
    *
-   * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}} once <a
-   * href="https://github.com/wala/ML/issues/537">wala/ML#537</a> lands the shape propagation
-   * through Keras functional-model chains. Concrete batch dims (256 / 96) come from {@code
-   * train_step}'s {@code images} parameter (per {@link #testGanTutorial}); a complete fix would
-   * propagate those through the discriminator chain rather than dropping to {@code None}.
+   * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}} once the output shape can be
+   * recovered through Keras functional-model chains. The output node <em>is</em> reachable (the
+   * {@code outputs} formal parameter of the synthetic {@code Model.do} node points at the {@code
+   * Dense(1)} call), but that {@code DenseCall} returns {@code null} shapes in the functional-API
+   * codepath (its {@code Flatten}-to-{@code Dense} input shape isn't tracked); recovering {@code
+   * (batch, 1)} needs functional-mode {@code DenseCall} shape inference plus batch-dim propagation
+   * (concrete batch dims 256 / 96 come from {@code train_step}'s {@code images} parameter, per
+   * {@link #testGanTutorial}). Tracked by <a
+   * href="https://github.com/wala/ML/issues/537">wala/ML#537</a>.
    */
   @Test
   public void testGanTutorialGeneratorLoss()
@@ -2162,7 +2166,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "generator_loss",
         1,
         2,
-        Map.of(2, Set.of(TENSOR_NONE_100_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -9869,6 +9873,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         2,
         Map.of(2, Set.of(TENSOR_1_2_FLOAT32), 3, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
+   * Pins the output type of a functional {@code tf.keras.Model} call whose output shape <em>differs
+   * from</em> its input shape: a {@code Dense(3)} model maps a {@code (1, 2)} call input to a
+   * {@code (1, 3)} output. {@code ModelCall} recovers the model's output generator (the {@code
+   * Dense(3)} call, reached via the {@code outputs} construction argument) and reports the
+   * transformed {@code (1, 3)} shape — both for positional ({@code Model(in, out)}) and keyword
+   * ({@code Model(outputs=...)}) construction. Before wala/ML#537, {@code ModelCall} fell back to
+   * the call's input shape when the output generator wasn't reached, which would have reported the
+   * unsound {@code (1, 2)} here (input shape, not output). Companion to {@link #testModelInit}
+   * (whose {@code Dense(2)}-on-dim-2 models are shape-preserving, so they can't distinguish the two
+   * behaviors) and to {@link #testGanTutorialGeneratorLoss} (whose deep convolutional chain leaves
+   * the output generator shapeless, exercising the ⊤ path).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testModelCallOutputShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_call_output_shape.py",
+        "consume_positional",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_1_3_FLOAT32)));
+    test(
+        "tf2_test_model_call_output_shape.py",
+        "consume_keyword",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_1_3_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2148,15 +2148,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * (wala/ML#537): the input shape now only refines a recovered output shape's batch dim, never
    * substitutes for it.
    *
-   * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}} once the output shape can be
-   * recovered through Keras functional-model chains. The output node <em>is</em> reachable (the
-   * {@code outputs} formal parameter of the synthetic {@code Model.do} node points at the {@code
-   * Dense(1)} call), but that {@code DenseCall} returns {@code null} shapes in the functional-API
-   * codepath (its {@code Flatten}-to-{@code Dense} input shape isn't tracked); recovering {@code
-   * (batch, 1)} needs functional-mode {@code DenseCall} shape inference plus batch-dim propagation
-   * (concrete batch dims 256 / 96 come from {@code train_step}'s {@code images} parameter, per
-   * {@link #testGanTutorial}). Tracked by <a
-   * href="https://github.com/wala/ML/issues/537">wala/ML#537</a>.
+   * <p>The runtime shape is {@code (256, 1)} / {@code (96, 1)} (verified by running the fixture:
+   * {@code noise (256, 100)} -&gt; generator {@code (256, 28, 28, 1)} -&gt; discriminator {@code
+   * (256, 1)}), confirming the old {@code (None, 100)} was the noise shape leaking through, not the
+   * discriminator output.
+   *
+   * <p>TODO: tighten to {@code {(256, 1) float32, (96, 1) float32}}. The output node <em>is</em>
+   * reachable now (the {@code outputs} construction argument points at the {@code Dense(1)} call),
+   * but that {@code DenseCall} returns {@code null} shapes here because its input — the {@code
+   * Flatten} of a {@code Conv2D} chain — isn't shape-tracked; recovering {@code (batch, 1)} needs
+   * {@code DenseCall} output-shape inference through chained layer calls (tracked by <a
+   * href="https://github.com/wala/ML/issues/358">wala/ML#358</a>), which in turn needs {@code
+   * Conv2D}/{@code Flatten} output-shape modeling. Concrete batch dims 256 / 96 come from {@code
+   * train_step}'s {@code images} parameter, per {@link #testGanTutorial}. (wala/ML#537 fixed the
+   * unsound mis-propagation; this residual precision is wala/ML#358's domain.)
    */
   @Test
   public void testGanTutorialGeneratorLoss()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
@@ -29,19 +29,6 @@ import java.util.Set;
  */
 public class Model extends TensorGenerator {
 
-  /** Field names for the attributes of the {@code Model}. */
-  protected enum Fields {
-    /** The input(s) of the model. */
-    INPUTS,
-
-    /** The output(s) of the model. */
-    OUTPUTS;
-
-    public String getName() {
-      return name().toLowerCase(Locale.ROOT);
-    }
-  }
-
   /** Parameter positions and names for {@code tf.keras.Model}. */
   protected enum Parameters {
     /** The input(s) of the model. */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -1,25 +1,30 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
-import static com.ibm.wala.cast.python.types.PythonTypes.Root;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MODEL;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
-import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
+import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CALL_STRING;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
-import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
+import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
-import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.ipa.callgraph.propagation.cfa.CallString;
+import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -101,12 +106,17 @@ public class ModelCall extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, Parameters.INPUTS.getIndex(), Parameters.INPUTS.getName());
 
-    if (inputsPTS != null && !inputsPTS.isEmpty()) {
+    // The input shape is only used to refine the batch dimension of a recovered output shape; it is
+    // NOT a fallback for the whole output shape. A `tf.keras.Model` generally transforms its input
+    // shape (e.g., the GAN discriminator's `Dense(1)` collapses `(batch, 28, 28, 1)` to `(batch,
+    // 1)`), so returning the input shape when no output generator resolves emits a load-bearing but
+    // unsound result. When the output shape can't be recovered, return ⊤ (null shape) instead and
+    // let the dtype axis (see getDefaultDTypes) carry the still-sound dtype. See <a
+    // href="https://github.com/wala/ML/issues/537">wala/ML#537</a>.
+    if (!outputShapes.isEmpty() && inputsPTS != null && !inputsPTS.isEmpty()) {
       Set<List<Dimension<?>>> inputShapes = this.getShapesOfValue(builder, inputsPTS);
 
       if (!inputShapes.isEmpty()) {
-        if (outputShapes.isEmpty()) return inputShapes; // Fallback if no output generators found.
-
         Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
         for (List<Dimension<?>> outShape : outputShapes) {
           for (List<Dimension<?>> inShape : inputShapes) {
@@ -133,11 +143,19 @@ public class ModelCall extends TensorGenerator {
   }
 
   /**
-   * Finds tensor generators for the outputs of this model call
+   * Finds tensor generators for the outputs of this model call.
    *
-   * <p>Finds tensor generators for the outputs of this model call by traversing the points-to graph
-   * from the model instance (SELF) to its 'outputs' field, and then to the allocation sites of the
-   * output tensors.
+   * <p>For a functional-API {@code tf.keras.Model(inputs, outputs)}, the output tensor(s) are
+   * recovered from the {@code outputs} <em>formal parameter</em> of the synthetic {@code Model.do}
+   * node that allocates the model instance (SELF), then mapped to the allocation sites of the
+   * output tensors and their manual generators. Reading the model instance's {@code outputs}
+   * <em>field</em> instead loses these through synthetic-method PTS-loss (the field's points-to set
+   * comes back empty); the formal parameter's points-to set survives. See <a
+   * href="https://github.com/wala/ML/issues/537">wala/ML#537</a>.
+   *
+   * <p>Subclassed models (no {@code outputs} constructor argument; the output flows from the {@code
+   * call} method) are not handled here and yield no generators, so {@link #getDefaultShapes}
+   * returns ⊤ for them rather than an unsound shape.
    *
    * @param builder The propagation call graph builder.
    * @return A set of tensor generators for the outputs of this model call.
@@ -149,69 +167,125 @@ public class ModelCall extends TensorGenerator {
     OrdinalSet<InstanceKey> selfPts =
         this.getArgumentPointsToSet(builder, Parameters.SELF.getIndex(), Parameters.SELF.getName());
 
+    // IR index of the `outputs` formal in `Model.do` (paramNames="self inputs outputs name"): the
+    // implicit `self` receiver occupies index 0, so the parameter's index is offset by one.
+    int outputsParamIRIndex = Model.Parameters.OUTPUTS.getIndex() + 1;
+
     for (InstanceKey selfIK : selfPts) {
-      // 2. Resolve the Model generator for this instance by finding its allocation site.
+      // 2. Resolve the Model instance's allocation site (the synthetic `Model.do` node).
       AllocationSiteInNode selfASIN = getAllocationSiteInNode(selfIK);
+      if (selfASIN == null) continue;
 
-      if (selfASIN != null) {
-        // create a field reference for the `outputs` field of the `Model` instance.
-        FieldReference outputsFieldRef =
-            FieldReference.findOrCreate(
-                selfASIN.getConcreteType().getReference(),
-                findOrCreateAsciiAtom(Model.Fields.OUTPUTS.getName()),
-                Root);
+      // Only functional-API models carry an `outputs` constructor argument.
+      if (!selfASIN.getConcreteType().getReference().equals(MODEL.getDeclaringClass())) continue;
 
-        IField field = builder.getClassHierarchy().resolveField(outputsFieldRef);
+      CGNode modelDoNode = selfASIN.getNode();
+      IR ir = modelDoNode.getIR();
+      if (ir == null) continue;
 
-        if (field != null) {
-          PointerKey fieldPK = builder.getPointerKeyForInstanceField(selfASIN, field);
-          LOGGER.finer(
-              "Found field pointer key: "
-                  + fieldPK
-                  + " for field reference: "
-                  + outputsFieldRef
+      // 3. Collect the `outputs` points-to set from two complementary sources, unioned:
+      //   (a) the caller-side `Model(...)` invoke's `outputs` argument, resolved by keyword name or
+      //       position (covers both `Model(in, out)` and `Model(outputs=out, ...)`); and
+      //   (b) the `outputs` formal parameter of the synthetic `Model.do` node (a positional binding
+      //       that survives even when the caller invoke can't be located).
+      OrdinalSet<InstanceKey> outputsPTS = getOutputsArgumentPTS(builder, modelDoNode);
+      if (outputsParamIRIndex < ir.getNumberOfParameters()) {
+        int outputsVn = ir.getParameter(outputsParamIRIndex);
+        PointerKey outputsPK =
+            builder
+                .getPointerAnalysis()
+                .getHeapModel()
+                .getPointerKeyForLocal(modelDoNode, outputsVn);
+        outputsPTS =
+            OrdinalSet.unify(outputsPTS, builder.getPointerAnalysis().getPointsToSet(outputsPK));
+      }
+      final OrdinalSet<InstanceKey> finalOutputsPTS = outputsPTS;
+      LOGGER.finer(
+          () ->
+              "Found outputs points-to set: "
+                  + finalOutputsPTS
+                  + " for node: "
+                  + modelDoNode
                   + ".");
 
-          OrdinalSet<InstanceKey> outputsPTS = builder.getPointerAnalysis().getPointsToSet(fieldPK);
-          LOGGER.finer(
-              () ->
-                  "Found points-to set: "
-                      + outputsPTS
-                      + " for field pointer key: "
-                      + fieldPK
-                      + ".");
+      for (InstanceKey outputIK : outputsPTS) {
+        LOGGER.finest("Found output instance key: " + outputIK + ".");
 
-          for (InstanceKey outputIK : outputsPTS) {
-            LOGGER.finest("Found output instance key: " + outputIK + ".");
+        AllocationSiteInNode outputASIN = getAllocationSiteInNode(outputIK);
+        if (outputASIN != null) {
+          LOGGER.finest(
+              "Found output allocation site: "
+                  + outputASIN
+                  + " for instance key: "
+                  + outputIK
+                  + ".");
 
-            AllocationSiteInNode outputASIN = getAllocationSiteInNode(outputIK);
+          TensorGenerator outputGenerator = createManualGenerator(outputASIN.getNode(), builder);
+          if (outputGenerator != null) {
+            LOGGER.finest(
+                "Created tensor generator: "
+                    + outputGenerator
+                    + " for output allocation site: "
+                    + outputASIN
+                    + ".");
 
-            if (outputASIN != null) {
-              LOGGER.finest(
-                  "Found output allocation site: "
-                      + outputASIN
-                      + " for instance key: "
-                      + outputIK
-                      + ".");
-
-              TensorGenerator outputGenerator =
-                  createManualGenerator(outputASIN.getNode(), builder);
-              if (outputGenerator != null) {
-                LOGGER.finest(
-                    "Created tensor generator: "
-                        + outputGenerator
-                        + " for output allocation site: "
-                        + outputASIN
-                        + ".");
-
-                ret.add(outputGenerator);
-              }
-            }
+            ret.add(outputGenerator);
           }
         }
       }
     }
 
+    return ret;
+  }
+
+  /**
+   * Resolves the points-to set of the {@code outputs} argument at the caller-side {@code
+   * Model(...)} invoke that created the given synthetic {@code Model.do} node. Walks the node's
+   * {@link CallString} context to each calling invoke and reads the {@code outputs} use by keyword
+   * name first (covers {@code Model(outputs=...)}) then by position (covers {@code Model(in,
+   * out)}). Reading the caller invoke handles keyword construction, which the {@code Model.do}
+   * formal-parameter binding alone does not.
+   *
+   * @param builder The propagation call graph builder.
+   * @param modelDoNode The synthetic {@code Model.do} node allocating the model instance.
+   * @return The union of the resolved {@code outputs} argument points-to sets, or an empty set if
+   *     none could be located.
+   */
+  private OrdinalSet<InstanceKey> getOutputsArgumentPTS(
+      PropagationCallGraphBuilder builder, CGNode modelDoNode) {
+    CallString cs = (CallString) modelDoNode.getContext().get(CALL_STRING);
+    if (cs == null) return OrdinalSet.empty();
+
+    OrdinalSet<InstanceKey> ret = OrdinalSet.empty();
+    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
+      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
+      IMethod callerMethod = cs.getMethods()[i];
+
+      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(modelDoNode); it.hasNext(); ) {
+        CGNode caller = it.next();
+        if (!caller.getMethod().equals(callerMethod)) continue;
+
+        IR callerIR = caller.getIR();
+        if (callerIR == null) continue;
+
+        for (SSAAbstractInvokeInstruction callInstr : callerIR.getCalls(siteRef)) {
+          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
+          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
+
+          int argVn = pyCall.getUse(Model.Parameters.OUTPUTS.getName());
+          if (argVn == -1) {
+            int numPositionalArgs = pyCall.getNumberOfPositionalParameters() - 1;
+            int outputsPos = Model.Parameters.OUTPUTS.getIndex();
+            if (outputsPos < numPositionalArgs) argVn = pyCall.getUse(outputsPos + 1);
+          }
+          if (argVn <= 0) continue;
+
+          PointerKey argPK =
+              builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, argVn);
+          ret = OrdinalSet.unify(ret, builder.getPointerAnalysis().getPointsToSet(argPK));
+        }
+      }
+    }
     return ret;
   }
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call_output_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call_output_shape.py
@@ -1,0 +1,40 @@
+import tensorflow as tf
+
+
+def consume_positional(x):
+    pass
+
+
+def consume_keyword(x):
+    pass
+
+
+# A functional `tf.keras.Model` whose output shape differs from its input shape:
+# `Dense(3)` maps a `(*, 2)` input to a `(*, 3)` output. Exercises `ModelCall`
+# recovering the model's output generator (and thus the transformed shape) rather
+# than passing the call's input shape through. See wala/ML#537.
+def positional():
+    input_node = tf.keras.Input(shape=(2,), dtype=tf.float32)
+    output_node = tf.keras.layers.Dense(3)(input_node)
+    model = tf.keras.Model(input_node, output_node)
+
+    out = model(tf.ones((1, 2)))
+    assert out.shape.as_list() == [1, 3]
+    assert out.dtype == tf.float32
+    consume_positional(out)
+
+
+def keyword():
+    input_node = tf.keras.Input(shape=(2,), dtype=tf.float32)
+    output_node = tf.keras.layers.Dense(3)(input_node)
+    model = tf.keras.Model(outputs=output_node, inputs=input_node)
+
+    out = model(tf.ones((1, 2)))
+    assert out.shape.as_list() == [1, 3]
+    assert out.dtype == tf.float32
+    consume_keyword(out)
+
+
+if __name__ == "__main__":
+    positional()
+    keyword()


### PR DESCRIPTION
## Problem

`ModelCall.getDefaultShapes` fell back to the model call's **input** shape whenever no output generator resolved. `getOutputGenerators` read the model instance's `outputs` **field**, whose points-to set comes back empty through synthetic-method PTS-loss, so for functional-API models that fallback always fired — emitting a load-bearing but unsound shape.

In the GAN tutorial, `generator_loss(fake_output)` was inferred as `(None, 100)` (the generator's noise input dim from `tf.keras.Input((100,))`) instead of the discriminator's `Dense(1)` output. The dtype was correct; only the shape was unsound.

## Fix

Recover the output generator from the `outputs` **argument** instead of the (empty) instance field:
- union the caller-side `Model(...)` invoke's `outputs` use — resolved by keyword name then position, covering both `Model(in, out)` and `Model(outputs=...)` — with
- the `outputs` formal parameter of the synthetic `Model.do` node.

Both survive where the instance field does not. When the output shape still can't be recovered (a deep convolutional chain whose `DenseCall` is shapeless, or a subclassed model whose output flows through `call`), return ⊤ rather than the input shape; the dtype axis keeps the still-sound dtype. The input shape now only refines a recovered output shape's batch dimension, never substitutes for it.

Also drops the now-unused `Model.Fields` enum (only the removed instance-field read referenced it).

## Test impact

- `testGanTutorialGeneratorLoss`: `fake_output` is now `float32` with shape ⊤ (was the unsound `(None, 100)`, which empirically is the noise input shape — running the fixture gives `noise (256, 100)` → generator `(256, 28, 28, 1)` → discriminator `(256, 1)`, so the old value was provably wrong, not just imprecise). The output node `Dense(1)` is recovered but shapeless in the functional-API codepath (its `Flatten`-of-`Conv2D` input shape isn't tracked); recovering `(batch, 1)` needs `DenseCall` output-shape inference through chained layer calls, tracked by wala/ML#358 (this PR fixes the unsound mis-propagation; #358 owns the residual precision, so the TODO points there rather than at the closing #537).
- New `testModelCallOutputShape`: a functional `Dense(3)`-on-`(1, 2)` model whose `(1, 3)` output shape differs from its input shape, pinned for both positional and keyword construction — a positive guard that the recovery reports the transformed shape. (The shape-preserving `Dense(2)`-on-dim-2 models in `testModelInit` can't distinguish the fixed behavior from the old fallback.)

Full suite green locally: 805 tests, 0 failures, 0 errors (`mvn clean install`).

Closes wala/ML#537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
