### PR TITLE
Floor unresolvable-argument throws in the nested ragged generators

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11887,6 +11887,43 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Captured-gap regression for the {@code RaggedFromNested} shape floor (<a
+   * href="https://github.com/wala/ML/issues/612">wala/ML#612</a>): {@code
+   * tf.RaggedTensor.from_nested_row_lengths} with an opaque (unresolvable) {@code
+   * nested_row_lengths} floors the shape to ⊤ (unknown) rather than aborting the whole analysis
+   * with "Could not calculate shapes". The dtype still resolves to {@code int32} from the {@code
+   * flat_values}.
+   */
+  @Test
+  public void testRaggedFromNestedRowLengthsUnresolvable()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_nested_row_lengths_unresolvable.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * Captured-gap regression for the {@code RaggedFromNestedValueRowIds} shape and dtype floors (<a
+   * href="https://github.com/wala/ML/issues/612">wala/ML#612</a>): {@code
+   * tf.RaggedTensor.from_nested_value_rowids} with opaque (unresolvable) {@code flat_values} and
+   * {@code nested_value_rowids} floors both the shape and the dtype to ⊤ rather than aborting with
+   * "Could not calculate shapes" / "Could not determine dtypes".
+   */
+  @Test
+  public void testRaggedFromNestedValueRowIdsUnresolvable()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_ragged_from_nested_value_rowids_unresolvable.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
+  /**
    * Guards constant-step subscript-slice shape propagation on ndarrays (wala/ML#405): {@code
    * x_train[:5]} on a {@code (60000, 28, 28) uint8} ndarray yields a {@code (5, 28, 28) uint8}
    * tensor. Implemented via {@link SliceBuiltinOperation}; the receiver-shape leak that previously

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
@@ -205,10 +205,16 @@ public abstract class RaggedFromNested extends RaggedTensorFromValues {
       }
     }
 
-    // Handle case where we didn't find any shapes (e.g. points to sets empty)
+    // The shape rides on mandatory arguments (e.g. the nested row lengths and values); when they're
+    // unresolvable the points-to sets are empty and no shape can be built. Floor to ⊤ (unknown
+    // shape) rather than aborting the whole analysis. wala/ML#612.
     if (ret.isEmpty()) {
-      throw new IllegalStateException(
-          "Could not calculate shapes for " + this.getClass().getSimpleName());
+      LOGGER.fine(
+          () ->
+              "Could not calculate shapes for "
+                  + this.getClass().getSimpleName()
+                  + "; flooring to unknown (⊤).");
+      return null;
     }
 
     LOGGER.fine("Final calculated shapes: " + ret);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -293,12 +293,12 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
       }
     }
 
+    // The shape rides on mandatory arguments (the nested value-row-ids and values); when they're
+    // unresolvable the points-to sets are empty and no shape can be built. Floor to ⊤ (unknown
+    // shape) rather than aborting the whole analysis. wala/ML#612.
     if (ret.isEmpty()) {
-      throw new IllegalStateException("Could not calculate shapes for RaggedFromNestedValueRowIds");
-    }
-
-    if (ret.isEmpty()) {
-      throw new IllegalStateException("Could not calculate shapes for RaggedFromNestedValueRowIds");
+      LOGGER.fine("Could not calculate shapes for RaggedFromNestedValueRowIds; flooring to ⊤.");
+      return null;
     }
 
     return ret;
@@ -354,7 +354,10 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
     if (valuesPts != null && !valuesPts.isEmpty()) {
       return getDTypesOfValue(builder, valuesPts);
     }
-    throw new IllegalStateException("Could not determine dtypes for RaggedFromNestedValueRowIds");
+    // The dtype comes from the mandatory `values` argument; when it's unresolvable, floor to ⊤
+    // (unknown dtype) rather than aborting the whole analysis. wala/ML#612.
+    LOGGER.fine("Could not determine dtypes for RaggedFromNestedValueRowIds; flooring to ⊤.");
+    return Set.of(DType.UNKNOWN);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_nested_row_lengths_unresolvable.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_nested_row_lengths_unresolvable.py
@@ -1,0 +1,16 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(a):
+    pass
+
+
+# `nested_row_lengths` comes from an opaque `json.loads`, so the ragged structure is unresolvable to
+# the analysis. `RaggedFromNested` floors the shape to ⊤ (unknown) rather than aborting the whole
+# analysis with "Could not calculate shapes". wala/ML#612.
+x = [10, 20, 30, 40, 50, 60, 70]
+nested_row_lengths = json.loads("[[2, 1, 0, 2], [2, 0, 3, 1, 1]]")
+arg = tf.RaggedTensor.from_nested_row_lengths(x, nested_row_lengths)
+consume(arg)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_nested_value_rowids_unresolvable.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_ragged_from_nested_value_rowids_unresolvable.py
@@ -1,0 +1,17 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(rt):
+    pass
+
+
+# Both `flat_values` and `nested_value_rowids` come from opaque `json.loads`, so neither the ragged
+# structure nor the dtype is resolvable. `RaggedFromNestedValueRowIds` floors the shape to ⊤ and the
+# dtype to ⊤ rather than aborting with "Could not calculate shapes" / "Could not determine dtypes".
+# wala/ML#612.
+flat_values = json.loads('["a", "b", "c", "d", "e", "f", "g"]')
+nested_value_rowids = json.loads("[[0, 0, 1, 2], [0, 1, 1, 2, 2, 2, 3]]")
+rt = tf.RaggedTensor.from_nested_value_rowids(flat_values, nested_value_rowids)
+consume(rt)


### PR DESCRIPTION
`RaggedFromNested.getShapes` and `RaggedFromNestedValueRowIds.getShapes`/`getDefaultDTypes` aborted the whole-project analysis with an `IllegalStateException` (`Could not calculate shapes`/`Could not determine dtypes`) whenever a mandatory ragged argument was unresolvable. Each now floors to ⊤ (unknown shape/unknown dtype), the crash-floor pattern from wala/ML#611.

Each generator gets a regression fixture whose mandatory ragged argument comes from an opaque `json.loads`, so it aborts the analysis on `master`: `from_nested_row_lengths` floors the shape to ⊤ while keeping `int32` from the values; `from_nested_value_rowids` floors both shape and dtype to ⊤.

🤖 Generated with [Claude Code](https://claude.com/claude-code)