### PR TITLE
Repoint `testModelCall` loop-residual Javadoc reference to wala/ML#599

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1745,8 +1745,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Dropout output retains {@code (20, 784)}; the final {@code Dense(10)} output is tracked at
    * concrete {@code (20, 10)} via the SSA-chain fallback in {@link
    * com.ibm.wala.cast.python.ml.client.DenseCall#getDefaultShapes}. The phi'd loop-local still
-   * shows {@code (20, 784)} because the 100-element {@code my_layers} list collapses under 1-CFA so
-   * the inner {@code Dense(64)} narrowing isn't reached here. See wala/ML#358.
+   * shows {@code (20, 784)} because the loop receiver {@code self.my_layers[idx]} resolves to ⊥
+   * under 1-CFA — the subscript read doesn't recover the list's {@code Dense(64)} element instances
+   * — so the inner {@code Dense(64)} call is never typed. That residual is a container/list-element
+   * resolution gap tracked by <a href="https://github.com/wala/ML/issues/599">wala/ML#599</a>,
+   * distinct from the chained-method-call recursion of <a
+   * href="https://github.com/wala/ML/issues/358">wala/ML#358</a> that narrows the direct {@code
+   * Dense(10)} call here.
    */
   @Test
   public void testModelCall()


### PR DESCRIPTION
## What

Repoints the `testModelCall` Javadoc's loop-residual reference from wala/ML#358 to the correctly-scoped wala/ML#599, and sharpens the root-cause wording.

## Why

While verifying wala/ML#358 (now closed — the chained-method-call `Dense` shape recursion is landed and regression-guarded; the direct `Dense(10)` narrows to `(20, 10)`), I confirmed the one residual imprecision in `SequentialModel.__call__` — the phi'd loop-local staying at `(20, 784)` instead of `(20, 64)` — is a **different** problem:

- The loop receiver `self.my_layers[idx]` has an **empty points-to set** under 1-CFA — the subscript read doesn't recover the list's `Dense(64)` element instances.
- So the loop call resolves no receiver and is never typed; a call-site generator could recover nothing.

That is a container/list-element-resolution gap, distinct from the chained-method-call recursion wala/ML#358 added. It is now tracked as wala/ML#599, and this Javadoc points there.

## Scope

Javadoc-only; no behavior change. `testModelCall` already pins the count (5) and the final `Dense` shape is guarded by `testModelCallConsume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
