### PR TITLE
Return ⊤ instead of throwing for an unresolvable `tf.fill` dims argument

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11683,6 +11683,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/606">wala/ML#606</a>: when
+   * {@code tf.fill}'s {@code dims} argument is unresolvable (here from {@code json.loads}), {@link
+   * com.ibm.wala.cast.python.ml.client.Fill#getDefaultShapes} must return ⊤ rather than throwing
+   * {@code UnsupportedOperationException}, which previously aborted the whole analysis. {@code
+   * Fill} extends {@code Constant}, so the base allocator floor (wala/ML#604) doesn't cover it. The
+   * result is ⊤-shape {@code int32} (the fill value's dtype).
+   */
+  @Test
+  public void testFillUnresolvableDims()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_fill_unresolvable_dims.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
    * Guards constant-step subscript-slice shape propagation on ndarrays (wala/ML#405): {@code
    * x_train[:5]} on a {@code (60000, 28, 28) uint8} ndarray yields a {@code (5, 28, 28) uint8}
    * tensor. Implemented via {@link SliceBuiltinOperation}; the receiver-shape leak that previously

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -1,11 +1,14 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static java.util.logging.Logger.getLogger;
+
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * A representation of the TensorFlow <code>fill()</code> function.
@@ -17,6 +20,8 @@ import java.util.Set;
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class Fill extends Constant {
+
+  private static final Logger LOGGER = getLogger(Fill.class.getName());
 
   protected enum Parameters {
     DIMS,
@@ -78,21 +83,43 @@ public class Fill extends Constant {
   }
 
   /**
-   * Returns ⊤ (unknown shape) when {@code tf.fill}'s {@code dims} argument can't be resolved (e.g.
-   * it flows from an unmodeled, content-dependent source). {@code tf.fill} always produces a
-   * tensor, so the correct lattice signal is ⊤ ({@code null}), not a crash. This previously threw
-   * {@link UnsupportedOperationException}, aborting the whole analysis (<a
-   * href="https://github.com/wala/ML/issues/606">wala/ML#606</a>); the same fix {@code
-   * TensorTypeAllocator} took for the standard allocators (<a
-   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>). {@code Fill} extends {@code
-   * Constant} rather than {@code TensorTypeAllocator}, so it carries the floor here. Recovering a
-   * genuinely content-dependent {@code dims} is the user-annotation problem tracked by wala/ML#370.
+   * Returns ⊤ (unknown shape) as the non-aborting floor when {@code tf.fill}'s shape can't be
+   * produced from its {@code dims} argument. Unlike the standard allocators, {@code tf.fill} has no
+   * default shape: {@code dims} is mandatory. Reaching this method therefore means one of two
+   * things, both ⊤ because a static analysis must not abort over a single call site:
+   *
+   * <ul>
+   *   <li>{@code dims} was supplied but is unresolvable (e.g. it flows from an unmodeled,
+   *       content-dependent source such as {@code json.loads(...)}). This is the wala/ML#370
+   *       recovery case, and is what actually triggered <a
+   *       href="https://github.com/wala/ML/issues/606">wala/ML#606</a>.
+   *   <li>{@code dims} was genuinely omitted: a malformed call ({@code tf.fill} raises {@code
+   *       TypeError} at runtime). The original code threw {@link UnsupportedOperationException}
+   *       here to document that {@code dims} is mandatory; that aborted the whole analysis
+   *       (wala/ML#606), so it is now a {@code FINE} marker instead.
+   * </ul>
+   *
+   * <p>Mirrors the ⊤ floor {@code TensorTypeAllocator} took for the standard allocators (<a
+   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>); {@code Fill} extends {@code
+   * Constant} rather than {@code TensorTypeAllocator}, so it carries the floor here.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @return {@code null} (⊤, unknown shape); never an empty set, since the allocation is a tensor.
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    boolean dimsSupplied =
+        this.isKeywordArgumentPresent(builder, Parameters.DIMS.getName())
+            || this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(n -> n >= Parameters.DIMS.getIndex() + 1);
+    LOGGER.fine(
+        dimsSupplied
+            ? "tf.fill's `dims` could not be resolved for source: "
+                + source
+                + "; returning ⊤. Candidate for a wala/ML#370 shape annotation."
+            : "tf.fill reached without its mandatory `dims` argument for source: "
+                + source
+                + " (malformed call?); returning ⊤.");
     return null;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -119,13 +119,13 @@ public class Fill extends Constant {
                 .anyMatch(n -> n >= Parameters.DIMS.getIndex() + 1);
     LOGGER.fine(
         dimsSupplied
-            ? "Could not resolve the `dims` argument of "
+            ? "Could not resolve the dims argument of "
                 + SIGNATURE
                 + " for source: "
                 + source
                 + "; returning ⊤. Candidate for a wala/ML#370 shape annotation."
             : SIGNATURE
-                + " reached without its mandatory `dims` argument for source: "
+                + " reached without its mandatory dims argument for source: "
                 + source
                 + " (malformed call?); returning ⊤.");
     return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -77,8 +77,22 @@ public class Fill extends Constant {
     return null;
   }
 
+  /**
+   * Returns ⊤ (unknown shape) when {@code tf.fill}'s {@code dims} argument can't be resolved (e.g.
+   * it flows from an unmodeled, content-dependent source). {@code tf.fill} always produces a
+   * tensor, so the correct lattice signal is ⊤ ({@code null}), not a crash. This previously threw
+   * {@link UnsupportedOperationException}, aborting the whole analysis (<a
+   * href="https://github.com/wala/ML/issues/606">wala/ML#606</a>); the same fix {@code
+   * TensorTypeAllocator} took for the standard allocators (<a
+   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>). {@code Fill} extends {@code
+   * Constant} rather than {@code TensorTypeAllocator}, so it carries the floor here. Recovering a
+   * genuinely content-dependent {@code dims} is the user-annotation problem tracked by wala/ML#370.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code null} (⊤, unknown shape); never an empty set, since the allocation is a tensor.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    throw new UnsupportedOperationException("Shape is mandatory and must be provided explicitly.");
+    return null;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TYPE_REFERENCE_TO_SIGNATURE;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -22,6 +24,9 @@ import java.util.logging.Logger;
 public class Fill extends Constant {
 
   private static final Logger LOGGER = getLogger(Fill.class.getName());
+
+  /** Canonical {@code tf.fill()} signature, reused in diagnostics. */
+  private static final String SIGNATURE = TYPE_REFERENCE_TO_SIGNATURE.get(FILL.getDeclaringClass());
 
   protected enum Parameters {
     DIMS,
@@ -114,10 +119,13 @@ public class Fill extends Constant {
                 .anyMatch(n -> n >= Parameters.DIMS.getIndex() + 1);
     LOGGER.fine(
         dimsSupplied
-            ? "tf.fill's `dims` could not be resolved for source: "
+            ? "Could not resolve the `dims` argument of "
+                + SIGNATURE
+                + " for source: "
                 + source
                 + "; returning ⊤. Candidate for a wala/ML#370 shape annotation."
-            : "tf.fill reached without its mandatory `dims` argument for source: "
+            : SIGNATURE
+                + " reached without its mandatory `dims` argument for source: "
                 + source
                 + " (malformed call?); returning ⊤.");
     return null;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_fill_unresolvable_dims.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_fill_unresolvable_dims.py
@@ -1,0 +1,15 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.fill`'s `dims` argument comes from an unmodeled source (`json.loads`), so it
+# can't be resolved statically. `tf.fill` is still a tensor, so the right signal is
+# ⊤ (unknown shape), not a crash. Regression guard for wala/ML#606:
+# `Fill.getDefaultShapes` previously threw `UnsupportedOperationException` here.
+dims = json.loads("[2, 3]")
+consume(tf.fill(dims, 5))


### PR DESCRIPTION
`Fill.getDefaultShapes` threw `UnsupportedOperationException("Shape is mandatory and must be provided explicitly.")` when `tf.fill`'s `dims` argument couldn't be resolved, aborting the whole analysis — the same crash class as wala/ML#604, in a sibling hierarchy (`Fill extends Constant`, so #604's base-class floor doesn't cover it). This returns `null` (⊤) instead, since `tf.fill` always produces a tensor.

Regression guard `testFillUnresolvableDims` pins the ⊤-shape `int32` result for `tf.fill(json.loads(...), 5)` (it errored with `UnsupportedOperationException` before). Full `TestTensorflow2Model` suite passes (826, 0 failures). Genuinely content-dependent `dims` stay ⊤ (wala/ML#370).

This is one of the corpus crashes blocking the runtime-evaluation run.

Closes wala/ML#606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)