### PR TITLE
Address post-merge review nits on the tensor-typing PRs

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -519,7 +519,8 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
         }
         return assign;
       } else {
-        // An annotation-only declaration outside a class body has no runtime effect.
+        // An annotation-only declaration outside a class body has no effect on variable binding or
+        // dataflow (it records the annotation in `__annotations__`, which is not modeled).
         return Ast.makeNode(CAstNode.EMPTY);
       }
     }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2528,10 +2528,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * is the runtime {@code num_segments} value. Verified via a {@code consume_sum} sink on the
    * aggregation result.
    *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
+   * <p>TODO: Recover the concrete shape when {@code num_segments} is static, per <a
+   * href="https://github.com/wala/ML/issues/582">wala/ML#582</a>.
    */
   @Test
   public void testUnsortedSegmentSum()
@@ -2547,11 +2545,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Pins the output type of {@code tf.math.unsorted_segment_max} (wala/ML#570). Same dtype-from-
    * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
    */
   @Test
   public void testUnsortedSegmentMax()
@@ -2567,11 +2560,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Pins the output type of {@code tf.math.unsorted_segment_mean} (wala/ML#570). Same dtype-from-
    * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
    */
   @Test
   public void testUnsortedSegmentMean()
@@ -6193,6 +6181,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * href="https://github.com/wala/ML/issues/584">wala/ML#584</a>. The result must still be
    * recognized as a tensor; the {@code int32} dtype is inherited from the literal and the shape is
    * ⊤ (the list-literal shape is not statically propagated through the op).
+   *
+   * <p>TODO: Tighten the shape from ⊤ to the concrete value once <a
+   * href="https://github.com/wala/ML/issues/585">wala/ML#585</a> infers a tensor's shape from a
+   * list literal.
    */
   @Test
   public void testExtractPatches2()
@@ -6726,6 +6718,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Rather than throw an exception that aborts the whole analysis, the element-wise generator
    * degrades the result shape to ⊤ (unknown) and continues; the {@code int32} dtype is still
    * recovered (<a href="https://github.com/wala/ML/issues/583">wala/ML#583</a>).
+   *
+   * <p>Here ⊤ is the correct final result — incompatible operands have no valid broadcast shape —
+   * so, unlike the recoverable list-literal case ({@link #testExtractPatches2}), there is no
+   * precision to recover and no shape-tightening TODO.
    */
   @Test
   public void testMultiply6()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -138,14 +138,17 @@ public class ElementWiseOperation extends ZerosLike {
         }
 
     if (ret.isEmpty() && sampleNonBroadcastableX != null) {
-      // wala/ML#583: every operand-shape pair is non-broadcastable. This is usually a
-      // context-collapse artifact (e.g. `accuracy(y_pred, y_true)` analyzed with `[256]` from
-      // training and `[10000]` from test, whose per-context shapes get crossed), not a real
-      // program error. Degrade the result shape to ⊤ (unknown) so the analysis continues, rather
-      // than throwing an exception that aborts the whole run; the dtype is still recovered by
-      // getDefaultDTypes. Per-context separation is the precise fix and is tracked separately.
-      // Log at FINE, not WARNING: element-wise ops are common and the other degrade-to-⊤ paths
-      // (Slice, Squeeze) are quiet, so a per-occurrence WARNING would flood normal runs.
+      /*
+       * https://github.com/wala/ML/issues/583: every operand-shape pair is non-broadcastable.
+       * This is usually a context-collapse artifact (e.g. `accuracy(y_pred, y_true)` analyzed with
+       * `[256]` from training and `[10000]` from test, whose per-context shapes get crossed), not a
+       * real program error. Degrade the result shape to ⊤ (unknown) so the analysis continues,
+       * rather than throwing an exception that aborts the whole run; the dtype is still recovered by
+       * getDefaultDTypes. Per-context separation is the precise fix, tracked at
+       * https://github.com/wala/ML/issues/530. Log at FINE, not WARNING: element-wise ops are common
+       * and the other degrade-to-⊤ paths (Slice, Squeeze) are quiet, so a per-occurrence WARNING
+       * would flood normal runs.
+       */
       final List<Dimension<?>> x = sampleNonBroadcastableX;
       final List<Dimension<?>> y = sampleNonBroadcastableY;
       LOGGER.fine(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field.py
@@ -1,7 +1,7 @@
-"""Exercises tensor-type propagation through a user-defined ``NamedTuple`` field (wala/ML#579).
+"""Exercises tensor-type propagation through a user-defined ``NamedTuple`` field (https://github.com/wala/ML/issues/579).
 
 A tensor stored in a ``NamedTuple`` field and read back out (``b = w.tensor``) keeps its original ``(4, 8) float32`` type.
-This is the minimal form of the GCN blocker in wala/ML#570, where ``GraphConvolution.call`` unwraps a ``GNNInput`` ``NamedTuple`` the same way.
+This is the minimal form of the GCN blocker in https://github.com/wala/ML/issues/570, where ``GraphConvolution.call`` unwraps a ``GNNInput`` ``NamedTuple`` the same way.
 """
 
 from typing import NamedTuple, List


### PR DESCRIPTION
Post-merge review feedback on #383/#385/#386:

- **Test Javadoc** (`TestTensorflow2Model`): add `TODO`s pointing at the recoverable-shape trackers—wala/ML#585 (list-literal `extract_patches` shape) and wala/ML#582 (static-`num_segments` unsorted-segment shape); note that `testMultiply6`'s ⊤ is the *correct* final result (incompatible operands have no valid broadcast shape), not a recoverable gap; drop the boilerplate `@throws` clauses from the unsorted-segment tests.
- **`ElementWiseOperation`**: the non-broadcastable degrade note is now a `/* */` block comment with issue URLs (and the per-context precise-fix tracker, wala/ML#530).
- **`PythonParser`**: `no runtime effect` → `no effect on variable binding or dataflow` for the annotation-only declaration.
- **`NamedTuple` fixture docstring**: bare `wala/ML#…` → URLs.

Comment/docstring/Javadoc only—no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
