### PR TITLE
Correct `testGcnCall`'s Javadoc to the real layer-output root cause

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2535,19 +2535,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * of edge tensors, not a tensor itself, so it is not a tensor parameter.)
    *
    * <p>The message-passing <em>output</em> locals (the {@code gc1}/{@code gc2} results) are
-   * inferred as ⊤ on <em>both</em> axes (unknown shape, unknown dtype). {@code
-   * tf.math.unsorted_segment_sum} is now modeled (dtype inherits from {@code data}, shape ⊤; <a
-   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so the aggregation results are
-   * recognized as tensor allocations — hence six tracked tensor variables rather than four. Their
-   * dtype is still ⊤, though, and the root cause is upstream of the aggregation: {@code
-   * GraphConvolution.call} receives its input as a {@code GNNInput} {@code NamedTuple} and unwraps
-   * it with {@code node_embeddings = inputs.node_embeddings}, but a tensor read back from a
-   * user-defined {@code NamedTuple} field is not tracked as a tensor (<a
-   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>). So {@code node_embeddings}
-   * arrives ⊤, the immediately-following {@code tf.linalg.matmul} produces ⊤, and every downstream
-   * op (including the modeled aggregation) inherits it. Resolving wala/ML#579 is the prerequisite
-   * for typing these layer outputs. The decorated function's input signature—the analysis goal—is
-   * nonetheless exact.
+   * inferred as ⊤ on <em>both</em> axes (unknown shape, unknown dtype). The aggregation ops are
+   * modeled ({@code tf.math.unsorted_segment_sum} etc.), so the results are recognized as tensor
+   * allocations (hence six tracked tensor variables rather than four), and the {@code GNNInput}
+   * {@code NamedTuple} field read {@code node_embeddings = inputs.node_embeddings} <em>does</em>
+   * recover {@code (4, 8) float32} inside {@code GraphConvolution.call} (so this is not the <a
+   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a> path, which is resolved). The drop
+   * is at {@code tf.linalg.matmul(node_embeddings, self.weight)}: {@code MatMul} is dispatched but
+   * returns ⊤ because it cannot recover {@code node_embeddings}' dtype. That dtype lives in {@code
+   * TensorTypeAnalysis} (seeded by the field read), while the generator's argument resolution
+   * consults the points-to/generator path, so the two never meet (the PTS-vs-{@code
+   * TensorTypeAnalysis} split). The ⊤ then cascades through {@code propagate} and the aggregation.
+   * Bridging {@code TensorTypeAnalysis}-seeded input types into generator argument resolution (<a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>) is what types these outputs. The
+   * decorated function's input signature, the analysis goal, is nonetheless exact.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.


### PR DESCRIPTION
## Summary

Corrects `testGcnCall`'s Javadoc, which misattributed the ⊤ `gc1`/`gc2` layer outputs to wala/ML#579.

## What changed

Documentation only (no behavior change). The prior Javadoc said the ⊤ outputs were caused by a `NamedTuple` field read not being tracked as a tensor (wala/ML#579). Re-baselining the fixture shows that is stale:

- Inside `GraphConvolution.call`, `node_embeddings = inputs.node_embeddings` (the `GNNInput` `NamedTuple` field read) **does** recover `(4, 8) float32` — wala/ML#579 is resolved.
- The actual drop is `tf.linalg.matmul(node_embeddings, self.weight)`: `MatMul` is dispatched but returns ⊤ because it resolves argument dtypes through the points-to/generator path, while the input's dtype lives in `TensorTypeAnalysis` (seeded by the field read). The two never meet (the PTS-vs-`TensorTypeAnalysis` split), and the ⊤ cascades through `propagate` and the aggregation.

Bridging `TensorTypeAnalysis`-seeded input types into generator argument resolution is the fix, tracked by the re-scoped wala/ML#570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
