### PR TITLE
Represent numpy `object` dtype as `DType.OBJECT`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -94,6 +94,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final String STRING = DType.STRING.name().toLowerCase();
 
+  private static final String OBJECT = DType.OBJECT.name().toLowerCase();
+
   private static final String UNKNOWN = DType.UNKNOWN.name().toLowerCase();
 
   private static final TensorType MNIST_INPUT = mnistInput();
@@ -455,8 +457,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_50000_1_INT64 =
       new TensorType(INT_64, asList(new NumericDim(50000), new NumericDim(1)));
 
-  private static final TensorType TENSOR_8982_UNKNOWN =
-      new TensorType(UNKNOWN, asList(new NumericDim(8982)));
+  private static final TensorType TENSOR_8982_OBJECT =
+      new TensorType(OBJECT, asList(new NumericDim(8982)));
 
   private static final TensorType TENSOR_102_13_FLOAT64 =
       new TensorType(FLOAT_64, asList(new NumericDim(102), new NumericDim(13)));
@@ -481,8 +483,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2246_INT64 =
       new TensorType(INT_64, asList(new NumericDim(2246)));
 
-  private static final TensorType TENSOR_2246_UNKNOWN =
-      new TensorType(UNKNOWN, asList(new NumericDim(2246)));
+  private static final TensorType TENSOR_2246_OBJECT =
+      new TensorType(OBJECT, asList(new NumericDim(2246)));
 
   /** A {@code float32} tensor whose shape cannot be statically inferred. */
   private static final TensorType TENSOR_UNKNOWN_SHAPE_FLOAT32 = new TensorType(FLOAT_32, null);
@@ -626,8 +628,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_25000_INT64 =
       new TensorType(INT_64, asList(new NumericDim(25000)));
 
-  private static final TensorType TENSOR_25000_UNKNOWN =
-      new TensorType(UNKNOWN, asList(new NumericDim(25000)));
+  private static final TensorType TENSOR_25000_OBJECT =
+      new TensorType(OBJECT, asList(new NumericDim(25000)));
 
   @Test
   public void testValueIndex()
@@ -6688,15 +6690,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator test for {@code tf.keras.datasets.reuters.load_data()}. Asserts on all four unpacked
-   * arrays at {@code vn=2..5}: {@code x_train} ({@code (8982,)} unknown dtype &mdash; newswires are
-   * variable-length integer-encoded sequences, modeled as ⊤-dtype), {@code y_train} ({@code
-   * (8982,)} {@code int64}), {@code x_test} ({@code (2246,)} unknown dtype), {@code y_test} ({@code
-   * (2246,)} {@code int64}).
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/488">wala/ML#488</a>): the inferred unknown
-   * dtype for {@code x_train} / {@code x_test} is imprecise &mdash; the runtime dtype is numpy
-   * {@code object} (the Python fixture asserts that). Tighten to a dedicated {@code OBJECT} dtype
-   * if/when the lattice gains one.
+   * arrays at {@code vn=2..5}: {@code x_train} ({@code (8982,)} {@code object} &mdash; newswires
+   * are variable-length integer-encoded sequences, so numpy stores them in an {@code object}
+   * array), {@code y_train} ({@code (8982,)} {@code int64}), {@code x_test} ({@code (2246,)} {@code
+   * object}), {@code y_test} ({@code (2246,)} {@code int64}). The {@code object} dtype matches the
+   * runtime truth the Python fixture asserts (wala/ML#488).
    */
   @Test
   public void testReutersLoadData()
@@ -6707,9 +6705,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_8982_UNKNOWN),
+            2, Set.of(TENSOR_8982_OBJECT),
             3, Set.of(TENSOR_8982_INT64),
-            4, Set.of(TENSOR_2246_UNKNOWN),
+            4, Set.of(TENSOR_2246_OBJECT),
             5, Set.of(TENSOR_2246_INT64)));
   }
 
