### PR TITLE
Return ⊤ instead of throwing for unresolvable allocator shapes

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11030,6 +11030,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/604">wala/ML#604</a>: when an
+   * allocator's {@code shape} argument is unresolvable (here {@code tf.zeros(json.loads(...))},
+   * whose source Ariadne does not model), {@code TensorTypeAllocator.getDefaultShapes} must return
+   * {@code null} (⊤, tensor with unknown shape) rather than throwing {@code
+   * UnsupportedOperationException}, which previously aborted the whole analysis. Recovering the
+   * content-dependent shape itself is the user-annotation problem tracked by wala/ML#370; this
+   * guard only pins the non-crashing ⊤ floor.
+   */
+  @Test
+  public void testZerosUnresolvableShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_zeros_unresolvable_shape.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
   @Test
   public void testRaggedFromNestedRowLengths()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -57,14 +57,6 @@ public class Input extends TensorTypeAllocator {
   }
 
   @Override
-  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    // `tf.keras.Input(...)` is always a tensor; if the `shape` argument is unresolvable, the right
-    // signal is ⊤ (unknown shape), not ⊥ (not a tensor). See wala/ML#355 and the lattice
-    // conventions in `CONTRIBUTING.md`.
-    return null;
-  }
-
-  @Override
   protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
     int valNum =
         this.getArgumentValueNumber(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -73,13 +73,23 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
    * which aborted the whole analysis (<a
    * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>). Mirrors the ⊤ signal {@code
    * Input} already used (<a href="https://github.com/wala/ML/issues/355">wala/ML#355</a>) and the
-   * lattice conventions in {@code CONTRIBUTING.md}.
+   * lattice conventions in {@code CONTRIBUTING.md}. Logs a {@code FINE} marker at each such site so
+   * the ⊤ here stays distinguishable from a genuine ⊤ and the wala/ML#370 annotation worklist is
+   * discoverable.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @return {@code null} (⊤, unknown shape); never an empty set, since the allocation is a tensor.
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Emit a discoverable marker so the ⊤ here is distinguishable from a "true" ⊤ elsewhere: this
+    // is exactly the set of sites where a user-supplied shape annotation would help. The set is
+    // grep-able as the wala/ML#370 annotation worklist without aborting the rest of the analysis
+    // (which is what throwing here did, wala/ML#604).
+    LOGGER.fine(
+        "Unresolved allocator shape for source: "
+            + source
+            + "; returning ⊤ (unknown shape). Candidate for a wala/ML#370 shape annotation.");
     return null;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -21,10 +21,10 @@ import java.util.logging.Logger;
  * Base for generators of TensorFlow/NumPy APIs that allocate a tensor from an explicit {@code
  * shape} argument plus an optional {@code dtype} argument (e.g. {@code tf.ones}, {@code tf.zeros},
  * {@code tf.keras.Input}, {@code tf.random.uniform}, {@code tf.one_hot}). It owns the {@code
- * SHAPE}/{@code DTYPE} parameter-slot machinery, the float32 default dtype, the "shape is
- * mandatory" contract, and the constant-extraction helper. It carries no value semantics, so it is
- * not itself dispatched: concrete subclasses (one per API) extend it. Introduced to replace {@code
- * extends Ones} code-reuse-not-is-a inheritance (<a
+ * SHAPE}/{@code DTYPE} parameter-slot machinery, the float32 default dtype, the ⊤-shape fallback
+ * for an unresolvable shape argument, and the constant-extraction helper. It carries no value
+ * semantics, so it is not itself dispatched: concrete subclasses (one per API) extend it.
+ * Introduced to replace {@code extends Ones} code-reuse-not-is-a inheritance (<a
  * href="https://github.com/wala/ML/issues/514">wala/ML#514</a>).
  */
 public abstract class TensorTypeAllocator extends TensorGenerator {
@@ -62,9 +62,25 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     return EnumSet.of(FLOAT32);
   }
 
+  /**
+   * Returns ⊤ (unknown shape) when no shape argument resolves. An allocator like {@code tf.zeros}
+   * always produces a tensor, so when the {@code shape} argument can't be resolved statically (e.g.
+   * it flows from an unmodeled, content-dependent source such as {@code json.loads(...)}), the
+   * correct lattice signal is ⊤ ({@code null}), not ⊥ and not a crash. Recovering such a
+   * content-dependent shape is the user-annotation problem tracked by <a
+   * href="https://github.com/wala/ML/issues/370">wala/ML#370</a>; this method is only the
+   * non-crashing floor beneath it. This previously threw {@link UnsupportedOperationException},
+   * which aborted the whole analysis (<a
+   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>). Mirrors the ⊤ signal {@code
+   * Input} already used (<a href="https://github.com/wala/ML/issues/355">wala/ML#355</a>) and the
+   * lattice conventions in {@code CONTRIBUTING.md}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code null} (⊤, unknown shape); never an empty set, since the allocation is a tensor.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    throw new UnsupportedOperationException("Shape is mandatory and must be provided explicitly.");
+    return null;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_zeros_unresolvable_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_zeros_unresolvable_shape.py
@@ -1,0 +1,10 @@
+import json
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+s = json.loads("[2, 3]")
+consume(tf.zeros(s))


### PR DESCRIPTION
`TensorTypeAllocator.getDefaultShapes` threw `UnsupportedOperationException("Shape is mandatory and must be provided explicitly.")` whenever an allocator's `shape` argument couldn't be resolved statically. That aborted the entire analysis (`PythonTensorAnalysisEngine.performAnalysis`), surfaced over the `NLPGNN`, `TensorFlow2.0-Examples`, and `deep_recommenders` subjects during the Hybridize Functions refactoring.

`tf.zeros`/`tf.ones`/`tf.random.*`/sparse-tensor allocations are still tensors, so when the `shape` argument flows from an unmodeled, content-dependent source (e.g. `tf.zeros(json.loads(...))`) the correct lattice signal is ⊤ (unknown shape), not a crash and not ⊥. This returns `null` (⊤) instead, matching the ⊤ signal `Input` already used for the same situation (wala/ML#355); `Input`'s now-redundant override is removed, and the base class Javadoc no longer claims a "shape is mandatory" contract.

Empirically, in the unit harness the throw reproduces **only** for genuinely-unknown shapes: explicit shapes passed as a local variable (`s = (2, 3); tf.zeros(s)`) or through a parameter (`def make(shape): return tf.zeros(shape)`) already resolve to `(2, 3)`. So this PR is the non-crashing floor only. Recovering a genuinely content-dependent shape is the user-annotation problem tracked by wala/ML#370, which is why this is `Part of` rather than `Closes`.

New regression guard `testZerosUnresolvableShape` (`tf2_test_zeros_unresolvable_shape.py`) pins the ⊤ float32 result for `tf.zeros(json.loads(...))`. The full `TestTensorflow2Model` suite passes (824 tests, 0 failures).

Part of wala/ML#604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)