### PR TITLE
Guard that a `tf.reshape`-fed parameter stays exact (wala/ML#548)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -871,11 +871,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Regression guard for wala/ML#548: a {@code tf.reshape} on the path to a {@code @tf.function}
    * parameter must not degrade the inferred parameter. Mirrors the cifar10 path in main.py ({@code
    * tf.reshape(labels)} feeding a {@code tf.data.Dataset} whose iteration binds {@code labels});
-   * {@code consume(labels)} pins the type. The parameter stays concrete and dtype-exact: {@code
-   * uint8} (matching cifar10's label dtype) with a concrete batch dim, confirming the reshape's
-   * imprecision lands on local results, not parameters. The union carries two batch dims ({@code
-   * 32} and {@code 16}) from distinct analysis contexts; both are concrete {@code uint8}, so the
-   * "not degraded" conclusion holds. See ponder-lab/Input-Signature-Inference-Paper#49.
+   * {@code consume(labels)} pins the type. The parameter is concrete and dtype-exact: {@code uint8}
+   * (matching cifar10's label dtype), and the union carries both correct batch shapes &mdash;
+   * {@code (32,)} for the full batches and {@code (16,)} for the final partial batch (cifar10's
+   * 50000 train labels batched by 32 leave {@code 50000 % 32 == 16}, since {@code drop_remainder}
+   * defaults to false). So the reshape not only fails to degrade the parameter, the parameter is
+   * inferred precisely. See ponder-lab/Input-Signature-Inference-Paper#49.
    */
   @Test
   public void testReshapeToParam()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -134,6 +134,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_32_UINT8 =
       new TensorType(UINT_8, asList(new NumericDim(32)));
 
+  private static final TensorType TENSOR_16_UINT8 =
+      new TensorType(UINT_8, asList(new NumericDim(16)));
+
   private static final TensorType TENSOR_256_784_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(784)));
 
@@ -862,6 +865,27 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         2,
         3,
         Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32), 3, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  /**
+   * Regression guard for wala/ML#548: a {@code tf.reshape} on the path to a {@code @tf.function}
+   * parameter must not degrade the inferred parameter. Mirrors the cifar10 path in main.py ({@code
+   * tf.reshape(labels)} feeding a {@code tf.data.Dataset} whose iteration binds {@code labels});
+   * {@code consume(labels)} pins the type. The parameter stays concrete and dtype-exact: {@code
+   * uint8} (matching cifar10's label dtype) with a concrete batch dim, confirming the reshape's
+   * imprecision lands on local results, not parameters. The union carries two batch dims ({@code
+   * 32} and {@code 16}) from distinct analysis contexts; both are concrete {@code uint8}, so the
+   * "not degraded" conclusion holds. See ponder-lab/Input-Signature-Inference-Paper#49.
+   */
+  @Test
+  public void testReshapeToParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_to_param.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_32_UINT8, TENSOR_16_UINT8)));
   }
 
   /** This is not a legal case. */

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_to_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_to_param.py
@@ -22,4 +22,9 @@ def train_step(images, labels):
 
 
 for images, labels in train_ds:
+    # Runtime truth mirrored by `testReshapeToParam`: the `tf.reshape`-fed `labels`
+    # parameter stays an exact `uint8` vector — `(32,)` for the full batches and
+    # `(16,)` for the final partial batch (50000 % 32 == 16).
+    assert labels.dtype == tf.uint8
+    assert labels.shape == (32,) or labels.shape == (16,)
     train_step(images, labels)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_to_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_to_param.py
@@ -1,0 +1,25 @@
+# Regression guard (wala/ML#548): a `tf.reshape` on the path to a `@tf.function` parameter must not
+# degrade the inferred parameter. Mirrors the cifar10 path in
+# TensorFlow2.0-Examples/3-Neural_Network_Architecture/main.py: tf.reshape(labels) feeds a
+# tf.data.Dataset whose iteration binds the @tf.function's `labels` parameter. `consume(labels)`
+# pins the type. See ponder-lab/Input-Signature-Inference-Paper#49 (corpus audit).
+import tensorflow as tf
+
+(x_train, y_train), _ = tf.keras.datasets.cifar10.load_data()
+x_train = x_train / 255.0
+y_train = tf.reshape(y_train, (-1,))
+
+train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train)).batch(32)
+
+
+def consume(t):
+    pass
+
+
+@tf.function
+def train_step(images, labels):
+    consume(labels)
+
+
+for images, labels in train_ds:
+    train_step(images, labels)


### PR DESCRIPTION
Adds a regression guard for the question raised under wala/ML#548: does a `tf.reshape` on the path to a `@tf.function` parameter degrade the inferred parameter?

The fixture mirrors main.py's cifar10 path: `tf.reshape(labels, (-1,))` feeding `tf.data.Dataset.from_tensor_slices(...).batch(32)`, whose iteration binds the `@tf.function`'s `labels` parameter. It pins `labels` via a `consume(labels)` sink.

**Finding:** `labels` is inferred precisely as `{(32,) uint8, (16,) uint8}`. `uint8` matches cifar10's label dtype, and the two shapes are the *correct* batch shapes: `(32,)` for the full batches and `(16,)` for the final partial batch (cifar10's 50000 train labels batched by 32 leave `50000 % 32 == 16`, since `drop_remainder` defaults to false). So the reshape does not degrade the parameter; it is inferred exactly. This is the empirical basis for keeping wala/ML#548 as code-health, not eval-moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
