### PR TITLE
Return ⊤ instead of throwing on unrecognized shape arguments

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BroadcastTo.java
@@ -73,27 +73,18 @@ public class BroadcastTo extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, Parameters.SHAPE.getIndex(), Parameters.SHAPE.getName());
     if (shapePts == null || shapePts.isEmpty()) return null;
-    Set<List<Dimension<?>>> shapes;
-    try {
-      // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it doesn't
-      // recognize. For `BroadcastTo` specifically, a runtime-tensor shape argument is an
-      // expected input pattern (e.g., `tf.broadcast_to(x, tf.shape(y))`), so we tolerate the
-      // throw here and degrade to ⊤ ("tensor of unknown shape"). Other callers let the throw
-      // propagate as a loud signal that modeling work is missing — see wala/ML#471's design
-      // discussion on PR #245.
-      shapes = this.getShapesFromShapeArgument(builder, shapePts);
-    } catch (IllegalStateException e) {
-      return null;
-    }
+    // A runtime-tensor shape argument (e.g. `tf.broadcast_to(x, tf.shape(y))`) is an expected input
+    // pattern; `getShapesFromShapeArgument` degrades such unrecognized forms to ⊤ rather than
+    // throwing (wala/ML#471).
+    Set<List<Dimension<?>>> shapes = this.getShapesFromShapeArgument(builder, shapePts);
     return shapes == null || shapes.isEmpty() ? null : shapes;
   }
 
   /**
-   * Routes the shape query through {@link #getDefaultShapes} unconditionally rather than deferring
-   * to the parent's PTS-based dispatch (which would call {@link #getShapesFromShapeArgument}
-   * directly without the tolerate-runtime-tensor catch). The point of this generator is the
-   * localized catch on `tf.broadcast_to(x, tf.shape(y))`; letting the parent's dispatch bypass it
-   * would defeat the purpose.
+   * Routes the shape query through {@link #getDefaultShapes} unconditionally so the output shape is
+   * read from the {@code shape} argument (via {@link #getShapesFromShapeArgument}) rather than the
+   * parent's input-passthrough dispatch. A runtime-tensor {@code shape} (e.g. {@code
+   * tf.broadcast_to(x, tf.shape(y))}) degrades to ⊤ instead of aborting (wala/ML#471).
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @return The shapes per {@link #getDefaultShapes}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -71,19 +71,11 @@ public class Reshape extends TensorGenerator {
             builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
     if (shapePts != null && !shapePts.isEmpty()) {
-      Set<List<Dimension<?>>> rawShapes;
-      try {
-        // `getShapesFromShapeArgument` throws `IllegalStateException` for shape forms it
-        // doesn't recognize. For `Reshape` specifically, `tf.reshape(arr, tf.shape(other))`
-        // is a common pattern where the shape argument is itself a runtime Tensor (the result
-        // of `tf.shape(...)`), so we tolerate the throw and degrade to ⊤ ("output shape
-        // unknown"). Other callers let the throw propagate as a loud signal that modeling
-        // work is missing. Mirrors the established `BroadcastTo#getDefaultShapes` precedent;
-        // see wala/ML#538 for the surfacing fixture (`tf2_test_take_along_axis.py`).
-        rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
-      } catch (IllegalStateException e) {
-        return null;
-      }
+      // `tf.reshape(arr, tf.shape(other))` is a common pattern where the shape argument is itself a
+      // runtime Tensor (the result of `tf.shape(...)`); `getShapesFromShapeArgument` degrades such
+      // unrecognized forms to ⊤ ("output shape unknown") rather than throwing (wala/ML#471). See
+      // wala/ML#538 for the surfacing fixture (`tf2_test_take_along_axis.py`).
+      Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
       // Soundness: when the `shape` argument is present but unparseable, the output shape is ⊤
       // (the result is determined by `shape`, not the input tensor — falling back to input-shape
       // inference would be unsound).

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -272,6 +272,10 @@ public abstract class TensorGenerator {
    * @throws IllegalArgumentException when the {@code pointsToSet} parameter is itself empty or
    *     {@code null}. That's a caller-contract violation (callers should check for empty PTS before
    *     invoking this helper); distinct from "shape was a runtime tensor."
+   * @throws IllegalStateException when a list/tuple's object-catalog field index is a non-integer
+   *     string (via {@link #getFieldIndex}) — an internal invariant violation (the catalog keys
+   *     should always be integer indices), distinct from an unrecognized shape form (which returns
+   *     ⊤).
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -245,38 +245,33 @@ public abstract class TensorGenerator {
   /**
    * Returns the possible shapes of the tensor returned by this generator.
    *
-   * <p>The strict-throw contract for unrecognized top-level forms is intentional: an unrecognized
-   * shape form means missing or incorrect modeling, and silencing it via a {@code null} return
-   * would suppress that diagnostic signal across the whole generator surface during development.
-   * The deeper fix (change the helper's contract to return {@code null} instead of throw) is
-   * tracked at <a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>; for now the
-   * tolerance is localized to the one caller where runtime-tensor shape arguments are the
-   * legitimate use case &mdash; {@link BroadcastTo#getDefaultShapes} wraps this helper in a {@code
-   * try/catch (IllegalStateException)} that returns {@code null} (lattice ⊤). Other callers stay
-   * strict; a missing case there surfaces as an analysis-aborting exception, which is the
-   * load-bearing "modeling gap" signal.
+   * <p>An unrecognized shape form (a runtime tensor such as the result of {@code tf.shape(y)}, an
+   * opaque builder value, or anything that isn't a list/tuple, {@code tf.constant}, {@code
+   * TensorSpec}, or {@code RaggedTensorSpec}) degrades to {@code null} (lattice ⊤, "tensor of
+   * unknown shape") rather than throwing, so the analysis doesn't abort on otherwise-valid programs
+   * (<a href="https://github.com/wala/ML/issues/471">wala/ML#471</a>). Callers that depend on the
+   * {@code shape} argument (e.g. {@link BroadcastTo}, {@link Reshape}) propagate that ⊤ rather than
+   * unsoundly falling back to input-shape inference; the {@code FINE}-level log records the
+   * unrecognized form for diagnosing modeling gaps.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param pointsToSet The points-to set of the shape argument. FIXME: Why not take a value number?
-   * @return A set of possible shapes, or {@code null} (lattice ⊤) for sub-parse failures during
-   *     recursive descent: when a {@code tf.constant} value PTS is empty after the call-site walk,
-   *     when a {@link com.ibm.wala.cast.python.ml.types.TensorFlowTypes#TENSOR_SPEC} or {@link
-   *     com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC} shape field has empty
-   *     PTS, or when a recursive call on any of these returns {@code null}. The {@code null}
-   *     returns signal "this shape's structure is recognized but the leaves aren't statically
-   *     resolvable" &mdash; distinct from the strict-throw contract for unrecognized top-level
-   *     forms, which signals "this kind of shape isn't modeled at all."
+   * @return A set of possible shapes, or {@code null} (lattice ⊤) when the shape cannot be resolved
+   *     statically. This covers sub-parse failures during recursive descent (an empty {@code
+   *     tf.constant} value PTS after the call-site walk, an empty {@link
+   *     com.ibm.wala.cast.python.ml.types.TensorFlowTypes#TENSOR_SPEC} or {@link
+   *     com.ibm.wala.cast.python.ml.types.TensorFlowTypes#RAGGED_TENSOR_SPEC} shape field, or a
+   *     recursive call returning {@code null}) and unrecognized forms — a runtime tensor (e.g. the
+   *     result of {@code tf.shape(y)}), an opaque builder object, or anything that isn't a
+   *     list/tuple, {@code tf.constant}, {@code TensorSpec}, or {@code RaggedTensorSpec}. Returning
+   *     ⊤ for unrecognized forms (rather than throwing) keeps the analysis from aborting on
+   *     otherwise-valid programs (wala/ML#471). Non-allocation {@code InstanceKey}s in the PTS
+   *     (e.g. a {@code ConstantKey} for a scalar Python int passed as the shape) are silently
+   *     skipped; if every key in the PTS is non-allocation, the method returns the empty set rather
+   *     than {@code null}.
    * @throws IllegalArgumentException when the {@code pointsToSet} parameter is itself empty or
    *     {@code null}. That's a caller-contract violation (callers should check for empty PTS before
    *     invoking this helper); distinct from "shape was a runtime tensor."
-   * @throws IllegalStateException when the shape argument's PTS contains an {@code
-   *     AllocationSiteInNode} of a type this method does not recognize as a static shape &mdash;
-   *     runtime tensors (e.g. the result of {@code tf.shape(y)}), opaque builder objects, or
-   *     anything that isn't a list/tuple, {@code tf.constant}, {@code TensorSpec}, or {@code
-   *     RaggedTensorSpec}. Non-allocation {@code InstanceKey}s in the PTS (e.g., {@code
-   *     ConstantKey} for a scalar Python int passed as the shape) are silently skipped rather than
-   *     throwing &mdash; if every key in the PTS is non-allocation, the method returns the empty
-   *     set rather than {@code null} or an exception.
    */
   protected Set<List<Dimension<?>>> getShapesFromShapeArgument(
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
@@ -372,20 +367,26 @@ public abstract class TensorGenerator {
                 if (nestedShapes == null) return null;
                 for (List<Dimension<?>> nestedShape : nestedShapes)
                   tensorDimensions.add(new CompoundDim(nestedShape));
-              } else
-                throw new IllegalStateException(
-                    "Expected a constant key or nested structure for instance field: "
+              } else {
+                // Nested element of an unrecognized form; the shape's structure isn't statically
+                // resolvable, so return ⊤ rather than aborting (wala/ML#471).
+                LOGGER.fine(
+                    "Unrecognized nested shape element for instance field: "
                         + pointerKeyForInstanceField
-                        + ", but got: "
+                        + ", got: "
                         + instanceFieldIK
-                        + ".");
-            } else
-              throw new IllegalStateException(
-                  "Expected a constant key or nested structure for instance field: "
+                        + "; treating the shape as unknown (⊤).");
+                return null;
+              }
+            } else {
+              LOGGER.fine(
+                  "Unrecognized shape element for instance field: "
                       + pointerKeyForInstanceField
-                      + ", but got: "
+                      + ", got: "
                       + instanceFieldIK
-                      + ".");
+                      + "; treating the shape as unknown (⊤).");
+              return null;
+            }
           }
 
           LOGGER.fine(
@@ -499,9 +500,20 @@ public abstract class TensorGenerator {
         Set<List<Dimension<?>>> specShapes = this.getShapesFromShapeArgument(builder, shapePts);
         if (specShapes == null) return null;
         ret.addAll(specShapes);
-      } else
-        throw new IllegalStateException(
-            "Expected a " + list + " or " + tuple + " for the shape, but got: " + reference + ".");
+      } else {
+        // Unrecognized top-level shape form — e.g. a runtime tensor such as the result of
+        // `tf.shape(y)`, an opaque builder value, or any type that isn't a list/tuple,
+        // `tf.constant`,
+        // `TensorSpec`, or `RaggedTensorSpec`. Return ⊤ ("tensor of unknown shape") rather than
+        // aborting the analysis on otherwise-valid programs (wala/ML#471).
+        LOGGER.fine(
+            "Unrecognized shape argument form: "
+                + reference
+                + " for source: "
+                + this.getSource()
+                + "; treating the shape as unknown (⊤).");
+        return null;
+      }
     }
 
     return ret;


### PR DESCRIPTION
`getShapesFromShapeArgument` threw `IllegalStateException` when the shape argument's points-to set contained a form it doesn't recognize — a runtime tensor (e.g. the result of `tf.shape(y)`), an opaque builder value, or anything that isn't a list/tuple, `tf.constant`, `TensorSpec`, or `RaggedTensorSpec`. The exception propagated up the dispatch chain and **aborted the analysis on otherwise-valid programs** (e.g. `tf.broadcast_to(x, tf.shape(y))`, `tf.reshape(arr, tf.shape(other))`).

This returns `null` (lattice ⊤, the documented convention for "tensor of unknown shape") instead, logging the unrecognized form at `FINE`. The tolerance was previously localized to `BroadcastTo` (and `Reshape`) via a `try/catch (IllegalStateException)`; those workarounds are now redundant and dropped, and **every** caller benefits.

The existing `testBroadcastToRuntimeShape` and `testReshapeRuntimeShape` now exercise the centralized ⊤ path; all affected callers already null-check the result.

Closes wala/ML#471.
