### PR TITLE
Drop Markdown backticks from `TensorGenerator` log messages

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1184,9 +1184,9 @@ public abstract class TensorGenerator {
       int inputVn = call.getUse(1);
       LOGGER.fine(
           () ->
-              "Recovering dtype through dtype-preserving op `"
+              "Recovering dtype through dtype-preserving op "
                   + calledName
-                  + "`: recursing from vn="
+                  + ": recursing from vn="
                   + vn
                   + " onto operand vn="
                   + inputVn
@@ -2514,7 +2514,7 @@ public abstract class TensorGenerator {
             // The source tensor's shape couldn't be resolved; fall through to ⊤.
             LOGGER.log(
                 Level.FINE,
-                "getShapeFromShapeAttributeArgument: could not resolve `.shape` source tensorVn="
+                "getShapeFromShapeAttributeArgument: could not resolve .shape source tensorVn="
                     + tensorVn
                     + " in caller="
                     + caller,


### PR DESCRIPTION
Backticks are a Markdown convention and read oddly in plain log lines. Removes the fences from the two `TensorGenerator` logs that had them: the op name in the dtype-preserving-op dtype recovery (ponder-lab/ML#432) and `.shape` in the shape-attribute-argument recovery (ponder-lab/ML#434). Log-string only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)