### PR TITLE
Add a tensor-typing test for `_gather_elements_along_row`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -308,6 +308,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
 
+  private static final TensorType TENSOR_2_4_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(4)));
+
   private static final TensorType TENSOR_2_6_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(6)));
 
@@ -2410,6 +2413,34 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             3, Set.of(TENSOR_2_3_4_FLOAT32),
             4, Set.of(TENSOR_4_4_FLOAT32),
             5, Set.of(TENSOR_2_INT32)));
+  }
+
+  /**
+   * Pins {@code _gather_elements_along_row(data, column_indices)}'s parameter types. Function body
+   * mirrors {@code _gather_elements_along_row} from {@code
+   * deep_recommenders/keras/models/retrieval/sbcnm.py} (identical to {@code _take_long_axis} in
+   * {@code factorized_top_k} per the source), a real-world recommender-systems utility, for
+   * tensor-type inference coverage. Both parameters infer concretely: {@code data} as {@code (2, 4)
+   * float32} and {@code column_indices} as {@code (2, 3) int32}. (The function's
+   * runtime-dimensioned final {@code tf.reshape} leaves the local <em>result</em> symbolic, but the
+   * parameters themselves are exact.)
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGatherElementsAlongRow()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_elements_along_row.py",
+        "_gather_elements_along_row",
+        2,
+        7,
+        Map.of(
+            2, Set.of(TENSOR_2_4_FLOAT32),
+            3, Set.of(TENSOR_2_3_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_elements_along_row.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_elements_along_row.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+
+
+# Mirrors `_gather_elements_along_row` from
+# `deep_recommenders/keras/models/retrieval/sbcnm.py` (the source docstring notes
+# it is identical to `_take_long_axis` in `factorized_top_k`), a real-world
+# recommender-systems utility, for tensor-type inference coverage.
+def _gather_elements_along_row(data, column_indices):
+    with tf.control_dependencies(
+        [tf.assert_equal(tf.shape(data)[0], tf.shape(column_indices)[0])]
+    ):
+        num_row = tf.shape(data)[0]
+        num_column = tf.shape(data)[1]
+        num_gathered = tf.shape(column_indices)[1]
+        row_indices = tf.tile(tf.expand_dims(tf.range(num_row), -1), [1, num_gathered])
+        flat_data = tf.reshape(data, [-1])
+        flat_indices = tf.reshape(row_indices * num_column + column_indices, [-1])
+        return tf.reshape(tf.gather(flat_data, flat_indices), [num_row, num_gathered])
+
+
+data = tf.constant([[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]], dtype=tf.float32)
+column_indices = tf.constant([[0, 1, 2], [1, 2, 3]], dtype=tf.int32)
+
+result = _gather_elements_along_row(data, column_indices)
+
+assert data.shape == (2, 4) and data.dtype == tf.float32
+assert column_indices.shape == (2, 3) and column_indices.dtype == tf.int32
+assert result.shape == (2, 3) and result.dtype == tf.float32


### PR DESCRIPTION
Adds `tf2_test_gather_elements_along_row.py`, mirroring `_gather_elements_along_row` from `deep_recommenders/keras/models/retrieval/sbcnm.py` (identical to `_take_long_axis` in `factorized_top_k` per the source — a real-world recommender-systems gather utility), and pins its parameter types in `TestTensorflow2Model`.

Both parameters infer concretely:
- `data` → `(2, 4) float32`
- `column_indices` → `(2, 3) int32`

matching the runtime (verified by running the fixture). The function's runtime-dimensioned final `tf.reshape` leaves the local result symbolic, but the parameters themselves are exact — so this is a positive coverage guard, no gap.

Full suite green locally: 806 tests, 0 failures (`mvn clean install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)