### PR TITLE
Compose the top_k output shape as `input.shape[:-1] + (k,)`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11760,11 +11760,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * recovers the element dtypes ({@code float32} values, {@code int32} indices). No {@code
    * read_data} is involved, so this is a case wala/ML#380 would not fix.
    *
-   * <p>TODO: the shape stays ⊤ because {@code tf.math.top_k} models its output dtype but not its
-   * shape ({@link com.ibm.wala.cast.python.ml.client.TopK#getDefaultShapes} returns ⊤, pending the
-   * input-shape + k composer); the {@code (k, ...)} shape is recoverable. Tracked by <a
-   * href="https://github.com/wala/ML/issues/609">wala/ML#609</a>. This test pins the dtype
-   * recovery.
+   * <p>The composed {@code (k,) = (2,)} shape now appears for both elements (the wala/ML#609
+   * composer), so the asserted set is a union of the precise {@code (2,)} shapes and the residual ⊤
+   * ones. The ⊤ components come from the wala/ML#480 attribute/slice path, which doesn't carry the
+   * composed per-element shape through; once wala/ML#480 lands they drop, narrowing this to {@code
+   * Set.of(TENSOR_2_FLOAT32, TENSOR_2_INT32)}.
    */
   @Test
   public void testTopkSliceCatalog()
@@ -11774,7 +11774,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32, TENSOR_INT32_UNKNOWN_SHAPE)));
+        Map.of(
+            2,
+            Set.of(
+                TENSOR_UNKNOWN_SHAPE_FLOAT32,
+                TENSOR_2_FLOAT32,
+                TENSOR_INT32_UNKNOWN_SHAPE,
+                TENSOR_2_INT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11723,6 +11723,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guards the unknown-input-shape path of the top_k composer (<a
+   * href="https://github.com/wala/ML/issues/609">wala/ML#609</a>): when the input tensor's shape is
+   * ⊤ (here {@code tf.ones(json.loads(...))}), {@code input.shape[:-1] + (k,)} can't be composed
+   * and the result degrades to ⊤. The dtype stays precise (float32).
+   */
+  @Test
+  public void testTopkUnknownInput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_topk_unknown_input.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Guards the top_k output-shape composer (<a href="https://github.com/wala/ML/issues/609">
    * wala/ML#609</a>): {@code values, indices = tf.math.top_k(x, k=2)} on a {@code (5,)} input
    * yields {@code values} of shape {@code (2,)} float32, composed as {@code input.shape[:-1] +

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -513,6 +513,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE =
       new TensorType(UNKNOWN, null);
 
+  private static final TensorType TENSOR_1_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(1)));
+
   private static final TensorType TENSOR_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(2)));
 
@@ -11689,6 +11692,34 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_1_1_3_2_FLOAT32)));
+  }
+
+  /**
+   * Guards the {@code k}-default path of the top_k composer (<a
+   * href="https://github.com/wala/ML/issues/609">wala/ML#609</a>): with {@code k} omitted it
+   * defaults to {@code 1}, so {@code values} of a {@code (4,)} input is {@code (1,)} float32.
+   */
+  @Test
+  public void testTopkDefaultK()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_topk_default_k.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_1_FLOAT32)));
+  }
+
+  /**
+   * Guards the non-constant-{@code k} path of the top_k composer (<a
+   * href="https://github.com/wala/ML/issues/609">wala/ML#609</a>): when {@code k} is not a
+   * resolvable integer constant (here from {@code json.loads}), the shape can't be composed and
+   * degrades to ⊤ rather than guessing. The dtype stays precise (float32).
+   */
+  @Test
+  public void testTopkNonConstantK()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_topk_nonconstant_k.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -868,6 +868,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_decorator11.py", "C.returned", 1, 1, Map.of(3, Set.of(TENSOR_5_INT32)));
   }
 
