### PR TITLE
Harden the Copilot merge gate: block while reviewing, don't deadlock when unrequested

### DIFF
--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -66,7 +66,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
@@ -77,44 +76,36 @@ jobs:
 
           # Whether Copilot is currently a requested reviewer: a review is in progress or about to
           # start. This re-populates on every push and on every (re-)request and clears once Copilot
-          # submits, so it stays true while Copilot reviews the head — the first review AND every
-          # subsequent one. We never go green while it is true.
+          # submits, so it stays true for the whole of a review — the first AND every subsequent one.
+          # The gate is the timing guard the requirement asks for: never merge *while* Copilot is
+          # reviewing. We deliberately do NOT require a review of the exact head SHA — that would
+          # deadlock when the head changes (e.g. a sync merge) and Copilot declines to re-review.
           copilot_pending () {
             gh api "repos/$REPO/pulls/$PR" \
               --jq '[.requested_reviewers[]? | select(.login | ascii_downcase | contains("copilot"))] | length'
           }
-          # Whether Copilot has submitted a review for the *current* head commit.
-          reviewed_head () {
+          # Whether Copilot has ever submitted a review on this PR (any commit).
+          copilot_reviewed () {
             gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
-              --jq '.[] | select((.user.login | ascii_downcase | contains("copilot")) and .commit_id == $ENV.HEAD_SHA) | .id' \
-              | grep -c . || true
-          }
-          # Whether Copilot was ever requested on this PR (the persistent timeline event): tells
-          # "engaged but not delivered yet" apart from "Copilot never reviews here".
-          ever_requested () {
-            gh api --paginate "repos/$REPO/issues/$PR/timeline" \
-              --jq '.[] | select(.event == "review_requested" and (((.requested_reviewer.login // "") | ascii_downcase) | contains("copilot"))) | .event' \
+              --jq '.[] | select(.user.login | ascii_downcase | contains("copilot")) | .id' \
               | grep -c . || true
           }
 
-          # Green only when Copilot's review of the current head is complete AND Copilot is not
-          # currently reviewing. If Copilot was never requested (disabled/outage), the antecedent is
-          # false and we must not block — pass after a brief poll for the request to propagate.
+          # RED while Copilot is reviewing (pending); GREEN once it is idle. If Copilot has reviewed
+          # and is not currently reviewing, the merge is allowed. On a fresh PR the request can take a
+          # moment to appear, so poll briefly before concluding Copilot is not engaged (which must
+          # also pass, so a disabled/outage Copilot never deadlocks every PR).
           for attempt in $(seq 1 6); do
             if [ "$(copilot_pending)" -gt 0 ]; then
               echo "::error::Copilot is currently reviewing PR #$PR (it is a requested reviewer). The PR cannot merge until that review completes; this check re-runs and turns green when Copilot submits."
               exit 1
             fi
-            if [ "$(reviewed_head)" -gt 0 ]; then
-              echo "Copilot has reviewed head commit $HEAD_SHA and is not currently reviewing. Gate satisfied."
+            if [ "$(copilot_reviewed)" -gt 0 ]; then
+              echo "Copilot has reviewed PR #$PR and is not currently reviewing. Gate satisfied."
               exit 0
             fi
-            if [ "$(ever_requested)" -gt 0 ]; then
-              echo "::error::Copilot was requested but has not yet reviewed head commit $HEAD_SHA. The PR cannot merge until Copilot finishes; this check re-runs when it submits."
-              exit 1
-            fi
-            echo "Attempt $attempt/6: Copilot is not requested, has not reviewed, and was never requested here; waiting for the request to propagate ..."
+            echo "Attempt $attempt/6: Copilot is neither reviewing nor has reviewed yet; waiting for a review request to appear ..."
             sleep 10
           done
-          echo "Copilot was never requested on this PR (antecedent false); the gate does not apply. Passing."
+          echo "Copilot is not reviewing and never reviewed this PR (not engaged); the gate does not apply. Passing."
           exit 0

--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -19,7 +19,17 @@ name: Await Copilot review
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `review_requested`/`review_request_removed` re-fire the gate when Copilot is (re-)requested or
+    # finishes, so a subsequent review flips it red again and back to green.
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        ready_for_review,
+        review_requested,
+        review_request_removed,
+      ]
   pull_request_review:
     types: [submitted, dismissed]
   merge_group:
@@ -64,15 +74,47 @@ jobs:
             echo "Draft PR: Copilot does not review drafts; passing."
             exit 0
           fi
