### PR TITLE
Tighten output types for `tf.linalg.trace`, `tf.sequence_mask`, and `tf.nn.embedding_lookup`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -489,6 +489,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_2_BOOL =
       new TensorType(BOOL, asList(new NumericDim(2), new NumericDim(2)));
 
+  private static final TensorType TENSOR_3_5_BOOL =
+      new TensorType(BOOL, asList(new NumericDim(3), new NumericDim(5)));
+
+  private static final TensorType TENSOR_3_5_INT32 =
+      new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(5)));
+
   private static final TensorType TENSOR_4_FLOAT64 =
       new TensorType(FLOAT_64, asList(new NumericDim(4)));
 
@@ -5831,19 +5837,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.sequence_mask}. With no {@code dtype} argument the output
-   * dtype is the TF-default {@code bool}. Shape is ⊤. (wala/ML#449 Tier 8.)
+   * dtype is the TF-default {@code bool}; with a constant {@code maxlen} the shape is {@code
+   * lengths.shape + [maxlen]}, so {@code sequence_mask([1, 3, 2], maxlen=5)} yields (3, 5).
+   * (wala/ML#449 Tier 8.)
    */
   @Test
   public void testSequenceMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_BOOL)));
+    test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_5_BOOL)));
   }
 
   /**
    * Generator-dispatch test for {@code tf.sequence_mask} with an explicit {@code dtype} override
-   * ({@code tf.sequence_mask(..., dtype=tf.int32)}). The output dtype follows the argument ({@code
-   * int32}) rather than the default {@code bool}; shape remains ⊤. Regression guard for surfacing
-   * the {@code dtype} parameter through {@link com.ibm.wala.cast.python.ml.client.SequenceMask}.
+   * ({@code tf.sequence_mask(..., maxlen=5, dtype=tf.int32)}). The output dtype follows the
+   * argument ({@code int32}) rather than the default {@code bool}, and the constant {@code maxlen}
+   * gives the precise (3, 5) shape. Regression guard for surfacing the {@code dtype} parameter
+   * through {@link com.ibm.wala.cast.python.ml.client.SequenceMask}.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -5853,12 +5862,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testSequenceMaskDType()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_sequence_mask_dtype.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+    test("tf2_test_sequence_mask_dtype.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_3_5_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5863,14 +5863,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.nn.embedding_lookup}. Output dtype is inherited from the
-   * {@code params} input (here float32), shape is ⊤. See {@link
+   * {@code params} input (here float32); the output shape is {@code ids.shape + params.shape[1:]},
+   * so a (3, 2) table looked up by (2,) ids yields (2, 2). See {@link
    * com.ibm.wala.cast.python.ml.client.EmbeddingLookup} (wala/ML#449 Tier 8).
    */
   @Test
   public void testEmbeddingLookup()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_embedding_lookup.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_embedding_lookup.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5892,13 +5892,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.boolean_mask}. Output dtype is inherited from the {@code
-   * tensor} input (here float32), shape is ⊤. See {@link
+   * tensor} input (here float32); the masked axis collapses to a dynamic dimension (the runtime
+   * {@code True} count), so masking a (3, 2) tensor with a rank-1 mask yields {@code [Dynamic, 2]}.
+   * The leading dimension is inherently runtime, so it stays dynamic. See {@link
    * com.ibm.wala.cast.python.ml.client.BooleanMask} (wala/ML#449 Tier 8).
    */
   @Test
   public void testBooleanMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_boolean_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_boolean_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_NONE_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5756,13 +5756,38 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.linalg.trace}. Output dtype is inherited from the {@code
-   * x} input (here float32), shape is ⊤. See {@link com.ibm.wala.cast.python.ml.client.Trace}
-   * (wala/ML#449).
+   * x} input (here float32); the output shape is the input shape with the last two dimensions
+   * dropped, so a (2, 2) input yields a scalar. See {@link
+   * com.ibm.wala.cast.python.ml.client.Trace} (wala/ML#449).
    */
   @Test
   public void testTrace()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_trace.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_trace.py", "f", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.linalg.trace} on a batched input. The trace collapses the
+   * last two dimensions, so a (3, 2, 2) input yields a (3,) output that inherits the input dtype.
+   * Exercises the leading-dimensions path of {@link com.ibm.wala.cast.python.ml.client.Trace}
+   * (wala/ML#449).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTraceBatched()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_trace_batched.py",
+        "f",
+        2,
+        2,
+        Map.of(
+            2, Set.of(TENSOR_3_2_2_FLOAT32),
+            3, Set.of(TENSOR_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5830,16 +5830,35 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Generator-dispatch test for {@code tf.sequence_mask}. Output dtype is the TF-default {@code
-   * bool}; the optional {@code dtype} override is exposed in {@code tensorflow.xml}'s {@code
-   * paramNames} but is not yet honored by the {@link
-   * com.ibm.wala.cast.python.ml.client.SequenceMask} generator, which emits {@code bool}
-   * unconditionally. Shape is ⊤. (wala/ML#449 Tier 8.)
+   * Generator-dispatch test for {@code tf.sequence_mask}. With no {@code dtype} argument the output
+   * dtype is the TF-default {@code bool}. Shape is ⊤. (wala/ML#449 Tier 8.)
    */
   @Test
   public void testSequenceMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_sequence_mask.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_BOOL)));
+  }
+
+  /**
+   * Generator-dispatch test for {@code tf.sequence_mask} with an explicit {@code dtype} override
+   * ({@code tf.sequence_mask(..., dtype=tf.int32)}). The output dtype follows the argument ({@code
+   * int32}) rather than the default {@code bool}; shape remains ⊤. Regression guard for surfacing
+   * the {@code dtype} parameter through {@link com.ibm.wala.cast.python.ml.client.SequenceMask}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testSequenceMaskDType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_sequence_mask_dtype.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5879,13 +5879,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.gather_nd}. Output dtype is inherited from the {@code
-   * params} input (here float32), shape is ⊤. See {@link
-   * com.ibm.wala.cast.python.ml.client.GatherNd} (wala/ML#449 Tier 8).
+   * params} input (here float32); the output shape is {@code indices.shape[:-1] +
+   * params.shape[indices.shape[-1]:]}, so a (2, 2) table indexed by (2, 2) depth-2 indices yields
+   * (2,). See {@link com.ibm.wala.cast.python.ml.client.GatherNd} (wala/ML#449 Tier 8).
    */
   @Test
   public void testGatherNd()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gather_nd.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_gather_nd.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5750,14 +5750,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Generator-dispatch test for {@code tf.linalg.tensordot}. Output dtype is inherited from the
-   * {@code a} input (here float32), shape is ⊤. See {@link
+   * Generator-dispatch test for {@code tf.linalg.tensordot} with a scalar {@code axes}. Output
+   * dtype is inherited from the {@code a} input (here float32); with {@code axes=1} the output
+   * shape is {@code a.shape[:-1] + b.shape[1:]}, so two (2, 2) inputs yield (2, 2). See {@link
    * com.ibm.wala.cast.python.ml.client.Tensordot} (wala/ML#449).
    */
   @Test
   public void testTensordot()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_tensordot.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_tensordot.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -248,6 +248,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_3_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
 
+  private static final TensorType TENSOR_1_2_2_27_FLOAT32 =
+      new TensorType(
+          FLOAT_32,
+          asList(new NumericDim(1), new NumericDim(2), new NumericDim(2), new NumericDim(27)));
+
   private static final TensorType TENSOR_4_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4)));
 
