### PR TITLE
Recover the output shape of layer calls iterated over a list field

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -427,6 +427,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_20_10_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(10)));
 
+  private static final TensorType TENSOR_20_64_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(64)));
+
   private static final TensorType TENSOR_60000_28_28_FLOAT32 =
       new TensorType(
           FLOAT_32, asList(new NumericDim(60000), new NumericDim(28), new NumericDim(28)));
@@ -1738,20 +1741,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Five tensor variables in {@code SequentialModel.__call__}: the {@code x} parameter (vn=3, shape
-   * {@code (20, 28, 28) f32}) plus four intermediate SSA values produced by the {@code
-   * self.flatten(x) → 100× Dense(64) → self.dropout(x) → self.dense_2(x)} chain. The Flatten result
-   * is concrete {@code (20, 784)} via {@link com.ibm.wala.cast.python.ml.client.FlattenCall}; the
-   * Dropout output retains {@code (20, 784)}; the final {@code Dense(10)} output is tracked at
-   * concrete {@code (20, 10)} via the SSA-chain fallback in {@link
-   * com.ibm.wala.cast.python.ml.client.DenseCall#getDefaultShapes}. The phi'd loop-local still
-   * shows {@code (20, 784)} because the loop receiver {@code self.my_layers[idx]} resolves to ⊥
-   * under 1-CFA — the subscript read doesn't recover the list's {@code Dense(64)} element instances
-   * — so the inner {@code Dense(64)} call is never typed. That residual is a container/list-element
-   * resolution gap tracked by <a href="https://github.com/wala/ML/issues/599">wala/ML#599</a>,
-   * distinct from the chained-method-call recursion of <a
-   * href="https://github.com/wala/ML/issues/358">wala/ML#358</a> that narrows the direct {@code
-   * Dense(10)} call here.
+   * Six tensor variables in {@code SequentialModel.__call__}: the {@code x} parameter (vn=3, shape
+   * {@code (20, 28, 28) f32}) plus five intermediate SSA values produced by the {@code
+   * self.flatten(x) → 100× Dense(64) → self.dropout(x) → self.dense_2(x)} chain. The {@code
+   * Flatten} result is concrete {@code (20, 784)} via {@link
+   * com.ibm.wala.cast.python.ml.client.FlattenCall} (vn=9); the loop's {@code Dense(64)} output is
+   * concrete {@code (20, 64)} (vn=22); the loop-head phi (vn=17) and the {@code Dropout} output
+   * (vn=26) union both reachable shapes {@code {(20, 784), (20, 64)}} (the pre-loop entry shape
+   * survives because an empty {@code my_layers} would leave {@code x} at the {@code Flatten}
+   * shape); the final {@code Dense(10)} output is concrete {@code (20, 10)} (vn=30).
+   *
+   * <p>The loop's {@code Dense(64)} narrows because {@code range(n)} now returns an iterable
+   * (non-empty) list, so the {@code self.my_layers} comprehension populates the list and the {@code
+   * self.my_layers[idx]} subscript read resolves to its {@code Dense(64)} elements (<a
+   * href="https://github.com/wala/ML/issues/599">wala/ML#599</a>). The direct {@code Dense(10)}
+   * narrows via the SSA-chain fallback in {@link
+   * com.ibm.wala.cast.python.ml.client.DenseCall#getDefaultShapes} (<a
+   * href="https://github.com/wala/ML/issues/358">wala/ML#358</a>).
    */
   @Test
   public void testModelCall()
@@ -1760,7 +1766,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_model_call.py",
         "SequentialModel.__call__",
         1,
-        5,
+        6,
         Map.of(3, Set.of(TENSOR_20_28_28_FLOAT32)));
   }
 
@@ -1771,7 +1777,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_model_call2.py",
         "SequentialModel.call",
         1,
-        5,
+        6,
         Map.of(3, Set.of(TENSOR_20_28_28_FLOAT32)));
   }
 
@@ -1782,7 +1788,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_model_call3.py",
         "SequentialModel.call",
         1,
-        5,
+        6,
         Map.of(3, Set.of(TENSOR_20_28_28_FLOAT32)));
   }
 
@@ -1793,7 +1799,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_model_call4.py",
         "SequentialModel.__call__",
         1,
-        5,
+        6,
         Map.of(3, Set.of(TENSOR_20_28_28_FLOAT32)));
   }
 
@@ -1846,7 +1852,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_model_call6.py",
         "SequentialModel.__call__",
         1,
-        5,
+        6,
         Map.of(3, Set.of(TENSOR_20_28_28_INT32)));
   }
 
