### PR TITLE
Tidy verbose workflow comments to concise documentation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,22 +32,11 @@ jobs:
         with:
           submodules: recursive
 
-      # Use `build-mode: none` for `java-kotlin` (added in CodeQL 2.16.5,
-      # March 2024). With `none`, the Java extractor scans source files
-      # directly instead of tracing a Maven/Ant build — which means the
-      # `paths-ignore` directive in `codeql-config-java-kotlin.yml` actually
-      # filters submodule paths (`IDE/`, `jython3/`) from the analysis. With
-      # the previous build-trace mode, `paths-ignore` translated to
-      # `LGTM_INDEX_FILTERS` but the Java extractor traced everything that
-      # got compiled by the Maven build (including submodules), so submodule
-      # alerts persisted regardless. See wala/ML#476.
-      #
-      # `build-mode: none` removes the need for `actions/setup-java`, the
-      # `Install Jython3` ant build, the `Install IDE` Maven install, and the
-      # `Build with Maven` step — none of those are needed when CodeQL works
-      # straight from sources. Builds for the other CI gates (regular
-      # `mvn test`, etc.) still happen in `continuous-integration.yml` — this
-      # change only affects the CodeQL job.
+      # `build-mode: none` (CodeQL 2.16.5+) scans Java sources directly instead of tracing a
+      # Maven/Ant build, so the config's `paths-ignore` actually filters the submodules (`IDE/`,
+      # `jython3/`); under the old build-trace mode the extractor traced everything compiled, so
+      # submodule alerts persisted. It also drops the need for the Java/Jython/IDE/Maven build steps
+      # here (those still run in `continuous-integration.yml`). See wala/ML#476.
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,30 +1,22 @@
 name: Continuous integration
 on:
   push:
-    # GitHub Merge Queue creates branches under `refs/heads/gh-readonly-queue/...` and pushes
-    # the queue's test commit there. That push fires this workflow's `push:` trigger AS WELL
-    # AS the `merge_group:` trigger — two runs in the same concurrency group, where the second
-    # cancels the first. The cancelled run is reported as failed to the merge queue, which
-    # kicks the PR out (per the PR #217 fix's known incompleteness — Copilot caught this on
-    # the equivalent Hybridize PR #443). Filtering out queue branches from `push:` lets
-    # `merge_group:` be the sole trigger for queue-branch pushes.
+    # Ignore queue branches (`gh-readonly-queue/...`): their pushes fire both `push:` and
+    # `merge_group:`, and the two runs collide in the concurrency group — the cancelled one is
+    # reported failed and kicks the PR out of the queue (wala/ML#217). Let `merge_group:` be their
+    # sole trigger.
     branches-ignore:
       - 'gh-readonly-queue/**'
-    # When only `branches`/`branches-ignore` is set on `push:`, GitHub Actions silently
-    # filters out tag-push events too. The release-deploy gate at the bottom of this
-    # workflow depends on `refs/tags/0.*` pushes firing the workflow, so explicitly
-    # allow all tags here.
+    # Setting `branches`/`branches-ignore` on `push:` silently drops tag-push events too; the
+    # release-deploy gate below needs `refs/tags/` pushes, so allow all tags explicitly.
     tags:
       - '**'
   pull_request:
   merge_group:
 concurrency:
-  # Group includes the workflow name so merge_group runs from different workflows don't collide.
-  # Cancel-in-progress is allowed for `pull_request` (new push to PR supersedes prior runs) and
-  # for non-tag `push` events (commits to a branch supersede prior runs); explicitly NOT for
-  # `merge_group` events, because GitHub Merge Queue spawns concurrent runs on the queue branch
-  # and cancellation marks the cancelled run as failed, kicking the PR out of the queue.
-  # Tags also run to completion so the deploy gate isn't accidentally cancelled.
+  # Cancel-in-progress for `pull_request` and non-tag `push` (a newer run supersedes), but NOT for
+  # `merge_group` or tags: cancelling a queue run marks it failed and kicks the PR out, and tags
+  # must finish so the deploy gate isn't cancelled.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
 permissions:
