### PR TITLE
Recover the unsorted-segment output shape when `num_segments` is static

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2770,42 +2770,34 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Pins the output type of {@code tf.math.unsorted_segment_sum} (wala/ML#570). The output dtype
-   * inherits from the {@code data} input ({@code float32}); the shape is ⊤ because the leading axis
-   * is the runtime {@code num_segments} value. Verified via a {@code consume_sum} sink on the
-   * aggregation result.
-   *
-   * <p>TODO: Recover the concrete shape when {@code num_segments} is static, per <a
-   * href="https://github.com/wala/ML/issues/582">wala/ML#582</a>.
+   * inherits from the {@code data} input ({@code float32}); the shape is the concrete {@code (2,
+   * 3)} — {@code [num_segments] ++ data.shape[segment_ids.ndim:]} with the static {@code
+   * num_segments = 2}, rank-1 {@code segment_ids}, and {@code (3, 3)} {@code data} (wala/ML#582).
+   * Verified via a {@code consume_sum} sink on the aggregation result.
    */
   @Test
   public void testUnsortedSegmentSum()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_unsorted_segment.py",
-        "consume_sum",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        "tf2_test_unsorted_segment.py", "consume_sum", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   /**
    * Pins the output type of {@code tf.math.unsorted_segment_max} (wala/ML#570). Same dtype-from-
-   * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
+   * {@code data} and static-{@code num_segments} {@code (2, 3)} shape recovery as {@link
+   * #testUnsortedSegmentSum} (wala/ML#582).
    */
   @Test
   public void testUnsortedSegmentMax()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_unsorted_segment.py",
-        "consume_max",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        "tf2_test_unsorted_segment.py", "consume_max", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   /**
    * Pins the output type of {@code tf.math.unsorted_segment_mean} (wala/ML#570). Same dtype-from-
-   * {@code data}, ⊤-shape modeling as {@link #testUnsortedSegmentSum}.
+   * {@code data} and static-{@code num_segments} {@code (2, 3)} shape recovery as {@link
+   * #testUnsortedSegmentSum} (wala/ML#582).
    */
   @Test
   public void testUnsortedSegmentMean()
@@ -2815,7 +2807,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume_mean",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1491,8 +1491,7 @@
         </method>
       </class>
       <class name="unsorted_segment_sum" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. Direct `<new>+<return>` paired with the dedicated `UnsortedSegmentReduction` generator (wala/ML#570): dtype inherits from `data`; shape is `[num_segments] ++ data.shape[segment_ids.ndim:]` when `num_segments` is a static
-          constant (wala/ML#582), else left at ⊤ since the leading axis is then a runtime value (forwarding `data`'s shape would be unsound). -->
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. `<new>+<return>` + `UnsortedSegmentReduction` generator: dtype from `data`; shape `[num_segments] ++ data.shape[segment_ids.ndim:]` when `num_segments` is static, else ⊤ (wala/ML#570, wala/ML#582). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data segment_ids num_segments name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1491,8 +1491,8 @@
         </method>
       </class>
       <class name="unsorted_segment_sum" allocatable="true">
-        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. Direct `<new>+<return>` paired with the dedicated `UnsortedSegmentReduction` generator (wala/ML#570): dtype inherits from `data`; shape is left at ⊤ since the output's leading axis is the runtime `num_segments` value
-          (forwarding `data`'s shape would be unsound). -->
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum. Direct `<new>+<return>` paired with the dedicated `UnsortedSegmentReduction` generator (wala/ML#570): dtype inherits from `data`; shape is `[num_segments] ++ data.shape[segment_ids.ndim:]` when `num_segments` is a static
+          constant (wala/ML#582), else left at ⊤ since the leading axis is then a runtime value (forwarding `data`'s shape would be unsound). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data segment_ids num_segments name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -101,12 +101,16 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
   /**
    * PTS-first arg-shape resolver with caller-walk fallback. Mirrors {@link Sigmoid#shapesOfArg}.
    *
+   * <p>Visible to subclasses that compute their output shape from more than one input argument
+   * (e.g. {@link UnsortedSegmentReduction}, which reads both its {@code data} and {@code
+   * segment_ids} arguments) and so cannot rely on the single-input {@link #getDefaultShapes}.
+   *
    * @param builder The propagation call graph builder.
    * @param paramPos The positional index of the arg.
    * @param paramName The keyword parameter name.
    * @return The resolved shapes, or {@code null} if neither path recovers.
    */
-  private Set<List<Dimension<?>>> shapesOfArg(
+  protected Set<List<Dimension<?>>> shapesOfArg(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
     if (paramPos == UNDEFINED_PARAMETER_POSITION)
       throw new IllegalStateException(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2104,6 +2104,42 @@ public abstract class TensorGenerator {
     return this.getNode().getIR().getParameter(index);
   }
 
+  /**
+   * Resolves a scalar integer argument to its static constant value, when one exists. Reads the
+   * argument's points-to set (via {@link #getArgumentPointsToSet(PropagationCallGraphBuilder, int,
+   * String)}, which handles the invoke-side, binary-op-side, and context-sensitive-caller cases)
+   * and returns the integer carried by a {@link ConstantKey} if every key in the set agrees on the
+   * same numeric value.
+   *
+   * <p>Returns {@code null} (signalling "not statically known") when the points-to set is empty,
+   * contains a non-{@link ConstantKey} key (a runtime value — e.g. a {@code tf.shape(...)} result),
+   * carries a non-numeric constant, or carries two differing numeric values. Used by generators
+   * whose output shape depends on a statically-supplied integer (e.g. {@code num_segments} for the
+   * unsorted-segment reductions), so the shape is recovered only when the value is genuinely a
+   * compile-time constant and left at ⊤ otherwise.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param paramPos The 0-based positional index of the argument (excluding {@code self}).
+   * @param paramName The keyword name of the argument, or {@code null}.
+   * @return The argument's static integer value, or {@code null} if it is not a single statically
+   *     resolvable integer.
+   */
+  protected Integer resolveStaticIntArgument(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
+    if (pts == null || pts.isEmpty()) return null;
+    Integer resolved = null;
+    for (InstanceKey instanceKey : pts) {
+      if (!(instanceKey instanceof ConstantKey)) return null;
+      Object value = ((ConstantKey<?>) instanceKey).getValue();
+      if (!(value instanceof Number)) return null;
+      int candidate = ((Number) value).intValue();
+      if (resolved != null && resolved != candidate) return null;
+      resolved = candidate;
+    }
+    return resolved;
+  }
+
   protected PythonInvokeInstruction getInvokeInstruction() {
     if (this.source == null) {
       return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
@@ -8,6 +8,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -32,17 +33,40 @@ import java.util.Set;
  */
 public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
 
-  /** Positional index (excluding {@code self}) of the {@code segment_ids} argument. */
-  private static final int SEGMENT_IDS_PARAMETER_POSITION = 1;
+  /**
+   * Positional parameters (after {@code self}) of {@code tf.math.unsorted_segment_*}: {@code data
+   * segment_ids num_segments name}. Only the three that participate in shape inference are modeled;
+   * the trailing {@code name} is omitted.
+   */
+  private enum Parameters {
+    /** The values tensor being aggregated; supplies the output's trailing axes and its dtype. */
+    DATA,
 
-  /** Keyword name of the {@code segment_ids} argument. */
-  private static final String SEGMENT_IDS_PARAMETER_NAME = "segment_ids";
+    /**
+     * The per-row segment assignments; its rank is the number of leading {@code data} axes the
+     * reduction consumes.
+     */
+    SEGMENT_IDS,
 
-  /** Positional index (excluding {@code self}) of the {@code num_segments} argument. */
-  private static final int NUM_SEGMENTS_PARAMETER_POSITION = 2;
+    /** The number of output segments; its static value becomes the output's leading axis. */
+    NUM_SEGMENTS;
 
-  /** Keyword name of the {@code num_segments} argument. */
-  private static final String NUM_SEGMENTS_PARAMETER_NAME = "num_segments";
+    /**
+     * @return The lowercase keyword-parameter name (e.g., {@code "segment_ids"}), suitable for
+     *     {@link TensorGenerator#getArgumentPointsToSet}.
+     */
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * @return The zero-based positional index (after {@code self}), suitable for {@link
+     *     TensorGenerator#getArgumentPointsToSet}.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
 
   public UnsortedSegmentReduction(PointsToSetVariable source) {
     super(source);
@@ -54,12 +78,12 @@ public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
 
   @Override
   protected int getInputParameterPosition() {
-    return 0;
+    return Parameters.DATA.getIndex();
   }
 
   @Override
   protected String getInputParameterName() {
-    return "data";
+    return Parameters.DATA.getName();
   }
 
   /**
@@ -80,13 +104,14 @@ public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
     // runtime num_segments (e.g. a node count via tf.shape) leaves the shape at ⊤.
     Integer numSegments =
         this.resolveStaticIntArgument(
-            builder, NUM_SEGMENTS_PARAMETER_POSITION, NUM_SEGMENTS_PARAMETER_NAME);
+            builder, Parameters.NUM_SEGMENTS.getIndex(), Parameters.NUM_SEGMENTS.getName());
     if (numSegments == null) return null;
 
     // The number of leading data axes consumed by segment_ids is segment_ids's rank.
     Integer segmentIdsRank =
         rankOf(
-            this.shapesOfArg(builder, SEGMENT_IDS_PARAMETER_POSITION, SEGMENT_IDS_PARAMETER_NAME));
+            this.shapesOfArg(
+                builder, Parameters.SEGMENT_IDS.getIndex(), Parameters.SEGMENT_IDS.getName()));
     if (segmentIdsRank == null) return null;
 
     Set<List<Dimension<?>>> dataShapes =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
@@ -1,9 +1,12 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -13,17 +16,33 @@ import java.util.Set;
  * {@code data} tensor of shape {@code [N, ...]} into {@code [num_segments, ...]} by aggregating the
  * rows that share a {@code segment_ids} value.
  *
- * <p>Output dtype inherits from the {@code data} (arg 0) input. Output shape is left at ⊤: the
- * leading axis becomes the runtime {@code num_segments} value (typically a {@code tf.shape(...)}
- * result rather than a static constant), so forwarding {@code data}'s shape would be unsound on the
- * first axis. Dtype is the load-bearing axis here; shape can follow. See <a
- * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>.
+ * <p>Output dtype inherits from the {@code data} (arg 0) input. Output shape is {@code
+ * [num_segments] ++ data.shape[segment_ids.ndim:]}: the leading axis is {@code num_segments} and
+ * the trailing axes are {@code data}'s axes after the ones consumed by {@code segment_ids}. That
+ * shape is recovered when {@code num_segments} is a static constant and the {@code data}/{@code
+ * segment_ids} shapes (hence {@code segment_ids}'s rank) are known; otherwise — notably when {@code
+ * num_segments} is a runtime value (e.g. a {@code tf.shape(...)} result, the common case in a GNN
+ * where it is the node count) — the shape is left at ⊤ rather than mis-forwarding {@code data}'s
+ * shape. See <a href="https://github.com/wala/ML/issues/570">wala/ML#570</a> and <a
+ * href="https://github.com/wala/ML/issues/582">wala/ML#582</a>.
  *
  * @see <a
  *     href="https://www.tensorflow.org/api_docs/python/tf/math/unsorted_segment_sum">tf.math.unsorted_segment_sum</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
+
+  /** Positional index (excluding {@code self}) of the {@code segment_ids} argument. */
+  private static final int SEGMENT_IDS_PARAMETER_POSITION = 1;
+
+  /** Keyword name of the {@code segment_ids} argument. */
+  private static final String SEGMENT_IDS_PARAMETER_NAME = "segment_ids";
+
+  /** Positional index (excluding {@code self}) of the {@code num_segments} argument. */
+  private static final int NUM_SEGMENTS_PARAMETER_POSITION = 2;
+
+  /** Keyword name of the {@code num_segments} argument. */
+  private static final String NUM_SEGMENTS_PARAMETER_NAME = "num_segments";
 
   public UnsortedSegmentReduction(PointsToSetVariable source) {
     super(source);
@@ -44,16 +63,64 @@ public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
   }
 
   /**
-   * Returns ⊤ (unknown shape). The output's leading axis is the runtime {@code num_segments} value,
-   * which is not statically known, so the shape is left unknown rather than mis-forwarding {@code
-   * data}'s shape. Dtype still inherits from {@code data} via the inherited {@link
-   * #getDefaultDTypes}.
+   * Computes the output shape {@code [num_segments] ++ data.shape[segment_ids.ndim:]} when {@code
+   * num_segments} resolves to a static constant and the {@code data}/{@code segment_ids} shapes are
+   * known, and returns ⊤ ({@code null}) otherwise. The leading axis becomes the constant {@code
+   * num_segments}; the trailing axes are {@code data}'s dimensions after the ones consumed by
+   * {@code segment_ids} (whose rank is read from its shape). Dtype still inherits from {@code data}
+   * via the inherited {@link #getDefaultDTypes}.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return {@code null} (⊤).
+   * @return The set of output shapes, or {@code null} (⊤) when {@code num_segments} is not a static
+   *     constant or the input shapes / {@code segment_ids}'s rank cannot be resolved.
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    // The leading output axis is num_segments; recoverable only when it is a static constant. A
+    // runtime num_segments (e.g. a node count via tf.shape) leaves the shape at ⊤.
+    Integer numSegments =
+        this.resolveStaticIntArgument(
+            builder, NUM_SEGMENTS_PARAMETER_POSITION, NUM_SEGMENTS_PARAMETER_NAME);
+    if (numSegments == null) return null;
+
+    // The number of leading data axes consumed by segment_ids is segment_ids's rank.
+    Integer segmentIdsRank =
+        rankOf(
+            this.shapesOfArg(builder, SEGMENT_IDS_PARAMETER_POSITION, SEGMENT_IDS_PARAMETER_NAME));
+    if (segmentIdsRank == null) return null;
+
+    Set<List<Dimension<?>>> dataShapes =
+        this.shapesOfArg(builder, this.getInputParameterPosition(), this.getInputParameterName());
+    if (dataShapes == null || dataShapes.isEmpty()) return null;
+
+    Set<List<Dimension<?>>> result = HashSetFactory.make();
+    for (List<Dimension<?>> dataShape : dataShapes) {
+      // segment_ids indexes data's leading axes, so data must be at least that rank.
+      if (dataShape == null || dataShape.size() < segmentIdsRank) return null;
+      List<Dimension<?>> outputShape = new ArrayList<>(dataShape.size() - segmentIdsRank + 1);
+      outputShape.add(new NumericDim(numSegments));
+      outputShape.addAll(dataShape.subList(segmentIdsRank, dataShape.size()));
+      result.add(outputShape);
+    }
+    return result;
+  }
+
+  /**
+   * Returns the common rank (number of dimensions) shared by every candidate shape, or {@code null}
+   * when the rank cannot be pinned down — an empty/⊤ shape set, a candidate of unknown rank, or
+   * candidates that disagree on rank.
+   *
+   * @param shapes The candidate shapes whose rank to resolve.
+   * @return The shared rank, or {@code null} if it is not unambiguously known.
+   */
+  private static Integer rankOf(Set<List<Dimension<?>>> shapes) {
+    if (shapes == null || shapes.isEmpty()) return null;
+    Integer rank = null;
+    for (List<Dimension<?>> shape : shapes) {
+      if (shape == null) return null;
+      if (rank != null && rank != shape.size()) return null;
+      rank = shape.size();
+    }
+    return rank;
   }
 }


### PR DESCRIPTION
## Problem

`tf.math.unsorted_segment_{sum,max,mean}` recovered the output **dtype** (inherited from `data`) but left the **shape** at ⊤. The output is not shape-preserving, so `UnsortedSegmentReduction.getDefaultShapes` returned `null` rather than mis-forwarding `data`'s shape: the leading axis becomes `num_segments`, which is generally a runtime value.

## Change

Recover the precise shape `[num_segments] ++ data.shape[segment_ids.ndim:]` in the statically-resolvable case — when `num_segments` is a compile-time constant and the `data`/`segment_ids` shapes (hence `segment_ids`'s rank) are known. The general dynamic case (a runtime `num_segments`, e.g. a node count in a GNN) correctly stays ⊤.

- Add `TensorGenerator.resolveStaticIntArgument`: reads an argument's points-to set and returns the integer carried by a `ConstantKey` when every key agrees, `null` otherwise (a runtime value, a non-numeric constant, or disagreeing values).
- Promote `PassThroughUnaryTensorGenerator.shapesOfArg` to `protected` so the generator can resolve both its `data` and `segment_ids` input shapes.
- Tighten `testUnsortedSegmentSum`/`Max`/`Mean` from `TENSOR_UNKNOWN_SHAPE_FLOAT32` to the concrete `(2, 3)`, matching the fixture's `assert s.shape == (2, 3)`.

The `#381` fixture has `num_segments = 2`, `(3, 3)` `data`, and rank-1 `segment_ids`, so the output is exactly `(2, 3)` — which the Python runtime confirms and the analysis now reports.

## Testing

Full suite green locally (`mvn test`): 850 tests, 0 failures, 0 errors (807 in `TestTensorflow2Model`).

Closes wala/ML#582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)