### PR TITLE
Type the `tf.linalg` rank-delta ops by their shape transforms

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6338,6 +6338,94 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Verifies that {@code tf.linalg.diag(diagonal)} increases rank by one: it places the input's
+   * last axis on the diagonal of a new trailing square, so a {@code (4,)} input yields {@code (4,
+   * 4)}. Previously modeled as a first-argument {@code pass_through}, which reported the input
+   * shape unchanged. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDiag()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_linalg_rank_delta.py",
+        "consume_diag",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.diag_part(input)} decreases rank by one: it extracts the
+   * diagonal of each trailing square, so a {@code (3, 3)} input yields {@code (3,)}. Previously
+   * modeled as a first-argument {@code pass_through}, which reported the input shape unchanged. See
+   * <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDiagPart()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_linalg_rank_delta.py",
+        "consume_diag_part",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.matrix_transpose(a)} swaps the last two axes, preserving leading
+   * batch dimensions, so a {@code (2, 3)} input yields {@code (3, 2)}. Previously modeled as a
+   * first-argument {@code pass_through}, which reported the input shape unchanged. See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testMatrixTranspose()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_linalg_rank_delta.py",
+        "consume_matrix_transpose",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_2_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.linalg.adjoint(matrix)} (conjugate transpose) swaps the last two axes
+   * exactly like {@code matrix_transpose}, so a {@code (2, 3)} input yields {@code (3, 2)}.
+   * Previously modeled as a first-argument {@code pass_through}, which reported the input shape
+   * unchanged. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testAdjoint()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_linalg_rank_delta.py",
+        "consume_adjoint",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_2_FLOAT32)));
+  }
+
+  /**
    * Tier-6 op (wala/ML#449): {@code tf.sort(values, ...)}. The XML routes the call through {@code
    * convert_to_tensor} of {@code values}, so shape and dtype pass through unchanged — no dedicated
    * generator needed.

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -518,17 +518,20 @@
         <putfield class="LRoot" field="range" fieldType="LRoot" ref="x" value="range"/>
         <putfield class="LRoot" field="range" fieldType="LRoot" ref="math_ops" value="range"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag -->
-        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="diag" class="Ltensorflow/math/diag"/>
+        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="linalg" value="diag"/>
+        <putfield class="LRoot" field="diag" fieldType="LRoot" ref="array_ops" value="diag"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag_part -->
-        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="diag_part" class="Ltensorflow/math/diag_part"/>
+        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="linalg" value="diag_part"/>
+        <putfield class="LRoot" field="diag_part" fieldType="LRoot" ref="array_ops" value="diag_part"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/set_diag -->
         <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="set_diag" fieldType="LRoot" ref="array_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/matrix_transpose -->
-        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="matrix_transpose" class="Ltensorflow/math/matrix_transpose"/>
+        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="linalg" value="matrix_transpose"/>
+        <putfield class="LRoot" field="matrix_transpose" fieldType="LRoot" ref="array_ops" value="matrix_transpose"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/band_part -->
         <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="band_part" fieldType="LRoot" ref="gen_array_ops" value="pass_through"/>
@@ -674,8 +677,9 @@
         <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="triangular_solve" fieldType="LRoot" ref="linalg_ops" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/adjoint -->
-        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg" value="pass_through"/>
-        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg_impl" value="pass_through"/>
+        <new def="adjoint" class="Ltensorflow/math/adjoint"/>
+        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg" value="adjoint"/>
+        <putfield class="LRoot" field="adjoint" fieldType="LRoot" ref="linalg_impl" value="adjoint"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/logdet -->
         <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg" value="pass_through"/>
         <putfield class="LRoot" field="logdet" fieldType="LRoot" ref="linalg_impl" value="pass_through"/>
@@ -1167,6 +1171,34 @@
       <class name="trace" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="diag" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag. `<new>+<return>` routed to the dedicated `Diag` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of the rank-increased `(..., M, M)`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self diagonal name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="diag_part" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/diag_part. `<new>+<return>` routed to the dedicated `DiagPart` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of the rank-decreased `(..., M)`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="matrix_transpose" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/matrix_transpose. `<new>+<return>` routed to the dedicated `MatrixTranspose` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of swapping the last two axes. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self a name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="adjoint" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/adjoint. `<new>+<return>` routed to the dedicated `Adjoint` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of swapping the last two axes. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self matrix name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Adjoint.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Adjoint.java
@@ -1,0 +1,41 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.linalg.adjoint}. The conjugate transpose swaps the last two dimensions
+ * exactly like {@link MatrixTranspose} (it differs only in conjugating the entries, which doesn't
+ * affect shape or — for the real dtypes modeled here — dtype), so the shape logic is inherited. The
+ * input argument is named {@code matrix} rather than {@code a}. Previously modeled as a
+ * first-argument {@code pass_through}. See <a
+ * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linalg/adjoint">tf.linalg.adjoint</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Adjoint extends MatrixTranspose {
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public Adjoint(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Adjoint(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "matrix";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Diag.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Diag.java
@@ -1,0 +1,75 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.linalg.diag}. Output dtype is inherited from the {@code diagonal} input.
+ * Output shape places the input's last axis on the diagonal of a new trailing square, so a {@code
+ * (..., M)} input yields {@code (..., M, M)} (rank increases by one). Previously modeled as a
+ * first-argument {@code pass_through}, which reported the input shape unchanged. See <a
+ * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linalg/diag">tf.linalg.diag</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Diag extends PassThroughUnaryTensorGenerator {
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public Diag(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Diag(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "diagonal";
+  }
+
+  /**
+   * Derives the output shape from the input by appending a copy of its last dimension, forming a
+   * trailing square whose diagonal is the input's last axis. A {@code (..., M)} input yields {@code
+   * (..., M, M)}. Reuses the superclass's input-shape resolution.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the input shape is unknown
+   *     or its rank is below 1 for every candidate.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      // The diagonal must have at least one axis to place on a square.
+      if (inputShape.isEmpty()) continue;
+      List<Dimension<?>> withDiag = new ArrayList<>(inputShape);
+      withDiag.add(inputShape.get(inputShape.size() - 1));
+      ret.add(withDiag);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DiagPart.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DiagPart.java
@@ -1,0 +1,74 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.linalg.diag_part}. Output dtype is inherited from the {@code input}. The
+ * batched diagonal extraction drops the last of the two square axes, so a {@code (..., M, M)} input
+ * yields {@code (..., M)} (rank decreases by one). Previously modeled as a first-argument {@code
+ * pass_through}, which reported the input shape unchanged. See <a
+ * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/linalg/diag_part">tf.linalg.diag_part</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class DiagPart extends PassThroughUnaryTensorGenerator {
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public DiagPart(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public DiagPart(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "input";
+  }
+
+  /**
+   * Derives the output shape from the input by dropping its last dimension, extracting the diagonal
+   * of each trailing square. A {@code (..., M, M)} input yields {@code (..., M)}. Reuses the
+   * superclass's input-shape resolution.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the input shape is unknown
+   *     or its rank is below 2 for every candidate.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      // The diagonal is extracted from the last two axes, so the input must have rank >= 2.
+      if (inputShape.size() < 2) continue;
+      ret.add(new ArrayList<>(inputShape.subList(0, inputShape.size() - 1)));
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatrixTranspose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatrixTranspose.java
@@ -1,0 +1,80 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code tf.linalg.matrix_transpose}. Output dtype is inherited from the {@code a}
+ * input. Output shape swaps the last two dimensions (the matrix transpose acts on the final two
+ * axes, preserving any leading batch dimensions), so a {@code (..., M, N)} input yields {@code
+ * (..., N, M)}. Previously modeled as a first-argument {@code pass_through}, which reported the
+ * input shape unchanged. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket
+ * 2a.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/linalg/matrix_transpose">tf.linalg.matrix_transpose</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class MatrixTranspose extends PassThroughUnaryTensorGenerator {
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public MatrixTranspose(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public MatrixTranspose(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "a";
+  }
+
+  /**
+   * Derives the output shape from the input by swapping its last two dimensions; leading batch
+   * dimensions are preserved. A {@code (..., M, N)} input yields {@code (..., N, M)}. Reuses the
+   * superclass's input-shape resolution.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the input shape is unknown
+   *     or its rank is below 2 for every candidate.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      // The matrix transpose is defined over the last two axes, so the input must have rank >= 2.
+      if (inputShape.size() < 2) continue;
+      List<Dimension<?>> transposed = new ArrayList<>(inputShape);
+      int last = transposed.size() - 1;
+      Dimension<?> tmp = transposed.get(last);
+      transposed.set(last, transposed.get(last - 1));
+      transposed.set(last - 1, tmp);
+      ret.add(transposed);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -5,6 +5,7 @@ import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.RESHAPE_METHOD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ACOSH;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJOINT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
@@ -57,6 +58,8 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_TAKE_TYP
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_WITH_OPTIONS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_ZIP_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DENSE_CALL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DIAG;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DIAG_PART;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DIVIDE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.EINSUM;
@@ -106,6 +109,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG1P;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG_SOFTMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MATMUL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MATRIX_TRANSPOSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MAXIMUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MAX_POOL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MESHGRID;
@@ -1249,6 +1253,11 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, ARGMIN.getDeclaringClass())) return new Argmin(source);
     else if (isType(calledFunction, TENSORDOT.getDeclaringClass())) return new Tensordot(source);
     else if (isType(calledFunction, TRACE.getDeclaringClass())) return new Trace(source);
+    else if (isType(calledFunction, DIAG.getDeclaringClass())) return new Diag(source);
+    else if (isType(calledFunction, DIAG_PART.getDeclaringClass())) return new DiagPart(source);
+    else if (isType(calledFunction, MATRIX_TRANSPOSE.getDeclaringClass()))
+      return new MatrixTranspose(source);
+    else if (isType(calledFunction, ADJOINT.getDeclaringClass())) return new Adjoint(source);
     else if (isType(calledFunction, TENSOR_SCATTER_ND_UPDATE.getDeclaringClass()))
       return new TensorScatterNdUpdate(source);
     else if (isType(calledFunction, SEQUENCE_MASK.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1070,6 +1070,43 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String TRACE_SIGNATURE = "tf.linalg.trace()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/linalg/diag. */
