### PR TITLE
Gate merges on Copilot review completion

### DIFF
--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -1,0 +1,69 @@
+name: Await Copilot review
+
+# Blocks a PR from merging until GitHub Copilot's automatic code review has completed for the
+# current head commit.
+#
+# Copilot reviews are advisory by design: Copilot always submits a "Comment" review, which never
+# satisfies required-approval or required-reviewer rules and never blocks merging. So without this
+# gate a PR can merge — via auto-merge or the merge queue — the instant the other required checks
+# go green, *before* Copilot's asynchronous review posts; the review comments then land on an
+# already-merged PR. GitHub acknowledges this gap and offers no native "require Copilot review"
+# setting (community discussion github.com/orgs/community/discussions/185265).
+#
+# This job is RED until a Copilot review exists for the head SHA, and flips GREEN the moment
+# Copilot submits its review (the `pull_request_review` trigger re-runs the gate on the same SHA).
+# Because `review_on_push` re-reviews every push, each new push re-arms the gate. `merge_group`
+# short-circuits to green so the required check still reports on the queue's temporary branch and
+# does not deadlock the merge queue (cf. the CodeQL-on-merge_group reporting requirement).
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: await-copilot-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  await-copilot-review:
+    name: await-copilot-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Pass through the merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "merge_group event: the Copilot gate is enforced at the PR level; passing."
+
+      - name: Require a Copilot review of the head commit
+        if: github.event_name != 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "Draft PR: Copilot does not review drafts; passing."
+            exit 0
+          fi
+          echo "Looking for a Copilot review of $HEAD_SHA on PR #$PR ..."
+          reviews=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100")
+          count=$(printf '%s' "$reviews" | jq "[.[]
+            | select((.user.login | ascii_downcase | contains(\"copilot\")) and .commit_id == \"$HEAD_SHA\")]
+            | length")
+          if [ "${count:-0}" -gt 0 ]; then
+            echo "Found $count Copilot review(s) for the head commit. Gate satisfied."
+            exit 0
+          fi
+          echo "::error::No Copilot review found for head commit $HEAD_SHA yet. The PR cannot merge until Copilot finishes reviewing; this check re-runs and turns green when Copilot submits its review."
+          exit 1

--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -37,6 +37,13 @@ jobs:
     name: await-copilot-review
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # The gate is only required on PRs targeting master (the ruleset's target). `pull_request` is
+    # already scoped to `master`, but `pull_request_review` fires for any base branch, so guard it
+    # to avoid noisy red checks on non-master PRs. `merge_group` always passes through.
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'pull_request'
+      || (github.event_name == 'pull_request_review' && github.event.pull_request.base.ref == 'master')
     steps:
       - name: Pass through the merge queue
         if: github.event_name == 'merge_group'
@@ -57,10 +64,11 @@ jobs:
             exit 0
           fi
           echo "Looking for a Copilot review of $HEAD_SHA on PR #$PR ..."
-          reviews=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100")
-          count=$(printf '%s' "$reviews" | jq "[.[]
-            | select((.user.login | ascii_downcase | contains(\"copilot\")) and .commit_id == \"$HEAD_SHA\")]
-            | length")
+          # `--paginate` streams every page; the `--jq` filter runs per page and emits one line per
+          # matching review, so `wc -l` aggregates the count across all pages (no 100-review cap).
+          count=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+            --jq '.[] | select((.user.login | ascii_downcase | contains("copilot")) and .commit_id == $ENV.HEAD_SHA) | .id' \
+            | wc -l | tr -d '[:space:]')
           if [ "${count:-0}" -gt 0 ]; then
             echo "Found $count Copilot review(s) for the head commit. Gate satisfied."
             exit 0


### PR DESCRIPTION
## Problem

Copilot's automatic code review is **advisory by design**: it always submits a *Comment* review, which never satisfies required-approval or required-reviewer rules and never blocks merging. With `review_on_push` enabled in our `Default branch` ruleset, Copilot is requested on every push—but nothing makes merge *wait* for it. So a PR merges (via auto-merge or the merge queue) the instant `build`/`Analyze` go green, **before** Copilot's asynchronous review posts, and the comments land on an already-merged PR.

This is a known, acknowledged GitHub gap, not a bug we can fix on their side:

- [community/discussions/185265](https://github.com/orgs/community/discussions/185265)—*exactly* this scenario; GitHub's response: "Copilot reviews aren't treated as a required review in GitHub's merge rules," with no native option and only manual workarounds.
- [community/discussions/184163](https://github.com/orgs/community/discussions/184163)—enforcement gap.
- The consensus fix everywhere is a custom required check; no reusable Action exists.

## Fix

An `await-copilot-review` job that:
- is **red** until a Copilot review exists for the current head SHA (queried from the reviews API),
- flips **green** the moment Copilot submits its review (the `pull_request_review` trigger re-runs it on the same SHA),
- re-arms on every push (since `review_on_push` re-reviews each push),
- passes drafts through (Copilot doesn't review drafts),
- short-circuits green on `merge_group` so the required check reports on the queue's temp branch and doesn't deadlock the queue (same reason CodeQL handles `merge_group`).

## Follow-Up (After Merge)

Add `await-copilot-review` to the `Default branch` ruleset's `required_status_checks`. This must happen **after** the workflow is on master—adding a required check that doesn't yet exist would deadlock every PR. I'll do that via `gh api` once this merges (or you can).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017edqsk5QRAvD2QebWZiysP