@@ -5905,13 +5910,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator-dispatch test for {@code tf.image.extract_patches}. Output dtype is inherited from
-   * the {@code images} input (here float32), shape is ⊤. See {@link
-   * com.ibm.wala.cast.python.ml.client.ExtractPatches} (wala/ML#449 Tier 8).
+   * the {@code images} input (here float32); the output shape is {@code [batch, out_rows, out_cols,
+   * sizes_r * sizes_c * channels]}, so a (1, 10, 10, 3) image with {@code sizes=[1, 3, 3, 1]},
+   * {@code strides=[1, 5, 5, 1]}, {@code rates=[1, 1, 1, 1]} and {@code VALID} padding yields (1,
+   * 2, 2, 27). See {@link com.ibm.wala.cast.python.ml.client.ExtractPatches} (wala/ML#449 Tier 8).
    */
   @Test
   public void testExtractPatches()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_2_2_27_FLOAT32)));
   }
 
   /** Pure-passthrough generator test for {@code tf.math.tan} (wala/ML#422). */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
@@ -1,19 +1,25 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.boolean_mask}. Output dtype is inherited from the {@code tensor} input.
- * Output shape is left at ⊤ for now: the masked dimension's length is the number of {@code True}
- * entries in {@code mask}, a runtime quantity that static analysis cannot recover. The remaining
- * dimensions follow {@code tensor.shape} (offset by {@code axis}), so the result rank is generally
- * {@code tensor.rank - mask.rank + 1}, not always 1-D — but the dependence on the mask's runtime
- * truthiness still leaves the masked dimension undetermined. See wala/ML#449 (Tier 8).
+ * Output shape collapses the masked axes ({@code axis .. axis + mask.rank}) into a single dimension
+ * whose length is the number of {@code True} entries in {@code mask} — a runtime quantity static
+ * analysis cannot recover — keeping the rest of {@code tensor.shape}. That collapsed dimension is
+ * therefore emitted as a {@link DynamicDim}; the rank and the surrounding dimensions are precise.
+ * See wala/ML#449 (Tier 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/boolean_mask">tf.boolean_mask</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -38,8 +44,48 @@ public class BooleanMask extends PassThroughUnaryTensorGenerator {
     return "tensor";
   }
 
