### PR TITLE
Compute the 0-extent `extract_patches` output shape for an undersized image

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -507,6 +507,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT32_UNKNOWN_SHAPE = new TensorType(INT_32, null);
 
+  private static final TensorType TENSOR_1_0_0_9_INT32 =
+      new TensorType(
+          INT_32,
+          asList(new NumericDim(1), new NumericDim(0), new NumericDim(0), new NumericDim(9)));
+
   private static final TensorType TENSOR_UNKNOWN_SHAPE_BOOL = new TensorType(BOOL, null);
 
   private static final TensorType TENSOR_3_INT32 =
@@ -6436,18 +6441,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for {@code tf.image.extract_patches} called with a Python <em>list
    * literal</em> {@code images} argument (rather than a {@code tf.Tensor}), per <a
-   * href="https://github.com/wala/ML/issues/584">wala/ML#584</a>. The result must still be
-   * recognized as a tensor; the {@code int32} dtype is inherited from the literal and the shape is
-   * ⊤ (the list-literal shape is not statically propagated through the op).
-   *
-   * <p>TODO: Tighten the shape from ⊤ to the concrete value once <a
-   * href="https://github.com/wala/ML/issues/585">wala/ML#585</a> infers a tensor's shape from a
-   * list literal.
+   * href="https://github.com/wala/ML/issues/584">wala/ML#584</a>. The list-literal shape {@code (1,
+   * 1, 1, 1)} is recovered from the nesting structure, and the result is the concrete {@code (1, 0,
+   * 0, 9) int32}: a {@code 3x3} patch does not fit the {@code 1x1} image, so {@code VALID} padding
+   * yields a 0-extent spatial output (depth {@code 3*3*1 = 9}), matching the runtime shape the
+   * Python fixture asserts (<a href="https://github.com/wala/ML/issues/585">wala/ML#585</a>).
    */
   @Test
   public void testExtractPatches2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_extract_patches2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+    test("tf2_test_extract_patches2.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_1_0_0_9_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
@@ -117,14 +117,18 @@ public class ExtractPatches extends PassThroughUnaryTensorGenerator {
    * @param stride The stride along this axis.
    * @param rate The dilation rate along this axis.
    * @param padding The padding mode ({@code "VALID"} or {@code "SAME"}).
-   * @return The output extent, or {@code null} when {@code padding} is unrecognized or no window
-   *     fits.
+   * @return The output extent, or {@code null} when {@code padding} is unrecognized or {@code
+   *     stride} is non-positive.
    */
   private static Integer windowedExtent(int in, int size, int stride, int rate, String padding) {
     if (stride <= 0) return null;
     if (padding.equalsIgnoreCase("VALID")) {
       int effectiveSize = (size - 1) * rate + 1;
-      if (in < effectiveSize) return null;
+      // No window fits when the image is smaller than the (dilated) patch: the output extent is 0,
+      // not ⊤. (Java integer division truncates toward zero, so the formula below would
+      // incorrectly yield 1 here; hence the explicit 0.) Matches TF, which produces a 0-extent
+      // output rather than erroring. See wala/ML#585.
+      if (in < effectiveSize) return 0;
       return (in - effectiveSize) / stride + 1;
     }
     if (padding.equalsIgnoreCase("SAME")) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_extract_patches2.py
@@ -5,8 +5,10 @@ def f(a):
     pass
 
 
-# `images` is a Python list literal (not a `tf.Tensor`); the result should still be
-# recognized as a tensor (wala/ML#584).
+# `images` is a Python list literal (not a `tf.Tensor`); the result is still recognized as a
+# tensor (wala/ML#584), and its `(1, 1, 1, 1)` shape is recovered from the literal's nesting.
+# A 3x3 patch does not fit the 1x1 image, so VALID padding yields a 0-extent spatial output
+# (depth 3*3*1 = 9): shape `(1, 0, 0, 9)` (wala/ML#585).
 r = tf.image.extract_patches(
     images=[[[[1]]]],
     sizes=[1, 3, 3, 1],
@@ -15,4 +17,5 @@ r = tf.image.extract_patches(
     padding="VALID",
 )
 assert r.dtype == tf.int32
+assert r.shape == (1, 0, 0, 9)
 f(r)


### PR DESCRIPTION
## Summary

`testExtractPatches2` feeds `tf.image.extract_patches` a list-literal `images` (`[[[[1]]]]`) and previously expected ⊤. The list-literal shape `(1, 1, 1, 1)` is in fact already recovered from the nesting (via `getShapesOfValue`); the ⊤ came from `windowedExtent` returning null for the degenerate window (a `3x3` patch in a `1x1` image). TF produces a 0-extent output there, so the correct shape is `(1, 0, 0, 9)`.

## Changes

- `ExtractPatches.windowedExtent`: for `VALID` padding when the image is smaller than the dilated patch, return `0` instead of null. Java integer division truncates toward zero, so the windowed-extent formula would wrongly yield `1`; the explicit `0` matches TF's 0-extent output.
- `testExtractPatches2`: tighten from `TENSOR_INT32_UNKNOWN_SHAPE` to the concrete `(1, 0, 0, 9) int32` (new constant `TENSOR_1_0_0_9_INT32`); the fixture asserts the runtime `r.shape == (1, 0, 0, 9)`.

## Note

The issue's premise (a list-literal's shape is not inferred) was stale: `getShapesOfValue` already infers it from the nesting (verified: the `images` operand resolves to `(1, 1, 1, 1)`). The actual blocker for tightening the test was the 0-extent window, fixed here.

Closes wala/ML#585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