-          echo "Looking for a Copilot review of $HEAD_SHA on PR #$PR ..."
-          # `--paginate` streams every page; the `--jq` filter runs per page and emits one line per
-          # matching review, so `wc -l` aggregates the count across all pages (no 100-review cap).
-          count=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
-            --jq '.[] | select((.user.login | ascii_downcase | contains("copilot")) and .commit_id == $ENV.HEAD_SHA) | .id' \
-            | wc -l | tr -d '[:space:]')
-          if [ "${count:-0}" -gt 0 ]; then
-            echo "Found $count Copilot review(s) for the head commit. Gate satisfied."
-            exit 0
-          fi
-          echo "::error::No Copilot review found for head commit $HEAD_SHA yet. The PR cannot merge until Copilot finishes reviewing; this check re-runs and turns green when Copilot submits its review."
-          exit 1
+
+          # Whether Copilot is currently a requested reviewer: a review is in progress or about to
+          # start. This re-populates on every push and on every (re-)request and clears once Copilot
+          # submits, so it stays true while Copilot reviews the head — the first review AND every
+          # subsequent one. We never go green while it is true.
+          copilot_pending () {
+            gh api "repos/$REPO/pulls/$PR" \
+              --jq '[.requested_reviewers[]? | select(.login | ascii_downcase | contains("copilot"))] | length'
+          }
+          # Whether Copilot has submitted a review for the *current* head commit.
+          reviewed_head () {
+            gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+              --jq '.[] | select((.user.login | ascii_downcase | contains("copilot")) and .commit_id == $ENV.HEAD_SHA) | .id' \
+              | grep -c . || true
+          }
+          # Whether Copilot was ever requested on this PR (the persistent timeline event): tells
+          # "engaged but not delivered yet" apart from "Copilot never reviews here".
+          ever_requested () {
+            gh api --paginate "repos/$REPO/issues/$PR/timeline" \
+              --jq '.[] | select(.event == "review_requested" and (((.requested_reviewer.login // "") | ascii_downcase) | contains("copilot"))) | .event' \
+              | grep -c . || true
+          }
+
+          # Green only when Copilot's review of the current head is complete AND Copilot is not
+          # currently reviewing. If Copilot was never requested (disabled/outage), the antecedent is
+          # false and we must not block — pass after a brief poll for the request to propagate.
+          for attempt in $(seq 1 6); do
+            if [ "$(copilot_pending)" -gt 0 ]; then
+              echo "::error::Copilot is currently reviewing PR #$PR (it is a requested reviewer). The PR cannot merge until that review completes; this check re-runs and turns green when Copilot submits."
+              exit 1
+            fi
+            if [ "$(reviewed_head)" -gt 0 ]; then
+              echo "Copilot has reviewed head commit $HEAD_SHA and is not currently reviewing. Gate satisfied."
+              exit 0
+            fi
+            if [ "$(ever_requested)" -gt 0 ]; then
+              echo "::error::Copilot was requested but has not yet reviewed head commit $HEAD_SHA. The PR cannot merge until Copilot finishes; this check re-runs when it submits."
+              exit 1
+            fi
+            echo "Attempt $attempt/6: Copilot is not requested, has not reviewed, and was never requested here; waiting for the request to propagate ..."
+            sleep 10
+          done
+          echo "Copilot was never requested on this PR (antecedent false); the gate does not apply. Passing."
+          exit 0

--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -1,20 +1,20 @@
 name: Await Copilot review
 
-# Blocks a PR from merging until GitHub Copilot's automatic code review has completed for the
-# current head commit.
+# Blocks a PR from merging while GitHub Copilot is reviewing it.
 #
-# Copilot reviews are advisory by design: Copilot always submits a "Comment" review, which never
-# satisfies required-approval or required-reviewer rules and never blocks merging. So without this
-# gate a PR can merge — via auto-merge or the merge queue — the instant the other required checks
-# go green, *before* Copilot's asynchronous review posts; the review comments then land on an
-# already-merged PR. GitHub acknowledges this gap and offers no native "require Copilot review"
-# setting (community discussion github.com/orgs/community/discussions/185265).
+# Copilot reviews are advisory: Copilot submits a "Comment" review, which never satisfies
+# required-approval/required-reviewer rules and never blocks merging. Without this gate a PR can
+# merge — via auto-merge or the merge queue — the instant the other required checks go green,
+# *before* Copilot's asynchronous review posts; the comments then land on an already-merged PR.
+# GitHub offers no native "require Copilot review" setting (community discussion
+# github.com/orgs/community/discussions/185265).
 #
-# This job is RED until a Copilot review exists for the head SHA, and flips GREEN the moment
-# Copilot submits its review (the `pull_request_review` trigger re-runs the gate on the same SHA).
-# Because `review_on_push` re-reviews every push, each new push re-arms the gate. `merge_group`
-# short-circuits to green so the required check still reports on the queue's temporary branch and
-# does not deadlock the merge queue (cf. the CodeQL-on-merge_group reporting requirement).
+# This job is RED while Copilot is a requested reviewer (a review is in progress — the first one or
+# any subsequent one) and GREEN once Copilot is idle (it has reviewed, or was never engaged). It
+# deliberately does NOT require a review of the exact head SHA, which would deadlock when the head
+# changes (e.g. a sync merge) and Copilot declines to re-review. `merge_group` short-circuits to
+# green so the required check still reports on the queue's temporary branch and does not deadlock the
+# merge queue (cf. the CodeQL-on-merge_group reporting requirement).
 
 on:
   pull_request:
@@ -22,14 +22,12 @@ on:
     # `review_requested`/`review_request_removed` re-fire the gate when Copilot is (re-)requested or
     # finishes, so a subsequent review flips it red again and back to green.
     types:
