### PR TITLE
Resolve property-read dtype via the receiver instance field

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2534,20 +2534,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * driver→GCN→GCNConv→MessagePassing} module boundaries. ({@code adjacency_lists} is a Python list
    * of edge tensors, not a tensor itself, so it is not a tensor parameter.)
    *
-   * <p>The message-passing <em>output</em> locals (the {@code gc1}/{@code gc2} results) are
-   * inferred as ⊤ on <em>both</em> axes (unknown shape, unknown dtype). {@code
-   * tf.math.unsorted_segment_sum} is now modeled (dtype inherits from {@code data}, shape ⊤; <a
-   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so the aggregation results are
-   * recognized as tensor allocations — hence six tracked tensor variables rather than four. Their
-   * dtype is still ⊤, though, and the root cause is upstream of the aggregation: {@code
-   * GraphConvolution.call} receives its input as a {@code GNNInput} {@code NamedTuple} and unwraps
-   * it with {@code node_embeddings = inputs.node_embeddings}, but a tensor read back from a
-   * user-defined {@code NamedTuple} field is not tracked as a tensor (<a
-   * href="https://github.com/wala/ML/issues/579">wala/ML#579</a>). So {@code node_embeddings}
-   * arrives ⊤, the immediately-following {@code tf.linalg.matmul} produces ⊤, and every downstream
-   * op (including the modeled aggregation) inherits it. Resolving wala/ML#579 is the prerequisite
-   * for typing these layer outputs. The decorated function's input signature—the analysis goal—is
-   * nonetheless exact.
+   * <p>The message-passing <em>output</em> locals (the {@code gc1}/{@code gc2} results) are still
+   * inferred as ⊤, but the cause is now downstream of the matmul rather than the {@code NamedTuple}
+   * field read. The aggregation ops are modeled, and the {@code GNNInput} {@code NamedTuple} field
+   * read {@code node_embeddings = inputs.node_embeddings} recovers {@code (4, 8) float32} (read off
+   * the instance field in the heap; <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>), so {@code tf.linalg.matmul} and
+   * {@code propagate} inside {@code GraphConvolution.call} now type to {@code float32}. What
+   * remains is the forward-result hop: {@code GraphConvolution.call} returns a typed tensor, but
+   * that result does not propagate to the caller's {@code self.gc1(...)} local &mdash; the
+   * user-subclass forward-result-typing gap (wala/ML#570, akin to <a
+   * href="https://github.com/wala/ML/issues/595">wala/ML#595</a>). The decorated function's input
+   * signature, the analysis goal, is nonetheless exact.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -8903,6 +8901,38 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testNamedTupleFieldRead()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_namedtuple_field.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Verifies dtype recovery for {@code tf.linalg.matmul} on a {@code NamedTuple} field threaded in
+   * as a parameter (<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>). {@code Inp}
+   * is constructed in the caller and passed into {@code layer}, which reads {@code inp.x} (a {@code
+   * NamedTuple} field) and feeds it to {@code matmul}; {@code consume(h)} pins the result. The
+   * field read has no points-to set at the read site (the {@code NamedTuple} was built in the
+   * caller), so the matmul input's dtype is recovered by reading the field off the object's
+   * instance in the heap &mdash; the minimal form of the {@code gcn_proj} {@code
+   * GraphConvolution.call} inner chain.
+   *
+   * <p>Before the fix, the field read's empty points-to set left the matmul input ⊤ on both axes;
+   * now the dtype is recovered from the instance field and, for this single-call shape, the
+   * existing shape machinery resolves the rest, so {@code consume}'s parameter is the concrete
+   * {@code (4, 4) float32}. (The harder multi-call/chained case &mdash; {@code gcn_proj}'s layer
+   * outputs &mdash; still needs forward-result propagation; see wala/ML#570.)
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNamedTupleFieldMatmul()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_namedtuple_field_matmul.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatMul.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatMul.java
@@ -90,7 +90,12 @@ public class MatMul extends TensorGenerator {
     OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
     if (pts != null && !pts.isEmpty()) {
       Set<DType> dtypes = this.getDTypesOfValue(builder, pts);
-      if (dtypes != null && !dtypes.isEmpty()) return dtypes;
+      // A non-empty result that is only ⊤ does not short-circuit: the synthetic `matmul.do` param
+      // PTS is often context-collapsed to a union of unrelated bare tensors (all `UNKNOWN`), so
+      // fall through to the per-context caller-walk, which resolves the actual argument at each
+      // call site. See wala/ML#570.
+      if (dtypes != null && !dtypes.isEmpty() && !dtypes.equals(EnumSet.of(DType.UNKNOWN)))
+        return dtypes;
     }
     return this.getArgumentDTypesViaCallers(builder, paramPos, paramName);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1656,6 +1656,20 @@ public abstract class TensorGenerator {
 
   private Set<DType> computeDTypes(
       PropagationCallGraphBuilder builder, CGNode node, int valueNumber) {
+    // wala/ML#570: a property read of a NamedTuple/object field (e.g. `inputs.node_embeddings`)
+    // often has no usable points-to set at the read site when the object was constructed in a
+    // caller and threaded in as a parameter. Resolve its dtype by reading the named field off the
+    // object's instance in the heap, where the positional-field write (wala/ML#579) is
+    // materialized. Only a concrete result is returned, so this strictly adds precision over the
+    // existing paths below.
+    SSAInstruction propDef = node.getDU().getDef(valueNumber);
+    if (propDef instanceof PythonPropertyRead) {
+      Set<DType> viaField =
+          this.dtypesFromInstanceField(builder, node, (PythonPropertyRead) propDef);
+      if (viaField != null && !viaField.isEmpty() && !viaField.equals(EnumSet.of(DType.UNKNOWN)))
+        return viaField;
+    }
+
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
     PointerKey valuePK = pointerAnalysis.getHeapModel().getPointerKeyForLocal(node, valueNumber);
     OrdinalSet<InstanceKey> valuePointsToSet = pointerAnalysis.getPointsToSet(valuePK);
@@ -1739,6 +1753,55 @@ public abstract class TensorGenerator {
             + " in: "
             + node
             + ".");
+  }
+
+  /**
+   * Resolves the dtypes of a property read ({@code obj.field}) by reading the named field off
+   * {@code obj}'s instance(s) in the heap, rather than from the read result's (often empty)
+   * points-to set. This recovers the type of a field whose value was written in a different frame
+   * &mdash; e.g. a {@code NamedTuple} constructed in a caller and threaded in as a parameter, whose
+   * positional fields are materialized by the synthesized constructor (wala/ML#579). Generalizes
+   * the receiver-field read that generators like {@link DenseCall} already use. See <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The CG node whose IR contains the property read.
+   * @param propRead The property-read instruction.
+   * @return The dtypes read from the field, or {@code null} if the field name, field, or any
+   *     instance field could not be resolved.
+   */
+  protected Set<DType> dtypesFromInstanceField(
+      PropagationCallGraphBuilder builder, CGNode node, PythonPropertyRead propRead) {
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    String fieldName = null;
+    for (InstanceKey ik :
+        pa.getPointsToSet(pa.getHeapModel().getPointerKeyForLocal(node, propRead.getMemberRef()))) {
+      if (ik instanceof ConstantKey && ((ConstantKey<?>) ik).getValue() instanceof String) {
+        fieldName = (String) ((ConstantKey<?>) ik).getValue();
+        break;
+      }
+    }
+    if (fieldName == null) return null;
+    IField f =
+        builder
+            .getClassHierarchy()
+            .resolveField(
+                FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldName), Root));
+    if (f == null) return null;
+    Set<DType> ret = null;
+    for (InstanceKey objIK :
+        pa.getPointsToSet(pa.getHeapModel().getPointerKeyForLocal(node, propRead.getObjectRef()))) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(objIK);
+      if (asin == null) continue;
+      OrdinalSet<InstanceKey> fieldPTS =
+          pa.getPointsToSet(builder.getPointerKeyForInstanceField(asin, f));
+      Set<DType> d = this.getDTypesOfValue(builder, fieldPTS);
+      if (d != null && !d.isEmpty()) {
+        if (ret == null) ret = EnumSet.noneOf(DType.class);
+        ret.addAll(d);
+      }
+    }
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field_matmul.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_namedtuple_field_matmul.py
@@ -1,0 +1,29 @@
+"""Exercises dtype recovery for ``tf.linalg.matmul`` on a ``NamedTuple`` field threaded in as a parameter (https://github.com/wala/ML/issues/570).
+
+``Inp`` is constructed in the caller and passed into ``layer``, which reads ``inp.x`` (a ``NamedTuple`` field) and feeds it to ``tf.linalg.matmul``. The matmul input's dtype is recovered (``float32``) by reading the field off the instance in the heap, even though the field read has no points-to set at the read site. This mirrors the minimal form of the ``gcn_proj`` ``GraphConvolution.call`` inner chain. Shape stays ⊤ (dtype is the load-bearing axis here; shape recovery is follow-up).
+"""
+
+from typing import NamedTuple, List
+
+import numpy as np
+import tensorflow as tf
+
+
+class Inp(NamedTuple):
+    x: tf.Tensor
+    rest: List
+
+
+def consume(t):
+    pass
+
+
+def layer(inp):
+    h = tf.linalg.matmul(inp.x, inp.x)
+    consume(h)
+    return h
+
+
+a = tf.constant(np.ones((4, 4), dtype=np.float32))
+assert a.shape == (4, 4) and a.dtype == tf.float32
+layer(Inp(a, []))


### PR DESCRIPTION
## Summary

Recovers the dtype of a `tf.linalg.matmul` input that is a `NamedTuple` field threaded in from a caller — the first ⊤ drop in `gcn_proj`'s `GraphConvolution.call` (wala/ML#570). Incremental #570 progress (see Scope).

## Changes

- `TensorGenerator.computeDTypes`: for a property read (`obj.field`) whose read result has no usable points-to set, resolve dtype by reading the named field off `obj`'s instance in the heap, where the positional-field write (wala/ML#579) is materialized. Generalizes the receiver-field read that generators like `DenseCall` already use; depth-independent (no call-string walk).
- `MatMul`: no longer short-circuits on a `{UNKNOWN}`-only argument points-to set — the synthetic `matmul.do` parameter PTS is often context-collapsed to a union of unrelated bare tensors, so it falls through to the per-context caller-walk.
- Test + fixture: `testNamedTupleFieldMatmul` / `tf2_test_namedtuple_field_matmul.py` (`consume`'s parameter recovers `(4, 4) float32`).
- Corrects `testGcnCall`'s Javadoc to the post-fix state (supersedes #417, which is now closed).

## Scope

This types the matmul and `propagate` inside `GraphConvolution.call`. The GCN layer **outputs** (`gc1`/`gc2` results in `GCNLayer.call`) remain ⊤ pending the forward-result hop: `GraphConvolution.call` returns a typed tensor, but it doesn't propagate to the caller's `self.gc1(...)` local — the user-subclass forward-result-typing gap (wala/ML#570 remaining, akin to wala/ML#595). So this is incremental progress on #570, not a full close.

## Testing

Full suite green (`mvn test` from the repository root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
