### PR TITLE
Folded into the wala/ML#598 fix

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11887,6 +11887,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Captured-gap fixture vendored from MusicTransformer-tensorflow2.0's `__dist_train_step` (the
+   * function the refactoring decorates; its `inp` is fed `np.array(...)` via `Data.seq2seq_batch`).
+   * The parameter lands at ⊥ (not tensor-classified): {@code np.array}'s tensor type isn't
+   * propagated to a callee parameter (<a href="https://github.com/wala/ML/issues/598">
+   * wala/ML#598</a>), whereas a {@code tf.constant} feed recovers concretely. So {@code consume}
+   * has 0 tensor parameters here.
+   *
+   * <p>TODO: once <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a> lands, {@code
+   * inp} should type and this flips to {@code consume} receiving a tensor parameter.
+   */
+  @Test
+  public void testMtDistTrainStep()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_mt_dist_train_step.py", "consume", 0, 0, Map.of());
+  }
+
+  /**
    * Guards constant-step subscript-slice shape propagation on ndarrays (wala/ML#405): {@code
    * x_train[:5]} on a {@code (60000, 28, 28) uint8} ndarray yields a {@code (5, 28, 28) uint8}
    * tensor. Implemented via {@link SliceBuiltinOperation}; the receiver-shape leak that previously

--- a/com.ibm.wala.cast.python.test/data/tf2_test_mt_dist_train_step.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_mt_dist_train_step.py
@@ -1,0 +1,30 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# Vendored from MusicTransformer-tensorflow2.0 (master <-> hybridize refactoring diff). The
+# refactoring decorates `__dist_train_step` (model.py); its `inp` parameter is fed the training
+# batch from `Data.seq2seq_batch` (data.py), which is `np.array(...)`. `__dist_train_step` is a
+# plain method (not a Keras `call`), so this isolates the result from the implicit-`call()`
+# blocker (wala/ML#106).
+#
+# `inp` lands at ⊥ (not tensor-classified): `np.array`'s tensor type is not propagated to a callee
+# parameter (wala/ML#598), whereas a `tf.constant` feed recovers concretely. This pins that
+# coverage loss. Once wala/ML#598 lands, `inp` should type and `consume` flips to a tensor
+# parameter.
+def seq2seq_batch():
+    return np.array([[1, 2, 3], [4, 5, 6]])
+
+
+class MusicTransformer:
+    @tf.function
+    def dist_train_step(self, inp):
+        consume(inp)
+        return inp
+
+
+MusicTransformer().dist_train_step(seq2seq_batch())


### PR DESCRIPTION
Closing. The regression test for `np.array` not propagating its tensor type to a callee parameter (wala/ML#598) lands with the #598 fix instead.