@@ -74,11 +66,8 @@ jobs:
         popd
     - name: Build with Maven
       run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco
-    # Catch the kind of drift that prompted https://github.com/wala/ML/issues/525:
-    # `run.sh`'s JAR path falling behind the project's actual version (previously
-    # hardcoded `0.40.0-SNAPSHOT`, ~5 minor versions stale). Verifies post-build
-    # that the script's glob resolves to exactly one fat JAR and that the JAR
-    # carries the standalone driver's `Main-Class` manifest entry.
+    # Guard against `run.sh`'s JAR path drifting behind the project version (wala/ML#525): verify
+    # its glob resolves to exactly one fat JAR carrying the driver's `Main-Class` manifest entry.
     - name: Smoke-test `run.sh` fat-JAR resolution
       run: |
         cd com.ibm.wala.cast.python.ml
@@ -99,20 +88,11 @@ jobs:
         slug: ponder-lab/ML
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    # Verify any tag-push deploy is on a commit that's an ancestor of master
-    # (per https://github.com/wala/ML/issues/421). Without this, a feature-branch tag could trigger
-    # a release deploy. Also confirm the tag name is semver-shaped — the deploy
-    # step's `if:` does the same regex via `endsWith`/`startsWith`, but we
-    # additionally guard the ancestor check itself so non-semver tags don't
-    # error out the run on the merge-base call. The `actions/checkout` above
-    # is shallow (default `fetch-depth: 1`), and the previous `--depth=1`
-    # fetch of master left both the tag commit and master's tip with no
-    # parent chain in the local object database — so `merge-base
-    # --is-ancestor` couldn't link them even when the tag was on master.
-    # The release-plugin's tag commit lands at master~1 (immediately followed
-    # by the SNAPSHOT-bump), so `--depth=50` gives plenty of headroom while
-    # staying tight. This is the root cause of the 0.44.0/0.45.0 deploy-gate
-    # misses tracked at https://github.com/wala/ML/issues/454.
+    # Gate the deploy: only a semver-shaped tag that's an ancestor of master, so a feature-branch
+    # tag can't trigger a release deploy (wala/ML#421). The non-semver early-exit also keeps the
+    # `merge-base` call from erroring on legacy tags. `--depth=50` (not the checkout's shallow
+    # `fetch-depth: 1`) gives the tag commit and master's tip a shared parent chain so `--is-ancestor`
+    # can link them — the root cause of the 0.44.0/0.45.0 deploy-gate misses (wala/ML#454).
     - name: Verify tag is a semver release tag on master
       if: startsWith(github.ref, 'refs/tags/')
       run: |