+  /**
+   * The {@code returned(a)} parameter is {@code a = tf.constant([1, 1.0])}, i.e. {@code (2,)
+   * float32}. The asserted set is a union across contexts (per the test helper's union-per-vn
+   * semantics): the {@code (2,) float32} is the parameter's real type, now precise after the top_k
+   * output-shape composer (<a href="https://github.com/wala/ML/issues/609">wala/ML#609</a>)
+   * sharpened the previous ⊤. The {@code (2,) int32} is a top_k {@code indices} output leaking in
+   * through a collapsed 1-CFA context (it was already present in the old union as ⊤ int32); the
+   * composer only made it concrete. The leak itself is a context-sensitivity artifact.
+   */
   @Test
   public void testDecorator12()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -11680,6 +11689,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_1_1_3_2_FLOAT32)));
+  }
+
+  /**
+   * Guards the top_k output-shape composer (<a href="https://github.com/wala/ML/issues/609">
+   * wala/ML#609</a>): {@code values, indices = tf.math.top_k(x, k=2)} on a {@code (5,)} input
+   * yields {@code values} of shape {@code (2,)} float32, composed as {@code input.shape[:-1] +
+   * (k,)} by {@link com.ibm.wala.cast.python.ml.client.TopK} rather than left at ⊤. Destructuring
+   * (not the wala/ML#480 attribute-access path) gives the precise per-element type.
+   */
+  @Test
+  public void testTopkShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_topk_shape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -3,12 +3,14 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -25,11 +27,11 @@ import java.util.Set;
  * non-Dataset use of the {@link TupleElementProvider} pattern; the established Dataset-side
  * precedent is {@link DatasetFromTensorsGenerator}.
  *
- * <p>Output shape precision is currently ⊤ — computing the precise {@code input.shape[:-1] + (k,)}
- * requires reading the input's shape (PA-resolvable for many cases) and the {@code k} argument
- * (PA-constant in the common case). A follow-up can wire that in. For now the per-element dtype
- * precision (FLOAT32 for values, INT32 for indices) is the load-bearing fix vs. the previous {@code
- * ReadDataFallback} routing, which produced {@code ⊤}/{@code unknown} for both.
+ * <p>The output shape {@code input.shape[:-1] + (k,)} is composed from the input tensor's shape and
+ * the {@code k} argument (default {@code 1}); see {@code composedShapes} and <a
+ * href="https://github.com/wala/ML/issues/609">wala/ML#609</a>. It degrades to ⊤ when {@code k} is
+ * not a resolvable constant or the input shape is unknown rank or rank-0. The per-element dtype
+ * (FLOAT32 for values, INT32 for indices) is resolved independently.
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/math/top_k">tf.math.top_k</a>
  * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
