### PR TITLE
Recover slice-subscript shapes through datasets, with ellipsis/newaxis

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2082,20 +2082,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Isolated repro for the slice-subscript-into-dataset gap (wala/ML#400). Python {@code a_sliced =
-   * a[:2, ..., tf.newaxis]; from_tensor_slices((a_sliced, y))}. With the multi-dim subscript-slice
-   * modeling (wala/ML#406) the result is no longer ⊤, but two gaps remain: (1) the {@code slice}
-   * builtin returns its receiver ({@code Either.forRight(2)}), so {@code a_sliced} aliases {@code
-   * a} and {@code from_tensor_slices} iterates the receiver's first axis — yielding {@code (2,)}
-   * rather than {@code a_sliced}'s {@code (2, 2, 1)} element {@code (2, 1)}; fixing this needs a
-   * distinct Tensor allocation for the subscript result (the regression-prone part — a generic
-   * {@code Lobject} allocation suppressed tensor identification when the wala/ML#398 binop analogue
-   * tried it). (2) The {@code ..., tf.newaxis} elements are not yet handled by the multi-dim path.
+   * Pins a slice-subscript result flowing into a dataset (wala/ML#400). Python {@code a_sliced =
+   * a[:2, ..., tf.newaxis]; from_tensor_slices((a_sliced, y))} over a {@code (3, 2)} tensor: the
+   * subscript is {@code (2, 2, 1)} (slice, ellipsis-fill, newaxis), so each iterated element is
+   * {@code (2, 1)}. Because the {@code slice} builtin returns its receiver ({@code
+   * Either.forRight(2)}), {@code a_sliced} aliases {@code a}; {@link
+   * DatasetFromTensorSlicesGenerator} recovers the slice's shape by dispatching {@link
+   * com.ibm.wala.cast.python.ml.client.SliceBuiltinOperation} on the stored value rather than
+   * reading the receiver-aliased field PTS.
    *
-   * <p>TODO: When wala/ML#400 is fixed, flip the annotation to plain {@code @Test} and remove this
-   * TODO line.
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSliceSubscriptThroughDataset()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_iso_slicesub_ds.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_1_FLOAT32)));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -251,6 +251,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_2_4_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(4)));
 
+  private static final TensorType TENSOR_2_2_1_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(1)));
+
   private static final TensorType TENSOR_2_5_6_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(5), new NumericDim(6)));
 
