### PR TITLE
Keep extract_patches result a tensor when its input can't be resolved

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6200,6 +6200,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_extract_patches2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
   }
 
+  /**
+   * Regression guard for {@code tf.image.extract_patches} called with an {@code images} argument
+   * built from a nested list <em>comprehension</em> (the wala/ML#584 corpus case), per <a
+   * href="https://github.com/wala/ML/issues/584">wala/ML#584</a>. Resolving such an {@code images}
+   * operand throws inside the generator; before the fix that aborted the whole type computation and
+   * the result dropped its tensor classification entirely. The result must still be recognized as a
+   * tensor — here ⊤ shape and ⊤ dtype, since a comprehension's computed elements (unlike a
+   * literal's constants) yield no statically inferable dtype.
+   */
+  @Test
+  public void testExtractPatchesComprehension()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_extract_patches_comprehension.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
   /** Pure-passthrough generator test for {@code tf.math.tan} (wala/ML#422). */
   @Test
   public void testTan()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
@@ -59,8 +59,16 @@ public class ExtractPatches extends PassThroughUnaryTensorGenerator {
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     // images=arg0 (NHWC); sizes=arg1; strides=arg2; rates=arg3; padding=arg4.
-    Set<List<Dimension<?>>> imageShapes =
-        this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "images", false));
+    Set<List<Dimension<?>>> imageShapes;
+    try {
+      imageShapes =
+          this.getShapes(builder, this.getArgumentValueNumber(builder, 0, "images", false));
+    } catch (IllegalArgumentException e) {
+      // wala/ML#584: the `images` operand can't be resolved to a tensor (e.g. a comprehension-built
+      // list, whose generator dispatch throws). The result is still a tensor, so degrade to ⊤ shape
+      // rather than letting the throw abort the whole type computation and drop the result.
+      return null;
+    }
     if (imageShapes == null) return null;
 
     List<Integer> sizes = resolveIntList(builder, 1, "sizes");

--- a/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches_comprehension.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches_comprehension.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+n = 10
+# `images` built from a nested list comprehension (the wala/ML#584 corpus case).
+images = [[[[x * n + y + 1] for y in range(n)] for x in range(n)]]
+r = tf.image.extract_patches(
+    images=images,
+    sizes=[1, 3, 3, 1],
+    strides=[1, 5, 5, 1],
+    rates=[1, 1, 1, 1],
+    padding="VALID",
+)
+assert r.dtype == tf.int32
+f(r)


### PR DESCRIPTION
Closes wala/ML#584.

## Root cause
`ExtractPatches.getDefaultShapes` resolves the `images` operand's shape via `getShapes(builder, imagesVn)`, which throws `IllegalArgumentException` when `images` isn't a recognized tensor source. An `images` argument built from a **nested list comprehension** (`[[[[x*n+y+1] for y in range(n)] for x in range(n)]]` — the actual #584 corpus case) is exactly such an operand. The throw propagated out of the generator and aborted the whole type computation, so the result dropped its tensor classification **entirely** (0 tensors, not even ⊤). A plain list literal resolves, which is why the original minimal-literal repro didn't reproduce it.

## Which change regressed it
Not #371 (the issue's guess), but **#373** (`fbb61487`, shipped in 0.48.0). At 0.47.0 `ExtractPatches.getDefaultShapes` was just `return null;` — always ⊤, never touching `images`, so it never threw and the comprehension result stayed typed. #373 replaced that with the precise-shape derivation that introduced the throwing `getShapes(images)` call. #371 and #373 both shipped in 0.48.0, so it was misattributed.

## Fix
Catch the throw and degrade to ⊤ shape. `extract_patches` always produces a tensor (a fresh `<new>+<return>` `Tensor` allocation), so the result stays classified — with ⊤ shape and ⊤ dtype, since a comprehension's computed elements (unlike a literal's constants) yield no statically inferable dtype.

## Verification
- `testExtractPatchesComprehension` (new fixture mirroring the Hybridize corpus) flips from 0 tensors to a recovered ⊤ tensor.
- The literal case (`testExtractPatches2`) and tensor-input case (`testExtractPatches`) still pass.
- Full root suite green (841 tests, 0 failures).

Unblocks the Hybridize 0.49.x bump (ponder-lab/Hybridize-Functions-Refactoring#620, blocked on #584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
