### PR TITLE
Guard against a null source in `getGeneratorBody`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
@@ -1,10 +1,12 @@
 package com.ibm.wala.cast.python.ml.test;
 
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
+import static org.junit.Assert.assertNull;
 
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
+import com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyWrite;
@@ -50,6 +52,25 @@ public class TestMNISTExamples extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     CallGraph CG = process(Ex1URL);
     verifyGraphAssertions(CG, assertionsEx1);
+  }
+
+  /**
+   * Direct regression guard for the null-source guards on the slice-dtype recovery path: {@code
+   * findCreator} (<a href="https://github.com/wala/ML/issues/613">wala/ML#613</a>) and {@code
+   * getGenerator}/{@code getGeneratorBody} (<a href="https://github.com/wala/ML/issues/614">
+   * wala/ML#614</a>) must yield null for a null {@link PointsToSetVariable} rather than throwing a
+   * {@link NullPointerException}. The full-corpus implicit points-to-key state that triggers this
+   * in the wild (an allocation whose local pointer key is implicit, so {@code getDTypesOfValue}
+   * passes a null source to the factory) isn't distillable to a single fixture, so this exercises
+   * the guard's contract directly against a real builder.
+   */
+  @Test
+  public void testGetGeneratorNullSource()
+      throws IllegalArgumentException, CancelException, IOException, URISyntaxException {
+    checkTensorOps(
+        Ex1URL,
+        (PropagationCallGraphBuilder cgBuilder, CallGraph CG, TensorTypeAnalysis result) ->
+            assertNull(TensorGeneratorFactory.getGenerator(null, cgBuilder)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -682,6 +682,10 @@ public class TensorGeneratorFactory {
       PropagationCallGraphBuilder builder,
       Set<PointsToSetVariable> visited) {
     source = findCreator(source, builder);
+    // `findCreator` can return null (an unresolvable points-to variable, e.g. a null source or a
+    // null assignment-graph predecessor it skipped, wala/ML#613). There is no generator for a null
+    // source, so return null here rather than dereferencing it in `getGeneratorBody`. wala/ML#614.
+    if (source == null) return null;
     if (!visited.add(source)) {
       final PointsToSetVariable cycleSource = source;
       LOGGER.log(


### PR DESCRIPTION
A second `NullPointerException` on the same slice-dtype recovery path as wala/ML#613. `getGenerator` calls `findCreator`, which can return null (its #613 guard skips unresolvable points-to variables, ponder-lab/ML#442), then passes the result to `getGeneratorBody`, which dereferenced it via `getPointerKey()` and aborted the whole-project analysis (wala/ML#614, reproduced on MusicTransformer/NLPGNN/TensorFlow2.0-Examples).

The fix returns null for a null source before `getGeneratorBody` runs.

The full-corpus implicit-pointer-key state that triggers this in the wild isn't distillable to a Python fixture, so `testGetGeneratorNullSource` guards it directly: it drives a real builder via the existing `checkTensorOps` harness and asserts `getGenerator(null, builder)` returns null. Removing the guard makes it fail with the exact `getGeneratorBody` NPE from the issue, and it covers the #613 `findCreator` guard the same way.

Closes wala/ML#614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)