### PR TITLE
Recover allocator shape from a `.shape` argument

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11683,6 +11683,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guards allocator-shape recovery from a {@code .shape} argument (<a
+   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>): {@code tf.ones(x.shape)} where
+   * {@code x} is {@code (2, 2)} yields {@code (2, 2) float32}. The shape argument is a {@code
+   * .shape} property read with an empty points-to set, so resolution falls to {@link
+   * com.ibm.wala.cast.python.ml.client.TensorTypeAllocator#getDefaultShapes}, which recovers the
+   * source tensor's shape via {@code getShapeFromShapeAttributeArgument} rather than dropping to ⊤.
+   */
+  @Test
+  public void testOnesTensorShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_ones_tensor_shape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
    * Guards constant-step subscript-slice shape propagation on ndarrays (wala/ML#405): {@code
    * x_train[:5]} on a {@code (60000, 28, 28) uint8} ndarray yields a {@code (5, 28, 28) uint8}
    * tensor. Implemented via {@link SliceBuiltinOperation}; the receiver-shape leak that previously

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2512,6 +2512,13 @@ public abstract class TensorGenerator {
             }
           } catch (IllegalArgumentException e) {
             // The source tensor's shape couldn't be resolved; fall through to ⊤.
+            LOGGER.log(
+                Level.FINE,
+                "getShapeFromShapeAttributeArgument: could not resolve `.shape` source tensorVn="
+                    + tensorVn
+                    + " in caller="
+                    + caller,
+                e);
           }
         }
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2460,6 +2460,66 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Recovers an allocator's shape when its shape argument is another tensor's {@code .shape} (e.g.
+   * {@code tf.ones(x.shape)}). Such an argument is a {@link PythonPropertyRead} of member {@code
+   * "shape"} whose points-to set is empty, so ordinary shape resolution falls through to {@link
+   * #getDefaultShapes}; this resolves the shape of the underlying tensor instead of dropping to ⊤.
+   * Walks the {@link CallString} callers (the allocation's synthetic node has no argument IR of its
+   * own) to find the call site and the shape argument's value number, mirroring {@link
+   * #getArgumentShapesViaCallers}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param paramPos The 0-based positional index of the shape parameter (excluding {@code self}).
+   * @param paramName The shape parameter's keyword name, or {@code null}.
+   * @return The union of the source tensors' shapes, or {@code null} if no {@code .shape} argument
+   *     is found or none resolves.
+   */
+  protected Set<List<Dimension<?>>> getShapeFromShapeAttributeArgument(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
+    if (cs == null) return null;
+    Set<List<Dimension<?>>> combined = null;
+    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
+      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
+      IMethod callerMethod = cs.getMethods()[i];
+      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
+          it.hasNext(); ) {
+        CGNode caller = it.next();
+        if (!caller.getMethod().equals(callerMethod)) continue;
+        for (SSAAbstractInvokeInstruction callInstr : caller.getIR().getCalls(siteRef)) {
+          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
+          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
+          int argVn = -1;
+          if (paramName != null) argVn = pyCall.getUse(paramName);
+          if (argVn == -1 && paramPos >= 0) {
+            int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+            if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+          }
+          if (argVn <= 0) continue;
+          SSAInstruction def = caller.getDU().getDef(argVn);
+          if (!(def instanceof PythonPropertyRead)) continue;
+          PythonPropertyRead propRead = (PythonPropertyRead) def;
+          SymbolTable st = caller.getIR().getSymbolTable();
+          int memberVn = propRead.getMemberRef();
+          if (!st.isStringConstant(memberVn) || !"shape".equals(st.getStringValue(memberVn)))
+            continue;
+          int tensorVn = propRead.getObjectRef();
+          try {
+            Set<List<Dimension<?>>> tensorShapes = this.getShapes(builder, caller, tensorVn);
+            if (tensorShapes != null && !tensorShapes.isEmpty()) {
+              if (combined == null) combined = HashSetFactory.make();
+              combined.addAll(tensorShapes);
+            }
+          } catch (IllegalArgumentException e) {
+            // The source tensor's shape couldn't be resolved; fall through to ⊤.
+          }
+        }
+      }
+    }
+    return combined;
+  }
+
+  /**
    * Dtype counterpart of {@link #getArgumentShapesViaCallers(PropagationCallGraphBuilder, int,
    * String)}. See that method for the rationale; the behaviour is the same but returns a set of
    * {@link DType}s resolved via {@link #getDTypes(PropagationCallGraphBuilder, CGNode, int)}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -82,6 +82,22 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Recovery: an allocator whose shape argument is another tensor's `.shape` (e.g.
+    // `tf.ones(x.shape)`) takes its shape from that tensor. Resolve it rather than dropping to ⊤.
+    // wala/ML#604.
+    Set<List<Dimension<?>>> fromShapeAttribute =
+        this.getShapeFromShapeAttributeArgument(
+            builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+    if (fromShapeAttribute != null && !fromShapeAttribute.isEmpty()) {
+      LOGGER.fine(
+          "Recovered allocator shape from a `.shape` argument for source: "
+              + source
+              + " -> "
+              + fromShapeAttribute
+              + ".");
+      return fromShapeAttribute;
+    }
+
     // Emit a discoverable marker so the ⊤ here is distinguishable from a "true" ⊤ elsewhere: this
     // is exactly the set of sites where a user-supplied shape annotation would help. The set is
     // grep-able as the wala/ML#370 annotation worklist without aborting the rest of the analysis

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ones_tensor_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ones_tensor_shape.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.ones(x.shape)` takes its shape from another tensor's `.shape`. The shape
+# argument is a `.shape` property read whose points-to set is empty, so resolution
+# falls to `getDefaultShapes`. Regression guard for wala/ML#604: recover the shape
+# from the source tensor (`x` has shape `(2, 2)`) rather than dropping to ⊤.
+x = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+consume(tf.ones(x.shape))


### PR DESCRIPTION
`tf.ones(x.shape)` (and `tf.zeros`/`tf.random.*` likewise) takes its shape from another tensor's `.shape`. That argument is a `.shape` property read whose points-to set is empty, so resolution fell through to `getDefaultShapes` and returned ⊤ (the wala/ML#604 floor from #430). This detects the `.shape` argument by walking the `CallString` callers to the source tensor and resolves its shape via the existing SSA-DU machinery (`getShapeFromShapeAttributeArgument`), so `tf.ones(x.shape)` with `x` of shape `(2, 2)` recovers `(2, 2) float32` rather than ⊤.

This is the recoverable firing form for #604, established by probing the unresolved-shape forms: list-with-dynamic-element and `tf.shape(x)` already resolve, a bare unmodeled var (`json.loads`) is genuinely-⊤ (correct, the #370 case), and `tensor.shape` reaches the fallback and is recoverable.

Regression guard `testOnesTensorShape` pins `(2, 2) float32`. Full `TestTensorflow2Model` suite passes (826, 0 failures).

Scope: covers the standard `SHAPE`-slot allocators (`Ones`/`Zeros`/`RandomDistribution`). `SparseTensor` takes its shape from `dense_shape` (a different argument) and would need its own override — a follow-up. Genuinely content-dependent shapes stay ⊤ (wala/ML#370).

Closes wala/ML#604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)