### PR TITLE
Scope `com.ibm.wala.cast.python.jython.test`'s resource directory

### DIFF
--- a/com.ibm.wala.cast.python.jython.test/pom.xml
+++ b/com.ibm.wala.cast.python.jython.test/pom.xml
@@ -52,6 +52,10 @@
     <resources>
       <resource>
         <directory>.</directory>
+        <includes>
+          <include>META-INF/**</include>
+          <include>build.properties</include>
+        </includes>
       </resource>
     </resources>
     <plugins>


### PR DESCRIPTION
`com.ibm.wala.cast.python.jython.test` declared its build resource as `<directory>.</directory>` with no `<includes>`, so the `maven-resources-plugin` copied the **entire module directory — including `target/` — into `target/classes/`** on every build. Each build therefore nested `target/classes/target/classes/...` one level deeper, eventually exhausting disk and inodes (a single local checkout reached **204 GB**).

The sibling test modules were already scoped — `com.ibm.wala.cast.python.test` to `data` and `com.ibm.wala.cast.python.jython3.test` to `META-INF/**` + `build.properties` (the wala/ML#156 "make test directories a resource" fix) — but this module was overlooked. This scopes it the same way as `jython3.test`.

Verified: after the change, `target/classes/` contains only `META-INF`, `build.properties`, and the compiled `com/` package — no nested `target/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)