### PR TITLE
Restore per-context layer-output shape via configurable selective k-CFA

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestPythonMLCallGraphShape.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestPythonMLCallGraphShape.java
@@ -46,7 +46,26 @@ public abstract class TestPythonMLCallGraphShape extends TestJythonCallGraphShap
   @Override
   protected PythonTensorAnalysisEngine makeEngine(List<File> pythonPath, String... name)
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    PythonTensorAnalysisEngine engine = new PythonTensorAnalysisEngine(pythonPath);
+    return makeEngine(PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH, pythonPath, name);
+  }
+
+  /**
+   * Builds an engine with a specific k-CFA depth. Mirrors the depth-parameterized analyzer
+   * construction used in the Java streams tooling so individual tests can opt into deeper context
+   * sensitivity (wala/ML#379, wala/ML#530) while the default stays at {@link
+   * PythonTensorAnalysisEngine#DEFAULT_TARGETED_CFA_DEPTH}.
+   *
+   * @param targetedCfaDepth The k-CFA depth for the targeted context selector.
+   * @param pythonPath The additional Python path entries for module resolution.
+   * @param name The script module file names to analyze.
+   * @return The configured engine.
+   */
+  protected PythonTensorAnalysisEngine makeEngine(
+      int targetedCfaDepth, List<File> pythonPath, String... name)
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine =
+        new PythonTensorAnalysisEngine(
+            pythonPath, PythonTensorAnalysisEngine.TENSORFLOW, targetedCfaDepth);
     Set<Module> modules = HashSetFactory.make();
     for (String n : name) {
       modules.add(getScript(n));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3004,6 +3004,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * A negative k-CFA depth is invalid (the depth is the call-string length for the targeted context
+   * selector) and is rejected at construction (wala/ML#379).
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeTargetedCfaDepthRejected() {
+    new PythonTensorAnalysisEngine(
+        emptyList(), PythonTensorAnalysisEngine.TENSORFLOW, /* targetedCfaDepth= */ -1);
+  }
+
+  /**
    * {@code encoder(x)} receives {@code x} from call sites {@code decoder(encoder(x))} inside {@code
    * run_optimization} (training loop) and {@code decoder(encoder(batch_x))} at the module-level
    * test loop. Both call sites pass batches of shape {@code (256, 784)} dtype {@code float32}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5542,6 +5542,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Tests that {@code tf.math.argmax} resolves its input when passed by keyword ({@code
+   * tf.math.argmax(input=x, axis=0)}). {@link com.ibm.wala.cast.python.ml.client.Argmax} delegates
+   * shape inference to {@link com.ibm.wala.cast.python.ml.client.ReduceMean}, whose input parameter
+   * is named {@code input_tensor}; argmax's is named {@code input}, so without overriding the
+   * input-parameter name the keyword lookup fails and shape inference throws {@code
+   * IllegalStateException}. The result {@code y} (vn=3) is the precise {@code (3,) int64}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgmaxInputKeyword()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmax_input_keyword.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_2_3_FLOAT32),
+            3, Set.of(TENSOR_3_INT64)));
+  }
+
+  /**
    * Counterpart of {@link #testArgmaxOutputType()} for {@code tf.math.argmin}. Same dispatch path
    * via the inherited {@link com.ibm.wala.cast.python.ml.client.Argmin} extends {@link
    * com.ibm.wala.cast.python.ml.client.Argmax} relationship; the result {@code y} (vn=3) has the

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5516,6 +5516,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Like {@link #testArgmaxOutputType()} but passes {@code output_type} positionally ({@code
+   * tf.math.argmax(x, 0, tf.int32)}). Shape inference must not misread the positional {@code
+   * output_type} argument as {@link com.ibm.wala.cast.python.ml.client.ReduceMean}'s {@code
+   * keepdims} (they share positional index 2); the result {@code y} (vn=3) is the precise {@code
+   * (3,) int32}, not a {@code keepdims=true} union (e.g. {@code (1, 3)}). Regression guard for the
+   * {@code getKeepDimsValues} override on {@link com.ibm.wala.cast.python.ml.client.Argmax}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testArgmaxOutputTypePositional()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_argmax_output_type_positional.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_2_3_FLOAT32),
+            3, Set.of(TENSOR_3_INT32)));
+  }
+
+  /**
    * Counterpart of {@link #testArgmaxOutputType()} for {@code tf.math.argmin}. Same dispatch path
    * via the inherited {@link com.ibm.wala.cast.python.ml.client.Argmin} extends {@link
    * com.ibm.wala.cast.python.ml.client.Argmax} relationship; the result {@code y} (vn=3) has the

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2860,18 +2860,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * fc1}, {@code fc2}, {@code out}, {@code softmax}). With the fix for wala/ML#358, the full {@code
    * fc1 → fc2 → out → softmax} chain narrows along the {@code units} axis ({@code 128 → 256 → 10 →
    * 10}) and every intermediate is registered as a tensor variable; combined with the per-context
-   * multiplicity (wala/ML#371) the actual registered count rises to 12. Count held at 12 to
-   * preserve regression detection; when wala/ML#371 Option 2 lands this count will drop to the
-   * source-level total.
+   * multiplicity (wala/ML#371) the actual registered count rises. This test runs at k-CFA depth 4
+   * (wala/ML#379) so {@code NeuralNet.call} is analyzed per caller (train vs. test vs.
+   * visualization) rather than collapsed (wala/ML#530); the extra caller contexts double the
+   * per-context multiplicity to 24. Count held at 24 to preserve regression detection; when
+   * wala/ML#371 Option 2 lands this count will drop to the source-level total.
    */
   @Test
   public void testNeuralNetwork()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
+        4,
         "neural_network.py",
         "NeuralNet.call",
         1,
-        12,
+        24,
         Map.of(3, Set.of(TENSOR_256_784_FLOAT32, TENSOR_10000_784_FLOAT32, TENSOR_5_784_FLOAT32)));
   }
 
@@ -2898,6 +2901,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNeuralNetwork2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
+        4,
         "neural_network.py",
         "cross_entropy_loss",
         2,
@@ -2932,6 +2936,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNeuralNetwork3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
+        4,
         "neural_network.py",
         "run_optimization",
         2,
