### PR TITLE
Recover `tf.fill`'s shape from a `.shape` dims argument

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11708,6 +11708,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guards {@code tf.fill}'s {@code .shape}-argument recovery (<a
+   * href="https://github.com/wala/ML/issues/610">wala/ML#610</a>): {@code tf.fill(x.shape, 5.0)}
+   * where {@code x} is {@code (2, 2)} yields {@code (2, 2) float32}. The {@code dims} argument is a
+   * {@code .shape} property read with an empty points-to set, so resolution falls to {@link
+   * com.ibm.wala.cast.python.ml.client.Fill#getDefaultShapes}, which recovers the source tensor's
+   * shape rather than dropping to ⊤.
+   */
+  @Test
+  public void testFillShapeArg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_fill_shape_arg.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/606">wala/ML#606</a>: when
    * {@code tf.fill}'s {@code dims} argument is unresolvable (here from {@code json.loads}), {@link
    * com.ibm.wala.cast.python.ml.client.Fill#getDefaultShapes} must return ⊤ rather than throwing

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -88,10 +88,16 @@ public class Fill extends Constant {
   }
 
   /**
-   * Returns ⊤ (unknown shape) as the non-aborting floor when {@code tf.fill}'s shape can't be
-   * produced from its {@code dims} argument. Unlike the standard allocators, {@code tf.fill} has no
-   * default shape: {@code dims} is mandatory. Reaching this method therefore means one of two
-   * things, both ⊤ because a static analysis must not abort over a single call site:
+   * Recovers the shape from a {@code .shape} {@code dims} argument when possible, else returns ⊤ as
+   * the non-aborting floor. {@code tf.fill(x.shape, v)} takes its shape from {@code x}, the same
+   * case the standard allocators recover (<a href="https://github.com/wala/ML/issues/610">
+   * wala/ML#610</a>, <a href="https://github.com/wala/ML/issues/604">wala/ML#604</a>); a
+   * list-literal {@code dims} (e.g. {@code tf.fill([2, 3], v)}) already resolves via the inherited
+   * shape-argument machinery before this method is reached.
+   *
+   * <p>Unlike the standard allocators, {@code tf.fill} has no default shape: {@code dims} is
+   * mandatory. Falling through to the ⊤ floor therefore means one of two things, both ⊤ because a
+   * static analysis must not abort over a single call site:
    *
    * <ul>
    *   <li>{@code dims} was supplied but is unresolvable (e.g. it flows from an unmodeled,
@@ -113,6 +119,22 @@ public class Fill extends Constant {
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Recovery: tf.fill(x.shape, v) takes its shape from x, the same case the standard allocators
+    // recover (wala/ML#604). Resolve it rather than dropping to ⊤. wala/ML#610.
+    Set<List<Dimension<?>>> fromShapeAttribute =
+        this.getShapeFromShapeAttributeArgument(
+            builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+    if (fromShapeAttribute != null && !fromShapeAttribute.isEmpty()) {
+      LOGGER.fine(
+          "Recovered "
+              + SIGNATURE
+              + " shape from a .shape argument for source: "
+              + source
+              + " -> "
+              + fromShapeAttribute
+              + ".");
+      return fromShapeAttribute;
+    }
     boolean dimsSupplied =
         this.isKeywordArgumentPresent(builder, Parameters.DIMS.getName())
             || this.getNumberOfPossiblePositionalArguments(builder).stream()

--- a/com.ibm.wala.cast.python.test/data/tf2_test_fill_shape_arg.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_fill_shape_arg.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.fill(x.shape, v)` takes its shape from `x`. Regression guard for wala/ML#610:
+# the `.shape` dims argument is recovered to `(2, 2)` rather than dropping to ⊤.
+x = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+consume(tf.fill(x.shape, 5.0))


### PR DESCRIPTION
`tf.fill(x.shape, v)` takes its shape from `x`, the same case the standard allocators recover for `tf.ones(x.shape)` (wala/ML#604). `Fill.getDefaultShapes` now calls `getShapeFromShapeAttributeArgument` with the `DIMS` parameter position before falling through to the ⊤ floor, mirroring `TensorTypeAllocator`. A list-literal `dims` (e.g. `tf.fill([2, 3], v)`) already resolved via the inherited shape-argument machinery, so this closes the remaining `.shape` gap.

`testFillShapeArg` pins `tf.fill(x.shape, 5.0)` on a `(2, 2)` `x` as `(2, 2) float32`.

Closes wala/ML#610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)