### PR TITLE
Guard that a list-literal `extract_patches` input stays typed

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6187,6 +6187,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_extract_patches.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_2_2_27_FLOAT32)));
   }
 
+  /**
+   * Regression guard for {@code tf.image.extract_patches} called with a Python <em>list
+   * literal</em> {@code images} argument (rather than a {@code tf.Tensor}), per <a
+   * href="https://github.com/wala/ML/issues/584">wala/ML#584</a>. The result must still be
+   * recognized as a tensor; the {@code int32} dtype is inherited from the literal and the shape is
+   * ⊤ (the list-literal shape is not statically propagated through the op).
+   */
+  @Test
+  public void testExtractPatches2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_extract_patches2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
   /** Pure-passthrough generator test for {@code tf.math.tan} (wala/ML#422). */
   @Test
   public void testTan()

--- a/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches2.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# `images` is a Python list literal (not a `tf.Tensor`); the result should still be
+# recognized as a tensor (wala/ML#584).
+r = tf.image.extract_patches(
+    images=[[[[1]]]],
+    sizes=[1, 3, 3, 1],
+    strides=[1, 5, 5, 1],
+    rates=[1, 1, 1, 1],
+    padding="VALID",
+)
+assert r.dtype == tf.int32
+f(r)


### PR DESCRIPTION
Re: wala/ML#584.

## Finding
wala/ML#584 reports that `tf.image.extract_patches` with a Python **list-literal** `images` argument (rather than a `tf.Tensor`) lost its tensor classification after #371, first shipped in 0.48.0.

The issue's exact minimal reproducer **already types correctly on current master**: the result is recovered as an `int32` unknown-shape tensor, so `f`'s argument keeps its tensor classification. Only #381 and #383 touched the analysis since 0.48.0, neither obviously related — so it appears to have been fixed incidentally between 0.48.0 and master.

## Change
Adds `testExtractPatches2` + `tf2_test_extract_patches2.py` as a regression guard for the list-literal case (the existing `testExtractPatches` covers the `tf.Tensor`-input case). No production change.

## Caveat
This guards the issue's *minimal* reproducer. If the Hybridize#603 corpus case that originally surfaced this drops the classification for a different reason, that snippet is needed to reproduce — I couldn't tie the minimal repro to a specific fixing commit. Not auto-closing #584 pending that validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)