### PR TITLE
Guard against a null points-to variable in `findCreator`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -399,6 +399,9 @@ public class TensorGeneratorFactory {
 
     while (!queue.isEmpty()) {
       PointsToSetVariable current = queue.poll();
+      // The assignment graph can yield a null predecessor (an unresolved points-to variable), which
+      // is enqueued below; skip it rather than dereferencing null. wala/ML#613.
+      if (current == null) continue;
       PointerKey pk = current.getPointerKey();
       LOGGER.fine("findCreator visiting: " + current);
 
@@ -421,7 +424,7 @@ public class TensorGeneratorFactory {
       for (Iterator<PointsToSetVariable> it = assignmentGraph.getPredNodes(current);
           it.hasNext(); ) {
         PointsToSetVariable pred = it.next();
-        if (visited.add(pred)) {
+        if (pred != null && visited.add(pred)) {
           LOGGER.fine("findCreator adding pred: " + pred);
           queue.add(pred);
         }


### PR DESCRIPTION
`findCreator`'s BFS over the assignment graph could enqueue a null predecessor (an unresolved points-to variable) and then dereference it via `getPointerKey()`, an `NullPointerException` that aborts the whole-project analysis (wala/ML#613, reproduced on MusicTransformer/NLPGNN/TensorFlow2.0-Examples). This surfaced once the slice-dtype recovery (#429, #432) let `getDefaultDTypes` walk the dtype chain far enough to reach such a variable.

The fix skips null predecessors when enqueueing and guards the polled `current`, exactly as the issue suggests.

**On testing:** I tried to distill a fixture from the real `_skewing` (the dynamic `padded.shape[...]` reshape, fed both a concrete and an unresolved tensor), but neither reaches the null-predecessor state without the surrounding layer context. So this ships as a defensive crash-guard without a reproducing fixture, like the allocator (#430) and `tf.range` (#440) floors; the existing slice-dtype fixtures still pass, confirming no regression on the resolved path.

Closes wala/ML#613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)