+  public static final MethodReference DIAG =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/diag")),
+          AstMethodReference.fnSelector);
+
+  private static final String DIAG_SIGNATURE = "tf.linalg.diag()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/linalg/diag_part. */
+  public static final MethodReference DIAG_PART =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/diag_part")),
+          AstMethodReference.fnSelector);
+
+  private static final String DIAG_PART_SIGNATURE = "tf.linalg.diag_part()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/linalg/matrix_transpose. */
+  public static final MethodReference MATRIX_TRANSPOSE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/math/matrix_transpose")),
+          AstMethodReference.fnSelector);
+
+  private static final String MATRIX_TRANSPOSE_SIGNATURE = "tf.linalg.matrix_transpose()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/linalg/adjoint. */
+  public static final MethodReference ADJOINT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/adjoint")),
+          AstMethodReference.fnSelector);
+
+  private static final String ADJOINT_SIGNATURE = "tf.linalg.adjoint()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/tensor_scatter_nd_update. */
   public static final MethodReference TENSOR_SCATTER_ND_UPDATE =
       MethodReference.findOrCreate(
@@ -1921,6 +1958,10 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
           Map.entry(TENSORDOT.getDeclaringClass(), TENSORDOT_SIGNATURE),
           Map.entry(TRACE.getDeclaringClass(), TRACE_SIGNATURE),
+          Map.entry(DIAG.getDeclaringClass(), DIAG_SIGNATURE),
+          Map.entry(DIAG_PART.getDeclaringClass(), DIAG_PART_SIGNATURE),
+          Map.entry(MATRIX_TRANSPOSE.getDeclaringClass(), MATRIX_TRANSPOSE_SIGNATURE),
+          Map.entry(ADJOINT.getDeclaringClass(), ADJOINT_SIGNATURE),
           Map.entry(
               TENSOR_SCATTER_ND_UPDATE.getDeclaringClass(), TENSOR_SCATTER_ND_UPDATE_SIGNATURE),
           Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_linalg_rank_delta.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_linalg_rank_delta.py
@@ -1,0 +1,48 @@
+import tensorflow as tf
+
+
+def consume_diag(a):
+    pass
+
+
+def consume_diag_part(a):
+    pass
+
+
+def consume_matrix_transpose(a):
+    pass
+
+
+def consume_adjoint(a):
+    pass
+
+
+# tf.linalg.diag: (M,) -> (M, M).
+d = tf.linalg.diag(tf.constant([1.0, 2.0, 3.0, 4.0]))
+assert isinstance(d, tf.Tensor)
+assert d.shape == (4, 4)
+assert d.dtype == tf.float32
+consume_diag(d)
+
+# tf.linalg.diag_part: (M, M) -> (M,).
+dp = tf.linalg.diag_part(
+    tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+)
+assert isinstance(dp, tf.Tensor)
+assert dp.shape == (3,)
+assert dp.dtype == tf.float32
+consume_diag_part(dp)
+
+# tf.linalg.matrix_transpose: (M, N) -> (N, M).
+mt = tf.linalg.matrix_transpose(tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+assert isinstance(mt, tf.Tensor)
+assert mt.shape == (3, 2)
+assert mt.dtype == tf.float32
+consume_matrix_transpose(mt)
+
+# tf.linalg.adjoint: (M, N) -> (N, M).
+adj = tf.linalg.adjoint(tf.constant([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+assert isinstance(adj, tf.Tensor)
+assert adj.shape == (3, 2)
+assert adj.dtype == tf.float32
+consume_adjoint(adj)


### PR DESCRIPTION
Addresses [wala/ML#513](https://github.com/wala/ML/issues/513) bucket 2a, the `tf.linalg` rank-delta group.

## Problem

`tf.linalg.diag`, `diag_part`, `matrix_transpose`, and `adjoint` were all modeled as first-argument `pass_through`, which reports the input shape unchanged. Each actually transforms its input's shape, so the reported shape was wrong whenever rank or axis order changed.

## Fix

Model each as a `<new>+<return>` summary routed to a dedicated `TensorGenerator`, all extending `PassThroughUnaryTensorGenerator` for the dtype-from-input path and overriding `getDefaultShapes` to compute the transform:

- `Diag`: append a copy of the last axis (`(..., M)` to `(..., M, M)`).
- `DiagPart`: drop the last axis (`(..., M, M)` to `(..., M)`).
- `MatrixTranspose`: swap the last two axes (`(..., M, N)` to `(..., N, M)`).
- `Adjoint`: conjugate transpose, swapping the last two axes; extends `MatrixTranspose` since the shape logic is identical.

## Tests

`testDiag`, `testDiagPart`, `testMatrixTranspose`, and `testAdjoint` over a new `tf2_test_linalg_rank_delta.py` fixture whose runtime asserts (verified against tf 2.9.3) confirm the transformed shapes. Full `TestTensorflow2Model` is green at 815 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
