### PR TITLE
Type `tf.tile` by multiplying each axis by its multiple

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -226,6 +226,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(2)));
 
+  private static final TensorType TENSOR_4_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(3)));
+
   private static final TensorType TENSOR_2_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
 
@@ -3215,6 +3218,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * runtime-dimensioned final {@code tf.reshape} leaves the local <em>result</em> symbolic, but the
    * parameters themselves are exact.)
    *
+   * <p>The local tensor-variable count is {@code 9}: the {@code tf.tile} call now allocates a
+   * distinct tensor rather than aliasing its input as first-argument {@code pass_through} did
+   * (wala/ML#513 bucket 2a), so {@code row_indices} and a downstream use are additionally counted
+   * as tensor locals.
+   *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
@@ -3227,7 +3235,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_gather_elements_along_row.py",
         "_gather_elements_along_row",
         2,
-        7,
+        9,
         Map.of(
             2, Set.of(TENSOR_2_4_FLOAT32),
             3, Set.of(TENSOR_2_3_INT32)));
@@ -6335,6 +6343,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2, Set.of(TENSOR_3_2_2_FLOAT32),
             3, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Verifies that {@code tf.tile(input, multiples)} multiplies each axis by the corresponding entry
+   * of {@code multiples}, so a {@code (2, 3)} input tiled by {@code [2, 1]} yields {@code (4, 3)}.
+   * Previously modeled as a first-argument {@code pass_through}, which reported the input shape
+   * unchanged. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testTile()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_tile.py", "consume_tile", 1, 1, Map.of(2, Set.of(TENSOR_4_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -546,8 +546,9 @@
         <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to"/>
         <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="broadcast_to"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile -->
-        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through"/>
-        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through"/>
+        <new def="tile" class="Ltensorflow/math/tile"/>
+        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="tile"/>
+        <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="tile"/>
         <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through"/>
@@ -1167,6 +1168,13 @@
       <class name="trace" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="tile" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile. `<new>+<return>` routed to the dedicated `Tile` generator (wala/ML#513 bucket 2a); was `pass_through`, which reported the input shape unchanged instead of multiplying each axis by the corresponding entry of `multiples`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input multiples name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -177,6 +177,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORDOT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR_SCATTER_ND_UPDATE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TEXT_LINE_DATASET_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TILE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TOP_K;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRACE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TRUNCATED_NORMAL;
@@ -1249,6 +1250,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, ARGMIN.getDeclaringClass())) return new Argmin(source);
     else if (isType(calledFunction, TENSORDOT.getDeclaringClass())) return new Tensordot(source);
     else if (isType(calledFunction, TRACE.getDeclaringClass())) return new Trace(source);