@@ -6737,14 +6735,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Generator test for {@code tf.keras.datasets.imdb.load_data()}. The four returned arrays each
    * have shape {@code (25000,)}: the {@code x_train} / {@code x_test} arrays carry numpy {@code
-   * object} dtype at runtime (variable-length integer-encoded sequences, modeled as ⊤-dtype); the
-   * {@code y_train} / {@code y_test} arrays have dtype {@code int64} (binary labels). Asserts on
-   * all four unpacked arrays at {@code vn=2..5}.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/488">wala/ML#488</a>): the inferred unknown
-   * dtype for {@code x_train} / {@code x_test} is imprecise &mdash; the runtime dtype is numpy
-   * {@code object} (the Python fixture asserts that). Tighten to a dedicated {@code OBJECT} dtype
-   * if/when the lattice gains one.
+   * object} dtype (variable-length integer-encoded sequences, so numpy stores them in an {@code
+   * object} array); the {@code y_train} / {@code y_test} arrays have dtype {@code int64} (binary
+   * labels). Asserts on all four unpacked arrays at {@code vn=2..5}. The {@code object} dtype
+   * matches the runtime truth the Python fixture asserts (wala/ML#488).
    */
   @Test
   public void testImdbLoadData()
@@ -6755,9 +6749,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         4,
         4,
         Map.of(
-            2, Set.of(TENSOR_25000_UNKNOWN),
+            2, Set.of(TENSOR_25000_OBJECT),
             3, Set.of(TENSOR_25000_INT64),
-            4, Set.of(TENSOR_25000_UNKNOWN),
+            4, Set.of(TENSOR_25000_OBJECT),
             5, Set.of(TENSOR_25000_INT64)));
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImdbInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImdbInputData.java
@@ -17,9 +17,9 @@ import java.util.Set;
  * <p>The four ndarrays have the following shapes and dtypes:
  *
  * <ul>
