### PR TITLE
Fail fast on a null `layout` in `TensorType.of`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -491,7 +491,7 @@ public class TensorType implements Iterable<Dimension<?>> {
    * @return A dense {@link TensorType} or a {@link SparseTensorType}, per {@code layout}.
    */
   public static TensorType of(DType dtype, List<Dimension<?>> dims, Layout layout) {
-    Objects.requireNonNull(layout, "TensorType layout must not be null");
+    Objects.requireNonNull(layout, TensorType.class.getSimpleName() + " layout must not be null");
     return switch (layout) {
       case DENSE -> new TensorType(dtype, dims);
       case SPARSE -> new SparseTensorType(dtype, dims);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -491,6 +491,7 @@ public class TensorType implements Iterable<Dimension<?>> {
    * @return A dense {@link TensorType} or a {@link SparseTensorType}, per {@code layout}.
    */
   public static TensorType of(DType dtype, List<Dimension<?>> dims, Layout layout) {
+    Objects.requireNonNull(layout, "TensorType layout must not be null");
     return switch (layout) {
       case DENSE -> new TensorType(dtype, dims);
       case SPARSE -> new SparseTensorType(dtype, dims);


### PR DESCRIPTION
Follow-up to #404. `TensorType.of` documents `layout` as non-null, but a null only triggered the switch-expression's generic `NullPointerException`. This adds an explicit `Objects.requireNonNull(layout, ...)` so the contract is enforced in code with a clear message for future callers (flagged by review on #404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)