### PR TITLE
Model the unsorted-segment aggregation ops for dtype passthrough

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2482,11 +2482,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * of edge tensors, not a tensor itself, so it is not a tensor parameter.)
    *
    * <p>The message-passing <em>output</em> locals (the {@code gc1}/{@code gc2} results) are
-   * inferred as ⊤ on <em>both</em> axes (unknown shape, unknown dtype): the custom aggregation
-   * ({@code tf.scatter_nd}, {@code tf.math.unsorted_segment_sum}, {@code tf.gather}) inside {@code
-   * MessagePassing} is not modeled (tracked by <a
-   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so the layer output type is
-   * lost. The decorated function's input signature—the analysis goal—is nonetheless exact.
+   * inferred as ⊤ on <em>both</em> axes (unknown shape, unknown dtype). {@code
+   * tf.math.unsorted_segment_sum} is now modeled (dtype inherits from {@code data}, shape ⊤; <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so the aggregation results are
+   * recognized as tensor allocations — hence six tracked tensor variables rather than four. Their
+   * dtype is still ⊤, though: it never reaches the aggregation's {@code data} argument because the
+   * message-construction chain feeding it ({@code tf.gather} → {@code tf.reshape} → Python-list
+   * {@code append} → {@code tf.concat}, across {@code MessagePassing._calculate_messages_all_type})
+   * does not forward dtype. That chain-forwarding gap is the remaining wala/ML#570 work. The
+   * decorated function's input signature—the analysis goal—is nonetheless exact.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2511,8 +2515,70 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "GCNLayer.call",
         "gcn_proj",
         1,
-        4,
+        6,
         Map.of(3, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Pins the output type of {@code tf.math.unsorted_segment_sum} (wala/ML#570). The output dtype
+   * inherits from the {@code data} input ({@code float32}); the shape is ⊤ because the leading axis
+   * is the runtime {@code num_segments} value. Verified via a {@code consume_sum} sink on the
+   * aggregation result.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testUnsortedSegmentSum()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_unsorted_segment.py",
+        "consume_sum",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Pins the output type of {@code tf.math.unsorted_segment_max} (wala/ML#570). Same dtype-from-
+   * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testUnsortedSegmentMax()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_unsorted_segment.py",
+        "consume_max",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Pins the output type of {@code tf.math.unsorted_segment_mean} (wala/ML#570). Same dtype-from-
+   * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testUnsortedSegmentMean()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_unsorted_segment.py",
+        "consume_mean",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2486,11 +2486,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * tf.math.unsorted_segment_sum} is now modeled (dtype inherits from {@code data}, shape ⊤; <a
    * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so the aggregation results are
    * recognized as tensor allocations — hence six tracked tensor variables rather than four. Their
-   * dtype is still ⊤, though: it never reaches the aggregation's {@code data} argument because the
-   * message-construction chain feeding it ({@code tf.gather} → {@code tf.reshape} → Python-list
-   * {@code append} → {@code tf.concat}, across {@code MessagePassing._calculate_messages_all_type})
-   * does not forward dtype. That chain-forwarding gap is the remaining wala/ML#570 work. The
-   * decorated function's input signature—the analysis goal—is nonetheless exact.
+   * dtype is still ⊤, though, and the root cause is upstream of the aggregation: {@code
+   * GraphConvolution.call} receives its input as a {@code GNNInput} {@code NamedTuple} and unwraps
+   * it with {@code node_embeddings = inputs.node_embeddings}, but a tensor read back from a
+   * user-defined {@code NamedTuple} field is not tracked as a tensor (<a
+   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>). So {@code node_embeddings}
+   * arrives ⊤, the immediately-following {@code tf.linalg.matmul} produces ⊤, and every downstream
+   * op (including the modeled aggregation) inherits it. Resolving wala/ML#579 is the prerequisite
+   * for typing these layer outputs. The decorated function's input signature—the analysis goal—is
+   * nonetheless exact.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -628,6 +628,18 @@
         <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="x" value="reduce_logsumexp"/>
         <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math" value="reduce_logsumexp"/>
         <putfield class="LRoot" field="reduce_logsumexp" fieldType="LRoot" ref="math_ops" value="reduce_logsumexp"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/unsorted_segment_sum -->
+        <new def="unsorted_segment_sum" class="Ltensorflow/math/unsorted_segment_sum"/>
+        <putfield class="LRoot" field="unsorted_segment_sum" fieldType="LRoot" ref="math" value="unsorted_segment_sum"/>
+        <putfield class="LRoot" field="unsorted_segment_sum" fieldType="LRoot" ref="math_ops" value="unsorted_segment_sum"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/unsorted_segment_max -->
+        <new def="unsorted_segment_max" class="Ltensorflow/math/unsorted_segment_max"/>
+        <putfield class="LRoot" field="unsorted_segment_max" fieldType="LRoot" ref="math" value="unsorted_segment_max"/>
+        <putfield class="LRoot" field="unsorted_segment_max" fieldType="LRoot" ref="math_ops" value="unsorted_segment_max"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/unsorted_segment_mean -->
+        <new def="unsorted_segment_mean" class="Ltensorflow/math/unsorted_segment_mean"/>
+        <putfield class="LRoot" field="unsorted_segment_mean" fieldType="LRoot" ref="math" value="unsorted_segment_mean"/>
+        <putfield class="LRoot" field="unsorted_segment_mean" fieldType="LRoot" ref="math_ops" value="unsorted_segment_mean"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/acos -->
         <new def="acos" class="Ltensorflow/math/acos"/>
         <putfield class="LRoot" field="acos" fieldType="LRoot" ref="x" value="acos"/>
@@ -1474,6 +1486,28 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_logsumexp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (`reduce_logsumexp` requires float input at runtime; static analysis just preserves whatever the input
           dtype was). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="unsorted_segment_sum" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. Direct `<new>+<return>` paired with the dedicated `UnsortedSegmentReduction` generator (wala/ML#570): dtype inherits from `data`; shape is left at ⊤ since the output's leading axis is the runtime `num_segments` value
+          (forwarding `data`'s shape would be unsound). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data segment_ids num_segments name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="unsorted_segment_max" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_max. See `unsorted_segment_sum` above; same `<new>+<return>` + `UnsortedSegmentReduction` modeling (wala/ML#570). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data segment_ids num_segments name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="unsorted_segment_mean" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_mean. See `unsorted_segment_sum` above; same `<new>+<return>` + `UnsortedSegmentReduction` modeling (wala/ML#570). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data segment_ids num_segments name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -184,6 +184,9 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNIFORM_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT_MAX;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT_MEAN;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT_SUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.VARIABLE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.WHERE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS;
@@ -1212,6 +1215,10 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, REDUCE_PROD.getDeclaringClass())) return new ReduceProd(source);
     else if (isType(calledFunction, REDUCE_LOGSUMEXP.getDeclaringClass()))
       return new ReduceLogSumExp(source);
+    else if (isType(calledFunction, UNSORTED_SEGMENT_SUM.getDeclaringClass())
+        || isType(calledFunction, UNSORTED_SEGMENT_MAX.getDeclaringClass())
+        || isType(calledFunction, UNSORTED_SEGMENT_MEAN.getDeclaringClass()))
+      return new UnsortedSegmentReduction(source);
     else if (isType(calledFunction, REDUCE_ALL.getDeclaringClass())) return new ReduceAll(source);
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
@@ -1,0 +1,59 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for the graph message-passing aggregation ops {@code tf.math.unsorted_segment_sum},
+ * {@code tf.math.unsorted_segment_max}, and {@code tf.math.unsorted_segment_mean}. These reduce a
+ * {@code data} tensor of shape {@code [N, ...]} into {@code [num_segments, ...]} by aggregating the
+ * rows that share a {@code segment_ids} value.
+ *
+ * <p>Output dtype inherits from the {@code data} (arg 0) input. Output shape is left at ⊤: the
+ * leading axis becomes the runtime {@code num_segments} value (typically a {@code tf.shape(...)}
+ * result rather than a static constant), so forwarding {@code data}'s shape would be unsound on the
+ * first axis. Dtype is the load-bearing axis here; shape can follow. See <a
+ * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum">tf.math.unsorted_segment_sum</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
+
+  public UnsortedSegmentReduction(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public UnsortedSegmentReduction(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "data";
+  }
+
+  /**
+   * Returns ⊤ (unknown shape). The output's leading axis is the runtime {@code num_segments} value,
+   * which is not statically known, so the shape is left unknown rather than mis-forwarding {@code
+   * data}'s shape. Dtype still inherits from {@code data} via the inherited {@link
+   * #getDefaultDTypes}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code null} (⊤).
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -746,6 +746,36 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String REDUCE_LOGSUMEXP_SIGNATURE = "tf.reduce_logsumexp()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. */
+  public static final MethodReference UNSORTED_SEGMENT_SUM =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/math/unsorted_segment_sum")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNSORTED_SEGMENT_SUM_SIGNATURE = "tf.math.unsorted_segment_sum()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_max. */
+  public static final MethodReference UNSORTED_SEGMENT_MAX =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/math/unsorted_segment_max")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNSORTED_SEGMENT_MAX_SIGNATURE = "tf.math.unsorted_segment_max()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_mean. */
+  public static final MethodReference UNSORTED_SEGMENT_MEAN =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/math/unsorted_segment_mean")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNSORTED_SEGMENT_MEAN_SIGNATURE = "tf.math.unsorted_segment_mean()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/math/reduce_all. */
   public static final MethodReference REDUCE_ALL =
       MethodReference.findOrCreate(
@@ -1845,6 +1875,9 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(REDUCE_MAX.getDeclaringClass(), REDUCE_MAX_SIGNATURE),
           Map.entry(REDUCE_PROD.getDeclaringClass(), REDUCE_PROD_SIGNATURE),
           Map.entry(REDUCE_LOGSUMEXP.getDeclaringClass(), REDUCE_LOGSUMEXP_SIGNATURE),
+          Map.entry(UNSORTED_SEGMENT_SUM.getDeclaringClass(), UNSORTED_SEGMENT_SUM_SIGNATURE),
+          Map.entry(UNSORTED_SEGMENT_MAX.getDeclaringClass(), UNSORTED_SEGMENT_MAX_SIGNATURE),
+          Map.entry(UNSORTED_SEGMENT_MEAN.getDeclaringClass(), UNSORTED_SEGMENT_MEAN_SIGNATURE),
           Map.entry(REDUCE_ALL.getDeclaringClass(), REDUCE_ALL_SIGNATURE),
           Map.entry(MODEL.getDeclaringClass(), MODEL_SIGNATURE),
           Map.entry(MODEL_CALL.getDeclaringClass(), MODEL_CALL_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_unsorted_segment.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_unsorted_segment.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+
+
+def consume_sum(y):
+    pass
+
+
+def consume_max(y):
+    pass
+
+
+def consume_mean(y):
+    pass
+
+
+# `tf.math.unsorted_segment_{sum,max,mean}(data, segment_ids, num_segments)` aggregate
+# the rows of `data` that share a `segment_ids` value into `num_segments` rows. The
+# output dtype is `data`'s; the leading axis is `num_segments` (a runtime value), so the
+# static analysis recovers the dtype but leaves the shape at ⊤ (wala/ML#570).
+data = tf.constant(
+    [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=tf.float32
+)
+segment_ids = tf.constant([0, 1, 0], dtype=tf.int32)
+num_segments = 2
+
+s = tf.math.unsorted_segment_sum(data, segment_ids, num_segments)
+assert s.shape == (2, 3) and s.dtype == tf.float32
+consume_sum(s)
+
+x = tf.math.unsorted_segment_max(data, segment_ids, num_segments)
+assert x.shape == (2, 3) and x.dtype == tf.float32
+consume_max(x)
+
+m = tf.math.unsorted_segment_mean(data, segment_ids, num_segments)
+assert m.shape == (2, 3) and m.dtype == tf.float32
+consume_mean(m)


### PR DESCRIPTION
Partially addresses #570.

`tf.math.unsorted_segment_sum`, `unsorted_segment_max`, and `unsorted_segment_mean` had no generator, so their results were dropped entirely (⊤ on both axes, and not even recognized as tensors). This models each as a `<new>+<return>` summary paired with a dedicated `UnsortedSegmentReduction` generator that:
- inherits the output dtype from the `data` input, and
- leaves the shape at ⊤ — the leading axis is the runtime `num_segments` value, so forwarding `data`'s shape would be unsound.

Dtype is the load-bearing axis; shape can follow.

## Verification
- `testUnsortedSegmentSum`/`Max`/`Mean` (new fixture `tf2_test_unsorted_segment.py` with `consume` sinks) pin the dtype-forward + ⊤-shape result directly. The fixture's runtime asserts match the static expectation.
- Full `TestTensorflow2Model` and the root suite are green.

## Why `testGcnCall`'s Outputs Are Still ⊤ (and What's Really Blocking It)
In `testGcnCall` the aggregation results are now recognized as tensor allocations (the tracked tensor-variable count rises 4→6), but their dtype stays ⊤. Tracing the run shows the loss is **not** in the message-construction chain — it is upstream of the aggregation. `GraphConvolution.call` unwraps its input from a `GNNInput` `NamedTuple` (`node_embeddings = inputs.node_embeddings`), and a tensor read back from a user-defined `NamedTuple` field is not tracked as a tensor at all. So `node_embeddings` arrives ⊤, the immediately-following `tf.linalg.matmul` produces ⊤, and every downstream op (including the modeled aggregation) inherits it.

That `NamedTuple`-field propagation gap is filed as wala/ML#579 and is the prerequisite for typing these GNN layer outputs end-to-end. The `testGcnCall` Javadoc documents this. The decorated function's input signature (the analysis goal) remains exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