@@ -2960,11 +2965,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * <p>Value 2 ({@code y_pred}) is tracked as a tensor parameter after the fix for wala/ML#358
    * (chained {@code Dense} shape propagation): the final {@code Dense(num_classes=10)} in {@code
    * NeuralNet.call} narrows to {@code (256, 10)} and that shape propagates back into {@code
-   * accuracy}'s {@code y_pred} parameter. The {@code (10000, 10)} shape from the test-set call site
-   * ({@code accuracy(pred, y_test)} where {@code pred = neural_net(x_test, ...)}) does not
-   * currently propagate, because the {@code x_test} chain resolves to a rank-preserving but
-   * shape-unknown tensor by the time it reaches {@code NeuralNet.call}'s first {@code Dense}
-   * operand. The remaining shape-propagation gap is orthogonal to #358.
+   * accuracy}'s {@code y_pred} parameter. This test runs at k-CFA depth 4 (wala/ML#379) so {@code
+   * NeuralNet.call} is analyzed per caller and its layer-output ({@code pred}) no longer collapses
+   * the training shape into the test context (wala/ML#530); value 2 is therefore the per-context
+   * union {@code {(256, 10) float32, ? float32}}. The test-context contribution is ⊤ shape because
+   * the {@code x_test} chain resolves to a rank-preserving but shape-unknown tensor by the time it
+   * reaches {@code NeuralNet.call}'s first {@code Dense} operand; closing that gap would narrow the
+   * ⊤ to {@code (10000, 10)} (orthogonal to #358/#530).
    */
   @Test
   public void testNeuralNetwork4()
@@ -2975,11 +2982,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     // are the argmax call sites and their downstream uses across the call
     // graph. Parameter-type expectations (`y_pred`, `y_true`) unchanged.
     test(
+        4,
         "neural_network.py",
         "accuracy",
         2,
         14,
-        Map.of(2, Set.of(TENSOR_256_10_FLOAT32), 3, Set.of(TENSOR_256_UINT8, TENSOR_10000_UINT8)));
+        Map.of(
+            2,
+            // Per-context union: training call site `accuracy(pred, batch_y)` gives `(256, 10)`;
+            // the test-set call site `accuracy(pred, y_test)` resolves to ⊤ shape because the
+            // `x_test` chain is shape-unknown by the time it reaches `NeuralNet.call`'s first
+            // `Dense` operand. With the depth-4 context separation (wala/ML#530), `argmax`'s result
+            // no longer leaks the training shape into the test context. TODO: the test-context ⊤
+            // should narrow to `(10000, 10)` once the `x_test` shape gap is closed.
+            Set.of(TENSOR_256_10_FLOAT32, TENSOR_UNKNOWN_SHAPE_FLOAT32),
+            3,
+            Set.of(TENSOR_256_UINT8, TENSOR_10000_UINT8)));
   }
 
   /**
@@ -10571,6 +10589,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         expectedTensorParameterValueNumberToTypes);
   }
 
+  /**
+   * Single-file test helper with a configurable k-CFA depth. Delegates to the core depth-aware
+   * {@code test(...)}; used by tests that need deeper context sensitivity than the default
+   * (wala/ML#379, wala/ML#530).
+   *
+   * @param targetedCfaDepth The k-CFA depth for the targeted context selector.
+   * @param filename The file declaring the function under test.
+   * @param functionName The function whose tensor types are checked.
+   * @param expectedNumberOfTensorParameters The expected number of tensor parameters.
+   * @param expectedNumberOfTensorVariables The expected number of function-local tensor variables.
+   * @param expectedTensorParameterValueNumberToTypes The expected per-parameter tensor types.
+   */
+  protected void test(
+      int targetedCfaDepth,
+      String filename,
+      String functionName,
+      int expectedNumberOfTensorParameters,
+      int expectedNumberOfTensorVariables,
+      Map<Integer, Set<TensorType>> expectedTensorParameterValueNumberToTypes)
+      throws ClassHierarchyException, CancelException, IOException {
+    test(
+        targetedCfaDepth,
+        new String[] {filename},
+        filename,
+        functionName,
+        "",
+        expectedNumberOfTensorParameters,
+        expectedNumberOfTensorVariables,
+        expectedTensorParameterValueNumberToTypes);
+  }
+
   protected void test(
       String[] projectFilenames,
       String filename,
@@ -10580,8 +10629,45 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       int expectedNumberOfFunctionTensorVariables,
       Map<Integer, Set<TensorType>> expectedTensorParameterValueNumberToTypes)
       throws ClassHierarchyException, CancelException, IOException {
+    test(
+        PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH,
+        projectFilenames,
+        filename,
+        functionName,
+        pythonPath,
+        expectedNumberOfTensorParameters,
+        expectedNumberOfFunctionTensorVariables,
+        expectedTensorParameterValueNumberToTypes);
+  }
+
+  /**
+   * Core test helper with a configurable k-CFA depth. Most tests use the default-depth overloads;
+   * tests that exercise per-context layer-output precision (e.g. {@code testNeuralNetwork*}) opt
+   * into a deeper depth so a user model invoked from multiple sites does not collapse its
+   * layer-output allocations (wala/ML#379, wala/ML#530).
+   *
+   * @param targetedCfaDepth The k-CFA depth for the targeted context selector.
+   * @param projectFilenames The script module file names making up the project.
+   * @param filename The file declaring the function under test.
+   * @param functionName The function whose tensor types are checked.
+   * @param pythonPath The Python path root for module resolution.
+   * @param expectedNumberOfTensorParameters The expected number of tensor parameters.
+   * @param expectedNumberOfFunctionTensorVariables The expected number of function-local tensor
+   *     variables.
+   * @param expectedTensorParameterValueNumberToTypes The expected per-parameter tensor types.
+   */
+  protected void test(
+      int targetedCfaDepth,
+      String[] projectFilenames,
+      String filename,
+      String functionName,
+      String pythonPath,
+      int expectedNumberOfTensorParameters,
+      int expectedNumberOfFunctionTensorVariables,
+      Map<Integer, Set<TensorType>> expectedTensorParameterValueNumberToTypes)
+      throws ClassHierarchyException, CancelException, IOException {
     List<File> pathFiles = this.getPathFiles(pythonPath);
-    PythonTensorAnalysisEngine engine = makeEngine(pathFiles, projectFilenames);
+    PythonTensorAnalysisEngine engine = makeEngine(targetedCfaDepth, pathFiles, projectFilenames);
     PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
 
     addPytestEntrypoints(builder);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -477,6 +477,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3)));
 
