### PR TITLE
Floor mandatory-parameter throws in `range`/`eye`/`gamma`/`poisson`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -519,6 +519,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_FLOAT64 =
       new TensorType(FLOAT_64, asList(new NumericDim(2)));
 
+  private static final TensorType TENSOR_DYNAMIC_DYNAMIC_FLOAT32 =
+      new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE));
+
   private static final TensorType TENSOR_2_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2)));
 
@@ -11738,6 +11741,59 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testOnesTensorShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_ones_tensor_shape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
+   * Guards the {@code tf.eye} unresolvable-{@code num_rows} floor (<a
+   * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): when {@code num_rows} is
+   * unresolvable (here from {@code json.loads}), the result is still a rank-2 square matrix, so it
+   * floors to {@code (Dynamic, Dynamic)} float32 rather than throwing "num_rows parameter is
+   * required" (which previously aborted the whole analysis).
+   */
+  @Test
+  public void testEyeUnresolvable()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_eye_unresolvable.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_DYNAMIC_DYNAMIC_FLOAT32)));
+  }
+
+  /**
+   * Guards the {@code tf.random.gamma} unresolvable-{@code shape} floor (<a
+   * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): when the {@code shape} argument
+   * is unresolvable (here from {@code json.loads}) the output rank can't be known, so the result
+   * floors to ⊤ rather than throwing (which previously aborted the whole analysis). The dtype stays
+   * float32.
+   */
+  @Test
+  public void testGammaUnresolvable()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gamma_unresolvable.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Guards the {@code tf.random.poisson} unresolvable-{@code shape} floor (<a
+   * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): same as {@link
+   * #testGammaUnresolvable()}, the output rank rides on the unresolvable {@code shape}, so the
+   * result floors to ⊤ rather than throwing.
+   */
+  @Test
+  public void testPoissonUnresolvable()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_poisson_unresolvable.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EyeBase.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EyeBase.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -113,22 +114,16 @@ public abstract class EyeBase extends TensorTypeAllocator {
             // Build the shape using nRow and nCol.
             List<Dimension<?>> shape = new ArrayList<>();
 
-            NumericDim rowDim = new NumericDim(nRow.get());
-            NumericDim colDim = new NumericDim(nCol2.get());
-
-            shape.add(rowDim);
-            shape.add(colDim);
+            shape.add(axisDim(nRow));
+            shape.add(axisDim(nCol2));
 
             ret.add(shape);
           }
         } else {
           List<Dimension<?>> shape = new ArrayList<>();
 
-          NumericDim rowDim = new NumericDim(nRow.get());
-          NumericDim colDim = new NumericDim(nCol.get());
-
-          shape.add(rowDim);
-          shape.add(colDim);
+          shape.add(axisDim(nRow));
+          shape.add(axisDim(nCol));
 
           ret.add(shape);
         }
@@ -142,10 +137,24 @@ public abstract class EyeBase extends TensorTypeAllocator {
         this.getPossibleArgumentValues(
             builder, this.getNumRowsParameterPosition(), this.getNumRowsParameterName());
 
-    if (values == null || values.isEmpty())
-      throw new IllegalStateException("The num_rows parameter is required for tf.eye().");
+    // num_rows is mandatory, but when it's unresolvable (content-dependent) don't abort the whole
+    // analysis: treat it as a single unknown value so the shape floors to a dynamic rank-2 tensor
+    // rather than throwing. wala/ML#611.
+    if (values == null || values.isEmpty()) return Set.of(Optional.empty());
 
     return values;
+  }
+
+  /**
+   * Maps a possibly-unknown axis size to a dimension: a {@link NumericDim} when the value is known,
+   * a {@link DynamicDim} when it isn't (so an unresolvable {@code num_rows}/{@code num_columns}
+   * floors to a dynamic axis rather than crashing on {@link Optional#get()}). wala/ML#611.
+   *
+   * @param value The possibly-unknown axis size.
+   * @return A {@link NumericDim} if present, else {@link DynamicDim#INSTANCE}.
+   */
+  private static Dimension<?> axisDim(Optional<Integer> value) {
+    return value.isPresent() ? new NumericDim(value.get()) : DynamicDim.INSTANCE;
   }
 
   private Set<Optional<Integer>> getNumberOfColumns(PropagationCallGraphBuilder builder) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
