### PR TITLE
Broaden tensor-type inference coverage with real-world corpus fixtures

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -138,6 +138,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_256_784_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(784)));
 
+  private static final TensorType TENSOR_256_28_28_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(28), new NumericDim(28)));
+
   private static final TensorType TENSOR_10000_784_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(10000), new NumericDim(784)));
 
@@ -2362,6 +2365,65 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         5,
         Map.of(2, Set.of(TENSOR_256_256_3_FLOAT32), 3, Set.of(TENSOR_256_256_3_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code MaskSparseCategoricalCrossentropy.__call__(y_true, y_predict, input_mask)}'s
+   * parameter types. Class and method body mirror {@code MaskSparseCategoricalCrossentropy} from
+   * {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/Losess.py}, a real-world NLP utility (a mask-weighted
+   * sparse-categorical-crossentropy loss), for tensor-type inference coverage. Unlike the {@code
+   * tf.keras.Model.call} layer-chain methods ({@code testNeuralNetwork*}), this is a loss {@code
+   * __call__} on a plain class that reduces its inputs to a scalar.
+   *
+   * <p>All three parameters are inferred concretely — shape and dtype: {@code y_true} as {@code
+   * (4,) int32}, {@code y_predict} as {@code (4, 10) float32}, and {@code input_mask} as {@code
+   * (4,) float32}, flowing from the {@code tf.constant(np.ones(...))} call site.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testMaskedSparseCrossentropy()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_masked_sparse_ce.py",
+        "MaskSparseCategoricalCrossentropy.__call__",
+        3,
+        5,
+        Map.of(
+            3, Set.of(TENSOR_4_INT32),
+            4, Set.of(TENSOR_4_10_FLOAT32),
+            5, Set.of(TENSOR_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code LSTM.call(x)}'s parameter type. Class and method body mirror the {@code LSTM}
+   * recurrent model from {@code
+   * aymericdamien/TensorFlow-Examples/.../3_NeuralNetworks/recurrent_network.py}, a real-world
+   * sequence-classification utility (a built-in {@code tf.keras.layers.LSTM} followed by a {@code
+   * Dense} read-out), for tensor-type inference coverage.
+   *
+   * <p>The input parameter {@code x} is recovered concretely on both axes — {@code (256, 28, 28)
+   * float32} — flowing from the {@code lstm_net(x, is_training=True)} call site through {@code
+   * tf.keras.Model.__call__} dispatch.
+   *
+   * <p>The forward-pass locals ({@code lstm_layer} output, {@code out} output, {@code softmax}) are
+   * inferred as {@code float32} but with <em>unknown shape</em>: the built-in {@code LSTM}/{@code
+   * Dense} output shapes are not narrowed (the layer-chain shape gap tracked by <a
+   * href="https://github.com/wala/ML/issues/530">wala/ML#530</a>). The dtype axis — the
+   * load-bearing one — is exact; only shape is ⊤.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testLstmCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_lstm_call.py", "LSTM.call", 1, 4, Map.of(3, Set.of(TENSOR_256_28_28_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -230,6 +230,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_100_784_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(100), new NumericDim(784)));
 
+  private static final TensorType TENSOR_4_10_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(10)));
+
+  private static final TensorType TENSOR_4_1_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(4), new NumericDim(1)));
+
+  private static final TensorType TENSOR_256_256_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(256), new NumericDim(3)));
+
   private static final TensorType TENSOR_2_3_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
 
