### PR TITLE
Create full latest releases instead of pre-releases

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -188,17 +188,20 @@ jobs:
     # glob drift fail loudly instead of silently producing an assetless
     # release. See https://github.com/wala/ML/issues/561.
     # `action-gh-release` creates the Release for the pushed tag if one doesn't
-    # already exist, then attaches the fat JAR. `prerelease: true` matches the
-    # project's release convention; `generate_release_notes: true` fills the body
-    # from the PRs merged since the previous tag. Together with the `release.yml`
-    # dispatch (wala/ML#455), this makes cutting a release fully hands-off — no
-    # manual `gh release create`.
-    - name: Create prerelease and attach fat JAR
+    # already exist, then attaches the fat JAR. The releases are full (non-pre)
+    # releases marked as latest: a `0.x` version is not a SemVer pre-release (which
+    # would carry a `-identifier` suffix) — the major-zero already signals the
+    # unstable-API phase — so the newest tag should win GitHub's "Latest" badge.
+    # `generate_release_notes: true` fills the body from the PRs merged since the
+    # previous tag. Together with the `release.yml` dispatch (wala/ML#455), this
+    # makes cutting a release fully hands-off — no manual `gh release create`.
+    - name: Create release and attach fat JAR
       uses: softprops/action-gh-release@v3
       with:
         files: com.ibm.wala.cast.python.ml-*-fat.jar
         fail_on_unmatched_files: true
-        prerelease: true
+        prerelease: false
+        make_latest: "true"
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -188,20 +188,22 @@ jobs:
     # glob drift fail loudly instead of silently producing an assetless
     # release. See https://github.com/wala/ML/issues/561.
     # `action-gh-release` creates the Release for the pushed tag if one doesn't
-    # already exist, then attaches the fat JAR. The releases are full (non-pre)
-    # releases marked as latest: a `0.x` version is not a SemVer pre-release (which
-    # would carry a `-identifier` suffix) — the major-zero already signals the
-    # unstable-API phase — so the newest tag should win GitHub's "Latest" badge.
-    # `generate_release_notes: true` fills the body from the PRs merged since the
-    # previous tag. Together with the `release.yml` dispatch (wala/ML#455), this
-    # makes cutting a release fully hands-off — no manual `gh release create`.
+    # already exist, then attaches the fat JAR. Whether it's a full "latest" release
+    # is driven off the tag: a plain `X.Y.Z` tag is a full release marked latest (a
+    # `0.x` is NOT a SemVer pre-release — the major-zero already signals the unstable
+    # phase, no `-identifier` suffix), while a tag carrying a SemVer pre-release
+    # suffix (e.g. `1.0.0-rc.1`, which `tag_check` permits) is published as a GitHub
+    # pre-release and does not steal the "Latest" badge. `generate_release_notes:
+    # true` fills the body from the PRs merged since the previous tag. Together with
+    # the `release.yml` dispatch (wala/ML#455), this makes cutting a release fully
+    # hands-off — no manual `gh release create`.
     - name: Create release and attach fat JAR
       uses: softprops/action-gh-release@v3
       with:
         files: com.ibm.wala.cast.python.ml-*-fat.jar
         fail_on_unmatched_files: true
-        prerelease: false
-        make_latest: "true"
+        prerelease: ${{ contains(github.ref_name, '-') }}
+        make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 # of the 0.47.0 manual-deploy incident). `release:prepare` pushes two version-bump
 # commits and the release tag to `master`; the tag push then drives
 # `continuous-integration.yml`'s deploy gate (publish to GitHub Packages) and its
-# `release-upload` job (create the prerelease + attach the fat JAR). End to end,
+# `release-upload` job (create the release + attach the fat JAR). End to end,
 # dispatching this workflow is the whole release.
 #
 # SETUP (one-time): this workflow needs a `RELEASE_PAT` repository secret — a
@@ -157,6 +157,6 @@ jobs:
       run: |
         echo "### Release ${{ inputs.releaseVersion }} cut :rocket:" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "- Tag \`${{ inputs.releaseVersion }}\` pushed; the tag-push run in **Continuous integration** now deploys to GitHub Packages and creates the prerelease." >> "$GITHUB_STEP_SUMMARY"
+        echo "- Tag \`${{ inputs.releaseVersion }}\` pushed; the tag-push run in **Continuous integration** now deploys to GitHub Packages and creates the release." >> "$GITHUB_STEP_SUMMARY"
         echo "- Next development version set to \`${{ inputs.developmentVersion }}\`." >> "$GITHUB_STEP_SUMMARY"
       shell: bash


### PR DESCRIPTION
## Problem
The tag-push release step in `continuous-integration.yml` hard-coded `prerelease: true`, so every auto-created release was flagged as a GitHub pre-release. GitHub's **"Latest"** badge only considers non-pre-release, non-draft releases, so it stuck on **0.46.1** (the one release that happened to be un-flagged) instead of the newest tag — e.g. 0.47.0 and 0.48.0 were both excluded.

## Change
Set `prerelease: false` and `make_latest: "true"` so the newest tag wins the "Latest" badge.

A `0.x` version is **not** a SemVer pre-release: a pre-release version carries a `-identifier` suffix (`1.0.0-rc.1`), while the major-zero in `0.48.0` already conveys the "initial development, unstable API" phase (SemVer §4). So the GitHub pre-release flag was redundant with the `0.` and only caused the badge oddity.

Also fixes the stale "prerelease" wording in `release.yml`.

(0.48.0 has already been promoted to a full latest release by hand; this makes it the default going forward.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)