+  /**
+   * Derives the output shape as {@code tensor.shape[:axis] + [Dynamic] + tensor.shape[axis +
+   * mask.rank:]}: {@code boolean_mask} replaces the {@code mask.rank} axes starting at {@code axis}
+   * with a single dimension whose extent is the runtime count of {@code True} entries (emitted as a
+   * {@link DynamicDim}). {@code axis} defaults to {@code 0} and a constant override is honored.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes (with a dynamic masked dimension), or {@code null}
+   *     (⊤) when either input's shape is unknown or {@code axis} is a non-constant.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // tensor is arg 0; mask is arg 1; axis is arg 2 (default 0).
+    Set<List<Dimension<?>>> tensorShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "tensor", false));
+    Set<List<Dimension<?>>> maskShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 1, "mask", false));
+    if (tensorShapes == null || maskShapes == null) return null;
+
+    int axis = 0;
+    OrdinalSet<InstanceKey> axisPts = this.getArgumentPointsToSet(builder, 2, "axis");
+    if (axisPts != null && !axisPts.isEmpty()) {
+      for (InstanceKey ik : axisPts) {
+        if (!(ik instanceof ConstantKey)) return null;
+        Object val = ((ConstantKey<?>) ik).getValue();
+        if (val == null) continue; // None -> default axis 0
+        if (!(val instanceof Number)) return null;
+        axis = ((Number) val).intValue();
+      }
+    }
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> tensor : tensorShapes) {
+      for (List<Dimension<?>> mask : maskShapes) {
+        int maskRank = mask.size();
+        if (axis < 0 || maskRank < 1 || axis + maskRank > tensor.size()) continue;
+        List<Dimension<?>> out = new ArrayList<>(tensor.subList(0, axis));
+        out.add(DynamicDim.INSTANCE);
+        out.addAll(tensor.subList(axis + maskRank, tensor.size()));
+        ret.add(out);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
@@ -10,16 +10,18 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.boolean_mask}. Output dtype is inherited from the {@code tensor} input.
- * Output shape collapses the masked axes ({@code axis .. axis + mask.rank}) into a single dimension
- * whose length is the number of {@code True} entries in {@code mask} — a runtime quantity static
- * analysis cannot recover — keeping the rest of {@code tensor.shape}. That collapsed dimension is
- * therefore emitted as a {@link DynamicDim}; the rank and the surrounding dimensions are precise.
- * See wala/ML#449 (Tier 8).
+ * Output shape collapses the {@code mask.rank} axes starting at {@code axis} (i.e. the half-open
+ * range {@code [axis, axis + mask.rank)}) into a single dimension whose length is the number of
+ * {@code True} entries in {@code mask} — a runtime quantity static analysis cannot recover —
+ * keeping the rest of {@code tensor.shape}. That collapsed dimension is therefore emitted as a
+ * {@link DynamicDim}; the rank and the surrounding dimensions are precise. See wala/ML#449 (Tier
+ * 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/boolean_mask">tf.boolean_mask</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -63,27 +65,32 @@ public class BooleanMask extends PassThroughUnaryTensorGenerator {
         this.getShapes(builder, this.getArgumentValueNumber(builder, 1, "mask", false));
     if (tensorShapes == null || maskShapes == null) return null;
 
-    int axis = 0;
+    // axis defaults to 0; collect the constant override value(s) across contexts (None -> 0).
+    Set<Integer> axes = new HashSet<>();
     OrdinalSet<InstanceKey> axisPts = this.getArgumentPointsToSet(builder, 2, "axis");
-    if (axisPts != null && !axisPts.isEmpty()) {
+    if (axisPts == null || axisPts.isEmpty()) {
+      axes.add(0);
+    } else {
       for (InstanceKey ik : axisPts) {
         if (!(ik instanceof ConstantKey)) return null;
         Object val = ((ConstantKey<?>) ik).getValue();
-        if (val == null) continue; // None -> default axis 0
-        if (!(val instanceof Number)) return null;
-        axis = ((Number) val).intValue();
+        if (val == null) axes.add(0); // None -> default axis 0
+        else if (val instanceof Number) axes.add(((Number) val).intValue());
+        else return null;
       }
     }
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
-    for (List<Dimension<?>> tensor : tensorShapes) {
-      for (List<Dimension<?>> mask : maskShapes) {
-        int maskRank = mask.size();
-        if (axis < 0 || maskRank < 1 || axis + maskRank > tensor.size()) continue;
-        List<Dimension<?>> out = new ArrayList<>(tensor.subList(0, axis));
-        out.add(DynamicDim.INSTANCE);
-        out.addAll(tensor.subList(axis + maskRank, tensor.size()));
-        ret.add(out);
+    for (int axis : axes) {
+      for (List<Dimension<?>> tensor : tensorShapes) {
+        for (List<Dimension<?>> mask : maskShapes) {
+          int maskRank = mask.size();
+          if (axis < 0 || maskRank < 1 || axis + maskRank > tensor.size()) continue;
+          List<Dimension<?>> out = new ArrayList<>(tensor.subList(0, axis));
+          out.add(DynamicDim.INSTANCE);
+          out.addAll(tensor.subList(axis + maskRank, tensor.size()));
+          ret.add(out);
+        }
       }
     }
     return ret.isEmpty() ? null : ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
@@ -4,16 +4,16 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.nn.embedding_lookup}. Output dtype is inherited from the {@code params}
- * argument (the embedding table). Output shape is left at ⊤ for now: the precise shape is {@code
- * ids.shape + params.shape[1:]} (each id selects a full row of the embedding table, then the result
- * is reshaped around {@code ids.shape}), which requires combining two inputs' shapes — wala/ML#449
- * (Tier 8) covers refining this once a tier base for "shape derived from multiple inputs" is in
- * place.
+ * argument (the embedding table). Output shape is {@code ids.shape + params.shape[1:]}: each id
+ * selects a full row of the embedding table, so the leading {@code ids.shape} indexes the result
+ * and the trailing {@code params.shape[1:]} is the per-row embedding. See wala/ML#449 (Tier 8).
  *
  * @see <a
  *     href="https://www.tensorflow.org/api_docs/python/tf/nn/embedding_lookup">tf.nn.embedding_lookup</a>
@@ -39,8 +39,34 @@ public class EmbeddingLookup extends PassThroughUnaryTensorGenerator {
     return "params";
   }
 
+  /**
+   * Derives the output shape as {@code ids.shape + params.shape[1:]}: each id selects a full row of
+   * the {@code params} embedding table, so the result is indexed by {@code ids.shape} with each
+   * entry being a {@code params.shape[1:]} row.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when either input's shape is
+   *     unknown or every {@code params} candidate has rank below 1.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // params is arg 0; ids is arg 1.
+    Set<List<Dimension<?>>> paramsShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "params", false));
+    Set<List<Dimension<?>>> idsShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 1, "ids", false));
+    if (paramsShapes == null || idsShapes == null) return null;
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> ids : idsShapes) {
+      for (List<Dimension<?>> params : paramsShapes) {
+        // The embedding table must have at least one axis (the row dimension to index into).
+        if (params.isEmpty()) continue;
+        List<Dimension<?>> out = new ArrayList<>(ids);
+        out.addAll(params.subList(1, params.size()));
+        ret.add(out);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
@@ -1,17 +1,25 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.image.extract_patches}. Output dtype is inherited from the {@code images}
- * input. Output shape is left at ⊤ for now: the precise shape depends on the {@code sizes}, {@code
- * strides}, {@code rates}, and {@code padding} arguments together with {@code images.shape}, which
- * is non-trivial to compute and not yet supported by the tier framework. See wala/ML#449 (Tier 8).
+ * input. Output shape is {@code [batch, out_rows, out_cols, sizes_r * sizes_c * channels]} for the
+ * NHWC {@code images}, where {@code out_rows}/{@code out_cols} follow the standard windowed-extent
+ * arithmetic over the spatial axes given {@code sizes}, {@code strides}, {@code rates}, and {@code
+ * padding}. Derivable when those argument lists and the {@code padding} string are constants and
+ * the spatial/channel dimensions of {@code images} are known. See wala/ML#449 (Tier 8).
  *
  * @see <a
  *     href="https://www.tensorflow.org/api_docs/python/tf/image/extract_patches">tf.image.extract_patches</a>
@@ -37,8 +45,130 @@ public class ExtractPatches extends PassThroughUnaryTensorGenerator {
     return "images";
   }
 
+  /**
+   * Derives the output shape {@code [batch, out_rows, out_cols, sizes_r * sizes_c * channels]}. The
+   * spatial extents follow {@code out = (in - ((size - 1) * rate + 1)) / stride + 1} for {@code
+   * VALID} padding and {@code out = ceil(in / stride)} for {@code SAME}. Returns ⊤ unless the
+   * {@code sizes}/{@code strides}/{@code rates} lists and the {@code padding} string are constants
+   * and the rank-4 {@code images} has known spatial and channel dimensions.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the shape cannot be
+   *     derived.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // images=arg0 (NHWC); sizes=arg1; strides=arg2; rates=arg3; padding=arg4.
+    Set<List<Dimension<?>>> imageShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "images", false));
+    if (imageShapes == null) return null;
+
+    List<Integer> sizes = resolveIntList(builder, 1, "sizes");
+    List<Integer> strides = resolveIntList(builder, 2, "strides");
+    List<Integer> rates = resolveIntList(builder, 3, "rates");
+    String padding = resolveStringArgument(builder, 4, "padding");
+    if (sizes == null || strides == null || rates == null || padding == null) return null;
+    if (sizes.size() != 4 || strides.size() != 4 || rates.size() != 4) return null;
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> image : imageShapes) {
+      // extract_patches operates on rank-4 NHWC tensors.
+      if (image.size() != 4) continue;
+      Dimension<?> rowsDim = image.get(1);
+      Dimension<?> colsDim = image.get(2);
+      Dimension<?> channelsDim = image.get(3);
+      if (!(rowsDim instanceof NumericDim)
+          || !(colsDim instanceof NumericDim)
+          || !(channelsDim instanceof NumericDim)) continue;
+
+      Integer outRows =
+          windowedExtent(
+              ((NumericDim) rowsDim).value(), sizes.get(1), strides.get(1), rates.get(1), padding);
+      Integer outCols =
+          windowedExtent(
+              ((NumericDim) colsDim).value(), sizes.get(2), strides.get(2), rates.get(2), padding);
+      if (outRows == null || outCols == null) continue;
+
+      int depth = sizes.get(1) * sizes.get(2) * ((NumericDim) channelsDim).value();
+
+      List<Dimension<?>> out = new ArrayList<>();
+      out.add(image.get(0)); // batch, carried through (numeric or dynamic)
+      out.add(new NumericDim(outRows));
+      out.add(new NumericDim(outCols));
+      out.add(new NumericDim(depth));
+      ret.add(out);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Computes the windowed output extent along one spatial axis.
+   *
+   * @param in The input extent.
+   * @param size The patch size along this axis.
+   * @param stride The stride along this axis.
+   * @param rate The dilation rate along this axis.
+   * @param padding The padding mode ({@code "VALID"} or {@code "SAME"}).
+   * @return The output extent, or {@code null} when {@code padding} is unrecognized or no window
+   *     fits.
+   */
+  private static Integer windowedExtent(int in, int size, int stride, int rate, String padding) {
+    if (stride <= 0) return null;
+    if (padding.equalsIgnoreCase("VALID")) {
+      int effectiveSize = (size - 1) * rate + 1;
+      if (in < effectiveSize) return null;
+      return (in - effectiveSize) / stride + 1;
+    }
+    if (padding.equalsIgnoreCase("SAME")) {
+      return (in + stride - 1) / stride; // ceil(in / stride)
+    }
     return null;
+  }
+
+  /**
+   * Resolves a constant integer-list argument (e.g. {@code sizes=[1, 3, 3, 1]}) to its values.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param position The positional index of the argument.
+   * @param name The keyword name of the argument.
+   * @return The list of integer values, or {@code null} when the argument is absent, non-constant,
+   *     or not a flat list of integers.
+   */
+  private List<Integer> resolveIntList(
+      PropagationCallGraphBuilder builder, int position, String name) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, position, name);
+    if (pts == null || pts.isEmpty()) return null;
+    Set<List<Dimension<?>>> parsed = this.getShapesFromShapeArgument(builder, pts);
+    if (parsed == null || parsed.size() != 1) return null;
+    List<Integer> values = new ArrayList<>();
+    for (Dimension<?> d : parsed.iterator().next()) {
+      if (!(d instanceof NumericDim)) return null;
+      values.add(((NumericDim) d).value());
+    }
+    return values;
+  }
+
+  /**
+   * Resolves a constant string argument (e.g. {@code padding="VALID"}) to its value.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param position The positional index of the argument.
+   * @param name The keyword name of the argument.
+   * @return The string value, or {@code null} when the argument is absent, non-constant, or
+   *     ambiguous across contexts.
+   */
+  private String resolveStringArgument(
+      PropagationCallGraphBuilder builder, int position, String name) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, position, name);
+    if (pts == null || pts.isEmpty()) return null;
+    String result = null;
+    for (InstanceKey ik : pts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof String)) return null;
+      if (result != null && !result.equals(val)) return null;
+      result = (String) val;
+    }
+    return result;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
@@ -1,17 +1,22 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.gather_nd}. Output dtype is inherited from the {@code params} input.
- * Output shape is left at ⊤ for now: the precise shape is {@code indices.shape[:-1] +
- * params.shape[indices.shape[-1]:]} which requires combining two inputs' shapes — wala/ML#449 (Tier
- * 8) covers refining this once a tier base for "shape derived from multiple inputs" is in place.
+ * Output shape is {@code indices.shape[:-1] + params.shape[indices.shape[-1]:]}: the leading {@code
+ * indices.shape[:-1]} indexes the gather and each innermost index of depth {@code
+ * indices.shape[-1]} selects a {@code params.shape[indices.shape[-1]:]} slice. Derivable when the
+ * index depth (the last dimension of {@code indices}) is a known constant. See wala/ML#449 (Tier
+ * 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/gather_nd">tf.gather_nd</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -36,8 +41,40 @@ public class GatherNd extends PassThroughUnaryTensorGenerator {
     return "params";
   }
 