+  private static final TensorType TENSOR_3_INT64 =
+      new TensorType(INT_64, asList(new NumericDim(3)));
+
   private static final TensorType TENSOR_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3)));
 
@@ -5435,19 +5438,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_size.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
-  // wala/ML#449 Tier 6: argmax/argmin produce int64 indices. Output shape is left at ⊤ for now;
-  // see `Argmax.getDefaultShapes` for why precise shape inference regresses `testNeuralNetwork*`.
+  // wala/ML#449 Tier 6: argmax/argmin produce int64 indices. Output shape is the input shape with
+  // the `axis` dimension removed (via `ReduceMean`), unblocked by the per-context layer-output
+  // fix (wala/ML#530) that stopped `testNeuralNetwork*` from regressing on the
+  // `ElementWiseOperation`
+  // cross-context cartesian pair.
 
   /**
    * Verifies that {@code tf.math.argmax(x, axis=0)} routes through the dedicated {@link
    * com.ibm.wala.cast.python.ml.client.Argmax} generator and emits the precise {@code int64} dtype
-   * (the TF default for argmax indices).
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): output shape is left
-   * at ⊤. Precise axis-aware shape composition (reading {@code input.shape[:axis] +
-   * input.shape[axis+1:]}) regresses {@code testNeuralNetwork*} via the {@code
-   * ElementWiseOperation} cartesian-pair issue tracked at #462. Tighten to the precise post-fix
-   * shape once #462 lands.
+   * (the TF default for argmax indices) and the precise {@code (3,)} shape ({@code (2, 3)} with
+   * {@code axis=0} removed). Shape precision was unblocked by wala/ML#530.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5457,17 +5458,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testArgmax()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_argmax.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+    test("tf2_test_argmax.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT64)));
   }
 
   /**
    * Counterpart of {@link #testArgmax()} for {@code tf.math.argmin}. Same semantics: dtype defaults
    * to {@code int64} (overridable via {@code output_type}, see {@link #testArgminOutputType()}),
-   * shape is left at ⊤. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): output shape is left
-   * at ⊤; same {@code ElementWiseOperation} cartesian-pair driver as for {@link #testArgmax()}.
-   * Tighten to the precise post-fix shape once #462 lands.
+   * and shape is the precise {@code (3,)} ({@code (2, 3)} with {@code axis=0} removed), unblocked
+   * by wala/ML#530. See {@link com.ibm.wala.cast.python.ml.client.Argmin}.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5477,7 +5475,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testArgmin()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+    test("tf2_test_argmin.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_INT64)));
   }
 
   /**
@@ -5486,12 +5484,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * int64} default. Exercises the dtype-arg dispatch path on {@link
    * com.ibm.wala.cast.python.ml.client.Argmax} after the wala/ML#463 fix. The fixture's sink {@code
    * f(x, y)} has two parameters so that each tensor's inferred type can be checked independently.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the inferred ⊤ shape
-   * on {@code y} (vn=3) is imprecise &mdash; precise axis-aware shape composition (reading {@code
-   * input.shape[:axis] + input.shape[axis+1:]}) regresses {@code testNeuralNetwork*} via the {@code
-   * ElementWiseOperation} cartesian-pair issue tracked at #462. Captured-imprecise per the
-   * prefer-observed-assertion convention; tighten to a precise {@code (3,) int32} once #462 lands.
+   * The result {@code y} (vn=3) has the precise {@code (3,) int32} shape ({@code (2, 3)} with
+   * {@code axis=0} removed), unblocked by wala/ML#530.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5508,18 +5502,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         Map.of(
             2, Set.of(TENSOR_2_3_FLOAT32),
-            3, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+            3, Set.of(TENSOR_3_INT32)));
   }
 
   /**
    * Counterpart of {@link #testArgmaxOutputType()} for {@code tf.math.argmin}. Same dispatch path
    * via the inherited {@link com.ibm.wala.cast.python.ml.client.Argmin} extends {@link
-   * com.ibm.wala.cast.python.ml.client.Argmax} relationship; same shape-imprecision driver too.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the inferred ⊤ shape
-   * on {@code y} (vn=3) is imprecise &mdash; precise axis-aware shape composition for {@code
-   * Argmin} is gated by the {@code ElementWiseOperation} cartesian-pair issue, same as for {@code
-   * Argmax}. Tighten to the precise post-fix shape once #462 lands.
+   * com.ibm.wala.cast.python.ml.client.Argmax} relationship; the result {@code y} (vn=3) has the
+   * precise {@code (3,) int32} shape, unblocked by wala/ML#530.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5536,7 +5526,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         Map.of(
             2, Set.of(TENSOR_2_3_FLOAT32),
-            3, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+            3, Set.of(TENSOR_3_INT32)));
   }
 
   /**
@@ -5544,13 +5534,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * call sites* shape: {@code def f(a): ...; f(x); f(y)}. Parameter {@code a} should union {@code
    * x}'s and {@code y}'s tensor types across the two call sites &mdash; verifies that the {@code
    * output_type=tf.int32} override on {@code y} survives the second sink call rather than being
-   * clobbered by the {@code int64} default.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the {@code y}
-   * contribution to the union is currently ⊤-shape ({@code TENSOR_INT32_UNKNOWN_SHAPE}) for the
-   * same reason as {@link #testArgmaxOutputType()} &mdash; gated by the {@code
-   * ElementWiseOperation} cartesian-pair issue. Tighten {@code y}'s contribution to its precise
-   * post-fix shape (a {@code (3,) int32}) once #462 lands.
+   * clobbered by the {@code int64} default. The {@code y} contribution to the union is the precise
+   * {@code (3,) int32} shape, unblocked by wala/ML#530.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5565,17 +5550,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         2,
-        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_3_INT32)));
   }
 
   /**
-   * Counterpart of {@link #testArgmaxOutputTypeDoubleSink()} for {@code tf.math.argmin}; same
-   * shape-imprecision driver.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>): the {@code y}
-   * contribution to the union is currently ⊤-shape ({@code TENSOR_INT32_UNKNOWN_SHAPE}) for the
-   * same reason as {@link #testArgmaxOutputTypeDoubleSink()}. Tighten to the precise {@code (3,)
-   * int32} once #462 lands.
+   * Counterpart of {@link #testArgmaxOutputTypeDoubleSink()} for {@code tf.math.argmin}; the {@code
+   * y} contribution to the union is the precise {@code (3,) int32} shape, unblocked by wala/ML#530.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5590,7 +5570,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         2,
-        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_3_INT32)));
   }
 
   // wala/ML#449 Tier 7: linspace/broadcast_to. Shape derives from a shape-arg (`num`/`shape`),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -85,6 +85,30 @@ public class Argmax extends ReduceMean {
     super(source);
   }
 
+  /**
+   * {@code argmax}'s input parameter is named {@code input} (not {@code reduce_mean}'s {@code
+   * input_tensor}), so resolving it by the superclass name would fail keyword calls like {@code
+   * tf.math.argmax(input=x, axis=0)}.
+   *
+   * @return The positional index of {@code argmax}'s {@code input} parameter.
+   */
+  @Override
+  protected int getInputTensorParameterPosition() {
+    return Parameters.INPUT.getIndex();
+  }
+
+  /**
+   * {@code argmax}'s input parameter is named {@code input} (not {@code reduce_mean}'s {@code
+   * input_tensor}), so resolving it by the superclass name would fail keyword calls like {@code
+   * tf.math.argmax(input=x, axis=0)}.
+   *
+   * @return The keyword name ({@code input}) of {@code argmax}'s input parameter.
+   */
+  @Override
+  protected String getInputTensorParameterName() {
+    return Parameters.INPUT.getName();
+  }
+
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     // argmax removes the `axis` dimension (no keepdims), which is exactly ReduceMean's

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -20,13 +20,15 @@ import java.util.Set;
  * answer for argmax, which always returns an integer index. The override resolves the {@code
  * output_type} argument via {@link #getDTypeParameterPosition} / {@link #getDTypeParameterName} and
  * uses it instead of the default &mdash; fix for <a
- * href="https://github.com/wala/ML/issues/463">wala/ML#463</a>. Output shape is left at ⊤ for now;
- * computing the precise shape (input.shape with the {@code axis} dimension removed) regresses tests
- * such as {@code testNeuralNetwork*}, where the per-context shape union for {@code y_true} (e.g.
- * {@code [256]} train vs. {@code [10000]} test) cross-products through {@code
- * ElementWiseOperation}'s strict broadcast check. Shape precision can be added once the EWO union
- * behaviour is addressed (<a href="https://github.com/wala/ML/issues/462">wala/ML#462</a>). See <a
- * href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 6).
+ * href="https://github.com/wala/ML/issues/463">wala/ML#463</a>. Output shape is the input shape
+ * with the {@code axis} dimension removed (delegated to {@link ReduceMean}'s keepdims=false
+ * reduction). Earlier this was left at ⊤ because the precise shape regressed {@code
+ * testNeuralNetwork*}: the per-context shape union (e.g. {@code [256]} train vs. {@code [10000]}
+ * test) cross-products through {@code ElementWiseOperation}'s strict broadcast check. That
+ * regression was resolved by per-context layer-output allocations under configurable k-CFA (<a
+ * href="https://github.com/wala/ML/issues/530">wala/ML#530</a>, <a
+ * href="https://github.com/wala/ML/issues/379">wala/ML#379</a>), so the precise shape is now
+ * emitted. See <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 6).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/argmax">tf.math.argmax</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -85,7 +87,10 @@ public class Argmax extends ReduceMean {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // argmax removes the `axis` dimension (no keepdims), which is exactly ReduceMean's
+    // keepdims=False reduction. With per-context layer-output allocations (wala/ML#530), the input
+    // shape is resolved per caller, so the result no longer collapses across contexts.
+    return super.getDefaultShapes(builder);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -90,6 +90,10 @@ public class Argmax extends ReduceMean {
     // argmax removes the `axis` dimension (no keepdims), which is exactly ReduceMean's
     // keepdims=False reduction. With per-context layer-output allocations (wala/ML#530), the input
     // shape is resolved per caller, so the result no longer collapses across contexts.
+    //
+    // ReduceMean resolves the reduction axis from the `axis` parameter only, so argmax's deprecated
+    // TF 1.x `dimension` alias is not honored for shape (a `tf.argmax(x, dimension=0)` call would
+    // reduce as `axis=None`). Honoring the alias precisely is tracked by wala/ML#572.
     return super.getDefaultShapes(builder);
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Argmax.java
@@ -98,6 +98,22 @@ public class Argmax extends ReduceMean {
   }
 
   /**
+   * Forces {@code keepdims=false}: {@code argmax} (and {@code argmin}) have no {@code keepdims}
+   * parameter and always remove the scanned axis. This also prevents {@link ReduceMean} from
+   * misreading {@code argmax}'s {@code output_type} argument &mdash; which sits at the same
+   * positional index as {@code ReduceMean}'s {@code keepdims} &mdash; as a {@code keepdims} flag,
+   * which would otherwise union a spurious {@code keepdims=true} shape for a positional call like
+   * {@code tf.argmax(x, 0, tf.int32)}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code Set.of(false)}.
+   */
+  @Override
+  protected Set<Boolean> getKeepDimsValues(PropagationCallGraphBuilder builder) {
+    return Set.of(false);
+  }
+
+  /**
    * The default output dtype when no {@code output_type} argument is passed. {@link
    * TensorGenerator#getDTypes} dispatches here only when the dtype-arg path returns no resolved
    * dtype, so this is the fallback. TF 2.9 default is {@code int64}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -864,16 +864,20 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         op,
         builder,
         (CGNode src, SSAAbstractInvokeInstruction call) -> {
-          if (call.getNumberOfUses() > param)
-            targets.put(
+          if (call.getNumberOfUses() > param) {
+            PointerKey defKey =
                 builder
-                    .getPropagationSystem()
-                    .findOrCreatePointsToSet(
-                        builder
-                            .getPointerAnalysis()
-                            .getHeapModel()
-                            .getPointerKeyForLocal(src, call.getDef())),
-                TensorType.shapeArg(src, call.getUse(param)));
+                    .getPointerAnalysis()
+                    .getHeapModel()
+                    .getPointerKeyForLocal(src, call.getDef());
+            // Materializing an implicitly-represented key would make WALA dump the entire call
+            // graph's IR (a no-op-assertion debug path), so skip it; implicit keys carry no
+            // explicit dataflow variable to pin (wala/ML#573).
+            if (!builder.getPropagationSystem().isImplicit(defKey))
+              targets.put(
+                  builder.getPropagationSystem().findOrCreatePointsToSet(defKey),
+                  TensorType.shapeArg(src, call.getUse(param)));
+          }
         });
     return targets;
   }
@@ -965,6 +969,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           }
         }
         if (!receiverEligible) continue;
+        // Skip implicitly-represented receivers: materializing one makes WALA dump the entire
+        // call graph's IR via a no-op-assertion debug path (wala/ML#573), and an implicit key has
+        // no explicit dataflow variable to pin.
+        if (builder.getPropagationSystem().isImplicit(receiverKey)) continue;
         targets.put(
             builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
             TensorType.shapeArg(caller, call.getUse(1)));
@@ -980,14 +988,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         op,
         builder,
         (CGNode src, SSAAbstractInvokeInstruction call) -> {
-          lvals.add(
-              builder
-                  .getPropagationSystem()
-                  .findOrCreatePointsToSet(
-                      builder
-                          .getPointerAnalysis()
-                          .getHeapModel()
-                          .getPointerKeyForLocal(src, call.getDef())));
+          PointerKey defKey =
+              builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(src, call.getDef());
+          // Skip implicitly-represented keys: materializing one makes WALA dump the entire call
+          // graph's IR via a no-op-assertion debug path (wala/ML#573), and an implicit key has no
+          // explicit dataflow variable to track.
+          if (!builder.getPropagationSystem().isImplicit(defKey))
+            lvals.add(builder.getPropagationSystem().findOrCreatePointsToSet(defKey));
         });
     return lvals;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -159,6 +159,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     final ContextSelector targetedCFA =
         new nCFAContextSelector(this.targetedCfaDepth, new ContextInsensitiveSelector());
     final IClass modelClass = cha.lookupClass(TensorFlowTypes.MODEL.getDeclaringClass());
+    // Deepening user model forward methods is only worthwhile when the caller has opted into a
+    // depth above the default: a user model invoked from multiple sites collapses its layer-output
+    // allocations through a chain (model __call__ -> forward method -> layer __call__), and
+    // retaining the script-level caller frame needs more than the default depth (wala/ML#530). At
+    // the default depth this would add context-sensitivity to every user
+    // `call`/`__call__`/`predict`
+    // suite-wide without retaining enough frames to help, so gate it on the opt-in.
+    final boolean deepenModelMethods = this.targetedCfaDepth > DEFAULT_TARGETED_CFA_DEPTH;
 
     builder.setContextSelector(
         new ContextSelector() {
@@ -170,13 +178,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               InstanceKey[] actualParameters) {
             String calleeClass = callee.getDeclaringClass().getName().toString();
             // Apply k-CFA for any methods in the target framework, which includes internal helpers,
-            // as well as methods declared on user-defined `tf.keras.Model` subclasses (e.g.
-            // `NeuralNet.call`). Without the latter, a user model called from multiple sites (train
-            // vs. test) merges into one context-insensitive node, collapsing its layer-output
-            // allocations across callers and losing per-context shape (wala/ML#530).
+            // as well as (when opted in) methods declared on user-defined `tf.keras.Model`
+            // subclasses (e.g. `NeuralNet.call`), so a model called from multiple sites does not
+            // merge into one context-insensitive node and collapse its layer-output allocations
+            // (wala/ML#530).
             if (calleeClass.contains(targetFramework)
-                || isModelSubclassMethod(callee, modelClass)
-                || isUserModelForwardMethod(calleeClass)) {
+                || (deepenModelMethods
+                    && (isModelSubclassMethod(callee, modelClass)
+                        || isUserModelForwardMethod(calleeClass)))) {
               return targetedCFA.getCalleeTarget(caller, site, callee, actualParameters);
             }
             return base.getCalleeTarget(caller, site, callee, actualParameters);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -73,7 +73,21 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
   public static final String TENSORFLOW = TensorFlowTypes.TENSORFLOW;
 
+  /**
+   * The default k-CFA depth applied to framework API methods (and user model subclasses). The
+   * migration from {@code read_data} synthetic methods to inline {@code do()} allocations required
+   * 2-CFA to keep framework-API precision; deeper context is occasionally needed when allocations
+   * merge across call sites (wala/ML#379, wala/ML#530).
+   */
+  public static final int DEFAULT_TARGETED_CFA_DEPTH = 2;
+
   private final String targetFramework;
+
+  /**
+   * The k-CFA depth applied to the targeted context selector. See {@link
+   * #DEFAULT_TARGETED_CFA_DEPTH}.
+   */
+  private final int targetedCfaDepth;
 
   public PythonTensorAnalysisEngine() {
     this(TENSORFLOW);
@@ -84,12 +98,38 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   public PythonTensorAnalysisEngine(String targetFramework) {
+    this(targetFramework, DEFAULT_TARGETED_CFA_DEPTH);
+  }
+
+  /**
+   * Constructs an engine with a configurable k-CFA depth for the targeted context selector.
+   *
+   * @param targetFramework The framework name prefix whose API methods receive deep context.
+   * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
+   *     higher values increase precision at the cost of analysis time.
+   */
+  public PythonTensorAnalysisEngine(String targetFramework, int targetedCfaDepth) {
     this.targetFramework = targetFramework;
+    this.targetedCfaDepth = targetedCfaDepth;
   }
 
   public PythonTensorAnalysisEngine(List<File> pythonPath, String targetFramework) {
+    this(pythonPath, targetFramework, DEFAULT_TARGETED_CFA_DEPTH);
+  }
+
+  /**
+   * Constructs an engine with an explicit Python path and a configurable k-CFA depth.
+   *
+   * @param pythonPath The additional Python path entries for module resolution.
+   * @param targetFramework The framework name prefix whose API methods receive deep context.
+   * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
+   *     higher values increase precision at the cost of analysis time.
+   */
+  public PythonTensorAnalysisEngine(
+      List<File> pythonPath, String targetFramework, int targetedCfaDepth) {
     super(pythonPath);
     this.targetFramework = targetFramework;
+    this.targetedCfaDepth = targetedCfaDepth;
   }
 
   @Override
@@ -98,8 +138,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     PythonSSAPropagationCallGraphBuilder builder = super.getCallGraphBuilder(cha, options, cache2);
 
     final ContextSelector base = builder.getContextSelector();
-    final ContextSelector targeted2CFA =
-        new nCFAContextSelector(2, new ContextInsensitiveSelector());
+    final ContextSelector targetedCFA =
+        new nCFAContextSelector(this.targetedCfaDepth, new ContextInsensitiveSelector());
+    final IClass modelClass = cha.lookupClass(TensorFlowTypes.MODEL.getDeclaringClass());
 
     builder.setContextSelector(
         new ContextSelector() {
@@ -110,9 +151,15 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               IMethod callee,
               InstanceKey[] actualParameters) {
             String calleeClass = callee.getDeclaringClass().getName().toString();
-            // Apply 2-CFA for any methods in the target framework, which includes internal helpers.
-            if (calleeClass.contains(targetFramework)) {
-              return targeted2CFA.getCalleeTarget(caller, site, callee, actualParameters);
+            // Apply k-CFA for any methods in the target framework, which includes internal helpers,
+            // as well as methods declared on user-defined `tf.keras.Model` subclasses (e.g.
+            // `NeuralNet.call`). Without the latter, a user model called from multiple sites (train
+            // vs. test) merges into one context-insensitive node, collapsing its layer-output
+            // allocations across callers and losing per-context shape (wala/ML#530).
+            if (calleeClass.contains(targetFramework)
+                || isModelSubclassMethod(callee, modelClass)
+                || isUserModelForwardMethod(calleeClass)) {
+              return targetedCFA.getCalleeTarget(caller, site, callee, actualParameters);
             }
             return base.getCalleeTarget(caller, site, callee, actualParameters);
           }
@@ -124,6 +171,46 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         });
 
     return builder;
+  }
+
+  /**
+   * Determines whether {@code callee} is declared on a user-defined subclass of {@code
+   * tf.keras.Model}. Walks the declaring class's superclass chain looking for {@code modelClass}.
+   * Methods on such classes (the forward-pass {@code call}/{@code predict}) receive deep context so
+   * a model invoked from multiple call sites does not merge its layer-output allocations
+   * (wala/ML#530).
+   *
+   * @param callee The method being dispatched.
+   * @param modelClass The resolved {@code tf.keras.Model} class, or {@code null} if it is absent
+   *     from the class hierarchy (in which case no method is treated as a model-subclass method).
+   * @return {@code true} if {@code callee}'s declaring class transitively extends {@code
+   *     modelClass}; {@code false} otherwise.
+   */
+  private static boolean isModelSubclassMethod(IMethod callee, IClass modelClass) {
+    if (modelClass == null) return false;
+    for (IClass c = callee.getDeclaringClass(); c != null; c = c.getSuperclass())
+      if (c.equals(modelClass)) return true;
+    return false;
+  }
+
+  /**
+   * Heuristic fallback for {@link #isModelSubclassMethod}: the front-end does not yet record a user
+   * model class's framework base class, so {@code class NeuralNet(Model)} has superclass {@code
+   * Lobject} rather than {@code tf.keras.Model} and the CHA-subtype check above never matches (see
+   * <a href="https://github.com/wala/ML/issues/571">wala/ML#571</a>). Until then, recognize a user
+   * model's forward method structurally by its declaring class name: a script-defined class whose
+   * final segment is a Keras forward-pass method ({@code call}, {@code __call__}, or {@code
+   * predict}). Once wala/ML#571 lands, this heuristic can be removed in favor of {@link
+   * #isModelSubclassMethod}.
+   *
+   * @param calleeClass The declaring class name of the dispatched method.
+   * @return {@code true} if {@code calleeClass} names a user-defined model forward method.
+   */
+  private static boolean isUserModelForwardMethod(String calleeClass) {
+    return calleeClass.contains("script ")
+        && (calleeClass.endsWith("/call")
+            || calleeClass.endsWith("/__call__")
+            || calleeClass.endsWith("/predict"));
   }
 
   /** A "fake" function name in the summaries that indicates that an API produces a new tensor. */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -226,8 +226,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    */
   private static boolean isUserModelForwardMethod(String calleeClass) {
     return calleeClass.contains("script ")
-        && (calleeClass.endsWith("/call")
-            || calleeClass.endsWith("/__call__")
+        && (calleeClass.endsWith("/" + PythonTypes.CALLABLE_METHOD_NAME_FOR_KERAS_MODELS)
+            || calleeClass.endsWith("/" + PythonTypes.CALLABLE_METHOD_NAME)
             || calleeClass.endsWith("/predict"));
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -102,15 +102,32 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
+   * Validates the requested k-CFA depth for the targeted context selector. The depth is the
+   * call-string length passed to {@link nCFAContextSelector}, so it must be non-negative (0 is
+   * context-insensitive; higher values are deeper).
+   *
+   * @param targetedCfaDepth The requested depth.
+   * @return {@code targetedCfaDepth} unchanged when valid.
+   * @throws IllegalArgumentException if {@code targetedCfaDepth} is negative.
+   */
+  private static int checkTargetedCfaDepth(int targetedCfaDepth) {
+    if (targetedCfaDepth < 0)
+      throw new IllegalArgumentException(
+          "The targeted k-CFA depth must be non-negative: " + targetedCfaDepth + ".");
+    return targetedCfaDepth;
+  }
+
+  /**
    * Constructs an engine with a configurable k-CFA depth for the targeted context selector.
    *
    * @param targetFramework The framework name prefix whose API methods receive deep context.
    * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
-   *     higher values increase precision at the cost of analysis time.
+   *     must be non-negative. Higher values increase precision at the cost of analysis time.
+   * @throws IllegalArgumentException if {@code targetedCfaDepth} is negative.
    */
   public PythonTensorAnalysisEngine(String targetFramework, int targetedCfaDepth) {
     this.targetFramework = targetFramework;
-    this.targetedCfaDepth = targetedCfaDepth;
+    this.targetedCfaDepth = checkTargetedCfaDepth(targetedCfaDepth);
   }
 
   public PythonTensorAnalysisEngine(List<File> pythonPath, String targetFramework) {
@@ -123,13 +140,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * @param pythonPath The additional Python path entries for module resolution.
    * @param targetFramework The framework name prefix whose API methods receive deep context.
    * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
-   *     higher values increase precision at the cost of analysis time.
+   *     must be non-negative. Higher values increase precision at the cost of analysis time.
+   * @throws IllegalArgumentException if {@code targetedCfaDepth} is negative.
    */
   public PythonTensorAnalysisEngine(
       List<File> pythonPath, String targetFramework, int targetedCfaDepth) {
     super(pythonPath);
     this.targetFramework = targetFramework;
-    this.targetedCfaDepth = targetedCfaDepth;
+    this.targetedCfaDepth = checkTargetedCfaDepth(targetedCfaDepth);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -159,14 +159,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     final ContextSelector targetedCFA =
         new nCFAContextSelector(this.targetedCfaDepth, new ContextInsensitiveSelector());
     final IClass modelClass = cha.lookupClass(TensorFlowTypes.MODEL.getDeclaringClass());
-    // Deepening user model forward methods is only worthwhile when the caller has opted into a
-    // depth above the default: a user model invoked from multiple sites collapses its layer-output
-    // allocations through a chain (model __call__ -> forward method -> layer __call__), and
-    // retaining the script-level caller frame needs more than the default depth (wala/ML#530). At
-    // the default depth this would add context-sensitivity to every user
-    // `call`/`__call__`/`predict`
-    // suite-wide without retaining enough frames to help, so gate it on the opt-in.
-    final boolean deepenModelMethods = this.targetedCfaDepth > DEFAULT_TARGETED_CFA_DEPTH;
 
     builder.setContextSelector(
         new ContextSelector() {
@@ -178,14 +170,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               InstanceKey[] actualParameters) {
             String calleeClass = callee.getDeclaringClass().getName().toString();
             // Apply k-CFA for any methods in the target framework, which includes internal helpers,
-            // as well as (when opted in) methods declared on user-defined `tf.keras.Model`
-            // subclasses (e.g. `NeuralNet.call`), so a model called from multiple sites does not
-            // merge into one context-insensitive node and collapse its layer-output allocations
-            // (wala/ML#530).
+            // as well as methods declared on user-defined `tf.keras.Model` subclasses (e.g.
+            // `NeuralNet.call`). Without the latter, a user model called from multiple sites (train
+            // vs. test) merges into one context-insensitive node, collapsing its layer-output
+            // allocations across callers and losing per-context shape (wala/ML#530).
             if (calleeClass.contains(targetFramework)
-                || (deepenModelMethods
-                    && (isModelSubclassMethod(callee, modelClass)
-                        || isUserModelForwardMethod(calleeClass)))) {
+                || isModelSubclassMethod(callee, modelClass)
+                || isUserModelForwardMethod(calleeClass)) {
               return targetedCFA.getCalleeTarget(caller, site, callee, actualParameters);
             }
             return base.getCalleeTarget(caller, site, callee, actualParameters);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -72,6 +72,11 @@ public class ReduceMean extends TensorGenerator {
             keepDimsValues.add(((Number) val).intValue() != 0);
           } else if (val == null) {
             keepDimsValues.add(false); // Default if None passed?
+          } else {
+            // A non-boolean, non-numeric constant can never be a boolean flag; widen to both for
+            // soundness.
+            keepDimsValues.add(false);
+            keepDimsValues.add(true);
           }
         } else {
           // assume both? or false?

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -43,26 +43,22 @@ public class ReduceMean extends TensorGenerator {
     super(source);
   }
 
-  @Override
-  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    // If no axis is specified, it reduces all dimensions to a scalar (unless keepdims=True).
-    // Default keepdims is False.
-
-    int inputValNum =
-        this.getArgumentValueNumber(
-            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
-    Set<List<Dimension<?>>> inputShapes = this.getShapes(builder, inputValNum);
-    if (inputShapes == null) return null;
-
-    OrdinalSet<InstanceKey> axisPts =
-        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+  /**
+   * Resolves the possible {@code keepdims} values for this reduction from the {@code keepdims}
+   * argument. When the argument is absent, defaults to {@code {false}}; a non-boolean, non-numeric
+   * constant (which can never be a boolean flag) widens to {@code {false, true}} to stay sound.
+   * Subclasses whose op has no {@code keepdims} parameter (e.g. {@code argmax}) override this to
+   * force {@code {false}}, which also prevents misreading an argument that sits at the same
+   * positional index as {@code keepdims} (see {@link Argmax}).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible {@code keepdims} values; never empty.
+   */
+  protected Set<Boolean> getKeepDimsValues(PropagationCallGraphBuilder builder) {
     OrdinalSet<InstanceKey> keepDimsPts =
         this.getArgumentPointsToSet(
             builder, Parameters.KEEPDIMS.getIndex(), Parameters.KEEPDIMS.getName());
 
-    Set<List<Dimension<?>>> ret = HashSetFactory.make();
-
-    // Determine possible values for keepdims
     Set<Boolean> keepDimsValues = new HashSet<>();
     if (keepDimsPts == null || keepDimsPts.isEmpty()) {
       keepDimsValues.add(false); // Default
@@ -85,6 +81,26 @@ public class ReduceMean extends TensorGenerator {
       }
     }
     if (keepDimsValues.isEmpty()) keepDimsValues.add(false);
+    return keepDimsValues;
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // If no axis is specified, it reduces all dimensions to a scalar (unless keepdims=True).
+    // Default keepdims is False.
+
+    int inputValNum =
+        this.getArgumentValueNumber(
+            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+    Set<List<Dimension<?>>> inputShapes = this.getShapes(builder, inputValNum);
+    if (inputShapes == null) return null;
+
+    OrdinalSet<InstanceKey> axisPts =
+        this.getArgumentPointsToSet(builder, Parameters.AXIS.getIndex(), Parameters.AXIS.getName());
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+
+    Set<Boolean> keepDimsValues = this.getKeepDimsValues(builder);
 
     // Determine possible values for axis
     Set<Set<Integer>> axisValues = new HashSet<>(); // Each element is a set of axes to reduce

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -44,6 +44,26 @@ public class ReduceMean extends TensorGenerator {
   }
 
   /**
+   * The positional index of the input-tensor parameter. Overridable so subclasses whose op names
+   * the input differently (e.g. {@code argmax}'s {@code input}) resolve keyword calls correctly.
+   *
+   * @return The zero-based positional index of the input-tensor parameter.
+   */
+  protected int getInputTensorParameterPosition() {
+    return Parameters.INPUT_TENSOR.getIndex();
+  }
+
+  /**
+   * The keyword name of the input-tensor parameter. Overridable so subclasses whose op names the
+   * input differently (e.g. {@code argmax}'s {@code input}) resolve keyword calls correctly.
+   *
+   * @return The keyword name of the input-tensor parameter.
+   */
+  protected String getInputTensorParameterName() {
+    return Parameters.INPUT_TENSOR.getName();
+  }
+
+  /**
    * Resolves the possible {@code keepdims} values for this reduction from the {@code keepdims}
    * argument. When the argument is absent, defaults to {@code {false}}; a non-boolean, non-numeric
    * constant (which can never be a boolean flag) widens to {@code {false, true}} to stay sound.
@@ -96,7 +116,10 @@ public class ReduceMean extends TensorGenerator {
 
     int inputValNum =
         this.getArgumentValueNumber(
-            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+            builder,
+            this.getInputTensorParameterPosition(),
+            this.getInputTensorParameterName(),
+            false);
     Set<List<Dimension<?>>> inputShapes = this.getShapes(builder, inputValNum);
     if (inputShapes == null) return null;
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -424,6 +424,9 @@ public class TensorGeneratorFactory {
 
   private static PointsToSetVariable getPointsToSetVariable(
       PointerKey key, PropagationCallGraphBuilder builder) {
+    // Materializing an implicitly-represented key makes WALA dump the entire call graph's IR via a
+    // no-op-assertion debug path (wala/ML#573); skip it (the caller treats null as "no PTS").
+    if (builder.getPropagationSystem().isImplicit(key)) return null;
     try {
       return builder.getPropagationSystem().findOrCreatePointsToSet(key);
     } catch (UnimplementedError e) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax_input_keyword.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax_input_keyword.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+def f(x, y):
+    pass
+
+
+# Counterpart of `tf2_test_argmax_output_type_positional.py` that passes the
+# input tensor by KEYWORD (`tf.math.argmax(input=x, axis=0)`). argmax's input
+# parameter is named `input`, not `reduce_mean`'s `input_tensor`, so resolving
+# it by the superclass name would fail keyword-argument resolution and throw
+# `IllegalStateException` during shape inference.
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+assert x.shape == (2, 3)
+assert x.dtype == tf.float32
+y = tf.math.argmax(input=x, axis=0)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int64
+
+f(x, y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type_positional.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_argmax_output_type_positional.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(x, y):
+    pass
+
+
+# Counterpart of `tf2_test_argmax_output_type.py` that passes `output_type`
+# POSITIONALLY (`tf.math.argmax(x, 0, tf.int32)`). Shape inference must not
+# misread the positional `output_type` argument as `keepdims` (they share
+# positional index 2 in `ReduceMean`); argmax always removes the scanned axis.
+x = tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+assert x.shape == (2, 3)
+assert x.dtype == tf.float32
+y = tf.math.argmax(x, 0, tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3,)
+assert y.dtype == tf.int32
+
+f(x, y)


### PR DESCRIPTION
## Summary

A user `tf.keras.Model` subclass invoked from multiple sites (e.g. a training loop and a test-set evaluation) merged into one context-insensitive call-graph node, collapsing its per-caller layer-output allocations and losing per-context tensor shape. Downstream, `tf.argmax` of a collapsed layer output leaked one caller's shape into another context and threw a `NonBroadcastableShapesException` in `tf.equal`, which is why `Argmax.getDefaultShapes` returned ⊤ to sidestep the regression.

This PR resolves that by making the targeted k-CFA depth configurable (https://github.com/wala/ML/issues/379) and applying deeper context to user model forward methods (https://github.com/wala/ML/issues/530), then restoring the precise `tf.argmax`/`tf.argmin` output shape.

## Changes

- **Configurable depth (https://github.com/wala/ML/issues/379):** the hard-coded `2` on the targeted context selector becomes `DEFAULT_TARGETED_CFA_DEPTH` (default 2, fully back-compat), exposed as a `PythonTensorAnalysisEngine` constructor parameter. Clients supply a deeper value when allocations merge across call sites; only the *targeted* selector (framework APIs plus model methods) uses it, never the whole program.
- **Model-aware context (https://github.com/wala/ML/issues/530):** the targeted predicate is extended to user `tf.keras.Model` forward methods so a model called from multiple sites is analyzed per caller, keeping its layer-output allocations distinct.
- **Precise `tf.argmax`/`tf.argmin` shape:** `Argmax.getDefaultShapes` now delegates to `ReduceMean`'s keepdims=false reduction (input shape with the `axis` dimension removed), since the per-context separation removes the broadcast regression that previously forced ⊤.
- **Test harness:** depth-parameterized `makeEngine`/`test` overloads (mirroring the analogous knob in the Java streams tooling), so `testNeuralNetwork1-4` opt into depth 4 while every other test stays at the default.

## Detection: Heuristic vs CHA-subtype (Dormant Path)

The clean way to recognize a user model method is a class-hierarchy subtype check against `tf.keras.Model`. That check is **wired but intentionally dormant**: the front-end does not yet record `class X(Model)` inheritance, so a user model class resolves its superclass to `Lobject` rather than the Keras `Model` type (filed as https://github.com/wala/ML/issues/571, an existing front-end TODO). Until that lands, a structural heuristic over user `call`/`__call__`/`predict` methods drives the predicate. When https://github.com/wala/ML/issues/571 is resolved, the heuristic is deleted and `isModelSubclassMethod` takes over—both are present so the switch is a one-line change.

## Testing

- Full suite green (all modules, `mvn test`).
- `testNeuralNetwork1-4` run at depth 4: `accuracy`'s `y_pred` is now the correct per-context union `{(256, 10) float32, ? float32}`, and the per-context multiplicity for `testNeuralNetwork` rises to 24.
- The six `tf.argmax`/`tf.argmin` shape tests tighten from ⊤ to the precise `(3,)` the fixtures assert at runtime.

Closes https://github.com/wala/ML/issues/379.
Closes https://github.com/wala/ML/issues/530.

