### PR TITLE
Propagate tensor types through `NamedTuple` fields

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -484,9 +484,26 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
             });
         return Ast.makeNode(CAstNode.EMPTY);
       } else if (value != null) {
-        // `target: annotation = value` outside a class body is an ordinary assignment.
-        return notePosition(
-            Ast.makeNode(CAstNode.ASSIGN, notePosition(target.accept(this), target), v), target);
+        // `target: annotation = value` outside a class body is an ordinary assignment. Mirror
+        // `visitAssign`: a simple-name target must be declared (wrapped in a DECL_STMT and
+        // registered via addDefinedName), otherwise it is left undeclared and trips leaveVar's
+        // symbol assertion.
+        CAstNode assign =
+            notePosition(
+                Ast.makeNode(CAstNode.ASSIGN, notePosition(target.accept(this), target), v),
+                target);
+        CAstNode targetNode = assign.getChild(0);
+        if (targetNode.getKind() == CAstNode.VAR
+            && targetNode.getChild(0).getValue() instanceof String) {
+          String name = (String) targetNode.getChild(0).getValue();
+          context.addDefinedName(name);
+          return Ast.makeNode(
+              CAstNode.BLOCK_STMT,
+              Ast.makeNode(
+                  CAstNode.DECL_STMT, Ast.makeConstant(new CAstSymbolImpl(name, CAstType.DYNAMIC))),
+              assign);
+        }
+        return assign;
       } else {
         // An annotation-only declaration outside a class body has no runtime effect.
         return Ast.makeNode(CAstNode.EMPTY);

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -447,7 +447,8 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
      * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>); the field name and its
      * declaration order are what downstream needs, so emit a field entity mirroring {@code
      * visitAssign}. The annotation expression itself is not modeled. When a value is present it is
-     * the field's AST; an annotation-only declaration uses a {@code None} placeholder.
+     * the field's AST; an annotation-only declaration uses an {@link CAstNode#EMPTY} AST so {@code
+     * leaveTypeEntity} records the field but emits no member {@code put} for it.
      *
      * @param arg0 the {@code AnnAssign} AST node to translate.
      * @return the translated {@link CAstNode}.

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -441,14 +441,20 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
 
     private int assign = 0;
 
