### PR TITLE
Fold arithmetic shape-argument dims and unify the two extraction paths

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -244,14 +244,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_4_8_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(8)));
 
+  private static final TensorType TENSOR_4_512_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(512)));
+
   private static final TensorType SPARSE_TENSOR_4_4_FLOAT32 =
       new SparseTensorType(FLOAT32, asList(new NumericDim(4), new NumericDim(4)));
-
-  private static final TensorType TENSOR_UNKNOWN_DYNAMIC_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE));
-
-  private static final TensorType TENSOR_UNKNOWN_UNKNOWN_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new SymbolicDim("?"), new SymbolicDim("?")));
 
   private static final TensorType TENSOR_4_10_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(10)));
@@ -8984,20 +8981,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Documents the current imprecision for <a
-   * href="https://github.com/wala/ML/issues/581">wala/ML#581</a>: a {@code tf.reshape} whose dim is
-   * arithmetic over instance attributes ({@code self.heads * self.out_features}) infers the
-   * per-context union {@code {(?, ?), (?, Dynamic)}} rather than the precise {@code (4, 512)}.
-   * Neither shape-argument extraction path folds it: the interpreter-based {@code
-   * TensorType.shapeArg} cannot evaluate {@code self.X} as source text, and the generator-side
-   * {@code getShapesFromShapeArgument} emits a {@code DynamicDim} for the unresolved binary op.
-   * Resolving it needs the generator-side path to fold a binary op over constant-valued field reads
-   * via the analysis (not the interpreter). This guard pins the current result so it flips when
-   * #581 lands.
-   *
-   * <p>TODO: tighten to {@code (4, 512)} once <a
-   * href="https://github.com/wala/ML/issues/581">wala/ML#581</a> reconciles the two shape-argument
-   * extraction paths.
+   * Regression guard for <a href="https://github.com/wala/ML/issues/581">wala/ML#581</a>: a {@code
+   * tf.reshape} whose dim is arithmetic over instance attributes ({@code self.heads *
+   * self.out_features}) infers the precise {@code (4, 512)}. Both shape-argument extraction paths
+   * now fold the binary op over constant-valued field reads through the points-to analysis (the
+   * shared {@link com.ibm.wala.cast.python.ml.types.TensorType#foldArithmeticDim}): the
+   * generator-side {@code getShapesFromShapeArgument} and the interpreter-based {@code
+   * TensorType.shapeArg}, which previously degraded to {@code DynamicDim} / {@code SymbolicDim}
+   * respectively since {@code interpretAsInt} cannot evaluate {@code self.X} as source text.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -9008,11 +8999,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testReshapeSelfArith()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_reshape_self_arith.py",
-        "consume",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_UNKNOWN_FLOAT32, TENSOR_UNKNOWN_DYNAMIC_FLOAT32)));
+        "tf2_test_reshape_self_arith.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_512_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -247,6 +247,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_4_512_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(512)));
 
+  private static final TensorType TENSOR_2_64_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(64)));
+
   private static final TensorType SPARSE_TENSOR_4_4_FLOAT32 =
       new SparseTensorType(FLOAT32, asList(new NumericDim(4), new NumericDim(4)));
 
@@ -9000,6 +9003,31 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
         "tf2_test_reshape_self_arith.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_512_FLOAT32)));
