### PR TITLE
Add a documented-gap guard for `tf.reshape` field-arithmetic dims

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8673,13 +8673,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Documents the current imprecision for <a
    * href="https://github.com/wala/ML/issues/581">wala/ML#581</a>: a {@code tf.reshape} whose dim is
-   * arithmetic over instance attributes ({@code self.heads * self.out_features}) infers {@code (?,
-   * Dynamic)} rather than the precise {@code (4, 512)}. Neither shape-argument extraction path
-   * folds it: the interpreter-based {@code TensorType.shapeArg} cannot evaluate {@code self.X} as
-   * source text, and the generator-side {@code getShapesFromShapeArgument} emits a {@code
-   * DynamicDim} for the unresolved binary op. Resolving it needs the generator-side path to fold a
-   * binary op over constant-valued field reads via the analysis (not the interpreter). This guard
-   * pins the current result so it flips when #581 lands.
+   * arithmetic over instance attributes ({@code self.heads * self.out_features}) infers the
+   * per-context union {@code {(?, ?), (?, Dynamic)}} rather than the precise {@code (4, 512)}.
+   * Neither shape-argument extraction path folds it: the interpreter-based {@code
+   * TensorType.shapeArg} cannot evaluate {@code self.X} as source text, and the generator-side
+   * {@code getShapesFromShapeArgument} emits a {@code DynamicDim} for the unresolved binary op.
+   * Resolving it needs the generator-side path to fold a binary op over constant-valued field reads
+   * via the analysis (not the interpreter). This guard pins the current result so it flips when
+   * #581 lands.
    *
    * <p>TODO: tighten to {@code (4, 512)} once <a
    * href="https://github.com/wala/ML/issues/581">wala/ML#581</a> reconciles the two shape-argument

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -238,6 +238,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_4_8_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(8)));
 
+  private static final TensorType TENSOR_UNKNOWN_DYNAMIC_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE));
+
+  private static final TensorType TENSOR_UNKNOWN_UNKNOWN_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new SymbolicDim("?"), new SymbolicDim("?")));
+
   private static final TensorType TENSOR_4_10_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(10)));
 
@@ -8662,6 +8668,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testTupleParam()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_tuple_param.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Documents the current imprecision for <a
+   * href="https://github.com/wala/ML/issues/581">wala/ML#581</a>: a {@code tf.reshape} whose dim is
+   * arithmetic over instance attributes ({@code self.heads * self.out_features}) infers {@code (?,
+   * Dynamic)} rather than the precise {@code (4, 512)}. Neither shape-argument extraction path
+   * folds it: the interpreter-based {@code TensorType.shapeArg} cannot evaluate {@code self.X} as
+   * source text, and the generator-side {@code getShapesFromShapeArgument} emits a {@code
+   * DynamicDim} for the unresolved binary op. Resolving it needs the generator-side path to fold a
+   * binary op over constant-valued field reads via the analysis (not the interpreter). This guard
+   * pins the current result so it flips when #581 lands.
+   *
+   * <p>TODO: tighten to {@code (4, 512)} once <a
+   * href="https://github.com/wala/ML/issues/581">wala/ML#581</a> reconciles the two shape-argument
+   * extraction paths.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testReshapeSelfArith()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_self_arith.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_UNKNOWN_FLOAT32, TENSOR_UNKNOWN_DYNAMIC_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -429,6 +429,10 @@ public abstract class TensorGenerator {
         // non-deterministic single shape per `i` rather than the full product.
         List<Set<Dimension<?>>> resolved = new ArrayList<>(possibleDimensions.length);
         for (Set<Dimension<?>> s : possibleDimensions) {
+          // TODO(https://github.com/wala/ML/issues/581): an empty position holding a binary op over
+          // constant-valued operands (e.g. `self.heads * self.out_features`) could be folded to a
+          // `NumericDim` via the analysis instead of degrading to `DynamicDim`. This is the
+          // generator-side half of the shape-argument-extraction reconciliation.
           if (s == null || s.isEmpty()) resolved.add(Collections.singleton(DynamicDim.INSTANCE));
           else resolved.add(s);
         }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -657,6 +657,10 @@ public class TensorType implements Iterable<Dimension<?>> {
             }
           }
         }
+        // TODO(https://github.com/wala/ML/issues/581): when the dim is a binary op over
+        // constant-valued operands (field reads such as `self.heads * self.out_features`, globals),
+        // fold it via the analysis instead of degrading to a symbolic dim. `interpretAsInt` above
+        // only handles pure-literal source text, so the generator-side path should own this.
         dims.put(index, new SymbolicDim("?"));
       }
     }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_self_arith.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_self_arith.py
@@ -1,0 +1,31 @@
+"""Scoping fixture for wala/ML#581: does shape inference resolve a `tf.reshape` whose dim is
+arithmetic over instance attributes (`self.heads * self.out_features`)?
+
+Mirrors the perf-eval corpus's pervasive pattern (NLPGNN attention, MusicTransformer/gpt-2
+attention, deep_recommenders CIN). The embedded interpreter cannot fold `self.X` (it evaluates
+source text and has no `self`), so resolving this dim needs the generator-side extraction that
+#581 reconciles.
+"""
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+class Attn:
+    def __init__(self):
+        self.heads = 8
+        self.out_features = 64
+
+    def reshape_it(self, x):
+        y = tf.reshape(x, [-1, self.heads * self.out_features])
+        assert y.shape == (4, 512) and y.dtype == tf.float32
+        consume(y)
+
+
+a = Attn()
+x = tf.ones([4, 16, 32])
+assert x.shape == (4, 16, 32)
+a.reshape_it(x)


### PR DESCRIPTION
Adds a documented-gap regression guard for wala/ML#581: shape inference does not fold a `tf.reshape` dim that is arithmetic over instance attributes.

## The Gap

`tf.reshape(x, [-1, self.heads * self.out_features])` (a common idiom in TF model code: attention reshapes, recommender CIN layers) infers the per-context union `{(?, ?), (?, Dynamic)}` instead of the precise `(4, 512)`. Neither shape-argument extraction path folds it:

1. **`TensorType.shapeArg`** (interpreter-based) reads the dim's source text and calls `interpretAsInt`; `interpretAsInt("self.heads * self.out_features")` fails because a source-text eval has no `self`, so it falls to `SymbolicDim("?")`.
1. **`getShapesFromShapeArgument`** (the generator-side path `Reshape` uses) emits a `DynamicDim` for the unresolved binary op.

The interpreter restoration (wala/ML#580, just landed) does not help here—resolving `self.X` needs the analysis (field values from `__init__`), not source-text evaluation.

## What This PR Does

- `tf2_test_reshape_self_arith.py` + `testReshapeSelfArith` pin the current imprecise union so it flips when wala/ML#581 reconciles the two paths. The Python fixture asserts the runtime truth (`(4, 512)`); the JUnit guard asserts the current analysis result, with a `TODO` to tighten when #581 lands.
- `TODO(wala/ML#581)` markers at both fold-sites (`TensorGenerator.getShapesFromShapeArgument` and `TensorType.shapeArg`) so the implementer finds them.

Comment-only production changes; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

