### PR TITLE
Preserve the full dotted base-class name in supertype capture

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -781,7 +781,7 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
      * @param e The base-class expression.
      * @return The dotted name of {@code e}.
      */
-    private String dottedName(expr e) {
+    private static String dottedName(expr e) {
       if (e instanceof Attribute) {
         Attribute attr = (Attribute) e;
         return dottedName(attr.getInternalValue()) + "." + attr.getInternalAttr();

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -769,6 +769,26 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
       return missingTypes.get(name);
     }
 
+    /**
+     * Reconstructs the dotted source name of a base-class expression (e.g. {@code
+     * tf.keras.layers.Layer} for an {@code Attribute} chain) so that a non-local base carries its
+     * full path rather than collapsing to the root identifier that {@link expr#getText()} yields
+     * for an attribute access (e.g. just {@code tf}). The full path is what a later pass needs to
+     * resolve the base against an imported / summary-modeled class. Falls back to {@code getText()}
+     * for forms that aren't a {@code Name}/{@code Attribute} chain (e.g. a subscripted generic
+     * base). See <a href="https://github.com/wala/ML/issues/571">wala/ML#571</a>.
+     *
+     * @param e The base-class expression.
+     * @return The dotted name of {@code e}.
+     */
+    private String dottedName(expr e) {
+      if (e instanceof Attribute) {
+        Attribute attr = (Attribute) e;
+        return dottedName(attr.getInternalValue()) + "." + attr.getInternalAttr();
+      }
+      return e.getText();
+    }
+
     @Override
     public CAstNode visitClassDef(ClassDef arg0) throws Exception {
       WalkContext parent = this.context;
@@ -780,11 +800,12 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
               Collection<CAstType> supertypes = HashSetFactory.make();
               for (expr e : arg0.getInternalBases()) {
                 try {
-                  CAstType type = types.getCAstTypeFor(e.getText());
+                  String baseName = dottedName(e);
+                  CAstType type = types.getCAstTypeFor(baseName);
                   if (type != null) {
                     supertypes.add(type);
                   } else {
-                    supertypes.add(getMissingType(e.getText()));
+                    supertypes.add(getMissingType(baseName));
                   }
                 } catch (Exception e1) {
                   assert false : e1;

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -8906,6 +8906,33 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Same as {@link #testNamedTupleFieldRead} but the {@code NamedTuple} base is written as the
+   * dotted attribute chain {@code typing.NamedTuple} rather than a bare {@code NamedTuple}. This
+   * guards the dotted-base path of {@code PythonConstructorTargetSelector.isPositionalFieldClass}:
+   * the front-end must record the full {@code typing.NamedTuple} supertype name (not just the root
+   * {@code typing}) for the positional-field synthesis to fire, so the tensor stored in the field
+   * and read back ({@code b = w.tensor}) keeps its {@code (4, 8) float32} type. Without the full
+   * dotted-name capture the supertype collapses to {@code typing}, {@code isPositionalFieldClass}
+   * returns {@code false}, and {@code consume} sees zero tensor parameters (<a
+   * href="https://github.com/wala/ML/issues/571">wala/ML#571</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNamedTupleFieldReadDotted()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_namedtuple_field_dotted.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
    * Verifies tensor types propagate through a {@code typing.Tuple}-annotated tuple-of-tensors
    * parameter: a 2-tuple of tensors passed to {@code f} and unpacked ({@code x, y = inputs}) keeps
    * each element's type, so {@code consume(x)} sees {@code (4, 8) float32}. This mirrors the

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field_dotted.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field_dotted.py
@@ -1,0 +1,26 @@
+"""Exercises tensor-type propagation through a ``NamedTuple`` field declared with a *dotted* base (``typing.NamedTuple``) rather than a bare ``NamedTuple`` (https://github.com/wala/ML/issues/571).
+
+Identical to ``tf2_test_namedtuple_field.py`` except the base class is written as the attribute chain ``typing.NamedTuple``. This pins the dotted-base path of ``PythonConstructorTargetSelector.isPositionalFieldClass``: only once ``getMissingTypeNames()`` carries the full ``typing.NamedTuple`` (not just the root ``typing``) does the positional-field synthesis fire, so ``b = w.tensor`` keeps its ``(4, 8) float32`` type.
+"""
+
+import typing
+
+import numpy as np
+import tensorflow as tf
+
+
+class Wrapper(typing.NamedTuple):
+    tensor: tf.Tensor
+    rest: typing.List
+
+
+def consume(x):
+    pass
+
+
+a = tf.constant(np.ones((4, 8), dtype=np.float32))
+assert a.shape == (4, 8) and a.dtype == tf.float32
+w = Wrapper(a, [])
+b = w.tensor
+assert b.shape == (4, 8) and b.dtype == tf.float32
+consume(b)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -886,11 +886,17 @@ public class PythonCAstToIRTranslator extends AstTranslator {
           .getMissingTypeNames()
           .forEach(
               tn -> {
-                int val = doLocalRead(code, tn, PythonTypes.Root);
+                // `tn` may now be a dotted base path (e.g. `tf.keras.layers.Layer`, wala/ML#571).
+                // The dummy field keys on the root identifier (`tf`), which is the actual in-scope
+                // variable, so its name and bound value are byte-for-byte unchanged from when only
+                // the root was captured; the full path is preserved in getMissingTypeNames() for
+                // base-class resolution.
+                String rootName = tn.contains(".") ? tn.substring(0, tn.indexOf('.')) : tn;
+                int val = doLocalRead(code, rootName, PythonTypes.Root);
                 FieldReference fr =
                     FieldReference.findOrCreate(
                         cls.getReference(),
-                        Atom.findOrCreateUnicodeAtom("missing_" + tn),
+                        Atom.findOrCreateUnicodeAtom("missing_" + rootName),
                         PythonTypes.Root);
                 code.cfg()
                     .addInstruction(


### PR DESCRIPTION
## Summary

`PythonParser.visitClassDef` recorded a base-class expression via `expr.getText()`, which for an attribute chain (`class GCN(tf.keras.layers.Layer)`) yields only the root identifier (`tf`), dropping the path that identifies the class. So `getMissingTypeNames()` held `tf` rather than `tf.keras.layers.Layer`, leaving an imported/summary-modeled base unidentifiable.

This reconstructs the full dotted name from the `Name`/`Attribute` AST chain (`dottedName`), falling back to `getText()` for other forms. The dummy `missing_<name>` field that `leaveTypeEntity` emits keeps keying on the root identifier (the actual in-scope variable), so its name and bound value are unchanged; only `getMissingTypeNames()` now carries the full path.

## Why

A base class that resolves only to an imported or summary-modeled type currently falls back to `Lobject`. Recovering it requires first knowing its fully-qualified name, which the root-only capture discarded. This is groundwork toward wala/ML#571 (resolving imported/cross-module base classes) and, downstream, wala/ML#595.

## Side Effect

This also makes the previously-dead `n.endsWith(".NamedTuple")` branch in `PythonConstructorTargetSelector.isPositionalFieldClass` reachable for a dotted `typing.NamedTuple` base.

## Testing

Full suite green via `mvn clean install` from the repository root (front-end change, so all modules including `com.ibm.wala.cast.python.test` were exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