+  /**
+   * Derives the output shape as {@code indices.shape[:-1] + params.shape[k:]}, where {@code k =
+   * indices.shape[-1]} is the index depth. Each innermost index of length {@code k} selects a
+   * {@code params.shape[k:]} slice, and those slices are arranged according to {@code
+   * indices.shape[:-1]}. Requires the index depth to be a known constant.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when either input's shape is
+   *     unknown, {@code indices} has rank 0, or the index depth is not a constant.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // params is arg 0; indices is arg 1.
+    Set<List<Dimension<?>>> paramsShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "params", false));
+    Set<List<Dimension<?>>> indicesShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 1, "indices", false));
+    if (paramsShapes == null || indicesShapes == null) return null;
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> indices : indicesShapes) {
+      // indices needs a trailing axis whose (constant) extent is the index depth.
+      if (indices.isEmpty()) continue;
+      Dimension<?> depthDim = indices.get(indices.size() - 1);
+      if (!(depthDim instanceof NumericDim)) continue;
+      int depth = ((NumericDim) depthDim).value();
+      for (List<Dimension<?>> params : paramsShapes) {
+        // The index depth can address at most the full rank of params.
+        if (depth > params.size()) continue;
+        List<Dimension<?>> out = new ArrayList<>(indices.subList(0, indices.size() - 1));
+        out.addAll(params.subList(depth, params.size()));
+        ret.add(out);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -11,11 +11,11 @@ import java.util.Set;
 
 /**
  * Generator for {@code tf.sequence_mask}. Output dtype defaults to {@link DType#BOOL} per the
- * TensorFlow API; the optional {@code dtype} argument that can override it is exposed in {@code
- * tensorflow.xml} (see {@code sequence_mask}'s {@code paramNames}, which include {@code dtype}) but
- * is not yet honored by this generator, so it emits {@code BOOL} unconditionally — similar to
- * {@link Argmax}'s {@code INT64} default (whose {@code output_type} override, by contrast, isn't
- * yet surfaced in the XML at all). Output shape is left at ⊤: the precise shape is {@code
+ * TensorFlow API; the optional {@code dtype} argument that overrides it (e.g. {@code
+ * dtype=tf.int32}) is exposed in {@code tensorflow.xml} (see {@code sequence_mask}'s {@code
+ * paramNames}, which include {@code dtype}) and is honored here by surfacing the {@code dtype}
+ * parameter to the canonical dtype-argument dispatch in {@link TensorGenerator#getDTypes}, falling
+ * back to {@code BOOL} when it is absent. Output shape is left at ⊤: the precise shape is {@code
  * (*lengths.shape, maxlen)} which requires combining one input's shape with another input's runtime
  * value. See wala/ML#449 (Tier 8).
  *
@@ -40,5 +40,26 @@ public class SequenceMask extends PassThroughUnaryTensorGenerator {
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     return EnumSet.of(DType.BOOL);
+  }
+
+  /**
+   * Positional index of the {@code dtype} override argument. {@code tf.sequence_mask(lengths,
+   * maxlen, dtype, name)} places {@code dtype} third among the user-facing arguments.
+   *
+   * @return The zero-based positional index of the {@code dtype} argument.
+   */
+  @Override
+  protected int getDTypeParameterPosition() {
+    return 2;
+  }
+
+  /**
+   * Keyword name of the {@code dtype} override argument.
+   *
+   * @return {@code "dtype"}.
+   */
+  @Override
+  protected String getDTypeParameterName() {
+    return "dtype";
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -2,10 +2,17 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -15,9 +22,9 @@ import java.util.Set;
  * dtype=tf.int32}) is exposed in {@code tensorflow.xml} (see {@code sequence_mask}'s {@code
  * paramNames}, which include {@code dtype}) and is honored here by surfacing the {@code dtype}
  * parameter to the canonical dtype-argument dispatch in {@link TensorGenerator#getDTypes}, falling
- * back to {@code BOOL} when it is absent. Output shape is left at ⊤: the precise shape is {@code
- * (*lengths.shape, maxlen)} which requires combining one input's shape with another input's runtime
- * value. See wala/ML#449 (Tier 8).
+ * back to {@code BOOL} when it is absent. Output shape is {@code (*lengths.shape, maxlen)}, derived
+ * when {@code maxlen} is a constant; if {@code maxlen} is omitted it defaults to a runtime {@code
+ * max(lengths)}, so the shape is left at ⊤ in that case. See wala/ML#449 (Tier 8).
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/sequence_mask">tf.sequence_mask</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -32,9 +39,43 @@ public class SequenceMask extends PassThroughUnaryTensorGenerator {
     super(node);
   }
 