-      [
-        opened,
-        synchronize,
-        reopened,
-        ready_for_review,
-        review_requested,
-        review_request_removed,
-      ]
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - review_requested
+      - review_request_removed
   pull_request_review:
     types: [submitted, dismissed]
   merge_group:
@@ -60,7 +58,7 @@ jobs:
         run: |
           echo "merge_group event; the Copilot gate is enforced at the PR level. Passing."
 
-      - name: Require a Copilot review of the head commit
+      - name: Block while Copilot is reviewing
         if: github.event_name != 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,37 +72,38 @@ jobs:
             exit 0
           fi
 
-          # Whether Copilot is currently a requested reviewer: a review is in progress or about to
-          # start. This re-populates on every push and on every (re-)request and clears once Copilot
-          # submits, so it stays true for the whole of a review — the first AND every subsequent one.
-          # The gate is the timing guard the requirement asks for: never merge *while* Copilot is
-          # reviewing. We deliberately do NOT require a review of the exact head SHA — that would
-          # deadlock when the head changes (e.g. a sync merge) and Copilot declines to re-review.
+          # Count Copilot reviewers currently *requested* on the PR (a review is in progress or about
+          # to start). This re-populates on every push and every (re-)request and clears once Copilot
+          # submits, so it is true for the whole of a review — the first one and every subsequent one.
+          # API errors fail the gate (red); never silently treat them as "not pending".
           copilot_pending () {
             gh api "repos/$REPO/pulls/$PR" \
-              --jq '[.requested_reviewers[]? | select(.login | ascii_downcase | contains("copilot"))] | length'
+              --jq '[.requested_reviewers[]? | select(.login | ascii_downcase | contains("copilot"))] | length' \
+              || { echo "::error::Could not query requested reviewers for PR #$PR." >&2; exit 1; }
           }
-          # Whether Copilot has ever submitted a review on this PR (any commit).
+          # Count non-dismissed Copilot reviews on the PR (any commit). A dismissed review does not
+          # count. `--paginate` + `jq -s add` aggregates across pages; API errors fail the gate.
           copilot_reviewed () {
             gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
-              --jq '.[] | select(.user.login | ascii_downcase | contains("copilot")) | .id' \
-              | grep -c . || true
+              --jq '.' \
+              | jq -s 'add | [.[] | select((.user.login | ascii_downcase | contains("copilot")) and .state != "DISMISSED")] | length' \
+              || { echo "::error::Could not query reviews for PR #$PR." >&2; exit 1; }
           }
 
-          # RED while Copilot is reviewing (pending); GREEN once it is idle. If Copilot has reviewed
-          # and is not currently reviewing, the merge is allowed. On a fresh PR the request can take a
-          # moment to appear, so poll briefly before concluding Copilot is not engaged (which must
-          # also pass, so a disabled/outage Copilot never deadlocks every PR).
+          # RED while Copilot is reviewing (pending); GREEN once it is idle (has reviewed, or is not
+          # engaged). On a fresh PR the request can take a moment to appear, so poll briefly before
+          # concluding Copilot is not engaged — which must also pass, so a disabled/outage Copilot
+          # never deadlocks every PR.
           for attempt in $(seq 1 6); do
             if [ "$(copilot_pending)" -gt 0 ]; then
-              echo "::error::Copilot is currently reviewing PR #$PR (it is a requested reviewer). The PR cannot merge until that review completes; this check re-runs and turns green when Copilot submits."
+              echo "::error::Copilot is currently reviewing PR #$PR (it is a requested reviewer). The PR cannot merge until that review completes; this check re-runs and turns green when Copilot finishes."
               exit 1
             fi
             if [ "$(copilot_reviewed)" -gt 0 ]; then
               echo "Copilot has reviewed PR #$PR and is not currently reviewing. Gate satisfied."
               exit 0
             fi
-            echo "Attempt $attempt/6: Copilot is neither reviewing nor has reviewed yet; waiting for a review request to appear ..."
+            echo "Attempt $attempt/6: Copilot is neither reviewing nor has it reviewed yet; waiting for a review request to appear ..."
             sleep 10
           done
           echo "Copilot is not reviewing and never reviewed this PR (not engaged); the gate does not apply. Passing."


### PR DESCRIPTION
Follow-up to #399/#402. Two robustness fixes to the `await-copilot-review` gate:

1. **Block while a review is in progress (first or subsequent).** Copilot can review more than once. The gate keyed only on "a review exists for the head," so a subsequent review would run while the check was already green, allowing a merge mid-review. It now gates on `requested_reviewers`: while Copilot is a requested reviewer the review is pending (any pass), so the gate stays red until it clears.
2. **Don't deadlock when Copilot was never requested.** If Copilot is disabled/having an outage/skips a PR, the antecedent is false and the gate must not block forever, so it passes when Copilot is neither a requested reviewer nor has reviewed the PR (after a short poll for request propagation).

The `review_requested/review_request_removed` triggers re-fire the gate on (re-)request and completion. `merge_group` still passes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

