### PR TITLE
Add `@dataclass` parse coverage and document the `NamedTuple`-field gap

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8507,6 +8507,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for the {@code @dataclass} half of <a
+   * href="https://github.com/wala/ML/issues/205">wala/ML#205</a>: a module containing a {@code
+   * @dataclass} definition loads and analyzes without a front-end parse error. The dataclass is
+   * defined but unused in the dataflow; {@code f} receives a tensor directly, so its parameter type
+   * is recovered iff the module parsed. Companion to {@link #testModule68}/{@link #testModule69},
+   * which guard the same for {@code NamedTuple}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDataclassParse()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataclass_parse.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_2_FLOAT32)));
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8526,6 +8526,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Documents the <a href="https://github.com/wala/ML/issues/579">wala/ML#579</a> gap: a tensor
+   * stored in a user-defined {@code NamedTuple} field and read back ({@code b = w.tensor}) loses
+   * its tensor type. At runtime {@code b} is the original {@code (4, 8) float32} tensor, but the
+   * analysis currently recovers {@code consume}'s parameter as <em>no</em> tensor at all (zero
+   * tensor variables). Unlike {@link #testModule68}/{@link #testModule69} — which only confirm a
+   * {@code NamedTuple} <em>definition</em> parses — this exercises actual field dataflow. It is the
+   * minimal form of the GCN blocker in wala/ML#570, where {@code GraphConvolution.call} unwraps a
+   * {@code GNNInput} {@code NamedTuple} the same way.
+   *
+   * <p>TODO: Tighten to {@code Map.of(2, Set.of(TENSOR_4_8_FLOAT32))} once wala/ML#579 propagates
+   * tensor types through {@code NamedTuple} fields.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNamedTupleFieldRead()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_namedtuple_field.py", "consume", 0, 0);
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataclass_parse.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataclass_parse.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+import tensorflow as tf
+
+
+# Regression guard for wala/ML#205: a module containing a `@dataclass` definition
+# must load and analyze without a front-end parse error. The dataclass is defined
+# but not used in the dataflow; `f` receives a tensor directly, so its parameter
+# types are recovered iff the module parsed. (Companion to `testModule68`/`69`,
+# which guard the same for `NamedTuple`.)
+@dataclass
+class Holder:
+    tensor: tf.Tensor
+
+
+def f(x):
+    pass
+
+
+t = tf.ones([1, 2])
+assert t.shape == (1, 2) and t.dtype == tf.float32
+f(t)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
@@ -1,0 +1,27 @@
+from typing import NamedTuple, List
+
+import numpy as np
+import tensorflow as tf
+
+
+# Documents the wala/ML#579 gap: a tensor stored in a user-defined `NamedTuple`
+# field and read back out loses its tensor type. At runtime `b` is the original
+# `(4, 8) float32` tensor (the asserts below hold), but the static analysis
+# currently recovers `consume`'s parameter as *no* tensor at all. This is the
+# concrete blocker for typing the GCN layer outputs in wala/ML#570, where
+# `GraphConvolution.call` unwraps a `GNNInput` `NamedTuple` the same way.
+class Wrapper(NamedTuple):
+    tensor: tf.Tensor
+    rest: List
+
+
+def consume(x):
+    pass
+
+
+a = tf.constant(np.ones((4, 8), dtype=np.float32))
+assert a.shape == (4, 8) and a.dtype == tf.float32
+w = Wrapper(a, [])
+b = w.tensor
+assert b.shape == (4, 8) and b.dtype == tf.float32
+consume(b)


### PR DESCRIPTION
Coverage for the two layers of #205, surfaced while investigating #570/#579.

## `@dataclass` Parse Guard (#205)
`testModule68`/`testModule69` guard that a module containing a `NamedTuple` definition parses, but the `@dataclass` half of #205's title had no coverage. `testDataclassParse` confirms a module with a `@dataclass` definition loads and analyzes without a front-end parse error.

This does **not** close #205. The reported parse crash is resolved (it was fixed upstream in a `jython3` bump, not by the 2024 test-adding commit), but #205's broader "support" is still incomplete — see below.

## `NamedTuple`-Field Gap (#579)
`testModule68`/`testModule69` only place a `NamedTuple` definition in a module and pass a tensor *directly* to the sink — they never construct the tuple or read a field, so they prove parsing, not support. `testNamedTupleFieldRead` exercises the actual field dataflow: a tensor stored in a `NamedTuple` field and read back (`b = w.tensor`) is currently recovered as **zero** tensor variables, even though at runtime it is the original `(4, 8) float32` tensor.

The test pins this observed gap with a `TODO` to tighten once #579 lands. It is the minimal form of the GCN blocker in #570: `GraphConvolution.call` unwraps a `GNNInput` `NamedTuple` the same way, which is why the modeled aggregation outputs stay ⊤.

Both fixtures' runtime asserts match the static expectation (the NamedTuple one deliberately documents the divergence). No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