- *   <li>{@code x_train} / {@code x_test}: shape {@code (25000,)}, dtype unknown — each element is a
- *       Python list of variable-length integer-encoded reviews (numpy {@code object} dtype at
- *       runtime, not directly representable as a regular tensor until padded).
+ *   <li>{@code x_train} / {@code x_test}: shape {@code (25000,)}, dtype {@code object} — each
+ *       element is a Python list of variable-length integer-encoded reviews (numpy {@code object}
+ *       dtype, not directly representable as a regular tensor until padded).
  *   <li>{@code y_train} / {@code y_test}: shape {@code (25000,)}, dtype {@link DType#INT64} —
  *       binary labels (0 or 1).
  * </ul>
@@ -40,7 +40,7 @@ public class ImdbInputData extends TensorGenerator {
    * @param source The {@link PointsToSetVariable} representing the tensor.
    * @param shape The IMDB shape to report — one of {@link #X_TRAIN_SHAPE}, {@link #Y_TRAIN_SHAPE},
    *     {@link #X_TEST_SHAPE}, {@link #Y_TEST_SHAPE}.
-   * @param dtypes The dtype set: {@code int64} for the {@code y_*} arrays, {@code unknown} for the
+   * @param dtypes The dtype set: {@code int64} for the {@code y_*} arrays, {@code object} for the
    *     {@code x_*} arrays (which are not regular tensors).
    */
   public ImdbInputData(PointsToSetVariable source, List<Dimension<?>> shape, Set<DType> dtypes) {
@@ -108,20 +108,23 @@ public class ImdbInputData extends TensorGenerator {
     return List.of(new NumericDim(n));
   }
 
-  /** Shape of {@code imdb.load_data()[0][0]}: {@code (25000,)} of unknown dtype. */
+  /** Shape of {@code imdb.load_data()[0][0]}: {@code (25000,)} of {@code object} dtype. */
   public static final List<Dimension<?>> X_TRAIN_SHAPE = reviewsShape(NUM_TRAIN_EXAMPLES);
 
   /** Shape of {@code imdb.load_data()[0][1]}: {@code (25000,)} of {@code int64}. */
   public static final List<Dimension<?>> Y_TRAIN_SHAPE = labelsShape(NUM_TRAIN_EXAMPLES);
 
-  /** Shape of {@code imdb.load_data()[1][0]}: {@code (25000,)} of unknown dtype. */
+  /** Shape of {@code imdb.load_data()[1][0]}: {@code (25000,)} of {@code object} dtype. */
   public static final List<Dimension<?>> X_TEST_SHAPE = reviewsShape(NUM_TEST_EXAMPLES);
 
   /** Shape of {@code imdb.load_data()[1][1]}: {@code (25000,)} of {@code int64}. */
   public static final List<Dimension<?>> Y_TEST_SHAPE = labelsShape(NUM_TEST_EXAMPLES);
 
-  /** Dtype set for the variable-length-sequence {@code x_*} arrays. */
-  public static final Set<DType> X_DTYPES = EnumSet.of(DType.UNKNOWN);
+  /**
+   * Dtype set for the variable-length-sequence {@code x_*} arrays: numpy {@code object}
+   * (wala/ML#488).
+   */
+  public static final Set<DType> X_DTYPES = EnumSet.of(DType.OBJECT);
 
   /** Dtype set for the binary-label {@code y_*} arrays. */
   public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReutersInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReutersInputData.java
@@ -17,10 +17,10 @@ import java.util.Set;
  * <p>The four ndarrays have the following shapes and dtypes:
  *
  * <ul>
- *   <li>{@code x_train}: shape {@code (8982,)}, dtype unknown — each element is a Python list of
- *       variable-length integer-encoded newswires (numpy {@code object} dtype at runtime).
+ *   <li>{@code x_train}: shape {@code (8982,)}, dtype {@code object} — each element is a Python
+ *       list of variable-length integer-encoded newswires (numpy {@code object} dtype).
  *   <li>{@code y_train}: shape {@code (8982,)}, dtype {@link DType#INT64} — topic labels.
- *   <li>{@code x_test}: shape {@code (2246,)}, dtype unknown.
+ *   <li>{@code x_test}: shape {@code (2246,)}, dtype {@code object}.
  *   <li>{@code y_test}: shape {@code (2246,)}, dtype {@link DType#INT64}.
  * </ul>
  *
@@ -40,7 +40,7 @@ public class ReutersInputData extends TensorGenerator {
    * @param source The {@link PointsToSetVariable} representing the tensor.
    * @param shape The Reuters shape — one of {@link #X_TRAIN_SHAPE}, {@link #Y_TRAIN_SHAPE}, {@link
    *     #X_TEST_SHAPE}, {@link #Y_TEST_SHAPE}.
-   * @param dtypes The dtype set: {@code int64} for labels, {@code unknown} for the
+   * @param dtypes The dtype set: {@code int64} for labels, {@code object} for the
    *     variable-length-sequence arrays.
    */
   public ReutersInputData(PointsToSetVariable source, List<Dimension<?>> shape, Set<DType> dtypes) {
@@ -108,20 +108,23 @@ public class ReutersInputData extends TensorGenerator {
     return List.of(new NumericDim(n));
   }
 
-  /** Shape of {@code reuters.load_data()[0][0]}: {@code (8982,)} of unknown dtype. */
+  /** Shape of {@code reuters.load_data()[0][0]}: {@code (8982,)} of {@code object} dtype. */
   public static final List<Dimension<?>> X_TRAIN_SHAPE = newswiresShape(NUM_TRAIN_EXAMPLES);
 
   /** Shape of {@code reuters.load_data()[0][1]}: {@code (8982,)} of {@code int64}. */
   public static final List<Dimension<?>> Y_TRAIN_SHAPE = labelsShape(NUM_TRAIN_EXAMPLES);
 
-  /** Shape of {@code reuters.load_data()[1][0]}: {@code (2246,)} of unknown dtype. */
+  /** Shape of {@code reuters.load_data()[1][0]}: {@code (2246,)} of {@code object} dtype. */
   public static final List<Dimension<?>> X_TEST_SHAPE = newswiresShape(NUM_TEST_EXAMPLES);
 
   /** Shape of {@code reuters.load_data()[1][1]}: {@code (2246,)} of {@code int64}. */
   public static final List<Dimension<?>> Y_TEST_SHAPE = labelsShape(NUM_TEST_EXAMPLES);
 
-  /** Dtype set for the variable-length-sequence {@code x_*} arrays. */
-  public static final Set<DType> X_DTYPES = EnumSet.of(DType.UNKNOWN);
+  /**
+   * Dtype set for the variable-length-sequence {@code x_*} arrays: numpy {@code object}
+   * (wala/ML#488).
+   */
+  public static final Set<DType> X_DTYPES = EnumSet.of(DType.OBJECT);
 
   /** Dtype set for the topic-label {@code y_*} arrays. */
   public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -37,6 +37,10 @@ public class TensorFlowTypes extends PythonTypes {
     UINT8(true, false, 8),
     BOOL(false, false, 1),
     STRING(false, false, 0),
+    // numpy `object` dtype: an ndarray of variable-length Python sequences (e.g. `reuters`/`imdb`
+    // `x_train`). Non-numeric, so `canConvertTo` only matches itself — it does not auto-convert to
+    // numeric dtypes, matching numpy's strict semantics. See wala/ML#488.
+    OBJECT(false, false, 0),
     UNKNOWN(false, false, 0);
 
     private boolean numeric;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_imdb_load_data.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_imdb_load_data.py
@@ -16,7 +16,7 @@ assert x_test.shape == (25000,)
 assert y_test.shape == (25000,)
 # `x_train` and `x_test` are numpy `object` arrays at runtime (each element is a
 # variable-length list of integer-encoded tokens, like reuters). The analyzer's `DType`
-# lattice has no `object` representation and reports `UNKNOWN` — see wala/ML#488.
+# lattice represents this as `OBJECT` (wala/ML#488), so the asserts and the JUnit agree.
 assert x_train.dtype == np.dtype("object")
 assert x_test.dtype == np.dtype("object")
 assert y_train.dtype == np.int64

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reuters_load_data.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reuters_load_data.py
@@ -14,10 +14,8 @@ assert y_train.shape == (8982,)
 assert x_test.shape == (2246,)
 assert y_test.shape == (2246,)
 # `x_train` and `x_test` are numpy `object` arrays at runtime (each element is a
-# variable-length list of integer-encoded tokens). The analyzer's `DType` lattice has no
-# `object` representation and reports `UNKNOWN` — see wala/ML#488. The Python assert here
-# documents runtime truth; the JUnit expectation captures the analyzer's current imprecise
-# answer until #488 lands.
+# variable-length list of integer-encoded tokens). The analyzer's `DType` lattice represents
+# this as `OBJECT` (wala/ML#488), so the Python assert and the JUnit expectation agree.
 assert x_train.dtype == np.dtype("object")
 assert x_test.dtype == np.dtype("object")
 assert y_train.dtype == np.int64


### PR DESCRIPTION
## Summary

Adds `OBJECT` to the `DType` lattice so numpy `object`-dtype arrays (variable-length Python sequences, e.g. `tf.keras.datasets.reuters`/`imdb`'s `x_train`/`x_test`) are represented distinctly instead of conflated with `UNKNOWN` ("don't know").

## Changes

- `TensorFlowTypes.DType`: add `OBJECT(false, false, 0)`. Non-numeric, so `canConvertTo` matches only itself (no auto-convert to numeric, matching numpy's strict semantics); `DType.valueOf("OBJECT")` makes the existing dtype-string parsing recognize it with no further change. No `DType` switch or `values()` iteration needs updating (none exist).
- `ReutersInputData.X_DTYPES` and `ImdbInputData.X_DTYPES`: changed from `UNKNOWN` to `OBJECT`.
- Tests: `TENSOR_{8982,2246,25000}_UNKNOWN` renamed to `..._OBJECT` (cell type `object`); reuters/imdb test Javadoc, generator Javadoc, and fixture comments updated. The fixtures already asserted `x_train.dtype == np.dtype("object")`, so the JUnit now agrees, resolving the #260 fixture/JUnit mismatch.

Closes wala/ML#488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
