### PR TITLE
Type `tf.transpose` by permuting its input axes

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -229,6 +229,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_4_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(4), new NumericDim(3)));
 
+  private static final TensorType TENSOR_4_3_2_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(3), new NumericDim(2)));
+
   private static final TensorType TENSOR_2_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
 
@@ -6391,6 +6394,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_2_4_3_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.transpose} resolves a {@code perm} passed as a tensor constant (rather
+   * than a Python list literal): a {@code (2, 3, 4)} input with {@code perm = tf.constant([2, 1,
+   * 0])} permutes precisely to {@code (4, 3, 2)}. Exercises the tensor-constant {@code perm}
+   * resolution path of {@link com.ibm.wala.cast.python.ml.client.Transpose}, distinct from the
+   * list-literal path. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket
+   * 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTransposeTensorPerm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_transpose.py",
+        "consume_transpose_tensor_perm",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_3_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -226,6 +226,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(2)));
 
+  private static final TensorType TENSOR_2_4_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(4), new NumericDim(3)));
+
   private static final TensorType TENSOR_2_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
 
@@ -3016,6 +3019,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * (wala/ML#513) drops the singleton. Both were previously {@code ⊤}-shaped (dtype only,
    * wala/ML#568).
    *
+   * <p>The local tensor-variable count is {@code 15}: the two {@code tf.transpose} calls now
+   * allocate distinct tensors rather than aliasing their inputs as first-argument {@code
+   * pass_through} did (wala/ML#513 bucket 2a), so one additional reassignment is counted as a
+   * tensor local.
+   *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
@@ -3028,7 +3036,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_forward",
         4,
-        14,
+        15,
         Map.of(
             2, Set.of(TENSOR_2_2_4_FLOAT32),
             3, Set.of(TENSOR_2_4_FLOAT32),
@@ -6335,6 +6343,51 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2, Set.of(TENSOR_3_2_2_FLOAT32),
             3, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.transpose(a)} with no {@code perm} reverses the axes, so a {@code (2,
+   * 3)} input yields {@code (3, 2)}. Previously modeled as a first-argument {@code pass_through},
+   * which reported the input shape unchanged. See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTransposeDefault()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_transpose.py",
+        "consume_transpose_default",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_2_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.transpose(a, perm)} with a constant {@code perm} permutes the axes so
+   * output axis {@code i} is input axis {@code perm[i]}: a {@code (2, 3, 4)} input with {@code perm
+   * = [0, 2, 1]} yields {@code (2, 4, 3)}. Previously modeled as a first-argument {@code
+   * pass_through}, which reported the input shape unchanged. See <a
+   * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTransposePerm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_transpose.py",
+        "consume_transpose_perm",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_4_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -454,8 +454,9 @@
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape"/>
         <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->
-        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through"/>
-        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="transpose" class="Ltensorflow/math/transpose"/>
+        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="transpose"/>
+        <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="transpose"/>
         <!-- `tf.clip_by_value` and `clip_ops.clip_by_value` now route through the dedicated `<class name="clip_by_value">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
         <new def="clip_by_global_norm" class="Ltensorflow/functions/clip_by_global_norm"/>
@@ -1167,6 +1168,13 @@
       <class name="trace" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="transpose" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose. `<new>+<return>` routed to the dedicated `Transpose` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of permuting (or, by default, reversing) the axes. -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self a perm name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -179,6 +179,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TEXT_LINE_DATASE
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TOP_K;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRACE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRANSPOSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL_OP;
@@ -1249,6 +1250,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, ARGMIN.getDeclaringClass())) return new Argmin(source);
     else if (isType(calledFunction, TENSORDOT.getDeclaringClass())) return new Tensordot(source);
     else if (isType(calledFunction, TRACE.getDeclaringClass())) return new Trace(source);
+    else if (isType(calledFunction, TRANSPOSE.getDeclaringClass())) return new Transpose(source);
     else if (isType(calledFunction, TENSOR_SCATTER_ND_UPDATE.getDeclaringClass()))
       return new TensorScatterNdUpdate(source);
     else if (isType(calledFunction, SEQUENCE_MASK.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
@@ -1,0 +1,179 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code tf.transpose(a, perm=None, conjugate=False, name='transpose')}. Output dtype
+ * is inherited from the {@code a} input. Output shape permutes the input axes by {@code perm}: when
+ * {@code perm} is absent or {@code None}, the axes are reversed (the default transpose); when
+ * {@code perm} is a constant permutation, axis {@code i} of the output is axis {@code perm[i]} of
+ * the input. A non-constant {@code perm}, or a {@code perm} that is not a valid permutation of the
+ * input's axes, falls back to ⊤ rather than risk an unsound shape. Previously modeled as a
+ * first-argument {@code pass_through}, which reported the input shape unchanged. See <a
+ * href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/transpose">tf.transpose</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Transpose extends PassThroughUnaryTensorGenerator {
+
+  private static final Logger LOGGER = Logger.getLogger(Transpose.class.getName());
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public Transpose(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Transpose(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "a";
+  }
+
+  /**
+   * Derives the output shape by permuting the {@code a} (arg 0) shape per the {@code perm} (arg 1)
+   * argument: reversed when {@code perm} is absent or {@code None}, otherwise reordered so output
+   * axis {@code i} is input axis {@code perm[i]}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when {@code a}'s shape is
+   *     unknown, {@code perm} is a non-constant, or {@code perm} is not a valid permutation of the
+   *     input's axes for some input alternative.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+
+    OrdinalSet<InstanceKey> permPts = this.getArgumentPointsToSet(builder, 1, "perm");
+    List<Integer> perm; // null means "reverse every axis" (the default transpose).
+    if (isAbsentOrNone(permPts)) {
+      perm = null;
+    } else {
+      perm = resolvePermList(builder, permPts);
+      if (perm == null) {
+        LOGGER.fine(() -> "Non-constant perm for " + this.getSource() + "; returning ⊤.");
+        return null;
+      }
+    }
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> input : inputShapes) {
+      List<Dimension<?>> out = permuteShape(input, perm);
+      // A ⊤ (null) for any input alternative joins to ⊤ for the whole result.
+      if (out == null) return null;
+      ret.add(out);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Permutes a single input shape. With a {@code null} permutation the axes are reversed; otherwise
+   * output axis {@code i} takes input axis {@code perm[i]}.
+   *
+   * @param input The input shape.
+   * @param perm The permutation, or {@code null} to reverse all axes.
+   * @return The permuted shape, or {@code null} (⊤) when {@code perm} is not a valid permutation of
+   *     {@code input}'s axes.
+   */
+  private static List<Dimension<?>> permuteShape(List<Dimension<?>> input, List<Integer> perm) {
+    if (perm == null) {
+      List<Dimension<?>> reversed = new ArrayList<>(input);
+      Collections.reverse(reversed);
+      return reversed;
+    }
+    // perm must be a permutation of exactly the input's axes; anything else is unsound.
+    if (perm.size() != input.size()) return null;
+    Set<Integer> seen = new HashSet<>();
+    for (int axis : perm) {
+      if (axis < 0 || axis >= input.size() || !seen.add(axis)) return null;
+    }
+    List<Dimension<?>> out = new ArrayList<>(input.size());
+    for (int axis : perm) out.add(input.get(axis));
+    return out;
+  }
+
+  /**
+   * Whether the {@code perm} argument is absent or {@code None} (i.e. reverse every axis).
+   *
+   * @param permPts The {@code perm} argument's points-to set.
+   * @return {@code true} iff {@code perm} is absent ({@code null}/empty PTS) or every element is
+   *     the {@code None} constant.
+   */
+  private static boolean isAbsentOrNone(OrdinalSet<InstanceKey> permPts) {
+    if (permPts == null || permPts.isEmpty()) return true;
+    for (InstanceKey ik : permPts) {
+      if (!(ik instanceof ConstantKey) || ((ConstantKey<?>) ik).getValue() != null) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Resolves the {@code perm} argument to its constant, ordered list of axis indices.
+   *
+   * <p>Each constant list/tuple is an alternative permutation candidate. When the analysis sees
+   * more than one distinct candidate, picking either would be unsound, so the method conservatively
+   * returns {@code null} (⊤).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param permPts The {@code perm} argument's points-to set.
+   * @return The single resolved permutation, or {@code null} when any element is non-constant or
+   *     there is more than one distinct candidate.
+   */
+  private List<Integer> resolvePermList(
+      PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> permPts) {
+    Set<List<Integer>> candidates = new HashSet<>();
+    for (InstanceKey ik : permPts) {
+      Set<List<Dimension<?>>> lists;
+      try {
+        lists = this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
+      } catch (IllegalStateException e) {
+        // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
+        LOGGER.fine(() -> "Could not resolve perm of " + this.getSource() + ": " + e + ".");
+        return null;
+      }
+      if (lists == null) return null;
+      for (List<Dimension<?>> list : lists) {
+        List<Integer> candidate = new ArrayList<>(list.size());
+        for (Dimension<?> d : list) {
+          if (!(d instanceof NumericDim)) return null;
+          candidate.add(((NumericDim) d).value());
+        }
+        candidates.add(candidate);
+      }
+    }
+    // Exactly one distinct candidate is the resolved permutation; zero or several is ⊤.
+    return candidates.size() == 1 ? candidates.iterator().next() : null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1070,6 +1070,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String TRACE_SIGNATURE = "tf.linalg.trace()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/transpose. */
+  public static final MethodReference TRANSPOSE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/transpose")),
+          AstMethodReference.fnSelector);
+
+  private static final String TRANSPOSE_SIGNATURE = "tf.transpose()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/tensor_scatter_nd_update. */
   public static final MethodReference TENSOR_SCATTER_ND_UPDATE =
       MethodReference.findOrCreate(
@@ -1921,6 +1930,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
           Map.entry(TENSORDOT.getDeclaringClass(), TENSORDOT_SIGNATURE),
           Map.entry(TRACE.getDeclaringClass(), TRACE_SIGNATURE),
+          Map.entry(TRANSPOSE.getDeclaringClass(), TRANSPOSE_SIGNATURE),
           Map.entry(
               TENSOR_SCATTER_ND_UPDATE.getDeclaringClass(), TENSOR_SCATTER_ND_UPDATE_SIGNATURE),
           Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_transpose.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_transpose.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+
+
+def consume_transpose_default(a):
+    pass
+
+
+def consume_transpose_perm(a):
+    pass
+
+
+# Default transpose reverses the axes: (2, 3) -> (3, 2).
+t = tf.transpose(tf.ones((2, 3)))
+assert isinstance(t, tf.Tensor)
+assert t.shape == (3, 2)
+assert t.dtype == tf.float32
+consume_transpose_default(t)
+
+# An explicit perm permutes the axes: (2, 3, 4) with perm [0, 2, 1] -> (2, 4, 3).
+tp = tf.transpose(tf.ones((2, 3, 4)), perm=[0, 2, 1])
+assert isinstance(tp, tf.Tensor)
+assert tp.shape == (2, 4, 3)
+assert tp.dtype == tf.float32
+consume_transpose_perm(tp)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_transpose.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_transpose.py
@@ -9,6 +9,10 @@ def consume_transpose_perm(a):
     pass
 
 
+def consume_transpose_tensor_perm(a):
+    pass
+
+
 # Default transpose reverses the axes: (2, 3) -> (3, 2).
 t = tf.transpose(tf.ones((2, 3)))
 assert isinstance(t, tf.Tensor)
@@ -22,3 +26,12 @@ assert isinstance(tp, tf.Tensor)
 assert tp.shape == (2, 4, 3)
 assert tp.dtype == tf.float32
 consume_transpose_perm(tp)
+
+# A perm passed as a tensor constant (rather than a Python list literal) is
+# still resolved to its constant values, so the permuted shape is recovered
+# precisely: (2, 3, 4) with perm [2, 1, 0] -> (4, 3, 2).
+dyn = tf.transpose(tf.ones((2, 3, 4)), tf.constant([2, 1, 0]))
+assert isinstance(dyn, tf.Tensor)
+assert dyn.shape == (4, 3, 2)
+assert dyn.dtype == tf.float32
+consume_transpose_tensor_perm(dyn)


### PR DESCRIPTION
Addresses [wala/ML#513](https://github.com/wala/ML/issues/513) bucket 2a, `tf.transpose` (the audit's #2 priority after the wrong-arg ops).

## Problem

`tf.transpose(a, perm)` was modeled as a first-argument `pass_through`, which reports the input shape unchanged. It actually permutes the axes, so the reported shape was wrong whenever the axis order changed.

## Fix

Model it as a `<new>+<return>` summary routed to a dedicated `Transpose` generator extending `PassThroughUnaryTensorGenerator`:

- No `perm` (or `perm=None`): reverse all axes, the default transpose.
- Constant `perm`: output axis `i` is input axis `perm[i]`.
- Non-constant `perm`, or a `perm` that is not a valid permutation of the input's axes: fall back to `⊤` rather than risk an unsound shape.

The constant `perm` is resolved with the same `ConstantKey`/shape-argument mechanism `Squeeze` already uses for its `axis`.

## Tests

`testTransposeDefault` (`(2, 3)` to `(3, 2)`) and `testTransposePerm` (`(2, 3, 4)` with `perm=[0, 2, 1]` to `(2, 4, 3)`) over a new `tf2_test_transpose.py` fixture, both verified against tf 2.9.3.

`testCrfForward`'s local tensor-variable count rises from 14 to 15: its two `tf.transpose` calls now allocate distinct tensors rather than aliasing their inputs, so one additional reassignment is counted as a tensor local. Its parameter shapes are unchanged. Full `TestTensorflow2Model` is green at 813 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
