### PR TITLE
Correct the implicit-key skip comments: the debug dump is unconditional, not a no-op assertion

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -862,7 +862,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                     .getHeapModel()
                     .getPointerKeyForLocal(src, call.getDef());
             // Materializing an implicitly-represented key would make WALA dump the entire call
-            // graph's IR (a no-op-assertion debug path), so skip it; implicit keys carry no
+            // graph's IR (an unconditional debug print), so skip it; implicit keys carry no
             // explicit dataflow variable to pin (wala/ML#573).
             if (!builder.getPropagationSystem().isImplicit(defKey))
               targets.put(
@@ -961,7 +961,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         }
         if (!receiverEligible) continue;
         // Skip implicitly-represented receivers: materializing one makes WALA dump the entire
-        // call graph's IR via a no-op-assertion debug path (wala/ML#573), and an implicit key has
+        // call graph's IR via an unconditional debug print (wala/ML#573), and an implicit key has
         // no explicit dataflow variable to pin.
         if (builder.getPropagationSystem().isImplicit(receiverKey)) continue;
         targets.put(
@@ -982,7 +982,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           PointerKey defKey =
               builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(src, call.getDef());
           // Skip implicitly-represented keys: materializing one makes WALA dump the entire call
-          // graph's IR via a no-op-assertion debug path (wala/ML#573), and an implicit key has no
+          // graph's IR via an unconditional debug print (wala/ML#573), and an implicit key has no
           // explicit dataflow variable to track.
           if (!builder.getPropagationSystem().isImplicit(defKey))
             lvals.add(builder.getPropagationSystem().findOrCreatePointsToSet(defKey));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -424,8 +424,8 @@ public class TensorGeneratorFactory {
 
   private static PointsToSetVariable getPointsToSetVariable(
       PointerKey key, PropagationCallGraphBuilder builder) {
-    // Materializing an implicitly-represented key makes WALA dump the entire call graph's IR via a
-    // no-op-assertion debug path (wala/ML#573); skip it (the caller treats null as "no PTS").
+    // Materializing an implicitly-represented key makes WALA dump the entire call graph's IR via an
+    // unconditional debug print (wala/ML#573); skip it (the caller treats null as "no PTS").
     if (builder.getPropagationSystem().isImplicit(key)) return null;
     try {
       return builder.getPropagationSystem().findOrCreatePointsToSet(key);


### PR DESCRIPTION
The `isImplicit` skip comments added with #371 described WALA's call-graph-IR dump as reached via a "no-op-assertion debug path." That's inaccurate: `Assertions.UNREACHABLE()` throws `UnimplementedError` unconditionally (it does not no-op when assertions are disabled), and the dump itself is an unconditional `System.err` print. Reworded the four comments to "unconditional debug print." Comment-only; no behavior change.

Surfaced by liblit in https://github.com/wala/WALA/pull/1934; the same correction was applied to wala/ML#573 and the WALA PR description.
