### PR TITLE
Add a regression guard for chained-slice dtype recovery

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -173,6 +173,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_5_28_28_UINT8 =
       new TensorType(UINT_8, asList(new NumericDim(5), new NumericDim(28), new NumericDim(28)));
 
+  private static final TensorType TENSOR_3_28_28_UINT8 =
+      new TensorType(UINT_8, asList(new NumericDim(3), new NumericDim(28), new NumericDim(28)));
+
   private static final TensorType TENSOR_1_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(2)));
 
@@ -11608,6 +11611,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_2_3_FLOAT64)));
+  }
+
+  /**
+   * Guards slice-receiver dtype recovery through a chained slice (<a
+   * href="https://github.com/wala/ML/issues/602">wala/ML#602</a>): {@code x_train[:5][:3]} on a
+   * {@code (60000, 28, 28) uint8} ndarray yields a {@code (3, 28, 28) uint8} tensor. The outer
+   * slice's receiver is the inner slice's result, whose dtype the PTS walk can't see; {@link
+   * com.ibm.wala.cast.python.ml.client.TensorGenerator#dtypesFromSSAChain} recovers it by recursing
+   * through the dtype-preserving slice op rather than falling back to {@code DType.UNKNOWN}.
+   */
+  @Test
+  public void testSliceChainedDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_slice_chained_dtype.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_28_28_UINT8)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_slice_chained_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_slice_chained_dtype.py
@@ -1,0 +1,23 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(tensor):
+    pass
+
+
+# A slice of a slice. The inner slice `x_train[:5]` recovers `(5, 28, 28) uint8`
+# because its receiver is the mnist source. The outer slice's receiver is the
+# inner slice's *result*, whose dtype the PTS walk can't see (empty PTS) and the
+# SSA-DU fallback misses unless it recurses through the dtype-preserving slice op.
+# This fixture pins the outer slice's dtype as the regression guard for that
+# recovery (wala/ML#602).
+(x_train, _), (_, _) = tf.keras.datasets.mnist.load_data()
+assert x_train.shape == (60000, 28, 28)
+assert x_train.dtype == np.uint8
+
+y = x_train[:5][:3]
+assert y.shape == (3, 28, 28)
+assert y.dtype == np.uint8
+
+consume(y)


### PR DESCRIPTION
`x_train[:5][:3]` on a `(60000, 28, 28) uint8` ndarray yields `(3, 28, 28) uint8`. The outer slice's receiver is the inner slice's result, whose dtype the PTS walk can't see; `TensorGenerator.dtypesFromSSAChain` recovers it by recursing through the dtype-preserving slice op rather than falling back to `DType.UNKNOWN`.

This already works on `master`; the test (`testSliceChainedDtype`, `tf2_test_slice_chained_dtype.py`) is a positive regression guard pinning it. It came out of the wala/ML#602 investigation, which found that the slice-receiver dtype recovery already covers every receiver kind reproducible in the unit harness (reshape, `expand_dims`, `argmax`, fed parameters, chained slices), so the recovery axis there is gated on a minimal reproducing example rather than new code.

Part of wala/ML#602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)