@@ -96,8 +98,52 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
 
   @Override
   public Set<List<Dimension<?>>> getShapesForIndex(PropagationCallGraphBuilder builder, int index) {
-    // Both values and indices share shape input.shape[:-1] + (k,). Currently emit ⊤ until an
-    // input-shape + k composer is added.
+    // Both values and indices share shape input.shape[:-1] + (k,). wala/ML#609.
+    return this.composedShapes(builder);
+  }
+
+  /**
+   * Composes the top_k output shape: {@code input.shape[:-1] + (k,)}. Resolves the input tensor's
+   * shape and the {@code k} argument (default {@code 1}) and replaces the last axis with {@code k}.
+   * Returns ⊤ ({@code null}) if {@code k} is not a resolvable constant or any input shape is
+   * unknown rank or rank-0. See <a href="https://github.com/wala/ML/issues/609">wala/ML#609</a>.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of composed output shapes, or {@code null} (⊤) if it can't be composed.
+   */
+  private Set<List<Dimension<?>>> composedShapes(PropagationCallGraphBuilder builder) {
+    Integer k = this.resolveK(builder);
+    if (k == null) return null;
+    OrdinalSet<InstanceKey> inputPts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.INPUT.getIndex(), Parameters.INPUT.getName());
+    if (inputPts == null || inputPts.isEmpty()) return null;
+    Set<List<Dimension<?>>> inputShapes = this.getShapesOfValue(builder, inputPts);
+    if (inputShapes == null || inputShapes.isEmpty()) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> in : inputShapes) {
+      // Unknown rank (null) or a rank-0 scalar can't have its last axis replaced; degrade to ⊤.
+      if (in == null || in.isEmpty()) return null;
+      List<Dimension<?>> out = new ArrayList<>(in);
+      out.set(out.size() - 1, new NumericDim(k));
+      ret.add(out);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Resolves the {@code k} argument as an integer constant, defaulting to {@code 1} when omitted.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The value of {@code k}, or {@code null} if {@code k} is present but not a resolvable
+   *     integer constant.
+   */
+  private Integer resolveK(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> kPts =
+        this.getArgumentPointsToSet(builder, Parameters.K.getIndex(), Parameters.K.getName());
+    if (kPts == null || kPts.isEmpty()) return 1;
+    for (Object value : getConstantValues(kPts, false))
+      if (value instanceof Number) return ((Number) value).intValue();
     return null;
   }
 
@@ -117,11 +163,16 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
 
   @Override
   public Set<TensorType> getTensorTypesForIndex(PropagationCallGraphBuilder builder, int index) {
-    // Shapes are uniformly ⊤ until the input-shape + k composer lands; emit one TensorType per
-    // dtype with null dims. When shapes become precise, this method needs to fan out per shape.
+    // Fan out per (dtype, composed shape). The shape is input.shape[:-1] + (k,) (wala/ML#609); when
+    // it can't be composed it's ⊤ (null dims).
     Set<DType> dtypes = this.getDTypesForIndex(builder, index);
+    Set<List<Dimension<?>>> shapes = this.composedShapes(builder);
     Set<TensorType> ret = HashSetFactory.make();
-    for (DType dt : dtypes) ret.add(new TensorType(dt.name().toLowerCase(Locale.ROOT), null));
+    for (DType dt : dtypes) {
+      String cellType = dt.name().toLowerCase(Locale.ROOT);
+      if (shapes == null || shapes.isEmpty()) ret.add(new TensorType(cellType, null));
+      else for (List<Dimension<?>> shape : shapes) ret.add(new TensorType(cellType, shape));
+    }
     return ret;
   }
 
@@ -144,8 +195,10 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    // ⊤ at the aggregate level — per-index access returns the precise shape (also currently ⊤
-    // pending the input-shape + k composer; both axes line up for now).
+    // A NamedTuple result has no single tensor shape, so the aggregate is ⊤; the per-element shape
+    // (input.shape[:-1] + (k,)) is composed in getShapesForIndex (wala/ML#609). Composing here
+    // instead would feed the wala/ML#480 attribute-access path, which reduces it to a wrong rank-0
+    // shape.
     return null;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -128,7 +128,9 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
       out.set(out.size() - 1, new NumericDim(k));
       ret.add(out);
     }