+  }
+
+  /**
+   * Coverage companion to {@link #testReshapeSelfArith()} for <a
+   * href="https://github.com/wala/ML/issues/581">wala/ML#581</a>: a {@code tf.reshape} dim of
+   * {@code self.base + 4} infers the precise {@code (2, 64)}. Exercises the {@code ADD} operator
+   * and a literal operand of the arithmetic fold (the sibling fixture covers {@code MUL} over two
+   * field reads), so {@link com.ibm.wala.cast.python.ml.types.TensorType#resolveConstantInt}
+   * resolves one operand via the symbol table ({@code 4}) and the other via the points-to analysis
+   * ({@code self.base}).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testReshapeSelfArithAdd()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_self_arith_add.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_64_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -897,7 +897,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             if (!builder.getPropagationSystem().isImplicit(defKey))
               targets.put(
                   builder.getPropagationSystem().findOrCreatePointsToSet(defKey),
-                  TensorType.shapeArg(src, call.getUse(param)));
+                  TensorType.shapeArg(src, call.getUse(param), builder));
           }
         });
     return targets;
@@ -996,7 +996,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         if (builder.getPropagationSystem().isImplicit(receiverKey)) continue;
         targets.put(
             builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
-            TensorType.shapeArg(caller, call.getUse(1)));
+            TensorType.shapeArg(caller, call.getUse(1), builder));
       }
     }
     return targets;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -57,9 +57,13 @@ import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.CallString;
+import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.ssa.SSAPutInstruction;
+import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -441,13 +445,19 @@ public abstract class TensorGenerator {
         // position's set but only retained the last iterated element, producing a
         // non-deterministic single shape per `i` rather than the full product.
         List<Set<Dimension<?>>> resolved = new ArrayList<>(possibleDimensions.length);
-        for (Set<Dimension<?>> s : possibleDimensions) {
-          // TODO(https://github.com/wala/ML/issues/581): an empty position holding a binary op over
-          // constant-valued operands (e.g. `self.heads * self.out_features`) could be folded to a
-          // `NumericDim` via the analysis instead of degrading to `DynamicDim`. This is the
-          // generator-side half of the shape-argument-extraction reconciliation.
-          if (s == null || s.isEmpty()) resolved.add(Collections.singleton(DynamicDim.INSTANCE));
-          else resolved.add(s);
+        for (int k = 0; k < possibleDimensions.length; k++) {
+          Set<Dimension<?>> s = possibleDimensions[k];
+          if (s != null && !s.isEmpty()) {
+            resolved.add(s);
+            continue;
+          }
+          // An empty position holds no resolved constant. Before degrading to `DynamicDim`, try to
+          // fold a binary op over constant-valued operands (e.g. `self.heads * self.out_features`)
+          // via the analysis. `interpretAsInt` in `TensorType.shapeArg` only handles pure-literal
+          // source text; this generator-side path resolves field reads and globals through the PTS,
+          // reconciling the two shape-argument-extraction paths (wala/ML#581).
+          Dimension<?> folded = foldArithmeticShapeDim(builder, asin, k);
+          resolved.add(Collections.singleton(folded != null ? folded : DynamicDim.INSTANCE));
         }
 
         List<List<Dimension<?>>> shapes = new ArrayList<>();
@@ -554,6 +564,74 @@ public abstract class TensorGenerator {
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Attempts to fold the shape dimension at {@code fieldIndex} of the shape list/tuple allocated at
+   * {@code listAsin} when that element is a binary op over constant-valued operands (e.g. {@code
+   * self.heads * self.out_features}).
+   *
+   * <p>The element write is located in the list's allocating node IR, and the binary op's operands
+   * are resolved to constants through the points-to analysis (so field reads and globals resolve,
+   * not just source-text literals). This is the generator-side half of the shape-argument
+   * reconciliation in wala/ML#581: {@link TensorType#shapeArg(CGNode, int,
+   * PropagationCallGraphBuilder)} can fold literal source text via the embedded interpreter but has
+   * no points-to analysis to resolve {@code self.X}.
+   *
+   * @param builder The propagation call graph builder, used to resolve operand points-to sets.
+   * @param listAsin The allocation site of the shape list/tuple.
+   * @param fieldIndex The position whose dimension is being folded.
+   * @return A {@link NumericDim} holding the folded value, or {@code null} if the element is not a
+   *     constant-foldable binary op.
+   */
+  private Dimension<?> foldArithmeticShapeDim(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin, int fieldIndex) {
+    CGNode node = listAsin.getNode();
+    if (node.getIR() == null) return null;
+    DefUse du = node.getDU();
+    SymbolTable st = node.getIR().getSymbolTable();
+    SSANewInstruction allocInstr = node.getIR().getNew(listAsin.getSite());
+    if (allocInstr == null) return null;
+    int listVn = allocInstr.getDef();
+
+    for (Iterator<SSAInstruction> uses = du.getUses(listVn); uses.hasNext(); ) {
+      SSAInstruction use = uses.next();
+      int objRef;
+      int writtenVal;
+      Integer index = null;
+
+      if (use instanceof PythonPropertyWrite) {
+        PythonPropertyWrite w = (PythonPropertyWrite) use;
+        objRef = w.getObjectRef();
+        writtenVal = w.getValue();
+        int memberVn = w.getMemberRef();
+        if (st.isNumberConstant(memberVn))
+          index = ((Number) st.getConstantValue(memberVn)).intValue();
+        else if (st.isStringConstant(memberVn)) {
+          try {
+            index = Integer.parseInt(st.getStringValue(memberVn));
+          } catch (NumberFormatException e) {
+            // not an index write.
+          }
+        }
+      } else if (use instanceof SSAPutInstruction) {
+        SSAPutInstruction p = (SSAPutInstruction) use;
+        if (p.isStatic()) continue;
+        objRef = p.getRef();
+        writtenVal = p.getVal();
+        try {
+          index = Integer.parseInt(p.getDeclaredField().getName().toString());
+        } catch (NumberFormatException e) {
+          // not an index write.
+        }
+      } else continue;
+
+      if (objRef != listVn || index == null || index.intValue() != fieldIndex) continue;
+
+      // Shared with `TensorType.shapeArg` so the two shape-argument paths agree (wala/ML#581).
+      return TensorType.foldArithmeticDim(builder, node, st, du, writtenVal);
+    }
     return null;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -23,7 +23,13 @@ import com.ibm.wala.cast.python.util.PythonInterpreter;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.cast.util.SourceBuffer;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.ssa.DefUse;
+import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSAPutInstruction;
 import com.ibm.wala.ssa.SymbolTable;
@@ -648,7 +654,8 @@ public class TensorType implements Iterable<Dimension<?>> {
     return new TensorType(FLOAT32.name().toLowerCase(Locale.ROOT), Arrays.asList(batch, vec));
   }
 
-  public static TensorType shapeArg(CGNode node, int literalVn) {
+  public static TensorType shapeArg(
+      CGNode node, int literalVn, PropagationCallGraphBuilder builder) {
     logger.fine(() -> node.getIR().toString());
     Map<Integer, Dimension<?>> dims = new TreeMap<>();
     DefUse du = node.getDU();
@@ -733,14 +740,101 @@ public class TensorType implements Iterable<Dimension<?>> {
             }
           }
         }
-        // TODO(https://github.com/wala/ML/issues/581): when the dim is a binary op over
-        // constant-valued operands (field reads such as `self.heads * self.out_features`, globals),
-        // fold it via the analysis instead of degrading to a symbolic dim. `interpretAsInt` above
-        // only handles pure-literal source text, so the generator-side path should own this.
-        dims.put(index, new SymbolicDim("?"));
+        // When the dim is a binary op over constant-valued operands (field reads such as
+        // `self.heads * self.out_features`, globals), fold it via the points-to analysis instead of
+        // degrading to a symbolic dim. `interpretAsInt` above only handles pure-literal source
+        // text; this PTS-based fold reconciles `shapeArg` with the generator-side shape-argument
+        // extraction (wala/ML#581).
+        Dimension<?> folded = foldArithmeticDim(builder, node, S, du, val);
+        dims.put(index, folded != null ? folded : new SymbolicDim("?"));
       }
     }
     return new TensorType(FLOAT32.name().toLowerCase(Locale.ROOT), new ArrayList<>(dims.values()));
