### PR TITLE
Name and document the recommended k-CFA depth for the model-forward archetype

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3137,7 +3137,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNeuralNetwork()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        4,
+        PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH,
         "neural_network.py",
         "NeuralNet.call",
         1,
@@ -3168,7 +3168,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNeuralNetwork2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        4,
+        PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH,
         "neural_network.py",
         "cross_entropy_loss",
         2,
@@ -3203,7 +3203,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNeuralNetwork3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        4,
+        PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH,
         "neural_network.py",
         "run_optimization",
         2,
@@ -3249,7 +3249,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     // are the argmax call sites and their downstream uses across the call
     // graph. Parameter-type expectations (`y_pred`, `y_true`) unchanged.
     test(
-        4,
+        PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH,
         "neural_network.py",
         "accuracy",
         2,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -90,8 +90,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * per-call-site layer-output allocations distinct; at the back-compat {@link
    * #DEFAULT_TARGETED_CFA_DEPTH} they merge and the per-context shapes collapse to &#8868;
    * (unknown). Depth 4 separates the typical two-to-four-layer chain &mdash; validated by {@code
-   * testNeuralNetwork1-4}, which recover e.g. {@code accuracy}'s {@code y_pred} as the per-context
-   * union {@code {(256, 10) float32, ? float32}} (wala/ML#379, wala/ML#530).
+   * testNeuralNetwork} through {@code testNeuralNetwork4}, which recover e.g. {@code accuracy}'s
+   * {@code y_pred} as the per-context union {@code {(256, 10) float32, ? float32}} (wala/ML#379,
+   * wala/ML#530).
    *
    * <p>This is a recommended default for the archetype, not a universal constant: the depth a model
    * needs scales with its layer-chain length and call-site nesting. The targeted context selector

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -82,6 +82,30 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    */
   public static final int DEFAULT_TARGETED_CFA_DEPTH = 2;
 
+  /**
+   * The recommended targeted k-CFA depth for consumers analyzing the <em>model-forward
+   * archetype</em>: {@code tf.keras.Model} subclasses whose {@code call}/{@code predict} chain
+   * layer invocations ({@code x = self.layer1(x); x = self.layer2(x)}). Such a model invoked from
+   * multiple call sites (e.g. train vs. test) needs enough call-string context to keep its
+   * per-call-site layer-output allocations distinct; at the back-compat {@link
+   * #DEFAULT_TARGETED_CFA_DEPTH} they merge and the per-context shapes collapse to &#8868;
+   * (unknown). Depth 4 separates the typical two-to-four-layer chain &mdash; validated by {@code
+   * testNeuralNetwork1-4}, which recover e.g. {@code accuracy}'s {@code y_pred} as the per-context
+   * union {@code {(256, 10) float32, ? float32}} (wala/ML#379, wala/ML#530).
+   *
+   * <p>This is a recommended default for the archetype, not a universal constant: the depth a model
+   * needs scales with its layer-chain length and call-site nesting. The targeted context selector
+   * applies deep context only to framework-API methods and {@code tf.keras.Model} forward methods
+   * (all other code stays context-insensitive), so the cost stays bounded to that subgraph rather
+   * than whole-program k-CFA; within it, context count still grows with depth. Deepen past this
+   * only when per-context layer outputs still merge (the symptom: a shape that should be a
+   * per-context union stays &#8868; or single-valued), and measure on the deepest model before
+   * raising it.
+   *
+   * <p>Usage: {@code new PythonTensorAnalysisEngine(TENSORFLOW, MODEL_FORWARD_CFA_DEPTH)}.
+   */
+  public static final int MODEL_FORWARD_CFA_DEPTH = 4;
+
   private final String targetFramework;
 
   /**
@@ -122,8 +146,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * Constructs an engine with a configurable k-CFA depth for the targeted context selector.
    *
    * @param targetFramework The framework name prefix whose API methods receive deep context.
-   * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
-   *     must be non-negative. Higher values increase precision at the cost of analysis time.
+   * @param targetedCfaDepth The k-CFA depth for the targeted context selector; must be
+   *     non-negative. Use {@link #DEFAULT_TARGETED_CFA_DEPTH} for framework-API precision, or
+   *     {@link #MODEL_FORWARD_CFA_DEPTH} when analyzing chained-layer {@code tf.keras.Model}
+   *     forward passes. Higher values increase precision at the cost of analysis time.
    * @throws IllegalArgumentException if {@code targetedCfaDepth} is negative.
    */
   public PythonTensorAnalysisEngine(String targetFramework, int targetedCfaDepth) {
@@ -140,8 +166,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    *
    * @param pythonPath The additional Python path entries for module resolution.
    * @param targetFramework The framework name prefix whose API methods receive deep context.
-   * @param targetedCfaDepth The k-CFA depth to apply (e.g. {@link #DEFAULT_TARGETED_CFA_DEPTH});
-   *     must be non-negative. Higher values increase precision at the cost of analysis time.
+   * @param targetedCfaDepth The k-CFA depth for the targeted context selector; must be
+   *     non-negative. Use {@link #DEFAULT_TARGETED_CFA_DEPTH} for framework-API precision, or
+   *     {@link #MODEL_FORWARD_CFA_DEPTH} when analyzing chained-layer {@code tf.keras.Model}
+   *     forward passes. Higher values increase precision at the cost of analysis time.
    * @throws IllegalArgumentException if {@code targetedCfaDepth} is negative.
    */
   public PythonTensorAnalysisEngine(


### PR DESCRIPTION
Names and documents the recommended targeted k-CFA depth for the model-forward archetype, answering wala/ML#587 and unblocking the consumer adoption in ponder-lab/Hybridize-Functions-Refactoring#600.

## What

- Adds `MODEL_FORWARD_CFA_DEPTH = 4`—the recommended depth for consumers analyzing chained-layer `tf.keras.Model` forward passes (`x = self.layer1(x); x = self.layer2(x)`). At the back-compat `DEFAULT_TARGETED_CFA_DEPTH` (2), a model invoked from multiple call sites merges its per-call-site layer-output allocations and the per-context shapes collapse to ⊤; depth 4 separates the typical two-to-four-layer chain (validated by `testNeuralNetwork` through `testNeuralNetwork4`).
- The constant's Javadoc documents the **cost/scoping model** (deep context is confined to framework + model methods, not whole-program k-CFA), the **deepen-when symptom**, and the **recommended constructor call**; the two depth-aware constructors now point at it.
- `testNeuralNetwork` through `testNeuralNetwork4` reference the constant instead of a literal `4`, making it the single source of truth.

## Why a Named Constant

Consumers currently have only the test harness's magic `4` to copy, with no guidance. wala/ML#587 asked the three usage questions (is 4 intended, does scoping bound cost, what's the recommended call); this gives those answers one documented home so ponder-lab/Hybridize-Functions-Refactoring#600 references a named value rather than hardcoding `4`.

No behavior change: the constant equals the literal it replaces; `testNeuralNetwork` through `testNeuralNetwork4` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

