### PR TITLE
Compute multi-dim subscript-slice shapes via slice-object modeling

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -1949,11 +1949,23 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
 
     @Override
     public CAstNode visitSlice(Slice arg0) throws Exception {
-      return Ast.makeNode(
-          CAstNode.ARRAY_LITERAL,
-          acceptOrNull(arg0.getInternalLower()),
-          acceptOrNull(arg0.getInternalUpper()),
-          acceptOrNull(arg0.getInternalStep()));
+      // Lower a slice dimension (a `:`-style element of a multi-dim subscript) to a `slice(lower,
+      // upper, step)` object construction rather than a bare `ARRAY_LITERAL`. The prior
+      // `ARRAY_LITERAL` representation collided with the keyword-argument convention in
+      // `PythonCAstToIRTranslator.doCall` (which folds an `ARRAY_LITERAL` call argument into a
+      // keyword named after `lower`, discarding `step` and the dimension order), the lossy
+      // multi-dim-subscript encoding tracked by wala/ML#406. As a positional `slice(...)` value the
+      // dimension survives faithfully — grouped, ordered, and distinguishable from an integer
+      // index.
+      return notePosition(
+          Ast.makeNode(
+              CAstNode.CALL,
+              Ast.makeNode(CAstNode.VAR, Ast.makeConstant("slice")),
+              Ast.makeNode(CAstNode.EMPTY),
+              acceptOrNull(arg0.getInternalLower()),
+              acceptOrNull(arg0.getInternalUpper()),
+              acceptOrNull(arg0.getInternalStep())),
+          arg0);
     }
 
     @Override

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2079,11 +2079,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Isolated repro for the slice-subscript PA-allocation gap — parallel to wala/ML#398 but for
-   * subscript instead of binop. Python {@code a_sliced = a[:2, ..., tf.newaxis];
-   * from_tensor_slices((a_sliced, y))} — the slice-subscript result has no PA allocation
-   * (NdarraySubscriptOperation only matches pure ellipsis+None patterns, a leading slice
-   * disqualifies), so the dataset's per-index walk returns ⊤.
+   * Isolated repro for the slice-subscript-into-dataset gap (wala/ML#400). Python {@code a_sliced =
+   * a[:2, ..., tf.newaxis]; from_tensor_slices((a_sliced, y))}. With the multi-dim subscript-slice
+   * modeling (wala/ML#406) the result is no longer ⊤, but two gaps remain: (1) the {@code slice}
+   * builtin returns its receiver ({@code Either.forRight(2)}), so {@code a_sliced} aliases {@code
+   * a} and {@code from_tensor_slices} iterates the receiver's first axis — yielding {@code (2,)}
+   * rather than {@code a_sliced}'s {@code (2, 2, 1)} element {@code (2, 1)}; fixing this needs a
+   * distinct Tensor allocation for the subscript result (the regression-prone part — a generic
+   * {@code Lobject} allocation suppressed tensor identification when the wala/ML#398 binop analogue
+   * tried it). (2) The {@code ..., tf.newaxis} elements are not yet handled by the multi-dim path.
    *
    * <p>TODO: When wala/ML#400 is fixed, flip the annotation to plain {@code @Test} and remove this
    * TODO line.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -248,6 +248,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_3_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
 
+  private static final TensorType TENSOR_2_2_4_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(4)));
+
+  private static final TensorType TENSOR_2_5_6_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(5), new NumericDim(6)));
+
+  private static final TensorType TENSOR_4_4_6_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4), new NumericDim(6)));
+
+  private static final TensorType TENSOR_4_6_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(6)));
+
   private static final TensorType TENSOR_4_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4)));
 
@@ -2654,31 +2666,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Pins {@code crf_decode_forward(inputs, state, transition_params, sequence_lengths)}'s parameter
    * types. Function body mirrors {@code crf_decode_forward} from {@code
    * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage. The caller passes
-   * {@code inputs} from {@code x[:, 1:, :]} and {@code state} from {@code x[:, 0, :]}, which should
-   * reduce to {@code (2, 2, 4)} and {@code (2, 4)} respectively. They are instead inferred as the
-   * base {@code (2, 3, 4)} because these middle-axis subscript slices fall through to the
-   * base-shape passthrough; recovering them requires the broader slice vocabulary tracked by <a
-   * href="https://github.com/wala/ML/issues/406">wala/ML#406</a>. Like {@code crf_forward} (reached
-   * via {@code tf.slice}/{@code tf.squeeze}, now dtype-typed with shape {@code ⊤} — wala/ML#568),
-   * the subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
-   *
-   * <p>WIP (this branch): the {@code doCall} change routes multi-dim slice literals positionally,
-   * which fixes the lost dimension order but, until the slice-object modeling and {@code
-   * SubscriptSlice} generator land, leaves the slice collapsed to its lower bound — so {@code
-   * SliceBuiltinOperation} misreads {@code inputs[:, 1:, :]} as {@code inputs[:1]}. Suppressed here
-   * to keep the draft green; flip back to a positive guard (and tighten {@code inputs} to {@code
-   * (2, 2, 4)}, {@code state} to {@code (2, 4)}) when the generator lands. See wala/ML#406,
-   * wala/ML#400.
-   *
-   * <p>TODO: Remove the {@code expected = AssertionError.class} suppression once the unified
-   * subscript-slice remodel (wala/ML#406, wala/ML#400) computes the multi-dim shape.
+   * {@code inputs} from {@code x[:, 1:, :]} and {@code state} from {@code x[:, 0, :]}, recovered as
+   * {@code (2, 2, 4)} and {@code (2, 4)} respectively via the multi-dim subscript-slice modeling
+   * (wala/ML#406): {@code inputs[:, 1:, :]} drops the leading element of the middle axis ({@code 3
+   * → 2}) and {@code inputs[:, 0, :]} drops the middle axis entirely (an integer index).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testCrfDecodeForward()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -2687,10 +2685,73 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         6,
         Map.of(
-            2, Set.of(TENSOR_2_3_4_FLOAT32),
-            3, Set.of(TENSOR_2_3_4_FLOAT32),
+            2, Set.of(TENSOR_2_2_4_FLOAT32),
+            3, Set.of(TENSOR_2_4_FLOAT32),
             4, Set.of(TENSOR_4_4_FLOAT32),
             5, Set.of(TENSOR_2_INT32)));
