### PR TITLE
Fix three latent correctness bugs from the tensor-generator audit

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -115,6 +115,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_1_1_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(1)));
 
+  private static final TensorType TENSOR_2_3_3_FLOAT32 =
+      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));
+
   private static final TensorType TENSOR_0_0_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(0), new NumericDim(0)));
 
@@ -11949,6 +11952,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
+  /**
+   * Covers {@code tf.eye} with a {@code batch_shape}, which prepends the batch dimensions to the
+   * identity shape (<a href="https://github.com/wala/ML/issues/591">wala/ML#591</a>): a {@code (3,
+   * 3)} identity with {@code batch_shape=[2]} is {@code (2, 3, 3)}. Exercises the fresh-list
+   * construction that replaced the shared-list mutation.
+   */
+  @Test
+  public void testEyeBatchShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_eye_batch_shape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_3_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
@@ -7,7 +7,9 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -56,11 +58,21 @@ public class Eye extends EyeBase {
     Set<List<Dimension<?>>> ret = super.getShapes(builder);
     Set<List<Dimension<?>>> batchShapes = this.getBatchShapes(builder);
 
-    // prepend batch dimensions to each shape.
-    for (List<Dimension<?>> batchDim : batchShapes)
-      for (List<Dimension<?>> retDim : ret) retDim.addAll(0, batchDim);
+    if (batchShapes.isEmpty()) return ret;
 
-    return ret;
+    // Prepend each batch shape to each base shape, building a fresh list per combination. Mutating
+    // the lists returned by super.getShapes would alias shared shape lists, and re-prepending per
+    // batch shape would stack multiple batch shapes onto the same list (double-prepend).
+    // wala/ML#591.
+    Set<List<Dimension<?>>> withBatchShapes = HashSetFactory.make();
+    for (List<Dimension<?>> batchDim : batchShapes)
+      for (List<Dimension<?>> retDim : ret) {
+        List<Dimension<?>> combined = new ArrayList<>(batchDim);
+        combined.addAll(retDim);
+        withBatchShapes.add(combined);
+      }
+
+    return withBatchShapes;
   }
 
   private Set<List<Dimension<?>>> getBatchShapes(PropagationCallGraphBuilder builder) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReadDataSets.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReadDataSets.java
@@ -49,6 +49,13 @@ public class ReadDataSets extends TensorTypeAllocator {
     return RESHAPE.ordinal();
   }
 
+  // Align the shape-parameter name with the overridden position above; the inherited name otherwise
+  // refers to a different parameter than `RESHAPE`. wala/ML#593.
+  @Override
+  protected String getShapeParameterName() {
+    return RESHAPE.getName();
+  }
+
   @Override
   protected int getDTypeParameterPosition() {
     return DTYPE.ordinal();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reduction.java
@@ -238,8 +238,15 @@ public abstract class Reduction extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    // Inherit dtype from input
-    return this.getDTypes(builder, Parameters.INPUT_TENSOR.getIndex());
+    // Inherit dtype from the input tensor. Resolve its IR value number first; `getDTypes(builder,
+    // int)` expects a value number, not the parameter index. wala/ML#592.
+    int inputValNum =
+        this.getArgumentValueNumber(
+            builder,
+            this.getInputTensorParameterPosition(),
+            this.getInputTensorParameterName(),
+            false);
+    return this.getDTypes(builder, inputValNum);
   }
 
   @Override
@@ -271,7 +278,10 @@ public abstract class Reduction extends TensorGenerator {
     // ops with different semantics override this (e.g. ReduceMean promotes integers to float32).
     int inputValNum =
         this.getArgumentValueNumber(
-            builder, Parameters.INPUT_TENSOR.getIndex(), Parameters.INPUT_TENSOR.getName(), false);
+            builder,
+            this.getInputTensorParameterPosition(),
+            this.getInputTensorParameterName(),
+            false);
     return this.getDTypes(builder, inputValNum);
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_batch_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_batch_shape.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.eye` with a `batch_shape` prepends the batch dimensions to the identity shape: a `(3, 3)`
+# identity with `batch_shape=[2]` is `(2, 3, 3)`. wala/ML#591.
+consume(tf.eye(3, batch_shape=[2]))


### PR DESCRIPTION
Three pre-existing latent correctness bugs surfaced by the same audit as #590 (children of wala/ML#590), each a self-contained fix:

- **wala/ML#591** — `Eye.getShapes` prepended `batch_shape` dimensions by mutating the shared lists returned from `super.getShapes` (aliasing) and re-prepended once per batch shape (double-prepend when more than one is possible). It now builds a fresh list per combination. `testEyeBatchShape` covers it.
- **wala/ML#592** — `Reduction.getDefaultDTypes` passed a parameter index where `getDTypes(builder, int)` expects an IR value number, and both it and `getDTypes(builder)` hardcoded `Parameters.INPUT_TENSOR` instead of the accessors. Latent: the `Reduce*` leaves override `getDTypes(builder)` and bypass these, so no fixture reaches it (expect an uncovered patch line here).
- **wala/ML#593** — `ReadDataSets`'s shape-parameter position (`RESHAPE`) and inherited name referred to different parameters; the name is now aligned. Exercised by the existing `read_data_sets` fixtures.

Closes wala/ML#591
Closes wala/ML#592
Closes wala/ML#593

🤖 Generated with [Claude Code](https://claude.com/claude-code)