+    /**
+     * Translates a PEP-526 annotated assignment {@code target: annotation [= value]}. In a class
+     * body this declares a field (the {@code NamedTuple}/dataclass case, <a
+     * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>); the field name and its
+     * declaration order are what downstream needs, so emit a field entity mirroring {@code
+     * visitAssign}. The annotation expression itself is not modeled. When a value is present it is
+     * the field's AST; an annotation-only declaration uses a {@code None} placeholder.
+     *
+     * @param arg0 the {@code AnnAssign} AST node to translate.
+     * @return the translated {@link CAstNode}.
+     * @throws Exception if translating the value or target subtree fails.
+     */
     @Override
     public CAstNode visitAnnAssign(AnnAssign arg0) throws Exception {
-      // A PEP-526 annotated assignment `target: annotation [= value]`. In a class body this
-      // declares
-      // a field (the NamedTuple/dataclass case, wala/ML#579); the field name and its declaration
-      // order are what downstream needs, so emit a field entity mirroring `visitAssign`. The
-      // annotation expression itself is not modeled. When a value is present it is the field's AST;
-      // an annotation-only declaration uses a `None` placeholder.
       expr target = arg0.getInternalTarget();
       expr value = arg0.getInternalValue();
       final CAstNode v =
@@ -484,10 +490,12 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
             });
         return Ast.makeNode(CAstNode.EMPTY);
       } else if (value != null) {
-        // `target: annotation = value` outside a class body is an ordinary assignment. Mirror
-        // `visitAssign`: a simple-name target must be declared (wrapped in a DECL_STMT and
-        // registered via addDefinedName), otherwise it is left undeclared and trips leaveVar's
-        // symbol assertion.
+        /*
+         * `target: annotation = value` outside a class body is an ordinary assignment. Mirror
+         * `visitAssign`: a simple-name target must be declared (wrapped in a DECL_STMT and
+         * registered via addDefinedName), otherwise it is left undeclared and trips leaveVar's
+         * symbol assertion.
+         */
         CAstNode assign =
             notePosition(
                 Ast.makeNode(CAstNode.ASSIGN, notePosition(target.accept(this), target), v),

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -452,6 +452,7 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
      *
      * @param arg0 the {@code AnnAssign} AST node to translate.
      * @return the translated {@link CAstNode}.
+     * @throws Exception if translating the value or target subtree fails.
      */
     @Override
     public CAstNode visitAnnAssign(AnnAssign arg0) throws Exception {

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -463,6 +463,11 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
               : Ast.makeNode(CAstNode.VAR, Ast.makeConstant("None"));
 
       if (context.entity().getKind() == CAstEntity.TYPE_ENTITY) {
+        // Only `target: T = value` assigns the class attribute; a bare `target: T` annotation
+        // declares the field (name and order) without creating the attribute, matching Python,
+        // where it populates `__annotations__` only. Give the annotation-only case an EMPTY AST so
+        // leaveTypeEntity records the field but emits no member `put` (wala/ML#579).
+        final CAstNode fieldAst = value != null ? v : Ast.makeNode(CAstNode.EMPTY);
         context.addScopedEntity(
             null,
             new AbstractFieldEntity(
@@ -475,7 +480,7 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
                 makePosition(target)) {
               @Override
               public CAstNode getAST() {
-                return v;
+                return fieldAst;
               }
 
               @Override

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -451,7 +451,6 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
      *
      * @param arg0 the {@code AnnAssign} AST node to translate.
      * @return the translated {@link CAstNode}.
-     * @throws Exception if translating the value or target subtree fails.
      */
     @Override
     public CAstNode visitAnnAssign(AnnAssign arg0) throws Exception {

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -67,6 +67,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.python.antlr.PythonTree;
+import org.python.antlr.ast.AnnAssign;
 import org.python.antlr.ast.Assert;
 import org.python.antlr.ast.Assign;
 import org.python.antlr.ast.AsyncFor;
@@ -441,6 +442,58 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     private int assign = 0;
 
     @Override
+    public CAstNode visitAnnAssign(AnnAssign arg0) throws Exception {
+      // A PEP-526 annotated assignment `target: annotation [= value]`. In a class body this
+      // declares
+      // a field (the NamedTuple/dataclass case, wala/ML#579); the field name and its declaration
+      // order are what downstream needs, so emit a field entity mirroring `visitAssign`. The
+      // annotation expression itself is not modeled. When a value is present it is the field's AST;
+      // an annotation-only declaration uses a `None` placeholder.
+      expr target = arg0.getInternalTarget();
+      expr value = arg0.getInternalValue();
+      final CAstNode v =
+          value != null
+              ? notePosition(value.accept(this), value)
+              : Ast.makeNode(CAstNode.VAR, Ast.makeConstant("None"));
+
+      if (context.entity().getKind() == CAstEntity.TYPE_ENTITY) {
+        context.addScopedEntity(
+            null,
+            new AbstractFieldEntity(
+                target.getText(),
+                PythonCAstToIRTranslator.Any,
+                Collections.emptySet(),
+                false,
+                context.entity(),
+                makePosition(target),
+                makePosition(target)) {
+              @Override
+              public CAstNode getAST() {
+                return v;
+              }
+
+              @Override
+              public Position getPosition(int arg) {
+                return null;
+              }
+
+              @Override
+              public Position getNamePosition() {
+                return makePosition(target);
+              }
+            });
+        return Ast.makeNode(CAstNode.EMPTY);
+      } else if (value != null) {
+        // `target: annotation = value` outside a class body is an ordinary assignment.
+        return notePosition(
+            Ast.makeNode(CAstNode.ASSIGN, notePosition(target.accept(this), target), v), target);
+      } else {
+        // An annotation-only declaration outside a class body has no runtime effect.
+        return Ast.makeNode(CAstNode.EMPTY);
+      }
+    }
+
+    @Override
     public CAstNode visitAssign(Assign arg0) throws Exception {
       String rvalName = "rval" + assign++;
       CAstNode v = notePosition(arg0.getInternalValue().accept(this), arg0.getInternalValue());
@@ -726,7 +779,9 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
       // TODO: CURRENTLY THIS WILL NOT BE CORRECT FOR EXTENDING CLASSES IMPORTED FROM ANOTHER MODULE
       types.map(arg0.getInternalName(), cls);
 
-      Collection<CAstEntity> members = HashSetFactory.make();
+      // Insertion-ordered so a class's members (notably annotated fields) keep declaration order,
+      // which positional NamedTuple/dataclass construction relies on (wala/ML#579).
+      Collection<CAstEntity> members = new java.util.LinkedHashSet<>();
 
       CAstEntity clse =
           new AbstractClassEntity(cls) {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8548,6 +8548,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Verifies a module-level PEP-526 annotated assignment with a value (`t: tf.Tensor = tf.ones([2,
+   * 3])`) declares its target and propagates the value (wala/ML#579). Outside a class body
+   * `visitAnnAssign` must declare a simple-name target like `visitAssign` does; otherwise the
+   * target is left undeclared. The tensor flows to `consume` as `(2, 3) float32`.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testAnnAssignLocal()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_annassign_local.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8507,6 +8507,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for the {@code @dataclass} half of <a
+   * href="https://github.com/wala/ML/issues/205">wala/ML#205</a>: a module containing a {@code
+   * @dataclass} definition loads and analyzes without a front-end parse error. The dataclass is
+   * defined but unused in the dataflow; {@code f} receives a tensor directly, so its parameter type
+   * is recovered iff the module parsed. Companion to {@link #testModule68}/{@link #testModule69},
+   * which guard the same for {@code NamedTuple}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDataclassParse()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataclass_parse.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_2_FLOAT32)));
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8635,6 +8635,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Verifies a class-body PEP-526 annotated assignment with a value ({@code weight: tf.Tensor =
+   * tf.ones([3, 4])}) assigns the class attribute and that reading it back ({@code y = C.weight})
+   * recovers the {@code (3, 4) float32} type (<a
+   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>). This guards the value-bearing
+   * branch of {@code visitAnnAssign}: unlike an annotation-only declaration ({@code x: T}, which
+   * declares the field but emits no member {@code put}), a value-bearing class field still emits
+   * the {@code put}, so the attribute is typed.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testClassAttrAnnAssign()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_classattr_annassign.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_3_4_FLOAT32)));
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8526,6 +8526,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Documents the <a href="https://github.com/wala/ML/issues/579">wala/ML#579</a> gap: a tensor
+   * stored in a user-defined {@code NamedTuple} field and read back ({@code b = w.tensor}) loses
+   * its tensor type. At runtime {@code b} is the original {@code (4, 8) float32} tensor, but the
+   * analysis currently recovers {@code consume}'s parameter as <em>no</em> tensor at all (zero
+   * tensor variables). Unlike {@link #testModule68}/{@link #testModule69} — which only confirm a
+   * {@code NamedTuple} <em>definition</em> parses — this exercises actual field dataflow. It is the
+   * minimal form of the GCN blocker in wala/ML#570, where {@code GraphConvolution.call} unwraps a
+   * {@code GNNInput} {@code NamedTuple} the same way.
+   *
+   * <p>TODO: Tighten to {@code Map.of(2, Set.of(TENSOR_4_8_FLOAT32))} once wala/ML#579 propagates
+   * tensor types through {@code NamedTuple} fields.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNamedTupleFieldRead()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_namedtuple_field.py", "consume", 0, 0);
+  }
+
+  /**
    * Test https://github.com/wala/ML/issues/210.
    *
    * <p>TODO: Remove {@code expected = AssertionError.class} once wala/ML#210 is fixed.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8642,11 +8642,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * branch of {@code visitAnnAssign}: unlike an annotation-only declaration ({@code x: T}, which
    * declares the field but emits no member {@code put}), a value-bearing class field still emits
    * the {@code put}, so the attribute is typed.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
    */
   @Test
   public void testClassAttrAnnAssign()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8526,17 +8526,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Documents the <a href="https://github.com/wala/ML/issues/579">wala/ML#579</a> gap: a tensor
-   * stored in a user-defined {@code NamedTuple} field and read back ({@code b = w.tensor}) loses
-   * its tensor type. At runtime {@code b} is the original {@code (4, 8) float32} tensor, but the
-   * analysis currently recovers {@code consume}'s parameter as <em>no</em> tensor at all (zero
-   * tensor variables). Unlike {@link #testModule68}/{@link #testModule69} — which only confirm a
-   * {@code NamedTuple} <em>definition</em> parses — this exercises actual field dataflow. It is the
-   * minimal form of the GCN blocker in wala/ML#570, where {@code GraphConvolution.call} unwraps a
-   * {@code GNNInput} {@code NamedTuple} the same way.
-   *
-   * <p>TODO: Tighten to {@code Map.of(2, Set.of(TENSOR_4_8_FLOAT32))} once wala/ML#579 propagates
-   * tensor types through {@code NamedTuple} fields.
+   * Verifies tensor types propagate through a user-defined {@code NamedTuple} field (<a
+   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>): a tensor stored in a {@code
+   * NamedTuple} field and read back ({@code b = w.tensor}) keeps its {@code (4, 8) float32} type.
+   * Unlike {@link #testModule68}/{@link #testModule69} — which only confirm a {@code NamedTuple}
+   * <em>definition</em> parses — this exercises actual field dataflow: PEP-526 annotated fields now
+   * reach the CAst as ordered field entities (jython3 grammar/AST support), and the synthesized
+   * constructor populates them positionally. It is the minimal form of the GCN blocker in
+   * wala/ML#570, where {@code GraphConvolution.call} unwraps a {@code GNNInput} {@code NamedTuple}
+   * the same way.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -8546,7 +8544,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testNamedTupleFieldRead()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_namedtuple_field.py", "consume", 0, 0);
+    test("tf2_test_namedtuple_field.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_annassign_local.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_annassign_local.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def consume(y):
+    pass
+
+
+# Module-level PEP-526 annotated assignment with a value. The target `t` must be
+# declared (not just assigned), or the analysis leaves it undeclared. The tensor
+# value flows to `consume`.
+t: tf.Tensor = tf.ones([2, 3])
+assert t.shape == (2, 3) and t.dtype == tf.float32
+consume(t)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_classattr_annassign.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_classattr_annassign.py
@@ -1,0 +1,20 @@
+"""Exercises a class-body PEP-526 annotated assignment with a value (wala/ML#579).
+
+A value-bearing class field ``weight: tf.Tensor = tf.ones([3, 4])`` assigns the class attribute, and reading it back (``y = C.weight``) recovers the ``(3, 4) float32`` type.
+This is the value-bearing counterpart to the annotation-only field in ``tf2_test_namedtuple_field.py``.
+"""
+
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+class C:
+    weight: tf.Tensor = tf.ones([3, 4])
+
+
+y = C.weight
+assert y.shape == (3, 4) and y.dtype == tf.float32
+consume(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataclass_parse.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataclass_parse.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+import tensorflow as tf
+
+
+# Regression guard for wala/ML#205: a module containing a `@dataclass` definition
+# must load and analyze without a front-end parse error. The dataclass is defined
+# but not used in the dataflow; `f` receives a tensor directly, so its parameter
+# types are recovered iff the module parsed. (Companion to `testModule68`/`69`,
+# which guard the same for `NamedTuple`.)
+@dataclass
+class Holder:
+    tensor: tf.Tensor
+
+
+def f(x):
+    pass
+
+
+t = tf.ones([1, 2])
+assert t.shape == (1, 2) and t.dtype == tf.float32
+f(t)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
@@ -1,15 +1,16 @@
+"""Exercises tensor-type propagation through a user-defined ``NamedTuple`` field (wala/ML#579).
+
+A tensor stored in a ``NamedTuple`` field and read back out (``b = w.tensor``) keeps its original
+``(4, 8) float32`` type. This is the minimal form of the GCN blocker in wala/ML#570, where
+``GraphConvolution.call`` unwraps a ``GNNInput`` ``NamedTuple`` the same way.
+"""
+
 from typing import NamedTuple, List
 
 import numpy as np
 import tensorflow as tf
 
 
-# Documents the wala/ML#579 gap: a tensor stored in a user-defined `NamedTuple`
-# field and read back out loses its tensor type. At runtime `b` is the original
-# `(4, 8) float32` tensor (the asserts below hold), but the static analysis
-# currently recovers `consume`'s parameter as *no* tensor at all. This is the
-# concrete blocker for typing the GCN layer outputs in wala/ML#570, where
-# `GraphConvolution.call` unwraps a `GNNInput` `NamedTuple` the same way.
 class Wrapper(NamedTuple):
     tensor: tf.Tensor
     rest: List

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
@@ -1,0 +1,27 @@
+from typing import NamedTuple, List
+
+import numpy as np
+import tensorflow as tf
+
+
+# Documents the wala/ML#579 gap: a tensor stored in a user-defined `NamedTuple`
+# field and read back out loses its tensor type. At runtime `b` is the original
+# `(4, 8) float32` tensor (the asserts below hold), but the static analysis
+# currently recovers `consume`'s parameter as *no* tensor at all. This is the
+# concrete blocker for typing the GCN layer outputs in wala/ML#570, where
+# `GraphConvolution.call` unwraps a `GNNInput` `NamedTuple` the same way.
+class Wrapper(NamedTuple):
+    tensor: tf.Tensor
+    rest: List
+
+
+def consume(x):
+    pass
+
+
+a = tf.constant(np.ones((4, 8), dtype=np.float32))
+assert a.shape == (4, 8) and a.dtype == tf.float32
+w = Wrapper(a, [])
+b = w.tensor
+assert b.shape == (4, 8) and b.dtype == tf.float32
+consume(b)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
@@ -1,8 +1,7 @@
 """Exercises tensor-type propagation through a user-defined ``NamedTuple`` field (wala/ML#579).
 
-A tensor stored in a ``NamedTuple`` field and read back out (``b = w.tensor``) keeps its original
-``(4, 8) float32`` type. This is the minimal form of the GCN blocker in wala/ML#570, where
-``GraphConvolution.call`` unwraps a ``GNNInput`` ``NamedTuple`` the same way.
+A tensor stored in a ``NamedTuple`` field and read back out (``b = w.tensor``) keeps its original ``(4, 8) float32`` type.
+This is the minimal form of the GCN blocker in wala/ML#570, where ``GraphConvolution.call`` unwraps a ``GNNInput`` ``NamedTuple`` the same way.
 """
 
 from typing import NamedTuple, List

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -21,11 +21,13 @@ import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.loader.IPythonClass;
+import com.ibm.wala.cast.python.loader.PythonLoader;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.core.util.strings.Atom;
@@ -46,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -78,7 +81,17 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
                   receiver.getClassLoader().getReference(), receiver.getName() + "/__init__");
           IClass ctorCls = cha.lookupClass(ctorRef);
           IMethod init = ctorCls == null ? null : ctorCls.getMethod(AstMethodReference.fnSelector);
-          int params = init == null ? 1 : init.getNumberOfParameters();
+          // wala/ML#579: a NamedTuple with no explicit __init__ maps positional constructor
+          // arguments to its declared fields in declaration order. Collect those fields so the
+          // synthesized constructor can populate them on the new instance below.
+          List<IField> tupleFields =
+              init == null && isPositionalFieldClass(receiver)
+                  ? new ArrayList<>(receiver.getDeclaredStaticFields())
+                  : Collections.emptyList();
+          int params =
+              init != null
+                  ? init.getNumberOfParameters()
+                  : (tupleFields.isEmpty() ? 1 : 1 + tupleFields.size());
           int v = params + 2;
           int pc = 0;
           int inst = v++;
@@ -132,6 +145,20 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
           ctor.addStatement(
               insts.NewInstruction(pc, inst, NewSiteReference.make(pc, PythonTypes.object)));
           pc++;
+
+          // wala/ML#579: store each positional constructor argument into the corresponding declared
+          // field, in declaration order. Param 1 is the callable; the positional arguments are
+          // value
+          // numbers 2, 3, ... So field[i] is populated from argument value number 2 + i.
+          for (int i = 0; i < tupleFields.size(); i++) {
+            ctor.addStatement(
+                insts.PutInstruction(
+                    pc++,
+                    inst,
+                    2 + i,
+                    FieldReference.findOrCreate(
+                        PythonTypes.Root, tupleFields.get(i).getName(), PythonTypes.Root)));
+          }
 
           Collection<TypeReference> innerReferences = Collections.emptyList();
           Collection<MethodReference> methodReferences = new ArrayList<>();
@@ -301,5 +328,26 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
       }
     }
     return base.getCalleeTarget(caller, site, receiver);
+  }
+
+  /**
+   * Whether {@code receiver} is a class whose constructor maps positional arguments to declared
+   * fields in declaration order &mdash; i.e. a {@code typing.NamedTuple} subclass. Such a class
+   * carries no explicit {@code __init__}; its fields come from PEP-526 annotations and are
+   * populated positionally (wala/ML#579). Detected via the unresolved {@code NamedTuple} supertype
+   * the loader records.
+   *
+   * @param receiver The class being constructed.
+   * @return {@code true} iff positional field population applies.
+   */
+  private static boolean isPositionalFieldClass(IClass receiver) {
+    if (!(receiver instanceof PythonLoader.PythonClass)) return false;
+    return ((PythonLoader.PythonClass) receiver)
+        .getMissingTypeNames().stream()
+            .anyMatch(
+                n ->
+                    n.equals("NamedTuple")
+                        || n.endsWith(".NamedTuple")
+                        || n.endsWith("/NamedTuple"));
   }
 }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -146,10 +146,11 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
               insts.NewInstruction(pc, inst, NewSiteReference.make(pc, PythonTypes.object)));
           pc++;
 