+    else if (isType(calledFunction, TILE.getDeclaringClass())) return new Tile(source);
     else if (isType(calledFunction, TENSOR_SCATTER_ND_UPDATE.getDeclaringClass()))
       return new TensorScatterNdUpdate(source);
     else if (isType(calledFunction, SEQUENCE_MASK.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
@@ -1,0 +1,150 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code tf.tile(input, multiples, name=None)}. Output dtype is inherited from the
+ * {@code input}. Output shape multiplies each axis by the corresponding entry of {@code multiples},
+ * so a {@code (M, N)} input with {@code multiples = [a, b]} yields {@code (a*M, b*N)}. A
+ * non-constant {@code multiples}, a {@code multiples} whose length differs from the input rank, or
+ * an input axis that is not statically numeric, falls back to ⊤ rather than risk an unsound shape.
+ * Previously modeled as a first-argument {@code pass_through}, which reported the input shape
+ * unchanged. See <a href="https://github.com/wala/ML/issues/513">wala/ML#513</a> bucket 2a.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/tile">tf.tile</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Tile extends PassThroughUnaryTensorGenerator {
+
+  private static final Logger LOGGER = Logger.getLogger(Tile.class.getName());
+
+  /**
+   * Constructs from a caller-side {@link PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public Tile(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Tile(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "input";
+  }
+
+  /**
+   * Derives the output shape by multiplying each {@code input} (arg 0) axis by the corresponding
+   * entry of the {@code multiples} (arg 1) argument.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when {@code input}'s shape is
+   *     unknown, {@code multiples} is a non-constant, its length differs from the input rank, or an
+   *     input axis is not statically numeric for some input alternative.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+
+    List<Integer> multiples =
+        resolveMultiplesList(builder, this.getArgumentPointsToSet(builder, 1, "multiples"));
+    if (multiples == null) {
+      LOGGER.fine(() -> "Non-constant multiples for " + this.getSource() + "; returning ⊤.");
+      return null;
+    }
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> input : inputShapes) {
+      List<Dimension<?>> out = tileShape(input, multiples);
+      // A ⊤ (null) for any input alternative joins to ⊤ for the whole result.
+      if (out == null) return null;
+      ret.add(out);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Tiles a single input shape, multiplying axis {@code i} by {@code multiples[i]}.
+   *
+   * @param input The input shape.
+   * @param multiples The per-axis tiling counts.
+   * @return The tiled shape, or {@code null} (⊤) when {@code multiples}'s length differs from the
+   *     input rank or an input axis is not statically numeric.
+   */
+  private static List<Dimension<?>> tileShape(List<Dimension<?>> input, List<Integer> multiples) {
+    if (multiples.size() != input.size()) return null;
+    List<Dimension<?>> out = new ArrayList<>(input.size());
+    for (int i = 0; i < input.size(); i++) {
+      Dimension<?> dim = input.get(i);
+      if (!(dim instanceof NumericDim)) return null;
+      out.add(new NumericDim(((NumericDim) dim).value() * multiples.get(i)));
+    }
+    return out;
+  }
+
+  /**
+   * Resolves the {@code multiples} argument to its constant, ordered list of per-axis counts.
+   *
+   * <p>Each constant list/tuple is an alternative candidate. When the analysis sees more than one
+   * distinct candidate, picking either would be unsound, so the method conservatively returns
+   * {@code null} (⊤).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param multiplesPts The {@code multiples} argument's points-to set.
+   * @return The single resolved list of counts, or {@code null} when {@code multiples} is absent or
+   *     any element is non-constant, or there is more than one distinct candidate.
+   */
+  private List<Integer> resolveMultiplesList(
+      PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> multiplesPts) {
+    if (multiplesPts == null || multiplesPts.isEmpty()) return null;
+    Set<List<Integer>> candidates = new HashSet<>();
+    for (InstanceKey ik : multiplesPts) {
+      Set<List<Dimension<?>>> lists;
+      try {
+        lists = this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
+      } catch (IllegalStateException e) {
+        // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
+        LOGGER.fine(() -> "Could not resolve multiples of " + this.getSource() + ": " + e + ".");
+        return null;
+      }
+      if (lists == null) return null;
+      for (List<Dimension<?>> list : lists) {
+        List<Integer> candidate = new ArrayList<>(list.size());
+        for (Dimension<?> d : list) {
+          if (!(d instanceof NumericDim)) return null;
+          candidate.add(((NumericDim) d).value());
+        }
+        candidates.add(candidate);
+      }
+    }
+    // Exactly one distinct candidate is the resolved list; zero or several is ⊤.
+    return candidates.size() == 1 ? candidates.iterator().next() : null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1070,6 +1070,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String TRACE_SIGNATURE = "tf.linalg.trace()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/tile. */
+  public static final MethodReference TILE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/math/tile")),
+          AstMethodReference.fnSelector);
+
+  private static final String TILE_SIGNATURE = "tf.tile()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/tensor_scatter_nd_update. */
   public static final MethodReference TENSOR_SCATTER_ND_UPDATE =
       MethodReference.findOrCreate(
@@ -1921,6 +1930,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(ARGMIN.getDeclaringClass(), ARGMIN_SIGNATURE),
           Map.entry(TENSORDOT.getDeclaringClass(), TENSORDOT_SIGNATURE),
           Map.entry(TRACE.getDeclaringClass(), TRACE_SIGNATURE),
+          Map.entry(TILE.getDeclaringClass(), TILE_SIGNATURE),
           Map.entry(
               TENSOR_SCATTER_ND_UPDATE.getDeclaringClass(), TENSOR_SCATTER_ND_UPDATE_SIGNATURE),
           Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tile.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tile.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def consume_tile(a):
+    pass
+
+
+# tf.tile multiplies each axis by the corresponding multiple: (2, 3) tiled by
+# [2, 1] -> (4, 3).
+t = tf.tile(tf.ones((2, 3)), [2, 1])
+assert isinstance(t, tf.Tensor)
+assert t.shape == (4, 3)
+assert t.dtype == tf.float32
+consume_tile(t)


### PR DESCRIPTION
Addresses [wala/ML#513](https://github.com/wala/ML/issues/513) bucket 2a, `tf.tile`.

## Problem

`tf.tile(input, multiples)` was modeled as a first-argument `pass_through`, which reports the input shape unchanged. It actually multiplies each axis by the corresponding entry of `multiples`, so the reported shape was wrong whenever any multiple was not 1.

## Fix

Model it as a `<new>+<return>` summary routed to a dedicated `Tile` generator extending `PassThroughUnaryTensorGenerator`. Output axis `i` is `input[i] * multiples[i]`. A non-constant `multiples`, a length mismatch with the input rank, or a non-numeric input axis falls back to `⊤` rather than risk an unsound shape. The constant `multiples` is resolved with the same shape-argument mechanism `Transpose` and `Squeeze` use.

## Tests

`testTile` (`(2, 3)` tiled by `[2, 1]` to `(4, 3)`) over a new `tf2_test_tile.py` fixture, verified against tf 2.9.3.

`testGatherElementsAlongRow`'s local tensor-variable count rises from 7 to 9: its `tf.tile` call now allocates a distinct tensor rather than aliasing its input, so `row_indices` and a downstream use are additionally counted. Its parameter shapes are unchanged. Full `TestTensorflow2Model` is green at 812 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