@@ -131,22 +111,11 @@ jobs:
       env:
         GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Hybrid deploy gate (per wala/ML#421). Master pushes deploy SNAPSHOT
-      # versions (continuous SNAPSHOT publishing for downstream consumers
-      # like ponder-lab/Hybridize-Functions-Refactoring). Tag pushes deploy
-      # the immutable release. Tag pushes are critical for releases: the
-      # canonical `mvn release:prepare` flow lands two consecutive master
-      # commits ("Prepare for release X.Y.0." and "Set version for next
-      # development iteration to ...") in quick succession, and
-      # `concurrency: cancel-in-progress` cancels the first one — so the
-      # release version is only ever briefly on master and the
-      # SNAPSHOT-bump's run cancels the release run before its deploy step
-      # completes. Tag pushes are exempt from `cancel-in-progress` (per the
-      # workflow's `concurrency` block) and therefore reliably finish the
-      # deploy. The semver-tag regex (in `tag_check` above) keeps legacy /
-      # non-release tags (`todo_review`, `jython3`, etc.) from re-deploying;
-      # the ancestor-of-master check in the same step blocks feature-branch
-      # tags from sneaking through.
+      # Hybrid deploy gate (wala/ML#421): master pushes deploy SNAPSHOTs (for downstream consumers
+      # like ponder-lab/Hybridize-Functions-Refactoring); semver tag pushes deploy the immutable
+      # release. Tag pushes are exempt from `cancel-in-progress` (see the `concurrency` block) so the
+      # release deploy reliably finishes — release:prepare lands two master commits in quick
+      # succession, and the SNAPSHOT-bump run would otherwise cancel the release run mid-deploy.
       if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/tags/') && steps.tag_check.outputs.is_semver_release == 'true')) }}
     # On semver tag-push, upload the fat-classifier JAR as a CI artifact for the
     # downstream `release-upload` job to attach to the GitHub Release.
@@ -158,15 +127,9 @@ jobs:
         path: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
         if-no-files-found: error
         retention-days: 1
-  # Attach the fat-classifier JAR to the GitHub Release on semver tag-push. The
-  # Maven deploy step in `build` above publishes both jars (slim default + `-fat`
-  # classifier) to GitHub Packages, which requires a classic PAT with
-  # `read:packages` scope for downstream consumers. Attaching the fat JAR to the
-  # Release lets standalone-driver users (`java -jar`) fetch it directly with no
-  # auth.
-  #
-  # Run as a separate job (rather than a step in `build`) so the elevated
-  # `contents: write` permission is scoped to release tag-pushes only —
+  # Attach the fat-classifier JAR to the GitHub Release on semver tag-push, so standalone-driver
+  # users (`java -jar`) can fetch it without the `read:packages` PAT that GitHub Packages requires.
+  # A separate job scopes the elevated `contents: write` permission to release tag-pushes only;
   # PR/branch-push runs of `build` keep the workflow-level `contents: read`.
   release-upload:
     needs: build
@@ -179,14 +142,9 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         name: fat-jar
-    # `actions/download-artifact@v8` with only `name:` extracts to the workspace
-    # root (single-artifact archives flatten away their source path). The
-    # `build` job's `upload-artifact` step uploaded the JAR from
-    # `com.ibm.wala.cast.python.ml/target/`, but only the filename survives the
-    # round-trip — so the `files:` glob below must match the bare filename, not
-    # the original on-disk path. `fail_on_unmatched_files: true` makes a future
-    # glob drift fail loudly instead of silently producing an assetless
-    # release. See https://github.com/wala/ML/issues/561.
+    # `download-artifact@v8` with only `name:` flattens to the workspace root, so the `files:` glob
+    # below matches the bare filename (not the original `…/target/` path); `fail_on_unmatched_files:
+    # true` makes a future glob drift fail loudly rather than ship an assetless release (wala/ML#561).
     # `action-gh-release` creates the Release for the pushed tag if one doesn't
     # already exist, then attaches the fat JAR. A tag carrying a SemVer pre-release
     # suffix (e.g. `1.0.0-rc.1`, which `tag_check` permits) is published as a GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,12 @@
-# One-click release cutter (wala/ML#455).
+# One-click release cutter (wala/ML#455). Dispatched manually; runs `mvn release:prepare` on a
+# runner (no local toolchain/flags/pre-commit hook — the source of the 0.47.0 manual-deploy
+# incident). It pushes two version-bump commits and the release tag to `master`; the tag push then
+# drives `continuous-integration.yml`'s deploy gate and `release-upload` job.
 #
-# Dispatched manually from the Actions UI. Runs `mvn release:prepare` on a runner
-# — no local toolchain, no forgotten flags, no local pre-commit hook (the source
-# of the 0.47.0 manual-deploy incident). `release:prepare` pushes two version-bump
-# commits and the release tag to `master`; the tag push then drives
-# `continuous-integration.yml`'s deploy gate (publish to GitHub Packages) and its
-# `release-upload` job (create the release + attach the fat JAR). End to end,
-# dispatching this workflow is the whole release.
-#
-# SETUP (one-time): this workflow needs a `RELEASE_PAT` repository secret — a
-# *classic* PAT owned by an OrganizationAdmin (so its push bypasses the `master`
-# branch protection) with `repo` scope. The default `GITHUB_TOKEN` cannot be used:
-# `github-actions[bot]` is not a bypass actor on the branch ruleset, so its push to
-# `master` would be rejected. Fine-grained PATs also do not authenticate to
-# `maven.pkg.github.com`; a classic PAT is required.
+# SETUP (one-time): needs a `RELEASE_PAT` secret — a *classic* PAT from an OrganizationAdmin (so its
+# push bypasses `master` branch protection) with `repo` scope. The default `GITHUB_TOKEN` can't push
+# to `master` (not a bypass actor), and fine-grained PATs can't authenticate to
+# `maven.pkg.github.com`.
 name: Cut release
 on:
   workflow_dispatch:
@@ -31,11 +24,9 @@ on:
 permissions:
   contents: read
 
-# Serialize releases: a fixed group (not keyed by ref) means only one release runs at
-# a time. `cancel-in-progress: false` queues a second dispatch rather than cancelling an
-# in-progress one — cancelling mid-run could leave a partial state (commits pushed, tag
-# not). Without this, two close-together dispatches could both pass the tag-existence
-# check and then race on the version-bump pushes (non-fast-forward / tag collision).
+# Serialize releases: a fixed group (not keyed by ref) runs one release at a time, and
+# `cancel-in-progress: false` queues a second dispatch rather than cancelling a mid-run one (which
+# could leave a partial state — commits pushed, tag not).
 concurrency:
   group: cut-release
   cancel-in-progress: false
@@ -105,12 +96,9 @@ jobs:
         cache: 'pip'
     - name: Install Python dependencies
       run: pip install -r requirements.txt
-    # Mirror CI's formatting gates BEFORE release:prepare. Spotless is only declared
-    # in `pluginManagement` (not bound to the Maven lifecycle), so release:prepare's
-    # default `clean verify` does not run it — a formatting violation would otherwise
-    # be committed, tagged, and pushed, only to fail the tag-push deploy. Running the
-    # checks here aborts before any mutation. (The version-bumped POMs themselves stay
-    # Spotless-clean per wala/ML#566.)
+    # Run the formatting gates BEFORE release:prepare: Spotless is only in `pluginManagement` (not
+    # bound to the lifecycle), so release:prepare's `clean verify` skips it — a violation would
+    # otherwise be committed, tagged, and pushed only to fail the tag-push deploy (wala/ML#566).
     - name: Check formatting with Spotless
       run: mvn spotless:check -B
     - name: Check formatting with Black
@@ -140,13 +128,10 @@ jobs:
         git config url."https://github.com/".insteadOf "git@github.com:"
       shell: bash
     - name: Run release:prepare
-      # No -Dtag / -DignoreSnapshots / -DallowTimestampedSnapshots needed: the tag
-      # format is pinned to plain X.Y.Z (wala/ML#560) and the local deps are installed
-      # at release coordinates above. The default preparationGoals (`clean verify`)
-      # build and TEST the release version before tagging, so a failure aborts before
-      # anything is committed or pushed. On success, the two commits and the tag are
-      # pushed to master, firing the tag-push deploy + release-upload in
-      # continuous-integration.yml.
+      # No extra flags needed: the tag format is pinned to plain X.Y.Z (wala/ML#560) and the deps
+      # are installed at release coordinates above. `clean verify` builds and tests the release
+      # version before tagging, so a failure aborts before any commit or push; on success the two
+      # commits and the tag are pushed to master, firing the tag-push deploy + release-upload.
       run: |
         mvn release:clean -B
         mvn release:prepare -B \


### PR DESCRIPTION
The CI/release/CodeQL workflow comments had grown into multi-sentence incident narration ("notes to self"). This trims each block to one or two lines—keeping the non-obvious gotcha and the issue ref (which holds the full story)—and widens the narrow hand-wrapping.

Spotless doesn't reflow YAML comments (no formatter does—it's a Java-only capability of google-java-format), so this is necessarily manual; the trimmed comments are short enough not to need re-wrapping.

Comment-only across `continuous-integration.yml`, `release.yml`, and `codeql.yml`; no behavior change, and all three still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