-          // wala/ML#579: store each positional constructor argument into the corresponding declared
-          // field, in declaration order. Param 1 is the callable; the positional arguments are
-          // value
-          // numbers 2, 3, ... So field[i] is populated from argument value number 2 + i.
+          /*
+           * wala/ML#579: store each positional constructor argument into the corresponding declared
+           * field, in declaration order. Param 1 is the callable; the positional arguments are value
+           * numbers 2, 3, ... So field[i] is populated from argument value number 2 + i.
+           */
           for (int i = 0; i < tupleFields.size(); i++) {
             ctor.addStatement(
                 insts.PutInstruction(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -81,9 +81,11 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
                   receiver.getClassLoader().getReference(), receiver.getName() + "/__init__");
           IClass ctorCls = cha.lookupClass(ctorRef);
           IMethod init = ctorCls == null ? null : ctorCls.getMethod(AstMethodReference.fnSelector);
-          // wala/ML#579: a NamedTuple with no explicit __init__ maps positional constructor
-          // arguments to its declared fields in declaration order. Collect those fields so the
-          // synthesized constructor can populate them on the new instance below.
+          /*
+           * https://github.com/wala/ML/issues/579: a NamedTuple with no explicit __init__ maps
+           * positional constructor arguments to its declared fields in declaration order. Collect
+           * those fields so the synthesized constructor can populate them on the new instance below.
+           */
           List<IField> tupleFields =
               init == null && isPositionalFieldClass(receiver)
                   ? new ArrayList<>(receiver.getDeclaredStaticFields())
@@ -147,9 +149,10 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
           pc++;
 
           /*
-           * wala/ML#579: store each positional constructor argument into the corresponding declared
-           * field, in declaration order. Param 1 is the callable; the positional arguments are value
-           * numbers 2, 3, ... So field[i] is populated from argument value number 2 + i.
+           * https://github.com/wala/ML/issues/579: store each positional constructor argument into
+           * the corresponding declared field, in declaration order. Param 1 is the callable; the
+           * positional arguments are value numbers 2, 3, ... So field[i] is populated from argument
+           * value number 2 + i.
            */
           for (int i = 0; i < tupleFields.size(); i++) {
             ctor.addStatement(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -799,8 +799,16 @@ public class PythonCAstToIRTranslator extends AstTranslator {
               type, Atom.findOrCreateUnicodeAtom(field.getName()), PythonTypes.Root);
       int val;
       if (field.getKind() == CAstEntity.FIELD_ENTITY) {
-        this.visit(field.getAST(), code, this);
-        val = code.getValue(field.getAST());
+        CAstNode fieldAst = field.getAST();
+        if (fieldAst == null || fieldAst.getKind() == CAstNode.EMPTY) {
+          // Annotation-only field declaration (PEP-526 `x: T` in a class body): the loader already
+          // recorded the field name and order via defineField, so emit no member put. This matches
+          // Python, where a bare annotation populates `__annotations__` only and does not
+          // create/overwrite the class attribute (wala/ML#579).
+          continue;
+        }
+        this.visit(fieldAst, code, this);
+        val = code.getValue(fieldAst);
       } else if (field.getKind() == CAstEntity.TYPE_ENTITY) {
         String className = composeEntityName(typeContext, field);
         val = doGlobalRead(null, code, className, PythonTypes.Root);

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -100,11 +100,13 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
   }
 
   public class PythonClass extends CoreClass implements IPythonClass {
-    /*
-     * Insertion-ordered so declared fields keep declaration order for positional
-     * NamedTuple/dataclass construction (wala/ML#579).
+    /**
+     * Insertion-ordered so declared fields keep declaration order for positional {@code
+     * NamedTuple}/dataclass construction (<a
+     * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>).
      */
     Set<IField> staticFields = new java.util.LinkedHashSet<>();
+
     Set<MethodReference> methodTypes = HashSetFactory.make();
     private java.util.Set<TypeReference> innerTypes = HashSetFactory.make();
     Set<String> missingTypeNames;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -100,7 +100,9 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
   }
 
   public class PythonClass extends CoreClass implements IPythonClass {
-    Set<IField> staticFields = HashSetFactory.make();
+    // Insertion-ordered so declared fields keep declaration order for positional
+    // NamedTuple/dataclass construction (wala/ML#579).
+    Set<IField> staticFields = new java.util.LinkedHashSet<>();
     Set<MethodReference> methodTypes = HashSetFactory.make();
     private java.util.Set<TypeReference> innerTypes = HashSetFactory.make();
     Set<String> missingTypeNames;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -100,8 +100,10 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
   }
 
   public class PythonClass extends CoreClass implements IPythonClass {
-    // Insertion-ordered so declared fields keep declaration order for positional
-    // NamedTuple/dataclass construction (wala/ML#579).
+    /*
+     * Insertion-ordered so declared fields keep declaration order for positional
+     * NamedTuple/dataclass construction (wala/ML#579).
+     */
     Set<IField> staticFields = new java.util.LinkedHashSet<>();
     Set<MethodReference> methodTypes = HashSetFactory.make();
     private java.util.Set<TypeReference> innerTypes = HashSetFactory.make();


### PR DESCRIPTION
Closes #579. Unblocks #570 (the GCN `GNNInput` unwrap) and the substantive remainder of #205.

**Depends on ponder-lab/jython3#3** (the PEP-526 `AnnAssign` parser support)—this PR bumps the `jython3` submodule to that commit. Stacked on #382 (the `NamedTuple`/dataclass coverage); review/merge that first.

## Problem
A tensor stored in a user-defined `NamedTuple` field and read back (`b = w.tensor`) was recovered as *no tensor at all*. Two root causes, in sequence:
1. The jython3 grammar discarded annotated class attributes (`tensor: tf.Tensor`), so the field names never reached Ariadne (fixed in jython3#3).
2. The synthetic constructor allocated a bare object and never populated the declared fields.

## Change (Ariadne side)
- `PythonParser.visitAnnAssign`—emits an ordered `FIELD_ENTITY` for a class-body annotation (mirrors `visitAssign`'s class branch); a non-class `x: T = v` stays an ordinary assignment. `members` is now insertion-ordered.
- `PythonLoader.PythonClass.staticFields`—insertion-ordered, preserving declaration order to the constructor synthesizer.
- `PythonConstructorTargetSelector`—the synthesized constructor populates the new instance's declared fields from the positional constructor arguments in declaration order, **gated to `NamedTuple` subclasses** so ordinary classes are untouched.
- Submodule bump: `jython3`→the PEP-526 commit.

## Verification
`testNamedTupleFieldRead` flips from documenting the gap (0 tensors) to recovering `(4, 8) float32` through the field round-trip. `testModule68`/`69` (the #205 `NamedTuple` parse smoke tests) still pass, and the **entire root suite passes (0 failures)**—the construction gate keeps regular classes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
