### PR TITLE
Fix the unparseable `run:` line in the Copilot gate workflow

### DIFF
--- a/.github/workflows/await-copilot-review.yml
+++ b/.github/workflows/await-copilot-review.yml
@@ -47,7 +47,8 @@ jobs:
     steps:
       - name: Pass through the merge queue
         if: github.event_name == 'merge_group'
-        run: echo "merge_group event: the Copilot gate is enforced at the PR level; passing."
+        run: |
+          echo "merge_group event; the Copilot gate is enforced at the PR level. Passing."
 
       - name: Require a Copilot review of the head commit
         if: github.event_name != 'merge_group'


### PR DESCRIPTION
**Incident hotfix.** The `await-copilot-review` gate workflow (shipped in #399) has an unquoted `: ` in the merge-queue step's `run:` line, so the YAML fails to parse. Since the gate is a *required* check, the unparseable workflow blocks **every** PR (e.g. #400 shows `BLOCKED`). This fixes the line (block scalar, colon removed).

Admin-merging because the broken required check blocks its own fix (chicken-and-egg).