+  }
+
+  /**
+   * Folds a shape dimension that is a binary op over constant-valued operands (e.g. {@code
+   * self.heads * self.out_features}) to a {@link NumericDim}, resolving each operand to a constant
+   * through the points-to analysis (so instance-field reads and globals resolve, not just
+   * literals).
+   *
+   * <p>Shared by {@link #shapeArg(CGNode, int, PropagationCallGraphBuilder)} and the generator-side
+   * shape-argument extraction so the two paths agree (wala/ML#581).
+   *
+   * @param builder The propagation call graph builder, or {@code null} if unavailable (no fold).
+   * @param node The node whose IR defines {@code val}.
+   * @param symbolTable The symbol table of {@code node}'s IR.
+   * @param du The def-use of {@code node}.
+   * @param val The value number of the dimension expression.
+   * @return A {@link NumericDim} holding the folded value, or {@code null} if {@code val} is not a
+   *     constant-foldable binary op.
+   */
+  public static Dimension<?> foldArithmeticDim(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      SymbolTable symbolTable,
+      DefUse du,
+      int val) {
+    if (builder == null) return null;
+    SSAInstruction def = du.getDef(val);
+    if (!(def instanceof SSABinaryOpInstruction)) return null;
+    SSABinaryOpInstruction binOp = (SSABinaryOpInstruction) def;
+    Integer left = resolveConstantInt(builder, node, symbolTable, binOp.getUse(0));
+    Integer right = resolveConstantInt(builder, node, symbolTable, binOp.getUse(1));
+    if (left == null || right == null) return null;
+    Integer value = applyIntBinOp(binOp.getOperator(), left, right);
+    return value == null ? null : new NumericDim(value);
+  }
+
+  /**
+   * Resolves {@code vn} (in {@code node}) to a constant integer: a literal in the symbol table or a
+   * {@link ConstantKey} in its points-to set (e.g. an instance-field read of a numeric attribute
+   * set in {@code __init__}).
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The node whose IR contains {@code vn}.
+   * @param symbolTable The symbol table of {@code node}'s IR.
+   * @param vn The value number to resolve.
+   * @return The constant integer value, or {@code null} if {@code vn} is not unambiguously
+   *     constant.
+   */
+  public static Integer resolveConstantInt(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable symbolTable, int vn) {
+    if (vn <= 0) return null;
+    if (symbolTable.isNumberConstant(vn))
+      return ((Number) symbolTable.getConstantValue(vn)).intValue();
+
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    if (pk == null) return null;
+
+    Integer found = null;
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(pk)) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object value = ((ConstantKey<?>) ik).getValue();
+      if (!(value instanceof Number)) return null;
+      int iv = ((Number) value).intValue();
+      if (found != null && found.intValue() != iv) return null; // ambiguous
+      found = iv;
+    }
+    return found;
+  }
+
+  /**
+   * Applies an integer binary operator, mirroring the {@code SSABinaryOpInstruction} dispatch in
+   * the tensor-generator factory.
+   *
+   * @param operator The binary operator.
+   * @param left The left operand.
+   * @param right The right operand.
+   * @return The result, or {@code null} for an unsupported operator or division by zero.
+   */
+  public static Integer applyIntBinOp(
+      IBinaryOpInstruction.IOperator operator, int left, int right) {
+    if (operator == IBinaryOpInstruction.Operator.ADD) return left + right;
+    if (operator == IBinaryOpInstruction.Operator.SUB) return left - right;
+    if (operator == IBinaryOpInstruction.Operator.MUL) return left * right;
+    if (operator == IBinaryOpInstruction.Operator.DIV) return right != 0 ? left / right : null;
+    return null;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_self_arith_add.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_self_arith_add.py
@@ -1,0 +1,27 @@
+"""Coverage companion to `tf2_test_reshape_self_arith.py` for wala/ML#581: exercises the
+`ADD` operator and a literal operand in the shape-argument arithmetic fold (the sibling fixture
+covers `MUL` over two instance-field reads). `self.base + 4` mixes a field read (resolved via the
+points-to analysis) with a pure literal (resolved via the symbol table).
+"""
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+class Reshaper:
+    def __init__(self):
+        self.base = 60
+
+    def reshape_it(self, x):
+        y = tf.reshape(x, [-1, self.base + 4])
+        assert y.shape == (2, 64) and y.dtype == tf.float32
+        consume(y)
+
+
+r = Reshaper()
+x = tf.ones([8, 16])
+assert x.shape == (8, 16)
+r.reshape_it(x)


### PR DESCRIPTION
## What

Folds a shape-argument dimension that is a binary op over constant-valued operands (instance-field reads like `self.heads * self.out_features`, globals) to a concrete `NumericDim`, and reconciles the two shape-argument extraction paths so they agree.

## Why

Such a dim previously degraded to a symbolic/dynamic dim. Neither path folded it:
- `TensorType.shapeArg` evaluates source *text* via the embedded interpreter and cannot resolve `self.X`.
- the generator-side `getShapesFromShapeArgument` emitted a `DynamicDim` for the unresolved binary op.

## How

A shared `TensorType.foldArithmeticDim` resolves each operand to a constant through the **points-to analysis** (`ConstantKey`), so field reads and globals fold, not just literals. Both paths route through it:
- `TensorType.shapeArg` gains a `PropagationCallGraphBuilder` parameter (its two call sites already have the builder) and folds when `interpretAsInt` can't.
- `getShapesFromShapeArgument` folds an empty (binary-op) position via the list's allocating-node IR before degrading to `DynamicDim`.

## Result

`testReshapeSelfArith`'s `tf.reshape(x, [-1, self.heads * self.out_features])` (8 × 64) now infers the precise `(4, 512)` rather than the per-context union `{(?, ?), (?, Dynamic)}`. The test's expectation is tightened from a documented-imprecision guard to a positive `(4, 512)` assertion.

## Validation

Full `mvn test` from root is green: every module `Failures: 0, Errors: 0`. The `shapeArg` signature change (used by `set_shape` and shape-source calls) caused no regressions, and operand resolution uses a read-only `getPointsToSet` so it does not trigger the wala/ML#573 IR dump.

Closes wala/ML#581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