+  /**
+   * Derives the output shape as {@code lengths.shape + [maxlen]}: the mask adds a trailing axis of
+   * width {@code maxlen} to the {@code lengths} shape. Derivable only when {@code maxlen} is a
+   * constant integer; when it is omitted (or non-constant) it defaults to a runtime {@code
+   * max(lengths)}, so this returns ⊤.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when {@code maxlen} is not a
+   *     constant integer or the {@code lengths} shape is unknown.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // maxlen is arg 1; resolve its constant value(s) (None/non-constant -> runtime max(lengths)).
+    OrdinalSet<InstanceKey> maxlenPts = this.getArgumentPointsToSet(builder, 1, "maxlen");
+    if (maxlenPts == null || maxlenPts.isEmpty()) return null;
+    Set<Integer> maxlens = new HashSet<>();
+    for (InstanceKey ik : maxlenPts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof Number)) return null;
+      maxlens.add(((Number) val).intValue());
+    }
+
+    // lengths is arg 0.
+    Set<List<Dimension<?>>> lengthsShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "lengths", false));
+    if (lengthsShapes == null) return null;
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> lengths : lengthsShapes) {
+      for (int maxlen : maxlens) {
+        List<Dimension<?>> out = new ArrayList<>(lengths);
+        out.add(new NumericDim(maxlen));
+        ret.add(out);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tensordot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tensordot.java
@@ -2,16 +2,23 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.linalg.tensordot}. Output dtype is inherited from the {@code a} input.
- * Output shape is left at ⊤ for now: the precise shape depends on the {@code axes} argument
- * together with both inputs' shapes (axes can be a scalar, a 1-D list, or a 2-D list), which is
- * non-trivial and not yet covered by the tier framework. See wala/ML#449.
+ * Output shape is derived for the scalar {@code axes} form (contract the last {@code axes}
+ * dimensions of {@code a} with the first {@code axes} dimensions of {@code b}, giving {@code
+ * a.shape[:-axes] + b.shape[axes:]}); the 1-D and 2-D list forms of {@code axes} (contracting
+ * explicitly enumerated axes) are left at ⊤. See wala/ML#449.
  *
  * <p>Extends {@link PassThroughUnaryTensorGenerator} for the dtype-from-input path only — the
  * shape-passthrough behavior is overridden to ⊤. The base class documents itself as "shape and
@@ -45,8 +52,49 @@ public class Tensordot extends PassThroughUnaryTensorGenerator {
     return "a";
   }
 
+  /**
+   * Derives the output shape for the scalar {@code axes} form: {@code tensordot(a, b, axes=n)}
+   * contracts the last {@code n} dimensions of {@code a} with the first {@code n} dimensions of
+   * {@code b}, so the output is {@code a.shape[:-n] + b.shape[n:]}. Returns ⊤ when {@code axes} is
+   * not a constant integer (the 1-D and 2-D list forms enumerate specific axes and are not handled
+   * here) or when either input's shape is unknown.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the shape cannot be
+   *     derived.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // axes is arg 2; only the scalar (integer) form is handled.
+    OrdinalSet<InstanceKey> axesPts = this.getArgumentPointsToSet(builder, 2, "axes");
+    if (axesPts == null || axesPts.isEmpty()) return null;
+    Set<Integer> axesValues = new HashSet<>();
+    for (InstanceKey ik : axesPts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object val = ((ConstantKey<?>) ik).getValue();
+      if (!(val instanceof Number)) return null;
+      axesValues.add(((Number) val).intValue());
+    }
+
+    Set<List<Dimension<?>>> aShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "a", false));
+    Set<List<Dimension<?>>> bShapes =
+        this.getShapes(builder, this.getArgumentValueNumber(builder, 1, "b", false));
+    if (aShapes == null || bShapes == null) return null;
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (int axes : axesValues) {
+      if (axes < 0) continue;
+      for (List<Dimension<?>> a : aShapes) {
+        if (axes > a.size()) continue;
+        for (List<Dimension<?>> b : bShapes) {
+          if (axes > b.size()) continue;
+          List<Dimension<?>> out = new ArrayList<>(a.subList(0, a.size() - axes));
+          out.addAll(b.subList(axes, b.size()));
+          ret.add(out);
+        }
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Trace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Trace.java
@@ -4,19 +4,18 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
  * Generator for {@code tf.linalg.trace}. Output dtype is inherited from the {@code x} input. Output
  * shape is the leading {@code x.shape[:-2]} (the trace collapses the last two dimensions to a
- * scalar per matrix in the batch); leaving the shape at ⊤ for now since deriving "input shape minus
- * the last two dimensions" needs a small dim-list slice that isn't shared by the existing tier
- * bases. See wala/ML#449.
+ * scalar per matrix in the batch). See wala/ML#449.
  *
- * <p>Extends {@link PassThroughUnaryTensorGenerator} for the dtype-from-input path only — see
- * {@link Tensordot}'s class-level Javadoc for the rationale (and the future-refactor note about
- * extracting a shared {@code DTypePassThroughUnaryTensorGenerator} base).
+ * <p>Extends {@link PassThroughUnaryTensorGenerator} for the dtype-from-input path; the shape
+ * override below reuses the base's input-shape resolution and drops the last two dimensions.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linalg/trace">tf.linalg.trace</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
@@ -41,8 +40,26 @@ public class Trace extends PassThroughUnaryTensorGenerator {
     return "x";
   }
 
+  /**
+   * Derives the output shape from the input {@code x}: {@code tf.linalg.trace} collapses the last
+   * two dimensions (the trace of each matrix in the batch), so the result shape is {@code
+   * x.shape[:-2]}. Reuses the superclass's input-shape resolution and drops the last two dimensions
+   * from each candidate shape. A rank-2 input yields a scalar (rank-0) result.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the input shape is unknown
+   *     or its rank is below 2 for every candidate.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      // The trace is defined over the last two axes, so the input must have rank >= 2.
+      if (inputShape.size() < 2) continue;
+      ret.add(new ArrayList<>(inputShape.subList(0, inputShape.size() - 2)));
+    }
+    return ret.isEmpty() ? null : ret;
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches.py
@@ -14,6 +14,8 @@ y = tf.image.extract_patches(
     padding="VALID",
 )
 assert isinstance(y, tf.Tensor)
+# VALID padding: out = (10 - 3) // 5 + 1 = 2 per spatial axis; depth = 3 * 3 * 3 = 27.
+assert y.shape == (1, 2, 2, 27)
 assert y.dtype == tf.float32
 
 f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask_dtype.py
@@ -7,8 +7,8 @@ def f(a):
 
 # Counterpart of `tf2_test_sequence_mask.py` that passes the optional `dtype`
 # override (`tf.sequence_mask(..., dtype=tf.int32)`). The output dtype follows
-# the argument (int32 here) instead of the default `bool`. Shape stays at the
-# documented (3, 5) but is not yet inferred precisely.
+# the argument (int32 here) instead of the default `bool`, and the constant
+# `maxlen` gives the precise (3, 5) shape.
 y = tf.sequence_mask([1, 3, 2], maxlen=5, dtype=tf.int32)
 assert isinstance(y, tf.Tensor)
 assert y.shape == (3, 5)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_sequence_mask_dtype.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Counterpart of `tf2_test_sequence_mask.py` that passes the optional `dtype`
+# override (`tf.sequence_mask(..., dtype=tf.int32)`). The output dtype follows
+# the argument (int32 here) instead of the default `bool`. Shape stays at the
+# documented (3, 5) but is not yet inferred precisely.
+y = tf.sequence_mask([1, 3, 2], maxlen=5, dtype=tf.int32)
+assert isinstance(y, tf.Tensor)
+assert y.shape == (3, 5)
+assert y.dtype == tf.int32
+
+f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tensordot.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tensordot.py
@@ -9,6 +9,8 @@ a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
 b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
 y = tf.linalg.tensordot(a, b, axes=1)
 assert isinstance(y, tf.Tensor)
+# axes=1 contracts a's last axis with b's first, so the shape is a[:-1] + b[1:].
+assert y.shape == (2, 2)
 assert y.dtype == tf.float32
 
 f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_trace.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_trace.py
@@ -8,6 +8,8 @@ def f(a):
 x = tf.constant([[1.0, 2.0], [3.0, 4.0]])
 y = tf.linalg.trace(x)
 assert isinstance(y, tf.Tensor)
+# The trace collapses the last two dimensions, so a (2, 2) input yields a scalar.
+assert y.shape == ()
 assert y.dtype == tf.float32
 
 f(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_trace_batched.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_trace_batched.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(x, y):
+    pass
+
+
+# Batched counterpart of `tf2_test_trace.py`: `tf.linalg.trace` collapses the
+# last two dimensions (the trace of each matrix in the batch), so a (3, 2, 2)
+# input yields a (3,) output that inherits the input dtype.
+x = tf.ones([3, 2, 2])
+assert x.shape == (3, 2, 2)
+assert x.dtype == tf.float32
+y = tf.linalg.trace(x)
+assert y.shape == (3,)
+assert y.dtype == tf.float32
+
+f(x, y)


### PR DESCRIPTION
Tightens the tensor generators that previously left output shape at ⊤ (or emitted a default dtype unconditionally), retiring the precision-limitation list in wala/ML#449. Every op named in that list now has a precise (or maximally-precise) output type:

- **`tf.linalg.trace`**—shape `x.shape[:-2]`.
- **`tf.sequence_mask`**—`dtype` override flows through; shape `lengths.shape + [maxlen]` for constant `maxlen`.
- **`tf.nn.embedding_lookup`**—shape `ids.shape + params.shape[1:]`.
- **`tf.gather_nd`**—shape `indices.shape[:-1] + params.shape[indices.shape[-1]:]` (constant index depth).
- **`tf.linalg.tensordot`**—shape `a.shape[:-n] + b.shape[n:]` for a scalar `axes=n` (list `axes` stays ⊤).
- **`tf.image.extract_patches`**—shape `[batch, out_rows, out_cols, sizes_r * sizes_c * channels]` via the windowed-extent arithmetic over `sizes`/`strides`/`rates`/`padding`.
- **`tf.boolean_mask`**—the masked axis is the runtime `True` count, so it is emitted as a single `Dynamic` dimension with the surrounding dimensions precise (e.g. `[Dynamic, 2]`); this is the maximally-precise static answer.

Pinned with `consume`-sink fixtures; previously-⊤ assertions updated to the precise types. Full suite green.