-    return ret.isEmpty() ? null : ret;
+    // inputShapes is non-empty and the loop returns ⊤ for any null/empty shape, so ret is
+    // populated.
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TopK.java
@@ -132,19 +132,32 @@ public class TopK extends TensorGenerator implements TupleElementProvider {
   }
 
   /**
-   * Resolves the {@code k} argument as an integer constant, defaulting to {@code 1} when omitted.
+   * Resolves the {@code k} argument as an integer constant. Defaults to {@code 1} only when {@code
+   * k} is genuinely omitted; when {@code k} is supplied but its value can't be resolved (empty
+   * points-to set, or a non-constant such as an opaque or tensor {@code k}), returns {@code null}
+   * (⊤) rather than assuming the default, since composing {@code (1, ...)} for an unknown {@code k}
+   * would be unsound.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The value of {@code k}, or {@code null} if {@code k} is present but not a resolvable
-   *     integer constant.
+   * @return The value of {@code k}, {@code 1} if {@code k} is omitted, or {@code null} if {@code k}
+   *     is supplied but not a resolvable integer constant.
    */
   private Integer resolveK(PropagationCallGraphBuilder builder) {
+    // Distinguish a genuinely omitted k (→ default 1) from one that is supplied but unresolvable
+    // (→ ⊤). The synthetic method always has a k slot, so an empty points-to set alone can't tell
+    // the two apart; check whether the call site actually passes k, positionally or by keyword
+    // (the same idiom Input uses for its optional parameters).
+    boolean kPassed =
+        this.isKeywordArgumentPresent(builder, Parameters.K.getName())
+            || this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(n -> n >= Parameters.K.getIndex() + 1);
+    if (!kPassed) return 1; // k omitted; defaults to 1.
     OrdinalSet<InstanceKey> kPts =
         this.getArgumentPointsToSet(builder, Parameters.K.getIndex(), Parameters.K.getName());
-    if (kPts == null || kPts.isEmpty()) return 1;
+    if (kPts == null || kPts.isEmpty()) return null; // k supplied but unresolvable → ⊤.
     for (Object value : getConstantValues(kPts, false))
       if (value instanceof Number) return ((Number) value).intValue();
-    return null;
+    return null; // k supplied but not a constant int → ⊤.
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_top_k.py
@@ -11,7 +11,7 @@ def f_indices(a):
 
 # `tf.math.top_k(input, k)` returns a `(values, indices)` named tuple.
 # `values` shares the input dtype (float32 here); `indices` is int32.
-# Shape is `input.shape[:-1] + (k,)` for both — currently emitted as ⊤.
+# Shape is `input.shape[:-1] + (k,)` for both, i.e. (2,) here (wala/ML#609).
 x = tf.constant([1.0, 3.0, 2.0, 5.0, 4.0])
 result = tf.math.top_k(x, k=2)
 values, indices = result.values, result.indices

--- a/com.ibm.wala.cast.python.test/data/tf2_test_topk_default_k.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_topk_default_k.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(v):
+    pass
+
+
+# `tf.math.top_k` with `k` omitted defaults to `k=1`, so `values` of a `(4,)`
+# input is `(1,)`. Exercises the `k`-default path of the wala/ML#609 composer.
+values, indices = tf.math.top_k(tf.constant([1.0, 3.0, 2.0, 5.0]))
+consume(values)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_topk_nonconstant_k.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_topk_nonconstant_k.py
@@ -1,0 +1,15 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(v):
+    pass
+
+
+# `k` comes from an unmodeled source, so it isn't a resolvable integer constant.
+# The wala/ML#609 composer can't compose `input.shape[:-1] + (k,)` and degrades to
+# ⊤ rather than guessing. Exercises the non-constant-`k` path.
+k = json.loads("2")
+values, indices = tf.math.top_k(tf.constant([1.0, 3.0, 2.0, 5.0]), k=k)
+consume(values)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_topk_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_topk_shape.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def consume(v):
+    pass
+
+
+# `tf.math.top_k(x, k)` returns values/indices of shape `x.shape[:-1] + (k,)`.
+# Regression guard for wala/ML#609: `values` of `top_k((4,) input, k=2)` is `(2,)`
+# float32, composed from the input shape and k rather than left at ⊤.
+values, indices = tf.math.top_k(tf.constant([1.0, 3.0, 2.0, 5.0]), k=2)
+consume(values)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_topk_unknown_input.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_topk_unknown_input.py
@@ -1,0 +1,14 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(v):
+    pass
+
+
+# The input tensor's shape is unresolvable (it flows from `tf.ones(json.loads(...))`),
+# so `input.shape[:-1] + (k,)` can't be composed and the wala/ML#609 composer degrades
+# to ⊤. The dtype stays precise (float32, from tf.ones).
+vals, idx = tf.math.top_k(tf.ones(json.loads("[3, 4]")), k=2)
+consume(vals)


### PR DESCRIPTION
`TopK` left the output shape at ⊤. This composes it from the input tensor's shape and the `k` argument (default `1`), replacing the last axis with `k`, so the per-element shape is precise: `values, indices = tf.math.top_k(x, k=2)` on a `(5,)` input yields `values`/`indices` of shape `(2,)`. Degrades to ⊤ when `k` isn't a resolvable constant or the input shape is unknown rank or rank-0.

The aggregate `getDefaultShapes` stays ⊤ (a NamedTuple has no single tensor shape); composing it there would feed the wala/ML#480 attribute-access path, which reduces it to a wrong rank-0 shape. So the composer lives in the per-index `getShapesForIndex`/`getTensorTypesForIndex`, mirroring the per-index dtype design.

`testTopkShape` pins the composed `(2,)`. `testDecorator12` sharpens from ⊤ to `(2,)` — the `(2,) float32` is the parameter's real type, now precise; the `(2,) int32` is a pre-existing top_k `indices` leak through a collapsed 1-CFA context (already in the old union as ⊤ int32), which the composer only made concrete.

Closes wala/ML#609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)