@@ -2756,6 +2759,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_4_6_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of a multi-dim subscript that mixes a slice, an ellipsis, and a newaxis
+   * (wala/ML#406). {@code a[:2, ..., tf.newaxis]} over a {@code (3, 2)} tensor slices the first
+   * axis to 2, lets the ellipsis fill the remaining axis (2), and appends a size-1 axis for the
+   * newaxis: {@code (2, 2, 1)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSubscriptNewaxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_subscript_newaxis.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_1_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -11,6 +11,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonPropertyWrite;
+import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -19,8 +20,12 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
@@ -41,6 +46,11 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
 
   private static final Logger LOGGER =
       Logger.getLogger(DatasetFromTensorSlicesGenerator.class.getName());
+
+  /** The synthetic type of the Python {@code slice} builtin (see {@code SliceBuiltinOperation}). */
+  private static final TypeReference SLICE_BUILTIN =
+      TypeReference.findOrCreate(
+          PythonTypes.pythonLoader, TypeName.string2TypeName("Lwala/builtin/slice"));
 
   protected enum Parameters {
     TENSORS,
@@ -223,15 +233,41 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
               IField f = builder.getClassHierarchy().resolveField(subscript);
               if (f != null) {
                 PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
-                Set<List<Dimension<?>>> fieldShapes =
-                    this.getShapesOfValue(builder, builder.getPointerAnalysis().getPointsToSet(pk));
+                int storedVn =
+                    findTupleFieldStoreForIndex(asin.getNode(), asin, fieldIndex, builder);
+                Set<List<Dimension<?>>> fieldShapes = null;
+                // A slice-subscript result aliases its receiver (the `slice` builtin returns its
+                // receiver), so the field's PTS-based shape would be the receiver's, not the
+                // slice's. Prefer the generator-computed shape via the stored value number. See
+                // wala/ML#400.
+                if (storedVn > 0 && isSliceSubscriptResult(asin.getNode(), storedVn)) {
+                  // `getShapes`/`getShapesOrSSAChain` would follow the receiver alias (the field's
+                  // PTS is the receiver's). Dispatch `SliceBuiltinOperation` directly on the slice
+                  // result to get its computed shape.
+                  PointerKey spk =
+                      builder
+                          .getPointerAnalysis()
+                          .getHeapModel()
+                          .getPointerKeyForLocal(asin.getNode(), storedVn);
+                  if (!builder.getPropagationSystem().isImplicit(spk)) {
+                    PointsToSetVariable svar =
+                        builder.getPropagationSystem().findOrCreatePointsToSet(spk);
+                    try {
+                      fieldShapes = new SliceBuiltinOperation(svar).getShapes(builder);
+                    } catch (IllegalArgumentException e) {
+                      // leave as null
+                    }
+                  }
+                }
+                if (fieldShapes == null || fieldShapes.isEmpty())
+                  fieldShapes =
+                      this.getShapesOfValue(
+                          builder, builder.getPointerAnalysis().getPointsToSet(pk));
                 if (fieldShapes == null || fieldShapes.isEmpty()) {
                   // Implicit-PK fallback mirroring `getShapesOfTensorsArgument`: when the
                   // tuple-field's PTS is empty because the stored value is a synthetic-method
                   // return (e.g., `x_train / 255.0`), walk the SSA chain to recover the shape.
                   // See wala/WALA#1889.
-                  int storedVn =
-                      findTupleFieldStoreForIndex(asin.getNode(), asin, fieldIndex, builder);
                   if (storedVn > 0) {
                     try {
                       Set<List<Dimension<?>>> viaChain =
@@ -441,6 +477,28 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
       return this.getShapesOfValue(builder, valuePointsToSet);
     }
     return ret;
+  }
+
+  /**
+   * Returns whether {@code vn}'s defining instruction is a subscript-slice result &mdash; an invoke
+   * whose callee is the {@code slice} builtin allocation ({@link #SLICE_BUILTIN}). Such a result
+   * aliases its receiver (the builtin returns its first argument), so its field-PTS shape is the
+   * receiver's rather than the slice's; the caller recovers the slice's shape from {@code vn}
+   * instead. See wala/ML#400.
+   *
+   * @param node The CG node whose IR contains {@code vn}.
+   * @param vn The value number to inspect.
+   * @return {@code true} iff {@code vn} is defined by a slice-subscript invoke.
+   */
+  private static boolean isSliceSubscriptResult(CGNode node, int vn) {
+    if (vn <= 0) return false;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return false;
+    SSAAbstractInvokeInstruction inv = (SSAAbstractInvokeInstruction) def;
+    if (inv.getNumberOfUses() < 2) return false;
+    SSAInstruction funcDef = node.getDU().getDef(inv.getUse(0));
+    return funcDef instanceof SSANewInstruction
+        && ((SSANewInstruction) funcDef).getNewSite().getDeclaredType().equals(SLICE_BUILTIN);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.types.PythonTypes.ELLIPSIS;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
@@ -451,9 +452,60 @@ public class SliceBuiltinOperation extends TensorGenerator {
           bound(builder, caller, inv.getUse(2)),
           bound(builder, caller, inv.getUse(3)));
     }
+    // Ellipsis (`...`) expands to fill the unconsumed axes; newaxis (`None` or `tf.newaxis`)
+    // inserts a size-1 axis. (In a single `[:k]` slice the bare `None` bounds are not reached
+    // here — that form has no slice object, so `parseSubscriptDims` discards it.)
+    DimKind special = classifyEllipsisNewaxis(ptsOf(builder, caller, argVn));
+    if (special == DimKind.ELLIPSIS) return SubscriptDim.ellipsis();
+    if (special == DimKind.NEWAXIS) return SubscriptDim.newaxis();
     // A constant integer index drops its axis; the index value itself is not needed.
     if (constInt(builder, caller, argVn) != null) return SubscriptDim.index();
     return null;
+  }
+
+  /**
+   * Classifies a subscript argument's points-to set as ellipsis ({@code ...}) or newaxis ({@code
+   * None} / {@code tf.newaxis}), mirroring {@link NdarraySubscriptOperation}'s classifier.
+   *
+   * @param pts The argument's points-to set.
+   * @return {@link DimKind#ELLIPSIS} or {@link DimKind#NEWAXIS}, or {@code null} when the argument
+   *     is neither (an integer, a non-constant, an empty set, or an ambiguous mix).
+   */
+  private static DimKind classifyEllipsisNewaxis(OrdinalSet<InstanceKey> pts) {
+    if (pts == null || pts.isEmpty()) return null;
+    boolean ellipsis = false;
+    boolean newaxis = false;
+    for (InstanceKey ik : pts) {
+      if (ik instanceof ConstantKey) {
+        Object v = ((ConstantKey<?>) ik).getValue();
+        if (ELLIPSIS.equals(v)) ellipsis = true;
+        else if (v == null) newaxis = true; // `None` is `np.newaxis`.
+        else return null; // integer/other — not special.
+      } else {
+        AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+        if (asin != null && asin.getConcreteType().getReference().equals(TensorFlowTypes.NEWAXIS))
+          newaxis = true;
+        else return null;
+      }
+    }
+    if (ellipsis && newaxis) return null; // ambiguous.
+    return ellipsis ? DimKind.ELLIPSIS : newaxis ? DimKind.NEWAXIS : null;
+  }
+
+  /**
+   * Returns the points-to set of {@code vn} in {@code caller}, or {@code null} if {@code vn} is
+   * invalid.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param caller The caller {@link CGNode}.
+   * @param vn The value number.
+   * @return The points-to set, or {@code null}.
+   */
+  private static OrdinalSet<InstanceKey> ptsOf(
+      PropagationCallGraphBuilder builder, CGNode caller, int vn) {
+    if (vn <= 0) return null;
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, vn);
+    return builder.getPointerAnalysis().getPointsToSet(pk);
   }
 
   /**
@@ -501,15 +553,38 @@ public class SliceBuiltinOperation extends TensorGenerator {
    */
   private static List<Dimension<?>> applySubscriptDims(
       List<Dimension<?>> input, List<SubscriptDim> dims) {
+    // A slice or index consumes one receiver axis; newaxis and ellipsis do not. An ellipsis
+    // expands to the axes left over after the consuming dimensions; absent an ellipsis, those
+    // left-over axes form an implicit trailing `:`.
+    int consuming = 0;
+    int ellipsisCount = 0;
+    for (SubscriptDim d : dims) {
+      DimKind k = d.kind();
+      if (k == DimKind.SLICE || k == DimKind.INDEX) consuming++;
+      else if (k == DimKind.ELLIPSIS) ellipsisCount++;
+    }
+    if (ellipsisCount > 1 || consuming > input.size()) return null;
+    int ellipsisFill = input.size() - consuming;
+
     List<Dimension<?>> out = new ArrayList<>();
     int axis = 0;
     for (SubscriptDim d : dims) {
-      if (axis >= input.size()) return null; // more subscript dims than receiver rank.
-      if (d.isSlice()) out.add(sliceExtent(input.get(axis), d));
-      // An index dimension consumes the axis without contributing an output dim.
-      axis++;
+      switch (d.kind()) {
+        case NEWAXIS:
+          out.add(new NumericDim(1));
+          break;
+        case ELLIPSIS:
+          for (int k = 0; k < ellipsisFill; k++) out.add(input.get(axis++));
+          break;
+        case SLICE:
+          out.add(sliceExtent(input.get(axis++), d));
+          break;
+        case INDEX:
+          axis++; // drop the axis.
+          break;
+      }
     }
-    for (; axis < input.size(); axis++) out.add(input.get(axis));
+    for (; axis < input.size(); axis++) out.add(input.get(axis)); // implicit trailing `:`.
     return out;
   }
 
@@ -565,21 +640,37 @@ public class SliceBuiltinOperation extends TensorGenerator {
     }
   }
 
+  /** The kind of a multi-dim subscript dimension. */
+  private enum DimKind {
+    SLICE,
+    INDEX,
+    NEWAXIS,
+    ELLIPSIS
+  }
+
   /**
    * One dimension of a multi-dim subscript: a slice (carrying {@code lower}/{@code upper}/{@code
-   * step} bounds) or an integer index.
+   * step} bounds), an integer index, a newaxis, or an ellipsis.
    */
-  private record SubscriptDim(boolean slice, Bound lower, Bound upper, Bound step) {
+  private record SubscriptDim(DimKind kind, Bound lower, Bound upper, Bound step) {
     static SubscriptDim slice(Bound lower, Bound upper, Bound step) {
-      return new SubscriptDim(true, lower, upper, step);
+      return new SubscriptDim(DimKind.SLICE, lower, upper, step);
     }
 
     static SubscriptDim index() {
-      return new SubscriptDim(false, null, null, null);
+      return new SubscriptDim(DimKind.INDEX, null, null, null);
+    }
+
+    static SubscriptDim newaxis() {
+      return new SubscriptDim(DimKind.NEWAXIS, null, null, null);
+    }
+
+    static SubscriptDim ellipsis() {
+      return new SubscriptDim(DimKind.ELLIPSIS, null, null, null);
     }
 
     boolean isSlice() {
-      return slice;
+      return kind == DimKind.SLICE;
     }
   }
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_subscript_newaxis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_subscript_newaxis.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def consume(b):
+    pass
+
+
+a = tf.ones((3, 2), dtype=tf.float32)
+# `a[:2, ..., tf.newaxis]`: slice the first axis to 2, ellipsis fills the remaining
+# axis (2), and newaxis appends a size-1 axis -> (2, 2, 1).
+b = a[:2, ..., tf.newaxis]
+assert b.shape == (2, 2, 1) and b.dtype == tf.float32
+consume(b)


### PR DESCRIPTION
Closes the dataset half of wala/ML#400, building on the multi-dim subscript-slice modeling in #376. **Stacked on #376** (base branch `subscript-slice-remodel`)—review/merge that first; this diff is #400-only.

## Two Gaps, Both Closed

**Ellipsis/newaxis in the multi-dim path.** `SliceBuiltinOperation`'s multi-dim handler now recognizes `...` (ellipsis) and `None`/`tf.newaxis` (newaxis), mirroring `NdarraySubscriptOperation`'s classifier. A newaxis inserts a size-1 axis without consuming a receiver axis; an ellipsis expands to the axes left over after the consuming (slice/index) dimensions. So `a[:2, ..., tf.newaxis]` over `(3, 2)` is `(2, 2, 1)`. (`None` is classified as newaxis only in the multi-dim path, which requires a slice object—a single `[:k]`'s bare `None` bounds are unaffected.)

**Receiver-aliasing through `from_tensor_slices`.** The `slice` builtin returns its receiver (`Either.forRight(2)`), so a slice result aliases its receiver and the dataset tuple field's points-to set is the receiver's—`getShapesOfValue` yielded the receiver's shape, not the slice's. `DatasetFromTensorSlicesGenerator.getShapesForIndex` now detects a slice-subscript stored value (its def is a `slice` builtin invoke) and dispatches `SliceBuiltinOperation` directly on the stored value number, instead of following the alias.

## Tests

- `testSliceSubscriptThroughDataset` flips from a suppressed known-failure to a positive guard: `from_tensor_slices((a[:2, ..., tf.newaxis], y))` yields elements of `(2, 1)`.
- New `tf2_test_subscript_newaxis.py` + `testSubscriptNewaxis` pin the `(2, 2, 1)` shape directly.
- Full suite green (excluding the unrelated `com.ibm.wala.cast.python.jython.test` resource-copy bug, fixed separately in #377).

Closes wala/ML#400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