@@ -2252,6 +2261,107 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         16,
         Map.of(2, Set.of(TENSOR_100_784_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code logistic_regression(x)}'s parameter type. Function body mirrors {@code
+   * logistic_regression} from {@code
+   * aymericdamien/TensorFlow-Examples/.../2_BasicModels/logistic_regression.py}, a real-world
+   * image-classification utility (logistic regression: {@code softmax(W x + b)} over global {@code
+   * tf.Variable} weights and biases), for tensor-type inference coverage. Like {@link
+   * #testMultilayerPerceptron}, it uses raw {@code tf.matmul} / {@code tf.nn.softmax} rather than
+   * the {@code Dense}-layer subclass-{@code Model} approach of {@code testNeuralNetwork*}.
+   *
+   * <p>{@code x} is inferred as {@code (100, 784) float32} — both shape and dtype concrete —
+   * flowing from the caller's {@code tf.constant(np.ones((100, 784), dtype=np.float32))} via the
+   * {@code numpy → tf.constant} bridge (<a
+   * href="https://github.com/wala/ML/issues/539">wala/ML#539</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testLogisticRegression()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_logistic_regression.py",
+        "logistic_regression",
+        1,
+        6,
+        Map.of(2, Set.of(TENSOR_100_784_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code nce_loss(x_embed, y)}'s parameter types. Function body mirrors {@code nce_loss}
+   * from {@code aymericdamien/TensorFlow-Examples/.../2_BasicModels/word2vec.py}, a real-world
+   * word-embedding utility (the averaged noise-contrastive-estimation loss over global {@code
+   * tf.Variable} embedding/weight/bias matrices), for tensor-type inference coverage.
+   *
+   * <p>Both parameters are inferred concretely — shape and dtype: {@code x_embed} as {@code (4, 10)
+   * float32} and {@code y} as {@code (4, 1) int32}, flowing from the {@code
+   * tf.constant(np.ones(...))} call site.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNceLoss()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nce_loss.py",
+        "nce_loss",
+        2,
+        5,
+        Map.of(2, Set.of(TENSOR_4_10_FLOAT32), 3, Set.of(TENSOR_4_1_INT32)));
+  }
+
+  /**
+   * Pins {@code evaluate(x_embed)}'s parameter type. Function body mirrors {@code evaluate} from
+   * {@code aymericdamien/TensorFlow-Examples/.../2_BasicModels/word2vec.py}, a real-world
+   * word-embedding utility (the cosine similarity between an input embedding and every row of the
+   * global embedding matrix), for tensor-type inference coverage.
+   *
+   * <p>{@code x_embed} is inferred as {@code (4, 10) float32} — both shape and dtype concrete —
+   * flowing from the {@code tf.constant(np.ones(...))} call site.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testEvaluate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_evaluate.py", "evaluate", 1, 13, Map.of(2, Set.of(TENSOR_4_10_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code random_jitter(input_image, real_image)}'s parameter types. Function body (and the
+   * {@code resize}/{@code random_crop} helpers it calls) mirrors {@code random_jitter} from {@code
+   * YunYang1994/TensorFlow2.0-Examples/.../Pix2Pix.py}, a real-world image-to-image translation
+   * utility (random resize/crop/mirror data augmentation), for tensor-type inference coverage.
+   *
+   * <p>Both image parameters are inferred concretely — shape and dtype — as {@code (256, 256, 3)
+   * float32}, flowing from the {@code tf.constant(np.ones(...))} call site.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testRandomJitter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_random_jitter.py",
+        "random_jitter",
+        2,
+        5,
+        Map.of(2, Set.of(TENSOR_256_256_3_FLOAT32), 3, Set.of(TENSOR_256_256_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_evaluate.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_evaluate.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+import numpy as np
+
+# Mirrors `evaluate` from `TensorFlow-Examples/.../2_BasicModels/word2vec.py`, a
+# real-world word-embedding utility (the cosine similarity between an input
+# embedding and every row of the module-level embedding matrix), for tensor-type
+# inference coverage.
+vocabulary_size = 100
+embedding_size = 10
+
+embedding = tf.Variable(tf.random.normal([vocabulary_size, embedding_size]))
+
+
+def evaluate(x_embed):
+    # Compute the cosine similarity between input data embedding and every embedding vector.
+    x_embed = tf.cast(x_embed, tf.float32)
+    x_embed_norm = x_embed / tf.sqrt(tf.reduce_sum(tf.square(x_embed)))
+    embedding_norm = embedding / tf.sqrt(
+        tf.reduce_sum(tf.square(embedding), 1, keepdims=True), tf.float32
+    )
+    cosine_sim_op = tf.matmul(x_embed_norm, embedding_norm, transpose_b=True)
+    return cosine_sim_op
+
+
+x_embed = tf.constant(np.ones((4, embedding_size), dtype=np.float32))
+result = evaluate(x_embed)
+assert x_embed.shape == (4, embedding_size) and x_embed.dtype == tf.float32
+assert result.shape == (4, vocabulary_size) and result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_logistic_regression.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_logistic_regression.py
@@ -1,0 +1,23 @@
+import tensorflow as tf
+import numpy as np
+
+# Mirrors `logistic_regression` from
+# `TensorFlow-Examples/.../2_BasicModels/logistic_regression.py`, a real-world
+# image-classification utility (logistic regression: `softmax(W x + b)` over
+# module-level weight/bias variables), for tensor-type inference coverage.
+num_features = 784
+num_classes = 10
+
+W = tf.Variable(tf.ones([num_features, num_classes]), name="weight")
+b = tf.Variable(tf.zeros([num_classes]), name="bias")
+
+
+def logistic_regression(x):
+    # Apply softmax to normalize the logits to a probability distribution.
+    return tf.nn.softmax(tf.matmul(x, W) + b)
+
+
+x = tf.constant(np.ones((100, num_features), dtype=np.float32))
+result = logistic_regression(x)
+assert x.shape == (100, num_features) and x.dtype == tf.float32
+assert result.shape == (100, num_classes) and result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_lstm_call.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_lstm_call.py
@@ -1,0 +1,34 @@
+import tensorflow as tf
+import numpy as np
+from tensorflow.keras import Model, layers
+
+# Mirrors the `LSTM.call` recurrent model from
+# `aymericdamien/TensorFlow-Examples/.../3_NeuralNetworks/recurrent_network.py`,
+# a real-world sequence-classification utility (an LSTM layer followed by a dense
+# read-out), for tensor-type inference coverage. Unlike the pure-`Dense`
+# `NeuralNet.call` (`testNeuralNetwork*`), the forward pass begins with a
+# built-in `tf.keras.layers.LSTM` over a rank-3 `(batch, timesteps, features)`
+# input.
+num_units = 32
+num_classes = 10
+
+
+class LSTM(Model):
+    def __init__(self):
+        super(LSTM, self).__init__()
+        self.lstm_layer = layers.LSTM(units=num_units)
+        self.out = layers.Dense(num_classes)
+
+    def call(self, x, is_training=False):
+        x = self.lstm_layer(x)
+        x = self.out(x)
+        if not is_training:
+            x = tf.nn.softmax(x)
+        return x
+
+
+lstm_net = LSTM()
+x = tf.constant(np.ones((256, 28, 28), dtype=np.float32))
+result = lstm_net(x, is_training=True)
+assert x.shape == (256, 28, 28) and x.dtype == tf.float32
+assert result.shape == (256, num_classes) and result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_masked_sparse_ce.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_masked_sparse_ce.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+import numpy as np
+
+
+# Mirrors `MaskSparseCategoricalCrossentropy.__call__` from
+# `kyzhouhzau/NLPGNN/nlpgnn/metrics/Losess.py`, a real-world NLP utility (a
+# mask-weighted sparse-categorical-crossentropy loss), for tensor-type inference
+# coverage.
+class MaskSparseCategoricalCrossentropy:
+    def __init__(self, from_logits=False, use_mask=False):
+        self.from_logits = from_logits
+        self.use_mask = use_mask
+
+    def __call__(self, y_true, y_predict, input_mask=None):
+        cross_entropy = tf.keras.losses.sparse_categorical_crossentropy(
+            y_true, y_predict, self.from_logits
+        )
+        if self.use_mask:
+            input_mask = tf.cast(input_mask, dtype=tf.float32)
+            input_mask /= tf.reduce_mean(input_mask)
+            cross_entropy *= input_mask
+            # mask loss
+            return tf.reduce_mean(cross_entropy)
+        else:
+            return tf.reduce_mean(cross_entropy)
+
+
+loss = MaskSparseCategoricalCrossentropy(from_logits=True, use_mask=True)
+y_true = tf.constant(np.ones((4,), dtype=np.int32))
+y_predict = tf.constant(np.ones((4, 10), dtype=np.float32))
+input_mask = tf.constant(np.ones((4,), dtype=np.float32))
+result = loss(y_true, y_predict, input_mask)
+assert y_true.shape == (4,) and y_true.dtype == tf.int32
+assert y_predict.shape == (4, 10) and y_predict.dtype == tf.float32
+assert input_mask.shape == (4,) and input_mask.dtype == tf.float32
+assert result.shape == () and result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nce_loss.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nce_loss.py
@@ -1,0 +1,37 @@
+import tensorflow as tf
+import numpy as np
+
+# Mirrors `nce_loss` from `TensorFlow-Examples/.../2_BasicModels/word2vec.py`, a
+# real-world word-embedding utility (the averaged noise-contrastive-estimation
+# loss over module-level embedding/weight/bias variables), for tensor-type
+# inference coverage.
+vocabulary_size = 100
+embedding_size = 10
+num_sampled = 8
+
+embedding = tf.Variable(tf.random.normal([vocabulary_size, embedding_size]))
+nce_weights = tf.Variable(tf.random.normal([vocabulary_size, embedding_size]))
+nce_biases = tf.Variable(tf.zeros([vocabulary_size]))
+
+
+def nce_loss(x_embed, y):
+    y = tf.cast(y, tf.int64)
+    loss = tf.reduce_mean(
+        tf.nn.nce_loss(
+            weights=nce_weights,
+            biases=nce_biases,
+            labels=y,
+            inputs=x_embed,
+            num_sampled=num_sampled,
+            num_classes=vocabulary_size,
+        )
+    )
+    return loss
+
+
+x_embed = tf.constant(np.ones((4, embedding_size), dtype=np.float32))
+y = tf.constant(np.ones((4, 1), dtype=np.int32))
+result = nce_loss(x_embed, y)
+assert x_embed.shape == (4, embedding_size) and x_embed.dtype == tf.float32
+assert y.shape == (4, 1) and y.dtype == tf.int32
+assert result.shape == () and result.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_random_jitter.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_random_jitter.py
@@ -1,0 +1,51 @@
+import tensorflow as tf
+import numpy as np
+
+# Mirrors `random_jitter` (and the `resize`/`random_crop` helpers it calls) from
+# `TensorFlow2.0-Examples/.../Pix2Pix.py`, a real-world image-to-image
+# translation utility (random resize/crop/mirror data augmentation), for
+# tensor-type inference coverage.
+IMG_WIDTH = 256
+IMG_HEIGHT = 256
+
+
+def resize(input_image, real_image, height, width):
+    input_image = tf.image.resize(
+        input_image, [height, width], method=tf.image.ResizeMethod.NEAREST_NEIGHBOR
+    )
+    real_image = tf.image.resize(
+        real_image, [height, width], method=tf.image.ResizeMethod.NEAREST_NEIGHBOR
+    )
+
+    return input_image, real_image
+
+
+def random_crop(input_image, real_image):
+    stacked_image = tf.stack([input_image, real_image], axis=0)
+    cropped_image = tf.image.random_crop(
+        stacked_image, size=[2, IMG_HEIGHT, IMG_WIDTH, 3]
+    )
+
+    return cropped_image[0], cropped_image[1]
+
+
+def random_jitter(input_image, real_image):
+    # resizing to 286 x 286 x 3
+    input_image, real_image = resize(input_image, real_image, 286, 286)
+    # randomly cropping to 256 x 256 x 3
+    input_image, real_image = random_crop(input_image, real_image)
+
+    # random mirroring
+    if tf.random.uniform(()) > 0.5:
+        input_image = tf.image.flip_left_right(input_image)
+        real_image = tf.image.flip_left_right(real_image)
+
+    return input_image, real_image
+
+
+input_image = tf.constant(np.ones((256, 256, 3), dtype=np.float32))
+real_image = tf.constant(np.ones((256, 256, 3), dtype=np.float32))
+jittered_input, jittered_real = random_jitter(input_image, real_image)
+assert input_image.shape == (256, 256, 3) and input_image.dtype == tf.float32
+assert real_image.shape == (256, 256, 3) and real_image.dtype == tf.float32
+assert jittered_input.shape == (256, 256, 3) and jittered_input.dtype == tf.float32


### PR DESCRIPTION
Adds six faithful fixtures and their parameter-type tests, each mirroring a decorated function from a real-world TensorFlow project, to broaden tensor-type (shape and dtype) inference coverage. They extend the existing free-function fixtures (`testCrf*`, `testCreateAttentionMaskFromInputMask`, `testMultilayerPerceptron`, …) and `tf.keras.Model.call` method coverage (`testNeuralNetwork*`, `testMultiGPUTraining`, the `autoencoder.py` tests).

Free functions:
- `logistic_regression` — `softmax(W x + b)` over global `tf.Variable`s; param `x` infers as `(100, 784) float32`.
- `nce_loss` — averaged noise-contrastive-estimation loss; params `x_embed` `(4, 10) float32`, `y` `(4, 1) int32`.
- `evaluate` — cosine similarity against an embedding matrix; param `x_embed` `(4, 10) float32`.
- `random_jitter` — random resize/crop/mirror image augmentation; both image params infer as `(256, 256, 3) float32`.

Methods:
- `MaskSparseCategoricalCrossentropy.__call__` — a mask-weighted sparse-categorical-crossentropy loss; all three params infer concretely (`y_true` `(4,) int32`, `y_predict` `(4, 10) float32`, `input_mask` `(4,) float32`).
- `LSTM.call` — a built-in `tf.keras.layers.LSTM` plus a `Dense` read-out; input param `x` infers as `(256, 28, 28) float32`. The forward-pass locals keep their `float32` dtype but report unknown shape (the layer-chain shape gap, wala/ML#530).

Every decorated function has its full input signature recovered. Each fixture runs to completion under `python3.10`, with `assert`s on the runtime shape and dtype matching the static-analysis expectations.