+  }
+
+  /**
+   * Pins the output shape of a non-zero-start slice on the first axis of a multi-dim subscript
+   * (wala/ML#406). {@code x[1:3, :, :]} over a {@code (4, 5, 6)} tensor keeps 2 rows and the
+   * trailing axes intact: {@code (2, 5, 6)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSubscriptMultidimRows()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_subscript_multidim.py",
+        "consume_rows",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_5_6_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of a middle-axis slice in a multi-dim subscript (wala/ML#406). {@code
+   * x[:, 1:, :]} over a {@code (4, 5, 6)} tensor drops the leading element of the middle axis:
+   * {@code (4, 4, 6)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSubscriptMultidimCols()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_subscript_multidim.py",
+        "consume_cols",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_4_6_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of an integer index on the middle axis of a multi-dim subscript
+   * (wala/ML#406). {@code x[:, 0, :]} over a {@code (4, 5, 6)} tensor drops the middle axis
+   * entirely: {@code (4, 6)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSubscriptMultidimIndex()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_subscript_multidim.py",
+        "consume_index",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_6_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2662,12 +2662,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * via {@code tf.slice}/{@code tf.squeeze}, now dtype-typed with shape {@code ⊤} — wala/ML#568),
    * the subscript-slice path keeps the parameters tensor-typed, just shape-imprecise.
    *
+   * <p>WIP (this branch): the {@code doCall} change routes multi-dim slice literals positionally,
+   * which fixes the lost dimension order but, until the slice-object modeling and {@code
+   * SubscriptSlice} generator land, leaves the slice collapsed to its lower bound — so {@code
+   * SliceBuiltinOperation} misreads {@code inputs[:, 1:, :]} as {@code inputs[:1]}. Suppressed here
+   * to keep the draft green; flip back to a positive guard (and tighten {@code inputs} to {@code
+   * (2, 2, 4)}, {@code state} to {@code (2, 4)}) when the generator lands. See wala/ML#406,
+   * wala/ML#400.
+   *
+   * <p>TODO: Remove the {@code expected = AssertionError.class} suppression once the unified
+   * subscript-slice remodel (wala/ML#406, wala/ML#400) computes the multi-dim shape.
+   *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test
+  @Test(expected = AssertionError.class)
   public void testCrfDecodeForward()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -251,6 +251,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_2_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(4)));
 
+  private static final TensorType TENSOR_2_2_1_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(1)));
+
   private static final TensorType TENSOR_2_5_6_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(5), new NumericDim(6)));
 
@@ -2079,20 +2082,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Isolated repro for the slice-subscript-into-dataset gap (wala/ML#400). Python {@code a_sliced =
-   * a[:2, ..., tf.newaxis]; from_tensor_slices((a_sliced, y))}. With the multi-dim subscript-slice
-   * modeling (wala/ML#406) the result is no longer ⊤, but two gaps remain: (1) the {@code slice}
-   * builtin returns its receiver ({@code Either.forRight(2)}), so {@code a_sliced} aliases {@code
-   * a} and {@code from_tensor_slices} iterates the receiver's first axis — yielding {@code (2,)}
-   * rather than {@code a_sliced}'s {@code (2, 2, 1)} element {@code (2, 1)}; fixing this needs a
-   * distinct Tensor allocation for the subscript result (the regression-prone part — a generic
-   * {@code Lobject} allocation suppressed tensor identification when the wala/ML#398 binop analogue
-   * tried it). (2) The {@code ..., tf.newaxis} elements are not yet handled by the multi-dim path.
+   * Pins a slice-subscript result flowing into a dataset (wala/ML#400). Python {@code a_sliced =
+   * a[:2, ..., tf.newaxis]; from_tensor_slices((a_sliced, y))} over a {@code (3, 2)} tensor: the
+   * subscript is {@code (2, 2, 1)} (slice, ellipsis-fill, newaxis), so each iterated element is
+   * {@code (2, 1)}. Because the {@code slice} builtin returns its receiver ({@code
+   * Either.forRight(2)}), {@code a_sliced} aliases {@code a}; {@link
+   * DatasetFromTensorSlicesGenerator} recovers the slice's shape by dispatching {@link
+   * com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation} on the stored value rather than
+   * reading the receiver-aliased field PTS.
    *
-   * <p>TODO: When wala/ML#400 is fixed, flip the annotation to plain {@code @Test} and remove this
-   * TODO line.
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSliceSubscriptThroughDataset()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_iso_slicesub_ds.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_1_FLOAT32)));
@@ -2756,6 +2760,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_4_6_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of a multi-dim subscript that mixes a slice, an ellipsis, and a newaxis
+   * (wala/ML#406). {@code a[:2, ..., tf.newaxis]} over a {@code (3, 2)} tensor slices the first
+   * axis to 2, lets the ellipsis fill the remaining axis (2), and appends a size-1 axis for the
+   * newaxis: {@code (2, 2, 1)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSubscriptNewaxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_subscript_newaxis.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_1_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -11,6 +11,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonPropertyWrite;
+import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -19,8 +20,12 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
@@ -41,6 +46,11 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
 
   private static final Logger LOGGER =
       Logger.getLogger(DatasetFromTensorSlicesGenerator.class.getName());
+
+  /** The synthetic type of the Python {@code slice} builtin (see {@code SliceBuiltinOperation}). */
+  private static final TypeReference SLICE_BUILTIN =
+      TypeReference.findOrCreate(
+          PythonTypes.pythonLoader, TypeName.string2TypeName("Lwala/builtin/slice"));
 
   protected enum Parameters {
     TENSORS,
@@ -223,15 +233,41 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                Set<List<Dimension<?>>> fieldShapes =
-                    this.getShapesOfValue(builder, builder.getPointerAnalysis().getPointsToSet(pk));
+                int storedVn =
+                    findTupleFieldStoreForIndex(asin.getNode(), asin, fieldIndex, builder);
+                Set<List<Dimension<?>>> fieldShapes = null;
+                // A slice-subscript result aliases its receiver (the `slice` builtin returns its
+                // receiver), so the field's PTS-based shape would be the receiver's, not the
+                // slice's. Prefer the generator-computed shape via the stored value number. See
+                // wala/ML#400.
+                if (storedVn > 0 && isSliceSubscriptResult(asin.getNode(), storedVn)) {
+                  // `getShapes`/`getShapesOrSSAChain` would follow the receiver alias (the field's
+                  // PTS is the receiver's). Dispatch `SliceBuiltinOperation` directly on the slice
+                  // result to get its computed shape.
+                  PointerKey spk =
+                      builder
+                          .getPointerAnalysis()
+                          .getHeapModel()
+                          .getPointerKeyForLocal(asin.getNode(), storedVn);
+                  if (!builder.getPropagationSystem().isImplicit(spk)) {
+                    PointsToSetVariable svar =
+                        builder.getPropagationSystem().findOrCreatePointsToSet(spk);
+                    try {
+                      fieldShapes = new SliceBuiltinOperation(svar).getShapes(builder);
+                    } catch (IllegalArgumentException e) {
+                      // leave as null
+                    }
+                  }
+                }
+                if (fieldShapes == null || fieldShapes.isEmpty())
+                  fieldShapes =
+                      this.getShapesOfValue(
+                          builder, builder.getPointerAnalysis().getPointsToSet(pk));
                 if (fieldShapes == null || fieldShapes.isEmpty()) {
                   // Implicit-PK fallback mirroring `getShapesOfTensorsArgument`: when the
                   // tuple-field's PTS is empty because the stored value is a synthetic-method
                   // return (e.g., `x_train / 255.0`), walk the SSA chain to recover the shape.
                   // See wala/WALA#1889.
-                  int storedVn =
-                      findTupleFieldStoreForIndex(asin.getNode(), asin, fieldIndex, builder);
                   if (storedVn > 0) {
                     try {
                       Set<List<Dimension<?>>> viaChain =
@@ -441,6 +477,28 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
       return this.getShapesOfValue(builder, valuePointsToSet);
     }
     return ret;
+  }
+
+  /**
+   * Returns whether {@code vn}'s defining instruction is a subscript-slice result &mdash; an invoke
+   * whose callee is the {@code slice} builtin allocation ({@link #SLICE_BUILTIN}). Such a result
+   * aliases its receiver (the builtin returns its first argument), so its field-PTS shape is the
+   * receiver's rather than the slice's; the caller recovers the slice's shape from {@code vn}
+   * instead. See wala/ML#400.
+   *
+   * @param node The CG node whose IR contains {@code vn}.
+   * @param vn The value number to inspect.
+   * @return {@code true} iff {@code vn} is defined by a slice-subscript invoke.
+   */
+  private static boolean isSliceSubscriptResult(CGNode node, int vn) {
+    if (vn <= 0) return false;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return false;
+    SSAAbstractInvokeInstruction inv = (SSAAbstractInvokeInstruction) def;
+    if (inv.getNumberOfUses() < 2) return false;
+    SSAInstruction funcDef = node.getDU().getDef(inv.getUse(0));
+    return funcDef instanceof SSANewInstruction
+        && ((SSANewInstruction) funcDef).getNewSite().getDeclaredType().equals(SLICE_BUILTIN);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -622,13 +622,16 @@ public class SliceBuiltinOperation extends TensorGenerator {
     return new NumericDim(Math.max(0, hi - lo));
   }
 
-  /** A resolved slice bound: a constant integer, {@code None}, or unknown (non-constant). */
-  private record Bound(Integer value, boolean none, boolean unknown) {
-    static final Bound NONE = new Bound(null, true, false);
-    static final Bound UNKNOWN = new Bound(null, false, true);
+  /**
+   * A resolved slice bound: a constant integer ({@code value} non-null), {@code None} ({@code
+   * none}), or unknown/non-constant (neither).
+   */
+  private record Bound(Integer value, boolean none) {
+    static final Bound NONE = new Bound(null, true);
+    static final Bound UNKNOWN = new Bound(null, false);
 
     static Bound of(int v) {
-      return new Bound(v, false, false);
+      return new Bound(v, false);
     }
 
     boolean isNone() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -451,8 +451,8 @@ public class SliceBuiltinOperation extends TensorGenerator {
           bound(builder, caller, inv.getUse(2)),
           bound(builder, caller, inv.getUse(3)));
     }
-    Integer idx = constInt(builder, caller, argVn);
-    if (idx != null) return SubscriptDim.index(idx);
+    // A constant integer index drops its axis; the index value itself is not needed.
+    if (constInt(builder, caller, argVn) != null) return SubscriptDim.index();
     return null;
   }
 
@@ -574,7 +574,7 @@ public class SliceBuiltinOperation extends TensorGenerator {
       return new SubscriptDim(true, lower, upper, step);
     }
 
-    static SubscriptDim index(int unused) {
+    static SubscriptDim index() {
       return new SubscriptDim(false, null, null, null);
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.types.PythonTypes.ELLIPSIS;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
@@ -451,9 +452,60 @@ public class SliceBuiltinOperation extends TensorGenerator {
           bound(builder, caller, inv.getUse(2)),
           bound(builder, caller, inv.getUse(3)));
     }
+    // Ellipsis (`...`) expands to fill the unconsumed axes; newaxis (`None` or `tf.newaxis`)
+    // inserts a size-1 axis. (In a single `[:k]` slice the bare `None` bounds are not reached
+    // here — that form has no slice object, so `parseSubscriptDims` discards it.)
+    DimKind special = classifyEllipsisNewaxis(ptsOf(builder, caller, argVn));
+    if (special == DimKind.ELLIPSIS) return SubscriptDim.ellipsis();
+    if (special == DimKind.NEWAXIS) return SubscriptDim.newaxis();
     // A constant integer index drops its axis; the index value itself is not needed.
     if (constInt(builder, caller, argVn) != null) return SubscriptDim.index();
     return null;
+  }
+
+  /**
+   * Classifies a subscript argument's points-to set as ellipsis ({@code ...}) or newaxis ({@code
+   * None} / {@code tf.newaxis}), mirroring {@link NdarraySubscriptOperation}'s classifier.
+   *
+   * @param pts The argument's points-to set.
+   * @return {@link DimKind#ELLIPSIS} or {@link DimKind#NEWAXIS}, or {@code null} when the argument
+   *     is neither (an integer, a non-constant, an empty set, or an ambiguous mix).
+   */
+  private static DimKind classifyEllipsisNewaxis(OrdinalSet<InstanceKey> pts) {
+    if (pts == null || pts.isEmpty()) return null;
+    boolean ellipsis = false;
+    boolean newaxis = false;
+    for (InstanceKey ik : pts) {
+      if (ik instanceof ConstantKey) {
+        Object v = ((ConstantKey<?>) ik).getValue();
+        if (ELLIPSIS.equals(v)) ellipsis = true;
+        else if (v == null) newaxis = true; // `None` is `np.newaxis`.
+        else return null; // integer/other — not special.
+      } else {
+        AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+        if (asin != null && asin.getConcreteType().getReference().equals(TensorFlowTypes.NEWAXIS))
+          newaxis = true;
+        else return null;
+      }
+    }
+    if (ellipsis && newaxis) return null; // ambiguous.
+    return ellipsis ? DimKind.ELLIPSIS : newaxis ? DimKind.NEWAXIS : null;
+  }
+
+  /**
+   * Returns the points-to set of {@code vn} in {@code caller}, or {@code null} if {@code vn} is
+   * invalid.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param caller The caller {@link CGNode}.
+   * @param vn The value number.
+   * @return The points-to set, or {@code null}.
+   */
+  private static OrdinalSet<InstanceKey> ptsOf(
+      PropagationCallGraphBuilder builder, CGNode caller, int vn) {
+    if (vn <= 0) return null;
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, vn);
+    return builder.getPointerAnalysis().getPointsToSet(pk);
   }
 
   /**
@@ -501,15 +553,38 @@ public class SliceBuiltinOperation extends TensorGenerator {
    */
   private static List<Dimension<?>> applySubscriptDims(
       List<Dimension<?>> input, List<SubscriptDim> dims) {
+    // A slice or index consumes one receiver axis; newaxis and ellipsis do not. An ellipsis
+    // expands to the axes left over after the consuming dimensions; absent an ellipsis, those
+    // left-over axes form an implicit trailing `:`.
+    int consuming = 0;
+    int ellipsisCount = 0;
+    for (SubscriptDim d : dims) {
+      DimKind k = d.kind();
+      if (k == DimKind.SLICE || k == DimKind.INDEX) consuming++;
+      else if (k == DimKind.ELLIPSIS) ellipsisCount++;
+    }
+    if (ellipsisCount > 1 || consuming > input.size()) return null;
+    int ellipsisFill = input.size() - consuming;
+
     List<Dimension<?>> out = new ArrayList<>();
     int axis = 0;
     for (SubscriptDim d : dims) {
-      if (axis >= input.size()) return null; // more subscript dims than receiver rank.
-      if (d.isSlice()) out.add(sliceExtent(input.get(axis), d));
-      // An index dimension consumes the axis without contributing an output dim.
-      axis++;
+      switch (d.kind()) {
+        case NEWAXIS:
+          out.add(new NumericDim(1));
+          break;
+        case ELLIPSIS:
+          for (int k = 0; k < ellipsisFill; k++) out.add(input.get(axis++));
+          break;
+        case SLICE:
+          out.add(sliceExtent(input.get(axis++), d));
+          break;
+        case INDEX:
+          axis++; // drop the axis.
+          break;
+      }
     }
-    for (; axis < input.size(); axis++) out.add(input.get(axis));
+    for (; axis < input.size(); axis++) out.add(input.get(axis)); // implicit trailing `:`.
     return out;
   }
 
@@ -565,21 +640,37 @@ public class SliceBuiltinOperation extends TensorGenerator {
     }
   }
 
+  /** The kind of a multi-dim subscript dimension. */
+  private enum DimKind {
+    SLICE,
+    INDEX,
+    NEWAXIS,
+    ELLIPSIS
+  }
+
   /**
    * One dimension of a multi-dim subscript: a slice (carrying {@code lower}/{@code upper}/{@code
-   * step} bounds) or an integer index.
+   * step} bounds), an integer index, a newaxis, or an ellipsis.
    */
-  private record SubscriptDim(boolean slice, Bound lower, Bound upper, Bound step) {
+  private record SubscriptDim(DimKind kind, Bound lower, Bound upper, Bound step) {
     static SubscriptDim slice(Bound lower, Bound upper, Bound step) {
-      return new SubscriptDim(true, lower, upper, step);
+      return new SubscriptDim(DimKind.SLICE, lower, upper, step);
     }
 
     static SubscriptDim index() {
-      return new SubscriptDim(false, null, null, null);
+      return new SubscriptDim(DimKind.INDEX, null, null, null);
+    }
+
+    static SubscriptDim newaxis() {
+      return new SubscriptDim(DimKind.NEWAXIS, null, null, null);
+    }
+
+    static SubscriptDim ellipsis() {
+      return new SubscriptDim(DimKind.ELLIPSIS, null, null, null);
     }
 
     boolean isSlice() {
-      return slice;
+      return kind == DimKind.SLICE;
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -5,7 +5,9 @@ import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -18,6 +20,9 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
@@ -47,6 +52,16 @@ import java.util.logging.Logger;
 public class SliceBuiltinOperation extends TensorGenerator {
 
   private static final Logger LOGGER = Logger.getLogger(SliceBuiltinOperation.class.getName());
+
+  /**
+   * The synthetic type of the Python {@code slice} builtin allocation. A multi-dim subscript {@code
+   * x[d0, d1, ...]} lowers to {@code slice(x, d0, d1, ...)} where each {@code :}-style dimension is
+   * a {@code slice(lower, upper, step)} object of this type (see {@code PythonParser.visitSlice}).
+   * Used to tell a slice dimension apart from an integer-index dimension.
+   */
+  private static final TypeReference SLICE_BUILTIN =
+      TypeReference.findOrCreate(
+          PythonTypes.pythonLoader, TypeName.string2TypeName("Lwala/builtin/slice"));
 
   public SliceBuiltinOperation(PointsToSetVariable source) {
     super(source);
@@ -87,6 +102,22 @@ public class SliceBuiltinOperation extends TensorGenerator {
                 + " receiverShapes="
                 + capturedReceiverShapes);
     if (receiverShapes == null || receiverShapes.isEmpty()) return null;
+
+    // Multi-dim subscript: `slice(receiver, dim0, dim1, ...)` where each dimension is a
+    // `slice(lower, upper, step)` object or an integer index (wala/ML#406). Distinguished from the
+    // single `[:k]` form below by the presence of at least one slice-object argument.
+    List<SubscriptDim> dims = parseSubscriptDims(builder, view);
+    if (dims != null) {
+      Set<List<Dimension<?>>> ret = HashSetFactory.make();
+      for (List<Dimension<?>> shape : receiverShapes) {
+        List<Dimension<?>> out = applySubscriptDims(shape, dims);
+        if (out != null) ret.add(out);
+      }
+      if (!ret.isEmpty()) {
+        LOGGER.fine(() -> "Matched multi-dim subscript " + dims + " → " + ret);
+        return ret;
+      }
+    }
 
     boolean startOK =
         isNone(builder, view.callerNode(), view.startVn())
@@ -285,9 +316,19 @@ public class SliceBuiltinOperation extends TensorGenerator {
    *     {@code null} if the invoke's use count is smaller than expected.
    */
   private static CallSiteView viewOf(CGNode caller, SSAAbstractInvokeInstruction call) {
-    if (call.getNumberOfUses() < 5) return null;
+    // use(0) is the slice builtin; use(1) is the receiver; the rest are arguments. The single
+    // `[:k]` form has exactly `slice(receiver, start, stop, step)` (5 uses); multi-dim subscripts
+    // (wala/ML#406) can have fewer (e.g. `x[:, 1:]` is 4 uses) or more. Require only the receiver
+    // and at least one argument; absent start/stop/step slots are filled with -1.
+    if (call.getNumberOfUses() < 3) return null;
+    int n = call.getNumberOfUses();
     return new CallSiteView(
-        caller, call, call.getUse(1), call.getUse(2), call.getUse(3), call.getUse(4));
+        caller,
+        call,
+        call.getUse(1),
+        n > 2 ? call.getUse(2) : -1,
+        n > 3 ? call.getUse(3) : -1,
+        n > 4 ? call.getUse(4) : -1);
   }
 
   /**
@@ -359,6 +400,187 @@ public class SliceBuiltinOperation extends TensorGenerator {
       else if (result != n) return null;
     }
     return result;
+  }
+
+  /**
+   * Parses the arguments of a {@code slice(receiver, dim0, dim1, ...)} invoke as multi-dim
+   * subscript dimensions. Each argument is either a {@code slice(lower, upper, step)} object (a
+   * {@code :}-style dimension) or a constant integer (an index dimension that drops an axis).
+   * Returns the parsed dimensions only when at least one is a slice object; otherwise returns
+   * {@code null} so the caller falls through to the single {@code [:k]} form (whose bound arguments
+   * are bare constants, not slice objects).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param view The resolved slice call site.
+   * @return The parsed dimensions, or {@code null} if this is not a multi-dim subscript or any
+   *     argument is unrecognized.
+   */
+  private List<SubscriptDim> parseSubscriptDims(
+      PropagationCallGraphBuilder builder, CallSiteView view) {
+    SSAAbstractInvokeInstruction call = view.call();
+    CGNode caller = view.callerNode();
+    int n = call.getNumberOfUses();
+    List<SubscriptDim> dims = new ArrayList<>();
+    boolean sawSlice = false;
+    for (int u = 2; u < n; u++) {
+      SubscriptDim d = classifyDim(builder, caller, call.getUse(u));
+      if (d == null) return null; // bare bound (single `[:k]` form) or unrecognized.
+      if (d.isSlice()) sawSlice = true;
+      dims.add(d);
+    }
+    return sawSlice ? dims : null;
+  }
+
+  /**
+   * Classifies a single subscript-argument value number as a slice dimension or an integer index.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param caller The caller {@link CGNode}.
+   * @param argVn The argument value number.
+   * @return a slice or index {@link SubscriptDim}, or {@code null} when the argument is neither (a
+   *     bare {@code None}/non-constant — i.e. the single {@code [:k]} bound form).
+   */
+  private SubscriptDim classifyDim(PropagationCallGraphBuilder builder, CGNode caller, int argVn) {
+    if (argVn <= 0) return null;
+    if (isSliceObject(caller, argVn)) {
+      SSAAbstractInvokeInstruction inv =
+          (SSAAbstractInvokeInstruction) caller.getDU().getDef(argVn);
+      // slice(lower, upper, step): uses 1, 2, 3.
+      return SubscriptDim.slice(
+          bound(builder, caller, inv.getUse(1)),
+          bound(builder, caller, inv.getUse(2)),
+          bound(builder, caller, inv.getUse(3)));
+    }
+    Integer idx = constInt(builder, caller, argVn);
+    if (idx != null) return SubscriptDim.index(idx);
+    return null;
+  }
+
+  /**
+   * Returns whether {@code argVn}'s defining instruction is a {@code slice(...)} object
+   * construction (an invoke whose callee is the {@link #SLICE_BUILTIN} allocation).
+   *
+   * @param caller The caller {@link CGNode}.
+   * @param argVn The argument value number.
+   * @return {@code true} iff {@code argVn} is defined by a slice-object construction.
+   */
+  private static boolean isSliceObject(CGNode caller, int argVn) {
+    SSAInstruction def = caller.getDU().getDef(argVn);
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return false;
+    SSAAbstractInvokeInstruction inv = (SSAAbstractInvokeInstruction) def;
+    if (inv.getNumberOfUses() < 4) return false;
+    SSAInstruction funcDef = caller.getDU().getDef(inv.getUse(0));
+    return funcDef instanceof SSANewInstruction
+        && ((SSANewInstruction) funcDef).getNewSite().getDeclaredType().equals(SLICE_BUILTIN);
+  }
+
+  /**
+   * Resolves a slice bound ({@code lower}, {@code upper}, or {@code step}) value number to a {@link
+   * Bound}: a constant integer, {@code None}, or unknown (non-constant).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param caller The caller {@link CGNode}.
+   * @param vn The bound's value number.
+   * @return The resolved {@link Bound}.
+   */
+  private static Bound bound(PropagationCallGraphBuilder builder, CGNode caller, int vn) {
+    if (isNone(builder, caller, vn)) return Bound.NONE;
+    Integer v = constInt(builder, caller, vn);
+    return v != null ? Bound.of(v) : Bound.UNKNOWN;
+  }
+
+  /**
+   * Applies the parsed subscript dimensions to a single receiver shape. Walks the receiver's axes
+   * in order: a slice dimension maps its axis to the sliced extent; an index dimension drops its
+   * axis. Any receiver axes beyond the explicit dimensions are preserved (an implicit trailing
+   * {@code :}).
+   *
+   * @param input The receiver's shape dims, in order.
+   * @param dims The parsed subscript dimensions, in order.
+   * @return The output shape, or {@code null} when there are more dimensions than receiver axes.
+   */
+  private static List<Dimension<?>> applySubscriptDims(
+      List<Dimension<?>> input, List<SubscriptDim> dims) {
+    List<Dimension<?>> out = new ArrayList<>();
+    int axis = 0;
+    for (SubscriptDim d : dims) {
+      if (axis >= input.size()) return null; // more subscript dims than receiver rank.
+      if (d.isSlice()) out.add(sliceExtent(input.get(axis), d));
+      // An index dimension consumes the axis without contributing an output dim.
+      axis++;
+    }
+    for (; axis < input.size(); axis++) out.add(input.get(axis));
+    return out;
+  }
+
+  /**
+   * Computes the output extent of one axis under a slice dimension, per Python slice semantics with
+   * a unit (or absent) step. A full slice ({@code :}) preserves the axis. Constant bounds against a
+   * numeric axis compute the extent numerically (negative bounds index from the end); a {@code :k}
+   * slice against an unknown axis still yields {@code k}. Anything else degrades to a {@link
+   * DynamicDim} (the axis stays present but its extent is unknown), never to ⊤.
+   *
+   * @param recv The receiver's dimension for this axis.
+   * @param d The slice dimension.
+   * @return The output dimension for this axis.
+   */
+  private static Dimension<?> sliceExtent(Dimension<?> recv, SubscriptDim d) {
+    Bound lower = d.lower(), upper = d.upper(), step = d.step();
+    if (lower.isNone() && upper.isNone() && step.isNone()) return recv; // `:`
+    int s = step.isNone() ? 1 : (step.isInt() ? step.value() : 0);
+    if (s != 1) return DynamicDim.INSTANCE; // non-unit/non-constant/negative step.
+    Integer n = (recv instanceof NumericDim) ? ((NumericDim) recv).value() : null;
+    if (n == null) {
+      // Unknown axis: only `:k` (lower None, constant non-negative upper) is computable.
+      if (lower.isNone() && upper.isInt() && upper.value() >= 0)
+        return new NumericDim(upper.value());
+      return DynamicDim.INSTANCE;
+    }
+    if ((!lower.isNone() && !lower.isInt()) || (!upper.isNone() && !upper.isInt()))
+      return DynamicDim.INSTANCE; // non-constant bound against a known axis.
+    int lo = lower.isNone() ? 0 : lower.value();
+    int hi = upper.isNone() ? n : upper.value();
+    if (lo < 0) lo = Math.max(0, n + lo);
+    if (hi < 0) hi = Math.max(0, n + hi);
+    lo = Math.min(lo, n);
+    hi = Math.min(hi, n);
+    return new NumericDim(Math.max(0, hi - lo));
+  }
+
+  /** A resolved slice bound: a constant integer, {@code None}, or unknown (non-constant). */
+  private record Bound(Integer value, boolean none, boolean unknown) {
+    static final Bound NONE = new Bound(null, true, false);
+    static final Bound UNKNOWN = new Bound(null, false, true);
+
+    static Bound of(int v) {
+      return new Bound(v, false, false);
+    }
+
+    boolean isNone() {
+      return none;
+    }
+
+    boolean isInt() {
+      return value != null;
+    }
+  }
+
+  /**
+   * One dimension of a multi-dim subscript: a slice (carrying {@code lower}/{@code upper}/{@code
+   * step} bounds) or an integer index.
+   */
+  private record SubscriptDim(boolean slice, Bound lower, Bound upper, Bound step) {
+    static SubscriptDim slice(Bound lower, Bound upper, Bound step) {
+      return new SubscriptDim(true, lower, upper, step);
+    }
+
+    static SubscriptDim index(int unused) {
+      return new SubscriptDim(false, null, null, null);
+    }
+
+    boolean isSlice() {
+      return slice;
+    }
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -405,16 +405,21 @@ public class SliceBuiltinOperation extends TensorGenerator {
 
   /**
    * Parses the arguments of a {@code slice(receiver, dim0, dim1, ...)} invoke as multi-dim
-   * subscript dimensions. Each argument is either a {@code slice(lower, upper, step)} object (a
-   * {@code :}-style dimension) or a constant integer (an index dimension that drops an axis).
-   * Returns the parsed dimensions only when at least one is a slice object; otherwise returns
-   * {@code null} so the caller falls through to the single {@code [:k]} form (whose bound arguments
-   * are bare constants, not slice objects).
+   * subscript dimensions. Each argument is a {@code slice(lower, upper, step)} object (a {@code
+   * :}-style dimension), an ellipsis, a newaxis, or a constant integer index (which drops an axis).
+   *
+   * <p>Engages multi-dim handling only when at least one argument is a slice object, which is the
+   * marker that distinguishes a multi-dim subscript carrying a {@code :} from the single {@code
+   * [:k]} form (whose arguments are bare {@code None}/integer bounds, not slice objects).
+   * Subscripts with no slice &mdash; a pure-integer index like {@code x[0, 1]} or a pure
+   * ellipsis/newaxis like {@code x[..., None]} &mdash; are lowered to a different IR form (a {@code
+   * PythonPropertyRead} / {@code OBJECT_REF}) handled by {@link TensorElementGenerator} or {@link
+   * NdarraySubscriptOperation}, so they do not reach this method.
    *
    * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
    * @param view The resolved slice call site.
-   * @return The parsed dimensions, or {@code null} if this is not a multi-dim subscript or any
-   *     argument is unrecognized.
+   * @return The parsed dimensions, or {@code null} if there is no slice object (the single {@code
+   *     [:k]} form) or any argument is unrecognized.
    */
   private List<SubscriptDim> parseSubscriptDims(
       PropagationCallGraphBuilder builder, CallSiteView view) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_subscript_multidim.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_subscript_multidim.py
@@ -1,0 +1,32 @@
+import tensorflow as tf
+
+
+def consume_rows(r):
+    pass
+
+
+def consume_cols(c):
+    pass
+
+
+def consume_index(i):
+    pass
+
+
+x = tf.ones((4, 5, 6), dtype=tf.float32)
+assert x.shape == (4, 5, 6) and x.dtype == tf.float32
+
+# Non-zero start on the first axis: `[1:3]` keeps 2 rows, trailing axes intact.
+rows = x[1:3, :, :]
+assert rows.shape == (2, 5, 6)
+consume_rows(rows)
+
+# Slice on the middle axis: `[:, 1:, :]` drops its leading element (5 -> 4).
+cols = x[:, 1:, :]
+assert cols.shape == (4, 4, 6)
+consume_cols(cols)
+
+# Integer index on the middle axis drops that axis entirely: `[:, 0, :]` -> (4, 6).
+idx = x[:, 0, :]
+assert idx.shape == (4, 6)
+consume_index(idx)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_subscript_newaxis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_subscript_newaxis.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def consume(b):
+    pass
+
+
+a = tf.ones((3, 2), dtype=tf.float32)
+# `a[:2, ..., tf.newaxis]`: slice the first axis to 2, ellipsis fills the remaining
+# axis (2), and newaxis appends a size-1 axis -> (2, 2, 1).
+b = a[:2, ..., tf.newaxis]
+assert b.shape == (2, 2, 1) and b.dtype == tf.float32
+consume(b)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -938,15 +938,7 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     pospos.add(context.getSourceMap().getPosition(call.getChild(0)));
     for (int i = 2; i < call.getChildCount(); i++) {
       CAstNode cl = call.getChild(i);
-      // A keyword argument is lowered (in `visitCall`) as a 2-child `ARRAY_LITERAL(name, value)`.
-      // A slice dimension is lowered (in `visitSlice`) as a 3-child `ARRAY_LITERAL(lower, upper,
-      // step)`. Only the former is a keyword; treating the latter as one folds `lower` into the
-      // keyword name and discards `step` and the dimension's positional order, which is the lossy
-      // multi-dim-subscript encoding tracked by wala/ML#406. Route slice literals positionally so
-      // the dimension order survives. WIP: the slice still needs a faithful (lower, upper, step)
-      // grouping (a slice-object allocation) so it is distinguishable from an integer index and so
-      // its result is tracked by the pointer analysis (wala/ML#400).
-      if (cl.getKind() == CAstNode.ARRAY_LITERAL && cl.getChildCount() == 2) {
+      if (cl.getKind() == CAstNode.ARRAY_LITERAL) {
         keyp.add(
             Pair.make(String.valueOf(cl.getChild(0).getValue()), context.getValue(cl.getChild(1))));
         keypos.add(context.getSourceMap().getPosition(cl));

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -938,7 +938,15 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     pospos.add(context.getSourceMap().getPosition(call.getChild(0)));
     for (int i = 2; i < call.getChildCount(); i++) {
       CAstNode cl = call.getChild(i);
-      if (cl.getKind() == CAstNode.ARRAY_LITERAL) {
+      // A keyword argument is lowered (in `visitCall`) as a 2-child `ARRAY_LITERAL(name, value)`.
+      // A slice dimension is lowered (in `visitSlice`) as a 3-child `ARRAY_LITERAL(lower, upper,
+      // step)`. Only the former is a keyword; treating the latter as one folds `lower` into the
+      // keyword name and discards `step` and the dimension's positional order, which is the lossy
+      // multi-dim-subscript encoding tracked by wala/ML#406. Route slice literals positionally so
+      // the dimension order survives. WIP: the slice still needs a faithful (lower, upper, step)
+      // grouping (a slice-object allocation) so it is distinguishable from an integer index and so
+      // its result is tracked by the pointer analysis (wala/ML#400).
+      if (cl.getKind() == CAstNode.ARRAY_LITERAL && cl.getChildCount() == 2) {
         keyp.add(
             Pair.make(String.valueOf(cl.getChild(0).getValue()), context.getValue(cl.getChild(1))));
         keypos.add(context.getSourceMap().getPosition(cl));


### PR DESCRIPTION
Computes the output shape of multi-dim tensor/ndarray subscript-slices (`x[:, 1:, :]`, `x[:, 0, :]`, `x[1:3, :, :]`, ...), closing wala/ML#406.

## Root Cause

A subscript-slice lowers to the generic `slice` builtin, and `PythonCAstToIRTranslator.doCall` folded every `ARRAY_LITERAL` call argument into a keyword param (name = `lower`, value = `upper`, `step` dropped), colliding with `visitSlice`'s 3-child `ARRAY_LITERAL(lower, upper, step)`. The dimension order and the `upper`/`step` bounds were lost, and an integer-index dimension was indistinguishable from a slice.

## Fix

- **Front-end (`visitSlice`)**: a `:`-style slice dimension now lowers to a `slice(lower, upper, step)` object construction instead of a bare `ARRAY_LITERAL`. As a positional value each dimension survives faithfully — grouped, ordered, and distinguishable from an integer index. (This treats the cause; no `doCall` change is needed.)
- **`SliceBuiltinOperation` multi-dim path**: `slice(receiver, dim0, dim1, ...)` where each argument is a slice object (bounds read from its constructor invoke) or a constant integer index. Walks the receiver's axes, mapping a slice to its sliced extent (unit-step Python semantics, negative bounds from the end, `:k` against an unknown axis still yields `k`) and dropping the axis of an integer index; trailing axes are preserved. Non-constant bounds degrade to a dynamic dimension, never to ⊤.

## Tests

- `testCrfDecodeForward` (corpus, NLPGNN) un-suppressed and tightened: `inputs[:, 1:, :]` → `(2, 2, 4)`, `inputs[:, 0, :]` → `(2, 4)`.
- New `tf2_test_subscript_multidim.py` + `testSubscriptMultidim{Rows,Cols,Index}` covering a non-zero-start first-axis slice, a middle-axis slice, and a middle-axis integer index.
- Full suite green, including the `testNeuralNetwork`/`testAutoencoder*` canaries.

## Follow-Up (Not in This PR)

wala/ML#400 (slice-result-into-`from_tensor_slices`) is a separate, deeper problem documented on the issue and in `testSliceSubscriptThroughDataset`'s Javadoc: the `slice` builtin returns its receiver (`Either.forRight(2)`), so the result aliases the receiver and the dataset path reads the receiver's shape. Closing it needs a distinct (Tensor-typed, regression-safe) allocation for the subscript result plus ellipsis/newaxis handling — left to a focused follow-up.

Closes wala/ML#406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
