### PR TITLE
Recover slice-receiver dtype through dtype-preserving op chains

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -241,6 +241,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_3_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
 
+  private static final TensorType TENSOR_1_1_3_2_FLOAT32 =
+      new TensorType(
+          FLOAT_32,
+          asList(new NumericDim(1), new NumericDim(1), new NumericDim(3), new NumericDim(2)));
+
   private static final TensorType TENSOR_2_3_1_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(1)));
 
@@ -11650,6 +11655,31 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_3_28_28_UINT8)));
+  }
+
+  /**
+   * Guards slice-receiver dtype recovery through a {@code reshape(pad(x))} chain (<a
+   * href="https://github.com/wala/ML/issues/602">wala/ML#602</a>), the MRE distilled from
+   * MusicTransformer's {@code RelativeGlobalAttention._skewing}. The slice receiver is {@code
+   * tf.reshape} of {@code tf.pad}; neither op is itself dtype-modeled ({@code tf.pad} is unmodeled
+   * entirely), so the receiver dtype lands at ⊤ unless {@link
+   * com.ibm.wala.cast.python.ml.client.TensorGenerator#dtypesFromSSAChain} recurses through the
+   * dtype-preserving chain to the concrete {@code float32} input.
+   *
+   * <p>TODO: the shape stays {@code (1, 1, 3, 2)} (the reshape result) rather than {@code (1, 1, 2,
+   * 2)} &mdash; the {@code [:, :, 1:, :]} subscript isn't reducing axis 2, a shape-precision gap
+   * tracked by <a href="https://github.com/wala/ML/issues/607">wala/ML#607</a>. This test pins the
+   * dtype recovery and the currently-observed shape.
+   */
+  @Test
+  public void testSliceReshapePadDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_slice_reshape_pad_dtype.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_1_1_3_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1083,6 +1083,14 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Names of dtype-preserving TensorFlow ops: each returns a tensor with the same dtype as its
+   * first tensor operand. Recognized syntactically by {@link #dtypesFromSSAChain} so chains through
+   * them recover the underlying dtype, even when an op is unmodeled. See wala/ML#602.
+   */
+  private static final Set<String> DTYPE_PRESERVING_OP_NAMES =
+      Set.of("reshape", "pad", "expand_dims", "squeeze", "transpose", "identity");
+
+  /**
    * Dtype counterpart to {@link #shapesFromSSAChain(PropagationCallGraphBuilder, CGNode, int)}.
    * Handles: mnist invokes (all uint8); astype invokes (use astype's dtype arg — FLOAT32 default if
    * we can't resolve); tuple-unpack reads (peel via {@link #findTupleFieldStore}); binops involving
@@ -1159,6 +1167,50 @@ public abstract class TensorGenerator {
         // resolve the arg via `FIELD_REFERENCE_TO_DTYPE` — not yet implemented here.
         return EnumSet.of(DType.FLOAT32);
       }
+    }
+
+    // Dtype-preserving ops (`tf.reshape`, `tf.pad`, `tf.expand_dims`, ...) return a tensor with the
+    // same dtype as their first tensor operand. Recognize them syntactically by the called
+    // attribute
+    // name so this covers unmodeled ops too (e.g. `tf.pad`, which resolves to no call-graph
+    // target),
+    // and recurse on that operand. This lets chains like `reshape(pad(x))` recover `x`'s dtype
+    // rather
+    // than landing at ⊤ when no single op in the chain is itself dtype-modeled. See wala/ML#602.
+    String calledName = calledFunctionName(node, call);
+    if (calledName != null
+        && DTYPE_PRESERVING_OP_NAMES.contains(calledName)
+        && call.getNumberOfUses() >= 2) {
+      int inputVn = call.getUse(1);
+      try {
+        Set<DType> viaPts = getDTypes(builder, node, inputVn);
+        if (viaPts != null && !viaPts.isEmpty()) return viaPts;
+      } catch (IllegalArgumentException e) {
+        // Fall through to the SSA-DU recursion.
+      }
+      return dtypesFromSSAChain(builder, node, inputVn, visited);
+    }
+    return null;
+  }
+
+  /**
+   * Returns the called attribute's name for a function/method-style invoke {@code obj.name(...)} by
+   * reading the member of the {@link PythonPropertyRead} that def'd the invoke's function object.
+   * Used to recognize dtype-preserving ops (e.g. {@code tf.reshape}, {@code tf.pad}) by name,
+   * including unmodeled ones that resolve to no call-graph target.
+   *
+   * @param node The {@link CGNode} whose IR contains {@code call}.
+   * @param call The invoke whose called-attribute name is wanted.
+   * @return The called attribute's name, or {@code null} if it can't be resolved to a string
+   *     constant.
+   */
+  protected static String calledFunctionName(CGNode node, SSAAbstractInvokeInstruction call) {
+    if (call.getNumberOfUses() < 1) return null;
+    SSAInstruction funcDef = node.getDU().getDef(call.getUse(0));
+    if (funcDef instanceof PythonPropertyRead) {
+      int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
+      SymbolTable st = node.getIR().getSymbolTable();
+      if (st.isStringConstant(memberVn)) return st.getStringValue(memberVn);
     }
     return null;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1172,16 +1172,25 @@ public abstract class TensorGenerator {
     // Dtype-preserving ops (`tf.reshape`, `tf.pad`, `tf.expand_dims`, ...) return a tensor with the
     // same dtype as their first tensor operand. Recognize them syntactically by the called
     // attribute
-    // name so this covers unmodeled ops too (e.g. `tf.pad`, which resolves to no call-graph
-    // target),
+    // name (so this covers unmodeled ops too, e.g. `tf.pad`, which resolves to no call-graph
+    // target)
     // and recurse on that operand. This lets chains like `reshape(pad(x))` recover `x`'s dtype
-    // rather
-    // than landing at ⊤ when no single op in the chain is itself dtype-modeled. See wala/ML#602.
+    // rather than landing at ⊤ when no single op in the chain is itself dtype-modeled. See
+    // wala/ML#602.
     String calledName = calledFunctionName(node, call);
     if (calledName != null
         && DTYPE_PRESERVING_OP_NAMES.contains(calledName)
         && call.getNumberOfUses() >= 2) {
       int inputVn = call.getUse(1);
+      LOGGER.fine(
+          () ->
+              "Recovering dtype through dtype-preserving op `"
+                  + calledName
+                  + "`: recursing from vn="
+                  + vn
+                  + " onto operand vn="
+                  + inputVn
+                  + ".");
       try {
         Set<DType> viaPts = getDTypes(builder, node, inputVn);
         if (viaPts != null && !viaPts.isEmpty()) return viaPts;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_slice_reshape_pad_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_slice_reshape_pad_dtype.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# Distilled from MusicTransformer's `RelativeGlobalAttention._skewing` (wala/ML#602).
+# The slice receiver is `reshape(pad(tensor))`, a two-op dtype-preserving chain. The
+# slice's shape recovers but its dtype lands at ⊤ unless `dtypesFromSSAChain` recurses
+# through the `pad` and `reshape` ops back to the concrete-float32 input. Neither op
+# alone reproduces; only the `reshape(pad(x))` chain does.
+def skewing(tensor):
+    padded = tf.pad(tensor, [[0, 0], [0, 0], [0, 0], [1, 0]])
+    reshaped = tf.reshape(padded, [1, 1, 3, 2])
+    return reshaped[:, :, 1:, :]
+
+
+consume(skewing(tf.constant([[[[1.0, 2.0], [3.0, 4.0]]]], dtype=tf.float32)))


### PR DESCRIPTION
`dtypesFromSSAChain` returned ⊤ when the slice receiver was produced by a chain of dtype-preserving ops that aren't individually dtype-modeled. The MRE, distilled from MusicTransformer's `RelativeGlobalAttention._skewing`:

```python
def skewing(tensor):
    padded = tf.pad(tensor, [[0, 0], [0, 0], [0, 0], [1, 0]])
    reshaped = tf.reshape(padded, [1, 1, 3, 2])
    return reshaped[:, :, 1:, :]
```

`tf.pad` is unmodeled and resolves to no call-graph target, so neither `pad` nor the chain can be recognized by declaring class. The fix recognizes dtype-preserving ops (`reshape`, `pad`, `expand_dims`, `squeeze`, `transpose`, `identity`) **syntactically** by the called attribute name and recurses on their first tensor operand, so chains like `reshape(pad(x))` recover the underlying concrete dtype (`float32`) rather than landing at ⊤.

This is the recovery axis the issue was gated on (case 1 of the [three-way disambiguation](https://github.com/wala/ML/issues/602#issuecomment-4806110913)): an inferable op-output receiver. Case 3 (unfed candidate-root parameter) is the genuinely-⊤ path handled by the merged null-guard (#429); case 2 (missed-caller seeding) was not observed (the harness types parameters forward from call sites). Regression guard `testSliceReshapePadDtype` (`tf2_test_slice_reshape_pad_dtype.py`) pins the recovered dtype; full `TestTensorflow2Model` suite passes (823, 0 failures).

The slice's *shape* stays `(1, 1, 3, 2)` (the `[:, :, 1:, :]` axis-2 reduction is a separate multi-dim-subscript gap, tracked by wala/ML#607); this PR is dtype-only.

Closes wala/ML#602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)