@@ -11366,6 +11372,33 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
         "tf2_test_model_call_consume.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_20_10_FLOAT32)));
+  }
+
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/599">wala/ML#599</a>.
+   *
+   * <p>Derived from {@link #testModelCall()} (see {@code tf2_test_model_call.py}) by adding a
+   * {@code consume(x)} call <em>inside</em> the {@code for layer in self.my_layers} loop,
+   * immediately after {@code x = layer(x)}. At that point {@code x} is the loop's {@code Dense(64)}
+   * output, shape {@code (20, 64)} and dtype {@code float32}.
+   *
+   * <p>This pins the loop-iterated layer call's output, which is the gap wala/ML#599 closes:
+   * because {@code range(n)} now returns an iterable (non-empty) list, the {@code self.my_layers}
+   * comprehension populates the list, the {@code self.my_layers[idx]} subscript read resolves to
+   * its {@code Dense(64)} elements, and the loop call's output narrows to {@code (20, 64)} rather
+   * than carrying the upstream {@code Flatten} shape {@code (20, 784)} unchanged. {@link
+   * com.ibm.wala.cast.python.ml.client.DenseCall} breaks the resulting input-shape self-recursion
+   * (the loop's collapsed 1-CFA node feeds its own output back in) via a per-thread cycle guard.
+   */
+  @Test
+  public void testModelCallLoopConsume()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_call_loop_consume.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_20_64_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -38,6 +38,20 @@ public class DenseCall extends TensorGenerator {
   private static final String DENSE_UNITS_FIELD_NAME = "units";
 
   /**
+   * Per-thread set of {@code Dense.__call__} nodes whose input shape is currently being computed.
+   *
+   * <p>Breaks unbounded recursion when a layer call's input flows back to itself. The motivating
+   * case is a loop over a list of layers ({@code for layer in self.my_layers: x = layer(x)}): under
+   * 1-CFA the list elements collapse to a single {@code Dense.__call__} node, so that node's input
+   * points-to set includes its own output, and {@link #getInputShapes} would otherwise recurse on
+   * the same node forever. On re-entry for an in-progress node we return {@code null}, letting the
+   * other phi operand (e.g., the upstream {@code Flatten} output) supply the base shape. See
+   * wala/ML#599.
+   */
+  private static final ThreadLocal<Set<CGNode>> INPUT_SHAPE_NODES_IN_PROGRESS =
+      ThreadLocal.withInitial(HashSet::new);
+
+  /**
    * Parameter positions and names for calls to {@code tf.keras.layers.Dense}.
    *
    * @see <a
@@ -153,7 +167,40 @@ public class DenseCall extends TensorGenerator {
   }
 
   /**
-   * Resolves the input tensor shapes for this {@code Dense.__call__} invocation.
+   * Resolves the input tensor shapes for this {@code Dense.__call__} invocation, guarding against
+   * cyclic self-recursion before delegating to {@link
+   * #computeInputShapes(PropagationCallGraphBuilder)}.
+   *
+   * <p>The guard ({@link #INPUT_SHAPE_NODES_IN_PROGRESS}) breaks the recursion that arises when a
+   * layer call's input flows back to itself — e.g., a loop over a list of layers whose collapsed
+   * 1-CFA node feeds its own output back in as input. See wala/ML#599.
+   *
+   * @param builder The propagation call graph builder used for points-to analysis and factory
+   *     dispatch.
+   * @return The set of possible input shapes, or {@code null} if neither path resolves a shape or
+   *     the node is already being resolved on this thread (cycle).
+   */
+  private Set<List<Dimension<?>>> getInputShapes(PropagationCallGraphBuilder builder) {
+    CGNode self = this.getNode();
+    Set<CGNode> inProgress = INPUT_SHAPE_NODES_IN_PROGRESS.get();
+    if (!inProgress.add(self)) {
+      // Cyclic chain: this `Dense.__call__` node's input flows back to itself (e.g., a layer-list
+      // loop whose output feeds in as its own input under 1-CFA node collapse). Break the cycle;
+      // the other phi operand supplies the base shape. See wala/ML#599.
+      LOGGER.fine(() -> "getInputShapes: cycle detected at node " + self + "; breaking recursion.");
+      return null;
+    }
+    try {
+      return this.computeInputShapes(builder);
+    } finally {
+      inProgress.remove(self);
+    }
+  }
+
+  /**
+   * Computes the input tensor shapes for this {@code Dense.__call__} invocation. Always invoked
+   * under the {@link #INPUT_SHAPE_NODES_IN_PROGRESS} cycle guard established by {@link
+   * #getInputShapes(PropagationCallGraphBuilder)}.
    *
    * <p>Primary path: walks the {@code inputs} argument's points-to set and dispatches the
    * allocating node through {@link #createManualGenerator(CGNode, PropagationCallGraphBuilder)}.
@@ -171,9 +218,10 @@ public class DenseCall extends TensorGenerator {
    *
    * @param builder The propagation call graph builder used for points-to analysis and factory
    *     dispatch.
-   * @return The set of possible input shapes, or {@code null} if neither path resolves a shape.
+   * @return The set of possible input shapes, or {@code null} if neither the PTS walk nor the
+   *     SSA-chain fallback resolves a shape.
    */
-  private Set<List<Dimension<?>>> getInputShapes(PropagationCallGraphBuilder builder) {
+  private Set<List<Dimension<?>>> computeInputShapes(PropagationCallGraphBuilder builder) {
     OrdinalSet<InstanceKey> inputPts =
         this.getArgumentPointsToSet(
             builder, Parameters.INPUTS.getIndex(), Parameters.INPUTS.getName());

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call_loop_consume.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call_loop_consume.py
@@ -1,0 +1,46 @@
+import tensorflow as tf
+
+
+def consume(tensor):
+    pass
+
+
+# Create an override model to classify pictures
+
+
+class SequentialModel(tf.keras.Model):
+    def __init__(self, **kwargs):
+        super(SequentialModel, self).__init__(**kwargs)
+
+        self.flatten = tf.keras.layers.Flatten(input_shape=(28, 28))
+
+        # Add a lot of small layers
+        num_layers = 100
+        self.my_layers = [
+            tf.keras.layers.Dense(64, activation="relu") for n in range(num_layers)
+        ]
+
+        self.dropout = tf.keras.layers.Dropout(0.2)
+        self.dense_2 = tf.keras.layers.Dense(10)
+
+    def __call__(self, x):
+        x = self.flatten(x)
+
+        for layer in self.my_layers:
+            x = layer(x)
+            assert x.shape == (20, 64)
+            assert x.dtype == tf.float32
+            consume(x)
+
+        x = self.dropout(x)
+        x = self.dense_2(x)
+
+        return x
+
+
+input_data = tf.random.uniform([20, 28, 28])
+assert input_data.shape == (20, 28, 28)
+assert input_data.dtype == tf.float32
+
+model = SequentialModel()
+result = model(input_data)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -14,6 +14,7 @@ import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.ClassTargetSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ssa.ConstantValue;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
@@ -49,6 +50,48 @@ public class BuiltinFunctions {
     AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
     x.addStatement(factory.NewInstruction(0, 11, NewSiteReference.make(0, returnedType)));
     x.addStatement(factory.ReturnInstruction(1, 11, false));
+
+    return x;
+  }
+
+  private static IMethod iterableSummary(
+      IClass cls, String name, TypeReference containerType, TypeReference elementType) {
+    PythonSummary S = iterableSummary(cls, builtinFunction(name), containerType, elementType);
+    return new PythonSummarizedFunction(S.getMethod(), S, cls);
+  }
+
+  /**
+   * Builds a summary for a builtin that returns a freshly-allocated container holding one element
+   * of the given element type, written under a constant key.
+   *
+   * <p>Unlike {@link #typeSummary(IClass, TypeReference, TypeReference)}, which returns an
+   * <em>empty</em> container, this populates the container so that iterating it (via {@code
+   * EachElementGetInstruction}) yields the element. {@code range} needs this: a comprehension or
+   * {@code for} loop over {@code range(n)} reads each element's key off the result, and an empty
+   * container starves that read, which in turn starves any downstream element write (e.g., a list
+   * comprehension building {@code self.my_layers}). See wala/ML#599.
+   *
+   * @param cls The {@link IClass} the summarized function belongs to.
+   * @param containerType The type of the returned container (e.g., {@link PythonTypes#list}).
+   * @param elementType The type allocated for the container's single element (e.g., {@link
+   *     TypeReference#Int}).
+   * @return A {@link PythonSummary} returning a one-element container.
+   */
+  private static PythonSummary iterableSummary(
+      IClass cls, TypeReference type, TypeReference containerType, TypeReference elementType) {
+    MethodReference ref = MethodReference.findOrCreate(type, AstMethodReference.fnSelector);
+    PythonSummary x = new PythonSummary(ref, 10);
+
+    AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
+    int container = 11;
+    int element = 12;
+    int key = 13;
+
+    x.addStatement(factory.NewInstruction(0, container, NewSiteReference.make(0, containerType)));
+    x.addStatement(factory.NewInstruction(1, element, NewSiteReference.make(1, elementType)));
+    x.addConstant(key, new ConstantValue(0));
+    x.addStatement(factory.PropertyWrite(2, container, key, element));
+    x.addStatement(factory.ReturnInstruction(3, container, false));
 
     return x;
   }
@@ -92,7 +135,13 @@ public class BuiltinFunctions {
       this.cha = cha;
       this.ref = builtinFunction(name);
       this.builtinCode =
-          returnedType == null ? noopSummary(this, name) : typeSummary(this, name, returnedType);
+          returnedType == null
+              ? noopSummary(this, name)
+              // `range` must return an iterable (non-empty) container so that loops and
+              // comprehensions over it can recover element keys. See wala/ML#599.
+              : name.equals("range")
+                  ? iterableSummary(this, name, returnedType, TypeReference.Int)
+                  : typeSummary(this, name, returnedType);
     }
 
     private BuiltinFunction(IClassHierarchy cha, String name, int arg) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -56,7 +56,7 @@ public class BuiltinFunctions {
 
   private static IMethod iterableSummary(
       IClass cls, String name, TypeReference containerType, TypeReference elementType) {
-    PythonSummary S = iterableSummary(cls, builtinFunction(name), containerType, elementType);
+    PythonSummary S = iterableSummary(builtinFunction(name), containerType, elementType);
     return new PythonSummarizedFunction(S.getMethod(), S, cls);
   }
 
@@ -71,14 +71,14 @@ public class BuiltinFunctions {
    * container starves that read, which in turn starves any downstream element write (e.g., a list
    * comprehension building {@code self.my_layers}). See wala/ML#599.
    *
-   * @param cls The {@link IClass} the summarized function belongs to.
+   * @param type The {@link TypeReference} of the builtin function whose summary this is.
    * @param containerType The type of the returned container (e.g., {@link PythonTypes#list}).
    * @param elementType The type allocated for the container's single element (e.g., {@link
    *     TypeReference#Int}).
    * @return A {@link PythonSummary} returning a one-element container.
    */
   private static PythonSummary iterableSummary(
-      IClass cls, TypeReference type, TypeReference containerType, TypeReference elementType) {
+      TypeReference type, TypeReference containerType, TypeReference elementType) {
     MethodReference ref = MethodReference.findOrCreate(type, AstMethodReference.fnSelector);
     PythonSummary x = new PythonSummary(ref, 10);
 


### PR DESCRIPTION
## What

Types the output of layer calls iterated over a list field, the common Sequential pattern:

```python
self.my_layers = [tf.keras.layers.Dense(64, ...) for n in range(100)]
...
for layer in self.my_layers:
    x = layer(x)   # previously: x stayed (20, 784); now: (20, 64)
```

## Root Cause

A front-end modeling gap: `range(n)` was summarized as an **empty** `list`, so iterating it yielded no element keys. The `self.my_layers` comprehension iterates `range`, so its element write into the result list ran under an empty key and never materialized, leaving the list element-less and the `self.my_layers[idx]` subscript read resolving to ⊥. With no receiver, the loop call resolved no `Dense.__call__` callee and produced no tensor type.

(Verified by heap probe: `list@20` had no outgoing element edges, and the comprehension's `Dense(64)` was reachable only as the per-element function's return value, never linked to the list.)

## Fix

- **`BuiltinFunctions`**: `range` now returns a one-element (iterable) `list` via a new `iterableSummary`, so loops and comprehensions over `range(n)` recover an element key. Once the comprehension populates `self.my_layers`, the subscript read resolves to the `Dense(64)` elements and the **existing** tensor analysis types the loop call.
- **`DenseCall`**: resolving the loop receiver exposes a cycle (under 1-CFA the 100 list elements collapse to one node whose input points-to set includes its own output), so the input-shape recursion now runs under a per-thread in-progress-node guard. On re-entry it returns `null`, letting the other phi operand (the `Flatten` output) supply the base shape.

## Result

The loop's `Dense(64)` output narrows to `(20, 64)`. The loop-head phi and the `Dropout` output soundly union `{(20, 784), (20, 64)}` (an empty `my_layers` would leave `x` at the `Flatten` shape). `testModelCall{,2,3,4,6}` gain one tracked tensor variable (5→6), and new `testModelCallLoopConsume` pins the loop output at `(20, 64)`.

## Validation

Full `mvn test` from root is green: 853 + 80 + 46 tests, 0 failures (3 pre-existing skips). The front-end `range` change caused no regressions in any module, including the front-end test suite.

Closes wala/ML#599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
