### PR TITLE
Add a `TensorType.of` factory for dense/sparse construction

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -28,13 +28,13 @@ import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
-import com.ibm.wala.cast.python.ml.types.SparseTensorType;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.Layout;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -226,21 +226,16 @@ public abstract class TensorGenerator {
 
     Set<TensorType> ret = HashSetFactory.make();
 
-    final boolean sparse = this.producesSparseTensor();
+    final Layout layout = this.producesSparseTensor() ? Layout.SPARSE : Layout.DENSE;
 
     if (shapes == null) {
       // Shape is unknown (⊤), but dtype info may still be available. Emit TensorTypes with null
       // dims so the dtype information is preserved.
-      for (DType dtype : dTypes)
-        ret.add(sparse ? new SparseTensorType(dtype, null) : new TensorType(dtype, null));
+      for (DType dtype : dTypes) ret.add(TensorType.of(dtype, null, layout));
     } else {
       // Create a tensor type for each possible shape and dtype combination.
       for (List<Dimension<?>> dimensionList : shapes)
-        for (DType dtype : dTypes)
-          ret.add(
-              sparse
-                  ? new SparseTensorType(dtype, dimensionList)
-                  : new TensorType(dtype, dimensionList));
+        for (DType dtype : dTypes) ret.add(TensorType.of(dtype, dimensionList, layout));
     }
 
     LOGGER.fine("Generator " + this.getClass().getSimpleName() + " produced types: " + ret);
@@ -251,7 +246,7 @@ public abstract class TensorGenerator {
   /**
    * Whether this generator produces a sparse tensor (a {@code tf.sparse.SparseTensor} / {@code
    * tf.SparseTensor}), as opposed to a dense one. Sparse generators override this to {@code true};
-   * {@link #getTensorTypes} then emits a {@link SparseTensorType} for every result so a consumer
+   * {@link #getTensorTypes} then emits a sparse {@link TensorType} for every result so a consumer
    * can distinguish a sparse result from a dense one (<a
    * href="https://github.com/wala/ML/issues/588">wala/ML#588</a>).
    *

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -481,6 +481,23 @@ public class TensorType implements Iterable<Dimension<?>> {
   }
 
   /**
+   * Creates a {@link TensorType} of the given storage layout: a dense {@link TensorType} for {@link
+   * Layout#DENSE} and a {@link SparseTensorType} for {@link Layout#SPARSE}. Centralizes the
+   * layout-to-concrete-class mapping so call sites need not branch on the concrete type.
+   *
+   * @param dtype The tensor element type. Must not be null.
+   * @param dims The dimensions; may be null to indicate unknown rank (⊤ shape).
+   * @param layout The storage layout. Must not be null.
+   * @return A dense {@link TensorType} or a {@link SparseTensorType}, per {@code layout}.
+   */
+  public static TensorType of(DType dtype, List<Dimension<?>> dims, Layout layout) {
+    return switch (layout) {
+      case DENSE -> new TensorType(dtype, dims);
+      case SPARSE -> new SparseTensorType(dtype, dims);
+    };
+  }
+
+  /**
    * The storage layout of this tensor: the polymorphic source of truth for sparseness. Overridden
    * by {@link SparseTensorType}; the base {@code TensorType} is always {@link Layout#DENSE}.
    *
@@ -508,7 +525,7 @@ public class TensorType implements Iterable<Dimension<?>> {
    *     sparse.
    */
   public TensorType asSparse() {
-    return this.isSparse() ? this : new SparseTensorType(this.dtype, this.dims);
+    return this.isSparse() ? this : of(this.dtype, this.dims, Layout.SPARSE);
   }
 
   String toFormattedString(Format fmt) {


### PR DESCRIPTION
Follow-up to #398. The dense-vs-sparse construction choice (`new TensorType` vs `new SparseTensorType`) was duplicated inline in `TensorGenerator.getTensorTypes` and `TensorType.asSparse`.

This centralizes it in a static `TensorType.of(dtype, dims, layout)` factory and routes both call sites through it. Kept on `TensorType` rather than a separate factory class: the base already references its `SparseTensorType` subtype via `asSparse`, so the coupling is contained, not new.

Full suite green (845).

🤖 Generated with [Claude Code](https://claude.com/claude-code)