### PR TITLE
Type the `tf.linalg.solve` family from the `rhs` argument

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -540,6 +540,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_5_INT32 =
       new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(5)));
 
+  private static final TensorType TENSOR_3_5_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(5)));
+
   private static final TensorType TENSOR_4_FLOAT64 =
       new TensorType(FLOAT_64, asList(new NumericDim(4)));
 
@@ -6335,6 +6338,63 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2, Set.of(TENSOR_3_2_2_FLOAT32),
             3, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.solve(matrix, rhs)} reports the shape and dtype of the
+   * right-hand side {@code rhs} (arg 1), not the coefficient {@code matrix} (arg 0). A {@code (3,
+   * 3)} matrix and a {@code (3, 5)} rhs yield a {@code (3, 5)} result. Previously the op was
+   * modeled as a first-argument {@code pass_through}, which reported the {@code (3, 3)} matrix
+   * shape — an actively wrong answer. See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2b.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testSolve()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_solve.py", "consume_solve", 1, 1, Map.of(2, Set.of(TENSOR_3_5_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.cholesky_solve(chol, rhs)} reports the shape and dtype of the
+   * right-hand side {@code rhs} (arg 1), not the Cholesky factor {@code chol} (arg 0). See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2b.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testCholeskySolve()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_solve.py", "consume_cholesky_solve", 1, 1, Map.of(2, Set.of(TENSOR_3_5_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.triangular_solve(matrix, rhs)} reports the shape and dtype of
+   * the right-hand side {@code rhs} (arg 1), not the coefficient {@code matrix} (arg 0). See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2b.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTriangularSolve()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_solve.py",
+        "consume_triangular_solve",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_5_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -70,6 +70,7 @@
         <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature"/>
         <new def="pass_through" class="Ltensorflow/functions/pass_through"/>
         <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through"/>
+        <new def="pass_through_rhs" class="Ltensorflow/functions/pass_through_rhs"/>
         <new def="estimator" class="Lobject"/>
         <putfield class="LRoot" field="estimator" fieldType="LRoot" ref="x" value="estimator"/>
         <new def="data" class="Lobject"/>
@@ -539,8 +540,8 @@
         <putfield class="LRoot" field="inv" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="inv" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/solve -->
-        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through"/>
+        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through_rhs"/>
+        <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through_rhs"/>
         <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — fresh allocation routed to the dedicated `BroadcastTo` generator (wala/ML#449 Tier 7). Pre-fix used `value="pass_through"` aliasing, which routed the result through `PassThrough`'s identity semantics rather than computing the actual broadcast shape from the `shape` argument. -->
         <new def="broadcast_to" class="Ltensorflow/functions/broadcast_to"/>
         <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to"/>
@@ -647,8 +648,8 @@
         <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg" value="eye"/>
         <putfield class="LRoot" field="eye" fieldType="LRoot" ref="linalg_ops" value="eye"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/cholesky_solve -->
-        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
+        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg" value="pass_through_rhs"/>
+        <putfield class="LRoot" field="cholesky_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through_rhs"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/eigh -->
         <new def="eigh" class="Ltensorflow/functions/eigh"/>
         <putfield class="LRoot" field="eigh" fieldType="LRoot" ref="linalg" value="eigh"/>
@@ -671,8 +672,8 @@
         <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="eigvalsh" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/triangular_solve -->
-        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
+        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg" value="pass_through_rhs"/>
+        <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through_rhs"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/adjoint -->
         <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg_impl" value="pass_through"/>
@@ -2136,6 +2137,12 @@
       <class name="pass_through" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data features">
           <return value="data"/>
+        </method>
+      </class>
+      <!-- Pass-through of the *second* argument rather than the first. Used by the `tf.linalg.solve` family (`solve`, `cholesky_solve`, `triangular_solve`), whose result shares the shape and dtype of the right-hand-side `rhs` (arg 1), not the coefficient matrix (arg 0). Modeling these as plain `pass_through` returned `matrix.shape`, which is actively wrong: `solve(matrix (M,M), rhs (M,K))` yields `(M,K)`. See wala/ML#513 bucket 2b. -->
+      <class name="pass_through_rhs" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self matrix rhs">
+          <return value="rhs"/>
         </method>
       </class>
       <class name="parse_single_example" allocatable="true">

--- a/com.ibm.wala.cast.python.test/data/tf2_test_solve.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_solve.py
@@ -1,0 +1,44 @@
+import tensorflow as tf
+
+
+def consume_solve(a):
+    pass
+
+
+def consume_cholesky_solve(a):
+    pass
+
+
+def consume_triangular_solve(a):
+    pass
+
+
+# A (3, 3) coefficient matrix and a (3, 5) right-hand side. The solve-family
+# results all share the right-hand side's (3, 5) shape and float32 dtype, not
+# the coefficient matrix's (3, 3) shape. See wala/ML#513.
+matrix = tf.constant([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]])
+rhs = tf.constant(
+    [
+        [1.0, 2.0, 3.0, 4.0, 5.0],
+        [6.0, 7.0, 8.0, 9.0, 10.0],
+        [11.0, 12.0, 13.0, 14.0, 15.0],
+    ]
+)
+
+s = tf.linalg.solve(matrix, rhs)
+assert isinstance(s, tf.Tensor)
+assert s.shape == (3, 5)
+assert s.dtype == tf.float32
+consume_solve(s)
+
+cs = tf.linalg.cholesky_solve(matrix, rhs)
+assert isinstance(cs, tf.Tensor)
+assert cs.shape == (3, 5)
+assert cs.dtype == tf.float32
+consume_cholesky_solve(cs)
+
+ts = tf.linalg.triangular_solve(matrix, rhs)
+assert isinstance(ts, tf.Tensor)
+assert ts.shape == (3, 5)
+assert ts.dtype == tf.float32
+consume_triangular_solve(ts)


### PR DESCRIPTION
Addresses [wala/ML#513](https://github.com/wala/ML/issues/513) bucket 2b, the three "wrong-arg" `solve`-family ops.

## Problem

`tf.linalg.solve(matrix, rhs)`, `cholesky_solve(chol, rhs)`, and `triangular_solve(matrix, rhs)` all return a tensor whose shape and dtype match the right-hand side `rhs` (arg 1), not the coefficient matrix (arg 0). All three were modeled as first-argument `pass_through`, which reported the matrix shape. This is not merely imprecise; it is actively wrong: `solve(matrix (3,3), rhs (3,5))` was typed `(3,3)` instead of `(3,5)`.

## Fix

Add a `pass_through_rhs` summary class that returns its second argument (paired with a method-scoped `<new def="pass_through_rhs">` so the `<putfield value=...>` references resolve), and repoint the six solve-family bindings to it. Because each op's result shape equals an input argument, no shape-computing `TensorGenerator` is needed, only the correct argument.

## Tests

`testSolve`, `testCholeskySolve`, and `testTriangularSolve` over a new `tf2_test_solve.py` fixture whose runtime asserts (verified against tf 2.9.3) confirm the `(3,5)` result shape. Full `TestTensorflow2Model` is green at 814 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
