### PR TITLE
Delegate the latest-release badge to GitHub instead of forcing it

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -188,22 +188,24 @@ jobs:
     # glob drift fail loudly instead of silently producing an assetless
     # release. See https://github.com/wala/ML/issues/561.
     # `action-gh-release` creates the Release for the pushed tag if one doesn't
-    # already exist, then attaches the fat JAR. Whether it's a full "latest" release
-    # is driven off the tag: a plain `X.Y.Z` tag is a full release marked latest (a
-    # `0.x` is NOT a SemVer pre-release — the major-zero already signals the unstable
-    # phase, no `-identifier` suffix), while a tag carrying a SemVer pre-release
+    # already exist, then attaches the fat JAR. A tag carrying a SemVer pre-release
     # suffix (e.g. `1.0.0-rc.1`, which `tag_check` permits) is published as a GitHub
-    # pre-release and does not steal the "Latest" badge. `generate_release_notes:
-    # true` fills the body from the PRs merged since the previous tag. Together with
-    # the `release.yml` dispatch (wala/ML#455), this makes cutting a release fully
-    # hands-off — no manual `gh release create`.
+    # pre-release; a plain `X.Y.Z` tag (a `0.x` is NOT a SemVer pre-release — the
+    # major-zero already signals the unstable phase, no `-identifier` suffix) is a
+    # full release. `make_latest: legacy` delegates the "Latest" badge to GitHub,
+    # which awards it to the highest semantic version among non-pre-releases — so we
+    # do NOT force it: cutting an *older* release (a backport like `0.46.2` after
+    # `0.49.0`, or re-running on an old tag) won't steal the badge from the newer
+    # one. `generate_release_notes: true` fills the body from the PRs merged since
+    # the previous tag. Together with the `release.yml` dispatch (wala/ML#455), this
+    # makes cutting a release fully hands-off — no manual `gh release create`.
     - name: Create release and attach fat JAR
       uses: softprops/action-gh-release@v3
       with:
         files: com.ibm.wala.cast.python.ml-*-fat.jar
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref_name, '-') }}
-        make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
+        make_latest: legacy
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #387.

#387 set `make_latest` to force `true` for every plain `X.Y.Z` tag. That's wrong for **older-release builds**: a backport like `0.46.2` published after `0.49.0` (or a workflow re-run on an old tag) would steal the "Latest" badge from the newer release.

The original "0.46.1 stuck as Latest" problem was caused by the `prerelease: true` flag (now conditional), **not** `make_latest`. With normal releases marked `prerelease: false`, GitHub already awards "Latest" to the highest semantic version among non-pre-releases on its own.

So this stops forcing it: `make_latest: legacy` delegates the determination to GitHub (highest semver wins), while the conditional `prerelease` is kept so RC tags stay GitHub pre-releases and are excluded from Latest entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)