### PR TITLE
Guard against `null` dtypes in `SliceBuiltinOperation.getDefaultDTypes`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -200,7 +200,7 @@ public class SliceBuiltinOperation extends TensorGenerator {
       dtypes = Set.of();
     }
     // getDTypesOrSSAChain can return null (no dtype recovered via the SSA-DU fallback); treat it
-    // like an empty set rather than NPEing on isEmpty(). See wala/ML#602.
+    // like an empty set rather than NPEing on isEmpty(). See https://github.com/wala/ML/issues/602.
     return (dtypes == null || dtypes.isEmpty()) ? Set.of(DType.UNKNOWN) : dtypes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -199,7 +199,9 @@ public class SliceBuiltinOperation extends TensorGenerator {
           Level.FINE, "Receiver dtype lookup threw IAE for receiverVn=" + view.receiverVn(), e);
       dtypes = Set.of();
     }
-    return dtypes.isEmpty() ? Set.of(DType.UNKNOWN) : dtypes;
+    // getDTypesOrSSAChain can return null (no dtype recovered via the SSA-DU fallback); treat it
+    // like an empty set rather than NPEing on isEmpty(). See wala/ML#602.
+    return (dtypes == null || dtypes.isEmpty()) ? Set.of(DType.UNKNOWN) : dtypes;
   }
 
   @Override


### PR DESCRIPTION
`SliceBuiltinOperation.getDefaultDTypes` NPE'd on `dtypes.isEmpty()` when `getDTypesOrSSAChain` returned `null`. The `try` only caught `IllegalArgumentException`, but the SSA-DU fallback (added for wala/ML#405) can return `null` when neither the PTS lookup nor the DU walk recovers a concrete dtype and `getDTypes` doesn't throw, leaving `dtypes` null:

```java
return dtypes.isEmpty() ? Set.of(DType.UNKNOWN) : dtypes;   // NPE when dtypes == null
```

This guards the `null`, treating it like an empty set, mirroring the already-correct `null`-guard on the parallel shape path in `getDefaultShapes` (`receiverShapes == null || receiverShapes.isEmpty()`).

Surfaced during a `tf.function` candidacy/tensor-type analysis over a slice operation in the `MusicTransformer-tensorflow2.0` subject (Hybridize Functions refactoring).

The four existing slice tests (`testSlice`, `testSliceRemaining`, `testSubscriptSlicePreservesShape`, `testSliceSubscriptThroughDataset`) still pass.

Part of wala/ML#602. This PR is the defensive null-guard only. It stops the crash but intentionally does **not** close the issue, which tracks the precision work of *recovering* the receiver dtype where possible (⊤ only where genuinely unknown). Leaving #602 open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

