### PR TITLE
Degrade gracefully on non-numeric constant and null row dimensions

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -115,6 +115,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_1_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(1)));
 
+  private static final TensorType TENSOR_0_0_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(0), new NumericDim(0)));
+
   private static final TensorType TENSOR_1_2_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
 
@@ -11897,6 +11900,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testEyeBoolDim()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_eye_bool_dim.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_1_1_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testEyeBoolDim} covering the {@code int(False) == 0} branch of {@code
+   * getIntValueFromInstanceKey} (<a href="https://github.com/wala/ML/issues/590">wala/ML#590</a>):
+   * {@code tf.eye(False)} degrades the {@code Boolean} to {@code 0}, yielding a {@code (0, 0)}
+   * identity.
+   */
+  @Test
+  public void testEyeBoolDimFalse()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_eye_bool_dim_false.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_0_0_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11887,6 +11887,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression for the {@code getIntValueFromInstanceKey} non-numeric-constant degradation (<a
+   * href="https://github.com/wala/ML/issues/590">wala/ML#590</a>): {@code tf.eye(True)} models the
+   * Python {@code bool} as a {@code Boolean} constant, which degrades to {@code int(True) == 1} (a
+   * {@code (1, 1)} identity) rather than throwing a {@code ClassCastException} on the {@code
+   * Number} cast.
+   */
+  @Test
+  public void testEyeBoolDim()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_eye_bool_dim.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_1_1_FLOAT32)));
+  }
+
+  /**
    * Guards constant-step subscript-slice shape propagation on ndarrays (wala/ML#405): {@code
    * x_train[:5]} on a {@code (60000, 28, 28) uint8} ndarray yields a {@code (5, 28, 28) uint8}
    * tensor. Implemented via {@link SliceBuiltinOperation}; the receiver-shape leak that previously

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
@@ -141,7 +141,11 @@ public abstract class RaggedFromNested extends RaggedTensorFromValues {
                     if (!shape.isEmpty()) {
                       Dimension<?> dim = shape.get(0);
                       LOGGER.fine("Found row dimension from first element: " + dim);
-                      possibleRowDims.add(computeRowDim(dim));
+                      // `computeRowDim` returns null for a non-`NumericDim` (e.g.
+                      // `RaggedFromNestedRowSplits` on a dynamic dimension); fall back to a dynamic
+                      // dimension rather than adding a raw null to the shape. wala/ML#590.
+                      Dimension<?> rowDim = computeRowDim(dim);
+                      possibleRowDims.add(rowDim != null ? rowDim : DynamicDim.INSTANCE);
                       foundRowDim = true;
                     }
                   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -135,7 +135,12 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
       Object value = constantKey.getValue();
 
       if (value == null) return Optional.empty();
-      return Optional.of(((Number) value).intValue());
+      if (value instanceof Number) return Optional.of(((Number) value).intValue());
+      // WALA may model a Python `bool` as a `Boolean` rather than a `Number`; `int(True) == 1` and
+      // `int(False) == 0`. Any other non-numeric constant (e.g. a string) has no integer value, so
+      // degrade to ⊤ (empty) rather than throwing a `ClassCastException`. wala/ML#590.
+      if (value instanceof Boolean) return Optional.of(Boolean.TRUE.equals(value) ? 1 : 0);
+      return Optional.empty();
     }
 
     throw new IllegalArgumentException(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_bool_dim.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_bool_dim.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.eye(True)`: WALA models the Python `bool` as a `Boolean` constant. `getIntValueFromInstanceKey`
+# treats it as `int(True) == 1` (degrading gracefully) rather than throwing a `ClassCastException`
+# on the `Number` cast, so the identity matrix is `(1, 1)`. wala/ML#590.
+consume(tf.eye(True))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_bool_dim_false.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_bool_dim_false.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.eye(False)`: the Boolean degrades to `int(False) == 0` (the companion of `tf.eye(True)`),
+# yielding a `(0, 0)` identity rather than throwing a `ClassCastException` on the `Number` cast.
+# wala/ML#590.
+consume(tf.eye(False))


### PR DESCRIPTION
Two latent robustness bugs from the wala/ML#590 audit, fixed to degrade to ⊤/`DynamicDim` per the lattice conventions:

- `getIntValueFromInstanceKey` cast a constant value to `Number` unconditionally, throwing a `ClassCastException` when WALA models a Python `bool` as a `Boolean` (or for any other non-numeric constant). It now treats a `Boolean` as `int(True)`/`int(False)` and degrades any other non-numeric constant to ⊤. `testEyeBoolDim` covers this via `tf.eye(True)`, which aborts the analysis on `master`.
- `RaggedFromNested` added `computeRowDim(dim)` even when it returns null for a non-`NumericDim`, putting a raw null into the shape. It now falls back to `DynamicDim.INSTANCE`.

The third audit item (the `EyeBase.getShapes` `Optional.get()`) was already resolved by wala/ML#611's `axisDim` rework, so all three are addressed.

Closes wala/ML#590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)