### PR TITLE
Model keyword-only parameters as formal parameters

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -1169,6 +1169,13 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
         args = new LinkedList<>(args);
         args.add(aa.getInternalVararg());
       }
+      // Keyword-only parameters (declared after a bare `*` or `*args`) are formal parameters too;
+      // include them so downstream analyses can bind call-site keyword arguments to them
+      // (wala/ML#596). Without this they have no value number and cannot be tensor-typed.
+      if (aa.getInternalKwonlyargs() != null && !aa.getInternalKwonlyargs().isEmpty()) {
+        args = new LinkedList<>(args);
+        args.addAll(aa.getInternalKwonlyargs());
+      }
       java.util.Set<CAstNode> x = HashSetFactory.make();
       if (arg0.getDecorator_list() != null) {
         for (expr f : arg0.getInternalDecorator_list()) {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2114,6 +2114,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Keyword-only parameters are modeled as formal parameters (<a
+   * href="https://github.com/wala/ML/issues/596">wala/ML#596</a>). {@code f(x, *, y)} is called
+   * {@code f(tf.constant(1), y=tf.ones([2, 3]))}; the keyword-only {@code y} must be a formal so
+   * the call-site keyword argument binds to it. {@code consume(y)} pins {@code y}'s type, which is
+   * therefore {@code (2, 3) float32}. Before the fix, {@code y} had no value number and {@code
+   * consume} saw no tensor parameter.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testKwonlyParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_kwonly_param.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
    * Isolated repro for wala/ML#398 (binop drops PA allocation, bites through dataset). Python
    * {@code c = a + b; from_tensor_slices((c, y)); for x, _ in ds: consume(x)} — the binop result
    * {@code c} has no PA allocation and the tuple's field-0 PTS is empty. Passes without allocation

--- a/com.ibm.wala.cast.python.test/data/tf2_test_kwonly_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_kwonly_param.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def f(x, *, y):
+    # `y` is a keyword-only parameter (after the bare `*`). It must be modeled as a
+    # formal parameter so the call-site keyword argument binds to it (wala/ML#596).
+    consume(y)
+
+
+f(tf.constant(1), y=tf.ones([2, 3]))


### PR DESCRIPTION
`PythonParser.visitFunctionDef` built a function's formal-parameter list from the positional args plus `*args` and `**kwargs`, but never added the keyword-only parameters (`getInternalKwonlyargs`, declared after a bare `*`). So for `def f(x, *, y)`, `y` had no value number and no formal-parameter position, and no analysis could bind a call-site keyword argument to it or type it (wala/ML#596).

## Fix
Include the keyword-only parameters in the formal list.

## Verification
- `testKwonlyParam`: `f(tf.constant(1), y=tf.ones([2, 3]))` now binds the keyword-only `y` to the `(2, 3) float32` tensor (pinned via a `consume(y)` sink). Before the fix, `consume` saw no tensor parameter.
- Full suite green (850 tests, 0 failures): functions without keyword-only parameters are unaffected (the new branch only runs when `getInternalKwonlyargs()` is non-empty).

Unblocks ponder-lab/Hybridize-Functions-Refactoring#607 (inferring tensor types for keyword-only parameters), which was blocked on this.

Closes wala/ML#596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