@@ -87,8 +87,11 @@ public class Gamma extends TensorTypeAllocator {
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     Set<List<Dimension<?>>> shapes = super.getShapes(builder);
 
-    if (shapes.isEmpty())
-      throw new IllegalStateException("Cannot determine shape for mandatory shape parameter.");
+    // The shape argument is unresolvable (content-dependent) and the output rank rides on it, so
+    // floor to ⊤ rather than aborting the whole analysis. super.getShapes already computes the
+    // precise shape (and recovers a `.shape` argument, wala/ML#604) when it is resolvable.
+    // wala/ML#611.
+    if (shapes == null || shapes.isEmpty()) return null;
 
     // Get the shape of the alpha parameter.
     OrdinalSet<InstanceKey> alphaPointsToSet =
@@ -96,8 +99,8 @@ public class Gamma extends TensorTypeAllocator {
             builder, this.getAlphaParameterPosition(), this.getAlphaParameterName());
     Set<List<Dimension<?>>> alphaShapes = this.getShapesOfValue(builder, alphaPointsToSet);
 
-    if (alphaShapes.isEmpty())
-      throw new IllegalArgumentException("Cannot determine shape for mandatory alpha parameter.");
+    // alpha's shape is part of the output rank; ⊤ if unresolvable. wala/ML#611.
+    if (alphaShapes == null || alphaShapes.isEmpty()) return null;
 
     OrdinalSet<InstanceKey> betaPointsToSet =
         this.getArgumentPointsToSet(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Poisson.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Poisson.java
@@ -78,18 +78,20 @@ public class Poisson extends TensorTypeAllocator {
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     Set<List<Dimension<?>>> shapes = super.getShapes(builder);
 
-    if (shapes.isEmpty())
-      throw new IllegalStateException(
-          "Cannot determine shape for " + this.getSignature() + " call.");
+    // The shape argument is unresolvable (content-dependent) and the output rank rides on it, so
+    // floor to ⊤ rather than aborting the whole analysis. super.getShapes already computes the
+    // precise shape (and recovers a `.shape` argument, wala/ML#604) when it is resolvable.
+    // wala/ML#611.
+    if (shapes == null || shapes.isEmpty()) return null;
 
     // Get the shape of the lam parameter.
     OrdinalSet<InstanceKey> lamPTS =
         this.getArgumentPointsToSet(
             builder, this.getLamParameterPosition(), this.getLamParameterName());
 
-    if (lamPTS == null || lamPTS.isEmpty())
-      throw new IllegalStateException(
-          "Mandatory 'lam' argument missing for Poisson: " + this.getNode());
+    // lam's shape is part of the output rank; ⊤ if the mandatory argument is unresolvable.
+    // wala/ML#611.
+    if (lamPTS == null || lamPTS.isEmpty()) return null;
 
     Set<List<Dimension<?>>> lamShapes = this.getShapesOfValue(builder, lamPTS);
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -5,6 +5,7 @@ import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -19,6 +20,7 @@ import com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContext;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -288,10 +290,26 @@ public class Range extends TensorGenerator {
     return derived;
   }
 
+  /**
+   * Floors an unresolvable {@code tf.range} to a rank-1 tensor with a dynamic length. The precise
+   * length is computed in {@link #getShapes} from the numeric arguments; this fallback is reached
+   * only when those arguments are unresolvable (content-dependent). {@code tf.range} always
+   * produces a rank-1 tensor, so the rank is still known: floor to a single {@link DynamicDim} axis
+   * rather than throwing (which aborted the whole analysis) or dropping to ⊤. See <a
+   * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>, mirroring the floors in <a
+   * href="https://github.com/wala/ML/issues/604">wala/ML#604</a>/<a
+   * href="https://github.com/wala/ML/issues/606">wala/ML#606</a>.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return A single rank-1 shape with a {@link DynamicDim} length.
+   */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    throw new UnsupportedOperationException(
-        "Shapes for range() are derived from mandatory numeric arguments.");
+    List<Dimension<?>> rank1 = new ArrayList<>();
+    rank1.add(DynamicDim.INSTANCE);
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    ret.add(rank1);
+    return ret;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_unresolvable.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_unresolvable.py
@@ -1,0 +1,13 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.eye`'s `num_rows` is unresolvable here (`json.loads`). The result is still rank-2
+# (square), just with dynamic dims. Regression guard for wala/ML#611: `EyeBase` previously
+# threw "num_rows parameter is required" here.
+consume(tf.eye(json.loads("3")))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gamma_unresolvable.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gamma_unresolvable.py
@@ -1,0 +1,13 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.random.gamma`'s `shape` argument is unresolvable here (`json.loads`); the output
+# rank rides on it, so the result floors to ⊤. Regression guard for wala/ML#611:
+# `Gamma` previously threw "Cannot determine shape for mandatory shape parameter".
+consume(tf.random.gamma(json.loads("[2]"), 1.0))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_poisson_unresolvable.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_poisson_unresolvable.py
@@ -1,0 +1,13 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.random.poisson`'s `shape` argument is unresolvable here (`json.loads`); the output
+# rank rides on it, so the result floors to ⊤. Regression guard for wala/ML#611:
+# `Poisson` previously threw "Cannot determine shape" here.
+consume(tf.random.poisson(json.loads("[2]"), 1.0))


### PR DESCRIPTION
Several generators aborted the whole analysis with a throw when a mandatory shape/size argument was unresolvable, the same anti-pattern wala/ML#604 (allocators) and wala/ML#606 (`tf.fill`) fixed. Each throw becomes the most precise non-crashing floor, preserving rank where the op fixes it:

- `Range`: rank-1 `DynamicDim` (tf.range is always rank-1). Defensive only — the obvious unresolvable-arg fixture doesn't reach `getDefaultShapes` (`getShapes` returns empty first), and forcing `getShapes` to the floor regressed corpus tests, so the floor stays scoped to `getDefaultShapes`.
- `EyeBase`: an unresolvable `num_rows` floors to `(Dynamic, Dynamic)` (tf.eye is rank-2) instead of throwing / calling `Optional.get()` on an empty value.
- `Gamma`/`Poisson`: the output rank rides on the unresolvable `shape`, so they floor to ⊤; `super.getShapes` still computes the precise shape (and recovers a `.shape` argument, wala/ML#604) when it is resolvable.

`testEyeUnresolvable`, `testGammaUnresolvable`, `testPoissonUnresolvable` pin the floored results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)