### PR TITLE
Add a regression guard for `typing.Tuple`-typed tensor-container parameters

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8646,6 +8646,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Verifies tensor types propagate through a {@code typing.Tuple}-annotated tuple-of-tensors
+   * parameter: a 2-tuple of tensors passed to {@code f} and unpacked ({@code x, y = inputs}) keeps
+   * each element's type, so {@code consume(x)} sees {@code (4, 8) float32}. This mirrors the
+   * perf-eval corpus's {@code deep_recommenders} {@code CIN.call(self, inputs: Tuple[tf.Tensor,
+   * tf.Tensor])} — an {@code @tf.function}-decorated function the Hybridize tool refactors — and is
+   * the tuple-parameter analogue of {@link #testNamedTupleFieldRead}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTupleParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_tuple_param.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
    * Verifies a module-level PEP-526 annotated assignment with a value (`t: tf.Tensor = tf.ones([2,
    * 3])`) declares its target and propagates the value (wala/ML#579). Outside a class body
    * `visitAnnAssign` must declare a simple-name target like `visitAssign` does; otherwise the

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tuple_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tuple_param.py
@@ -1,0 +1,31 @@
+"""Exercises tensor-type propagation through a ``typing.Tuple``-annotated tuple-of-tensors parameter.
+
+Mirrors the perf-eval corpus's ``deep_recommenders`` ``CIN.call(self, inputs: Tuple[tf.Tensor,
+tf.Tensor])`` (an ``@tf.function``-decorated function the Hybridize tool refactors): a 2-tuple of
+tensors is passed in and unpacked (``x, y = inputs``); each element should keep its original type.
+This is the tuple-parameter analogue of the ``NamedTuple`` field case in wala/ML#579
+(``tf2_test_namedtuple_field.py``).
+"""
+
+from typing import Tuple
+
+import numpy as np
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+def f(inputs: Tuple[tf.Tensor, tf.Tensor]):
+    x, y = inputs
+    assert x.shape == (4, 8) and x.dtype == tf.float32
+    assert y.shape == (2, 3) and y.dtype == tf.float32
+    consume(x)
+
+
+a = tf.constant(np.ones((4, 8), dtype=np.float32))
+assert a.shape == (4, 8) and a.dtype == tf.float32
+b = tf.constant(np.ones((2, 3), dtype=np.float32))
+assert b.shape == (2, 3) and b.dtype == tf.float32
+f((a, b))


### PR DESCRIPTION
Adds a positive regression guard for `typing.Tuple`-typed tensor-container parameters.

`testTupleParam` passes a 2-tuple of tensors to a function and unpacks it (`x, y = inputs`), asserting each element keeps its type (`(4, 8) float32`) at a `consume` sink. It mirrors the perf-eval corpus's `deep_recommenders` `CIN.call(self, inputs: Tuple[tf.Tensor, tf.Tensor])` — an `@tf.function`-decorated function the refactoring tool decorates — and is the tuple-parameter analogue of `testNamedTupleFieldRead`.

The analysis already types this case correctly (tuple unpacking propagates the per-element tensor types); this fixture pins that behavior so it can't silently regress. Surfaced while auditing the corpus for structured-container parameters that reach refactored functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
