### PR TITLE
Add a concise all-numeric `TensorType.of(..., int...)` factory

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -110,89 +110,62 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType SCALAR_TENSOR_OF_BOOL = new TensorType(BOOL, emptyList());
 
-  private static final TensorType TENSOR_3_BOOL = new TensorType(BOOL, asList(new NumericDim(3)));
+  private static final TensorType TENSOR_3_BOOL = TensorType.of(BOOL, 3);
 
-  private static final TensorType TENSOR_1_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(1)));
+  private static final TensorType TENSOR_1_1_FLOAT32 = TensorType.of(FLOAT_32, 1, 1);
 
-  private static final TensorType TENSOR_2_3_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));
+  private static final TensorType TENSOR_2_3_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 3, 3);
 
-  private static final TensorType TENSOR_0_0_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(0), new NumericDim(0)));
+  private static final TensorType TENSOR_0_0_FLOAT32 = TensorType.of(FLOAT_32, 0, 0);
 
-  private static final TensorType TENSOR_1_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(2)));
+  private static final TensorType TENSOR_1_2_FLOAT32 = TensorType.of(FLOAT_32, 1, 2);
 
-  private static final TensorType TENSOR_1_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(5)));
+  private static final TensorType TENSOR_1_5_FLOAT32 = TensorType.of(FLOAT_32, 1, 5);
 
-  private static final TensorType TENSOR_1_10_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(10)));
+  private static final TensorType TENSOR_1_10_FLOAT32 = TensorType.of(FLOAT_32, 1, 10);
 
-  private static final TensorType TENSOR_1_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1), new NumericDim(3)));
+  private static final TensorType TENSOR_1_3_FLOAT32 = TensorType.of(FLOAT_32, 1, 3);
 
-  private static final TensorType TENSOR_3_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(1)));
+  private static final TensorType TENSOR_3_1_FLOAT32 = TensorType.of(FLOAT_32, 3, 1);
 
   @SuppressWarnings("unused")
-  private static final TensorType TENSOR_32_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(32)));
+  private static final TensorType TENSOR_32_INT32 = TensorType.of(INT_32, 32);
 
-  private static final TensorType TENSOR_32_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(32)));
+  private static final TensorType TENSOR_32_UINT8 = TensorType.of(UINT_8, 32);
 
-  private static final TensorType TENSOR_16_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(16)));
+  private static final TensorType TENSOR_16_UINT8 = TensorType.of(UINT_8, 16);
 
-  private static final TensorType TENSOR_256_784_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(784)));
+  private static final TensorType TENSOR_256_784_FLOAT32 = TensorType.of(FLOAT_32, 256, 784);
 
-  private static final TensorType TENSOR_256_28_28_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_256_28_28_FLOAT32 = TensorType.of(FLOAT_32, 256, 28, 28);
 
-  private static final TensorType TENSOR_10000_784_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(10000), new NumericDim(784)));
+  private static final TensorType TENSOR_10000_784_FLOAT32 = TensorType.of(FLOAT_32, 10000, 784);
 
-  private static final TensorType TENSOR_5_784_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(5), new NumericDim(784)));
+  private static final TensorType TENSOR_5_784_FLOAT32 = TensorType.of(FLOAT_32, 5, 784);
 
-  private static final TensorType TENSOR_60000_784_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(60000), new NumericDim(784)));
+  private static final TensorType TENSOR_60000_784_UINT8 = TensorType.of(UINT_8, 60000, 784);
 
-  private static final TensorType TENSOR_256_10_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(10)));
+  private static final TensorType TENSOR_256_10_FLOAT32 = TensorType.of(FLOAT_32, 256, 10);
 
-  private static final TensorType TENSOR_256_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(256)));
+  private static final TensorType TENSOR_256_UINT8 = TensorType.of(UINT_8, 256);
 
-  private static final TensorType TENSOR_10000_10_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(10000), new NumericDim(10)));
+  private static final TensorType TENSOR_10000_10_FLOAT32 = TensorType.of(FLOAT_32, 10000, 10);
 
-  private static final TensorType TENSOR_10000_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(10000)));
+  private static final TensorType TENSOR_10000_UINT8 = TensorType.of(UINT_8, 10000);
 
-  private static final TensorType TENSOR_32_28_28_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(32), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_32_28_28_UINT8 = TensorType.of(UINT_8, 32, 28, 28);
 
-  private static final TensorType TENSOR_5_28_28_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(5), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_5_28_28_UINT8 = TensorType.of(UINT_8, 5, 28, 28);
 
-  private static final TensorType TENSOR_3_28_28_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(3), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_3_28_28_UINT8 = TensorType.of(UINT_8, 3, 28, 28);
 
-  private static final TensorType TENSOR_1_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(2)));
+  private static final TensorType TENSOR_1_2_INT32 = TensorType.of(INT_32, 1, 2);
 
-  private static final TensorType TENSOR_1_5_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(5)));
+  private static final TensorType TENSOR_1_5_INT32 = TensorType.of(INT_32, 1, 5);
 
-  private static final TensorType TENSOR_1_10_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1), new NumericDim(10)));
+  private static final TensorType TENSOR_1_10_INT32 = TensorType.of(INT_32, 1, 10);
 
-  private static final TensorType TENSOR_2_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2)));
+  private static final TensorType TENSOR_2_2_FLOAT32 = TensorType.of(FLOAT_32, 2, 2);
 
   private static final TensorType TENSOR_NONE_32_FLOAT32 =
       new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(32)));
@@ -229,96 +202,64 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_2_RAGGED_RAGGED_INT32 =
       new TensorType(INT_32, asList(new NumericDim(2), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 
-  private static final TensorType TENSOR_2_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(2)));
+  private static final TensorType TENSOR_2_2_INT32 = TensorType.of(INT_32, 2, 2);
 
-  private static final TensorType TENSOR_3_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(2)));
+  private static final TensorType TENSOR_3_2_FLOAT32 = TensorType.of(FLOAT_32, 3, 2);
 
-  private static final TensorType TENSOR_2_4_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(4), new NumericDim(3)));
+  private static final TensorType TENSOR_2_4_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 4, 3);
 
-  private static final TensorType TENSOR_4_3_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(3), new NumericDim(2)));
+  private static final TensorType TENSOR_4_3_2_FLOAT32 = TensorType.of(FLOAT_32, 4, 3, 2);
 
-  private static final TensorType TENSOR_4_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(3)));
+  private static final TensorType TENSOR_4_3_FLOAT32 = TensorType.of(FLOAT_32, 4, 3);
 
-  private static final TensorType TENSOR_2_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_2_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 3);
 
-  private static final TensorType TENSOR_1_1_3_2_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(1), new NumericDim(1), new NumericDim(3), new NumericDim(2)));
+  private static final TensorType TENSOR_1_1_3_2_FLOAT32 = TensorType.of(FLOAT_32, 1, 1, 3, 2);
 
-  private static final TensorType TENSOR_2_3_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(1)));
+  private static final TensorType TENSOR_2_3_1_FLOAT32 = TensorType.of(FLOAT_32, 2, 3, 1);
 
-  private static final TensorType TENSOR_2_3_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_2_3_FLOAT64 = TensorType.of(FLOAT_64, 2, 3);
 
-  private static final TensorType TENSOR_4_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(4)));
+  private static final TensorType TENSOR_4_INT64 = TensorType.of(INT_64, 4);
 
-  private static final TensorType TENSOR_100_784_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(100), new NumericDim(784)));
+  private static final TensorType TENSOR_100_784_FLOAT32 = TensorType.of(FLOAT_32, 100, 784);
 
-  private static final TensorType TENSOR_4_8_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(8)));
+  private static final TensorType TENSOR_4_8_FLOAT32 = TensorType.of(FLOAT_32, 4, 8);
 
-  private static final TensorType TENSOR_4_512_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(512)));
+  private static final TensorType TENSOR_4_512_FLOAT32 = TensorType.of(FLOAT_32, 4, 512);
 
-  private static final TensorType TENSOR_2_64_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(64)));
+  private static final TensorType TENSOR_2_64_FLOAT32 = TensorType.of(FLOAT_32, 2, 64);
 
   private static final TensorType SPARSE_TENSOR_4_4_FLOAT32 =
       new SparseTensorType(FLOAT32, asList(new NumericDim(4), new NumericDim(4)));
 
-  private static final TensorType TENSOR_4_10_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(10)));
+  private static final TensorType TENSOR_4_10_FLOAT32 = TensorType.of(FLOAT_32, 4, 10);
 
-  private static final TensorType TENSOR_4_1_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4), new NumericDim(1)));
+  private static final TensorType TENSOR_4_1_INT32 = TensorType.of(INT_32, 4, 1);
 
-  private static final TensorType TENSOR_256_256_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(256), new NumericDim(3)));
+  private static final TensorType TENSOR_256_256_3_FLOAT32 = TensorType.of(FLOAT_32, 256, 256, 3);
 
-  private static final TensorType TENSOR_2_3_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
+  private static final TensorType TENSOR_2_3_4_FLOAT32 = TensorType.of(FLOAT_32, 2, 3, 4);
 
-  private static final TensorType TENSOR_2_2_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(4)));
+  private static final TensorType TENSOR_2_2_4_FLOAT32 = TensorType.of(FLOAT_32, 2, 2, 4);
 
-  private static final TensorType TENSOR_2_2_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(2), new NumericDim(1)));
+  private static final TensorType TENSOR_2_2_1_FLOAT32 = TensorType.of(FLOAT_32, 2, 2, 1);
 
-  private static final TensorType TENSOR_2_5_6_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(5), new NumericDim(6)));
+  private static final TensorType TENSOR_2_5_6_FLOAT32 = TensorType.of(FLOAT_32, 2, 5, 6);
 
-  private static final TensorType TENSOR_4_4_6_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4), new NumericDim(6)));
+  private static final TensorType TENSOR_4_4_6_FLOAT32 = TensorType.of(FLOAT_32, 4, 4, 6);
 
-  private static final TensorType TENSOR_4_6_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(6)));
+  private static final TensorType TENSOR_4_6_FLOAT32 = TensorType.of(FLOAT_32, 4, 6);
 
-  private static final TensorType TENSOR_1_2_2_27_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(1), new NumericDim(2), new NumericDim(2), new NumericDim(27)));
+  private static final TensorType TENSOR_1_2_2_27_FLOAT32 = TensorType.of(FLOAT_32, 1, 2, 2, 27);
 
-  private static final TensorType TENSOR_4_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(4)));
+  private static final TensorType TENSOR_4_4_FLOAT32 = TensorType.of(FLOAT_32, 4, 4);
 
-  private static final TensorType TENSOR_2_5_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(5)));
+  private static final TensorType TENSOR_2_5_INT32 = TensorType.of(INT_32, 2, 5);
 
-  private static final TensorType TENSOR_3_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(3)));
+  private static final TensorType TENSOR_3_3_FLOAT32 = TensorType.of(FLOAT_32, 3, 3);
 
-  private static final TensorType TENSOR_3_3_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(3)));
+  private static final TensorType TENSOR_3_3_INT32 = TensorType.of(INT_32, 3, 3);
 
   private static final TensorType TENSOR_0_RAGGED_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(0), RaggedDim.INSTANCE));
@@ -380,137 +321,91 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_3_RAGGED_1_FLOAT32 =
       new TensorType(FLOAT_32, asList(new NumericDim(3), RaggedDim.INSTANCE, new NumericDim(1)));
 
-  private static final TensorType TENSOR_2_3_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_2_3_INT32 = TensorType.of(INT_32, 2, 3);
 
-  private static final TensorType TENSOR_2_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(4)));
+  private static final TensorType TENSOR_2_4_FLOAT32 = TensorType.of(FLOAT_32, 2, 4);
 
-  private static final TensorType TENSOR_2_6_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(6)));
+  private static final TensorType TENSOR_2_6_INT32 = TensorType.of(INT_32, 2, 6);
 
-  private static final TensorType TENSOR_2_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(1)));
+  private static final TensorType TENSOR_2_1_FLOAT32 = TensorType.of(FLOAT_32, 2, 1);
 
-  private static final TensorType TENSOR_10_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(10), new NumericDim(2)));
+  private static final TensorType TENSOR_10_2_FLOAT32 = TensorType.of(FLOAT_32, 10, 2);
 
-  private static final TensorType TENSOR_10_2_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(10), new NumericDim(2)));
+  private static final TensorType TENSOR_10_2_FLOAT64 = TensorType.of(FLOAT_64, 10, 2);
 
-  private static final TensorType TENSOR_5_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(5), new NumericDim(2)));
+  private static final TensorType TENSOR_5_2_FLOAT32 = TensorType.of(FLOAT_32, 5, 2);
 
-  private static final TensorType TENSOR_5_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5), new NumericDim(2)));
+  private static final TensorType TENSOR_5_2_INT32 = TensorType.of(INT_32, 5, 2);
 
-  private static final TensorType TENSOR_5_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(5), new NumericDim(5)));
+  private static final TensorType TENSOR_5_5_FLOAT32 = TensorType.of(FLOAT_32, 5, 5);
 
-  private static final TensorType TENSOR_5_5_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5), new NumericDim(5)));
+  private static final TensorType TENSOR_5_5_INT32 = TensorType.of(INT_32, 5, 5);
 
   private static final TensorType TENSOR_5_RAGGED_INT32 =
       new TensorType(INT_32, asList(new NumericDim(5), RaggedDim.INSTANCE));
 
-  private static final TensorType TENSOR_2_3_3_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(3)));
+  private static final TensorType TENSOR_2_3_3_INT32 = TensorType.of(INT_32, 2, 3, 3);
 
-  private static final TensorType TENSOR_2_3_4_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2), new NumericDim(3), new NumericDim(4)));
+  private static final TensorType TENSOR_2_3_4_INT32 = TensorType.of(INT_32, 2, 3, 4);
 
-  private static final TensorType TENSOR_2_5_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(5), new NumericDim(3)));
+  private static final TensorType TENSOR_2_5_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 5, 3);
 
-  private static final TensorType TENSOR_3_2_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(2), new NumericDim(2)));
+  private static final TensorType TENSOR_3_2_2_FLOAT32 = TensorType.of(FLOAT_32, 3, 2, 2);
 
-  private static final TensorType TENSOR_7_5_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(7), new NumericDim(5), new NumericDim(2)));
+  private static final TensorType TENSOR_7_5_2_FLOAT32 = TensorType.of(FLOAT_32, 7, 5, 2);
 
-  private static final TensorType TENSOR_30_3_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(30), new NumericDim(3), new NumericDim(2)));
+  private static final TensorType TENSOR_30_3_2_FLOAT32 = TensorType.of(FLOAT_32, 30, 3, 2);
 
-  private static final TensorType TENSOR_3_2_2_3_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(3), new NumericDim(2), new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_3_2_2_3_FLOAT32 = TensorType.of(FLOAT_32, 3, 2, 2, 3);
 
-  private static final TensorType TENSOR_2_2_2_3_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(2), new NumericDim(2), new NumericDim(2), new NumericDim(3)));
+  private static final TensorType TENSOR_2_2_2_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 2, 2, 3);
 
-  private static final TensorType TENSOR_20_28_28_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_20_28_28_FLOAT32 = TensorType.of(FLOAT_32, 20, 28, 28);
 
-  private static final TensorType TENSOR_20_28_28_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(20), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_20_28_28_INT32 = TensorType.of(INT_32, 20, 28, 28);
 
-  private static final TensorType TENSOR_20_10_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(10)));
+  private static final TensorType TENSOR_20_10_FLOAT32 = TensorType.of(FLOAT_32, 20, 10);
 
-  private static final TensorType TENSOR_20_64_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(64)));
+  private static final TensorType TENSOR_20_64_FLOAT32 = TensorType.of(FLOAT_32, 20, 64);
 
   private static final TensorType TENSOR_60000_28_28_FLOAT32 =
-      new TensorType(
-          FLOAT_32, asList(new NumericDim(60000), new NumericDim(28), new NumericDim(28)));
+      TensorType.of(FLOAT_32, 60000, 28, 28);
 
-  private static final TensorType TENSOR_60000_28_28_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(60000), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_60000_28_28_UINT8 = TensorType.of(UINT_8, 60000, 28, 28);
 
   private static final TensorType TENSOR_50000_32_32_3_UINT8 =
-      new TensorType(
-          UINT_8,
-          asList(new NumericDim(50000), new NumericDim(32), new NumericDim(32), new NumericDim(3)));
+      TensorType.of(UINT_8, 50000, 32, 32, 3);
 
-  private static final TensorType TENSOR_8982_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(8982)));
+  private static final TensorType TENSOR_8982_INT64 = TensorType.of(INT_64, 8982);
 
-  private static final TensorType TENSOR_404_13_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(404), new NumericDim(13)));
+  private static final TensorType TENSOR_404_13_FLOAT64 = TensorType.of(FLOAT_64, 404, 13);
 
-  private static final TensorType TENSOR_404_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(404)));
+  private static final TensorType TENSOR_404_FLOAT64 = TensorType.of(FLOAT_64, 404);
 
-  private static final TensorType TENSOR_60000_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(60000)));
+  private static final TensorType TENSOR_60000_UINT8 = TensorType.of(UINT_8, 60000);
 
-  private static final TensorType TENSOR_50000_1_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(50000), new NumericDim(1)));
+  private static final TensorType TENSOR_50000_1_UINT8 = TensorType.of(UINT_8, 50000, 1);
 
-  private static final TensorType TENSOR_50000_1_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(50000), new NumericDim(1)));
+  private static final TensorType TENSOR_50000_1_INT64 = TensorType.of(INT_64, 50000, 1);
 
-  private static final TensorType TENSOR_8982_OBJECT =
-      new TensorType(OBJECT, asList(new NumericDim(8982)));
+  private static final TensorType TENSOR_8982_OBJECT = TensorType.of(OBJECT, 8982);
 
-  private static final TensorType TENSOR_102_13_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(102), new NumericDim(13)));
+  private static final TensorType TENSOR_102_13_FLOAT64 = TensorType.of(FLOAT_64, 102, 13);
 
-  private static final TensorType TENSOR_102_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(102)));
+  private static final TensorType TENSOR_102_FLOAT64 = TensorType.of(FLOAT_64, 102);
 
   private static final TensorType TENSOR_10000_32_32_3_UINT8 =
-      new TensorType(
-          UINT_8,
-          asList(new NumericDim(10000), new NumericDim(32), new NumericDim(32), new NumericDim(3)));
+      TensorType.of(UINT_8, 10000, 32, 32, 3);
 
-  private static final TensorType TENSOR_10000_1_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(10000), new NumericDim(1)));
+  private static final TensorType TENSOR_10000_1_UINT8 = TensorType.of(UINT_8, 10000, 1);
 
-  private static final TensorType TENSOR_10000_1_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(10000), new NumericDim(1)));
+  private static final TensorType TENSOR_10000_1_INT64 = TensorType.of(INT_64, 10000, 1);
 
-  private static final TensorType TENSOR_10000_28_28_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(10000), new NumericDim(28), new NumericDim(28)));
+  private static final TensorType TENSOR_10000_28_28_UINT8 = TensorType.of(UINT_8, 10000, 28, 28);
 
-  private static final TensorType TENSOR_2246_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(2246)));
+  private static final TensorType TENSOR_2246_INT64 = TensorType.of(INT_64, 2246);
 
-  private static final TensorType TENSOR_2246_OBJECT =
-      new TensorType(OBJECT, asList(new NumericDim(2246)));
+  private static final TensorType TENSOR_2246_OBJECT = TensorType.of(OBJECT, 2246);
 
   /** A {@code float32} tensor whose shape cannot be statically inferred. */
   private static final TensorType TENSOR_UNKNOWN_SHAPE_FLOAT32 = new TensorType(FLOAT_32, null);
@@ -519,157 +414,105 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final TensorType TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE =
       new TensorType(UNKNOWN, null);
 
-  private static final TensorType TENSOR_1_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(1)));
+  private static final TensorType TENSOR_1_FLOAT32 = TensorType.of(FLOAT_32, 1);
 
-  private static final TensorType TENSOR_2_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(2)));
+  private static final TensorType TENSOR_2_FLOAT32 = TensorType.of(FLOAT_32, 2);
 
-  private static final TensorType TENSOR_2_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(2)));
+  private static final TensorType TENSOR_2_FLOAT64 = TensorType.of(FLOAT_64, 2);
 
   private static final TensorType TENSOR_DYNAMIC_DYNAMIC_FLOAT32 =
       new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE));
 
-  private static final TensorType TENSOR_2_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(2)));
+  private static final TensorType TENSOR_2_INT32 = TensorType.of(INT_32, 2);
 
-  private static final TensorType TENSOR_2_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(2)));
+  private static final TensorType TENSOR_2_INT64 = TensorType.of(INT_64, 2);
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
   private static final TensorType TENSOR_INT32_UNKNOWN_SHAPE = new TensorType(INT_32, null);
 
-  private static final TensorType TENSOR_1_0_0_9_INT32 =
-      new TensorType(
-          INT_32,
-          asList(new NumericDim(1), new NumericDim(0), new NumericDim(0), new NumericDim(9)));
+  private static final TensorType TENSOR_1_0_0_9_INT32 = TensorType.of(INT_32, 1, 0, 0, 9);
 
   private static final TensorType TENSOR_UNKNOWN_SHAPE_BOOL = new TensorType(BOOL, null);
 
-  private static final TensorType TENSOR_3_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3)));
+  private static final TensorType TENSOR_3_INT32 = TensorType.of(INT_32, 3);
 
-  private static final TensorType TENSOR_3_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(3)));
+  private static final TensorType TENSOR_3_INT64 = TensorType.of(INT_64, 3);
 
-  private static final TensorType TENSOR_3_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3)));
+  private static final TensorType TENSOR_3_FLOAT32 = TensorType.of(FLOAT_32, 3);
 
-  private static final TensorType TENSOR_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4)));
+  private static final TensorType TENSOR_4_FLOAT32 = TensorType.of(FLOAT_32, 4);
 
-  private static final TensorType TENSOR_2_2_BOOL =
-      new TensorType(BOOL, asList(new NumericDim(2), new NumericDim(2)));
+  private static final TensorType TENSOR_2_2_BOOL = TensorType.of(BOOL, 2, 2);
 
-  private static final TensorType TENSOR_3_5_BOOL =
-      new TensorType(BOOL, asList(new NumericDim(3), new NumericDim(5)));
+  private static final TensorType TENSOR_3_5_BOOL = TensorType.of(BOOL, 3, 5);
 
-  private static final TensorType TENSOR_3_5_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(5)));
+  private static final TensorType TENSOR_3_5_INT32 = TensorType.of(INT_32, 3, 5);
 
-  private static final TensorType TENSOR_3_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(5)));
+  private static final TensorType TENSOR_3_5_FLOAT32 = TensorType.of(FLOAT_32, 3, 5);
 
-  private static final TensorType TENSOR_4_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(4)));
+  private static final TensorType TENSOR_4_FLOAT64 = TensorType.of(FLOAT_64, 4);
 
-  private static final TensorType TENSOR_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(5)));
+  private static final TensorType TENSOR_5_FLOAT32 = TensorType.of(FLOAT_32, 5);
 
-  private static final TensorType TENSOR_5_FLOAT64 =
-      new TensorType(FLOAT_64, asList(new NumericDim(5)));
+  private static final TensorType TENSOR_5_FLOAT64 = TensorType.of(FLOAT_64, 5);
 
-  private static final TensorType TENSOR_64_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(5)));
+  private static final TensorType TENSOR_64_5_FLOAT32 = TensorType.of(FLOAT_32, 64, 5);
 
-  private static final TensorType TENSOR_7_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(7)));
+  private static final TensorType TENSOR_7_FLOAT32 = TensorType.of(FLOAT_32, 7);
 
-  private static final TensorType TENSOR_32_7_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(32), new NumericDim(7)));
+  private static final TensorType TENSOR_32_7_FLOAT32 = TensorType.of(FLOAT_32, 32, 7);
 
-  private static final TensorType TENSOR_64_7_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(64), new NumericDim(7)));
+  private static final TensorType TENSOR_64_7_FLOAT32 = TensorType.of(FLOAT_32, 64, 7);
 
-  private static final TensorType TENSOR_20_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(5)));
+  private static final TensorType TENSOR_20_5_FLOAT32 = TensorType.of(FLOAT_32, 20, 5);
 
-  private static final TensorType TENSOR_20_7_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(20), new NumericDim(7)));
+  private static final TensorType TENSOR_20_7_FLOAT32 = TensorType.of(FLOAT_32, 20, 7);
 
-  private static final TensorType TENSOR_5_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(5)));
+  private static final TensorType TENSOR_5_INT32 = TensorType.of(INT_32, 5);
 
-  private static final TensorType TENSOR_5_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(5)));
+  private static final TensorType TENSOR_5_INT64 = TensorType.of(INT_64, 5);
 
-  private static final TensorType TENSOR_4_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(4)));
+  private static final TensorType TENSOR_4_INT32 = TensorType.of(INT_32, 4);
 
-  private static final TensorType TENSOR_1_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(1)));
+  private static final TensorType TENSOR_1_INT32 = TensorType.of(INT_32, 1);
 
-  private static final TensorType TENSOR_3_4_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(3), new NumericDim(4)));
+  private static final TensorType TENSOR_3_4_INT32 = TensorType.of(INT_32, 3, 4);
 
-  private static final TensorType TENSOR_3_4_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(3), new NumericDim(4)));
+  private static final TensorType TENSOR_3_4_FLOAT32 = TensorType.of(FLOAT_32, 3, 4);
 
-  private static final TensorType TENSOR_4_5_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(4), new NumericDim(5)));
+  private static final TensorType TENSOR_4_5_FLOAT32 = TensorType.of(FLOAT_32, 4, 5);
 
-  private static final TensorType TENSOR_1_28_28_1_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(1), new NumericDim(28), new NumericDim(28), new NumericDim(1)));
+  private static final TensorType TENSOR_1_28_28_1_FLOAT32 = TensorType.of(FLOAT_32, 1, 28, 28, 1);
 
-  private static final TensorType TENSOR_6_INT32 =
-      new TensorType(INT_32, asList(new NumericDim(6)));
+  private static final TensorType TENSOR_6_INT32 = TensorType.of(INT_32, 6);
 
-  private static final TensorType TENSOR_6_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(6)));
+  private static final TensorType TENSOR_6_FLOAT32 = TensorType.of(FLOAT_32, 6);
 
   private static final TensorType TENSOR_256_28_28_1_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(256), new NumericDim(28), new NumericDim(28), new NumericDim(1)));
+      TensorType.of(FLOAT_32, 256, 28, 28, 1);
 
   private static final TensorType TENSOR_32_28_28_1_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(32), new NumericDim(28), new NumericDim(28), new NumericDim(1)));
+      TensorType.of(FLOAT_32, 32, 28, 28, 1);
 
   private static final TensorType TENSOR_16_28_28_1_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(16), new NumericDim(28), new NumericDim(28), new NumericDim(1)));
+      TensorType.of(FLOAT_32, 16, 28, 28, 1);
 
-  private static final TensorType TENSOR_256_64_FLOAT32 =
-      new TensorType(FLOAT_32, asList(new NumericDim(256), new NumericDim(64)));
+  private static final TensorType TENSOR_256_64_FLOAT32 = TensorType.of(FLOAT_32, 256, 64);
 
   private static final TensorType TENSOR_96_28_28_1_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(96), new NumericDim(28), new NumericDim(28), new NumericDim(1)));
+      TensorType.of(FLOAT_32, 96, 28, 28, 1);
 
   private static final TensorType TENSOR_4096_32_32_3_FLOAT32 =
-      new TensorType(
-          FLOAT_32,
-          asList(new NumericDim(4096), new NumericDim(32), new NumericDim(32), new NumericDim(3)));
+      TensorType.of(FLOAT_32, 4096, 32, 32, 3);
 
-  private static final TensorType TENSOR_4096_UINT8 =
-      new TensorType(UINT_8, asList(new NumericDim(4096)));
+  private static final TensorType TENSOR_4096_UINT8 = TensorType.of(UINT_8, 4096);
 
-  private static final TensorType TENSOR_3_STRING =
-      new TensorType(STRING, asList(new NumericDim(3)));
+  private static final TensorType TENSOR_3_STRING = TensorType.of(STRING, 3);
 
-  private static final TensorType TENSOR_25000_INT64 =
-      new TensorType(INT_64, asList(new NumericDim(25000)));
+  private static final TensorType TENSOR_25000_INT64 = TensorType.of(INT_64, 25000);
 
-  private static final TensorType TENSOR_25000_OBJECT =
-      new TensorType(OBJECT, asList(new NumericDim(25000)));
+  private static final TensorType TENSOR_25000_OBJECT = TensorType.of(OBJECT, 25000);
 
   @Test
   public void testValueIndex()
@@ -1142,11 +985,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testDataset19()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    TensorType images =
-        new TensorType(
-            FLOAT_32,
-            asList(
-                new NumericDim(512), new NumericDim(112), new NumericDim(112), new NumericDim(3)));
+    TensorType images = TensorType.of(FLOAT_32, 512, 112, 112, 3);
     TensorType labels = new TensorType(FLOAT_32, asList(new NumericDim(512), DynamicDim.INSTANCE));
 
     test(
@@ -1582,30 +1421,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testDataset62()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_dataset62.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(new TensorType(INT_32, asList(new NumericDim(3))))));
-    test(
-        "tf2_test_dataset62.py",
-        "g",
-        1,
-        1,
-        Map.of(2, Set.of(new TensorType(FLOAT_32, asList(new NumericDim(3))))));
+    test("tf2_test_dataset62.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+    test("tf2_test_dataset62.py", "g", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_32, 3))));
   }
 
   /** Control test for {@link #testDataset62()}, utilizing only a single dataset. */
   @Test
   public void testDataset63()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_dataset63.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(new TensorType(INT_32, asList(new NumericDim(3))))));
+    test("tf2_test_dataset63.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(INT_32, 3))));
   }
 
   /**
@@ -4586,9 +4410,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testInputWithBatchSize()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    TensorType t1 = new TensorType(FLOAT_32, asList(new NumericDim(16), new NumericDim(32)));
-    TensorType t2 =
-        new TensorType(FLOAT_32, asList(new NumericDim(5), new NumericDim(10), new NumericDim(10)));
+    TensorType t1 = TensorType.of(FLOAT_32, 16, 32);
+    TensorType t2 = TensorType.of(FLOAT_32, 5, 10, 10);
     TensorType t3 = new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(5)));
 
     test(
@@ -4602,9 +4425,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testInputInt32()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    TensorType t1 = new TensorType(INT_32, asList(new NumericDim(32), new NumericDim(10)));
-    TensorType t2 =
-        new TensorType(INT_32, asList(new NumericDim(8), new NumericDim(5), new NumericDim(5)));
+    TensorType t1 = TensorType.of(INT_32, 32, 10);
+    TensorType t2 = TensorType.of(INT_32, 8, 5, 5);
 
     test("tf2_test_input_int32.py", "check_input", 2, 2, Map.of(2, Set.of(t1), 3, Set.of(t2)));
   }
@@ -4613,10 +4435,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testInputMixedArgs()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     // input1: shape=(32, 10), dtype=int32
-    TensorType t1 = new TensorType(INT_32, asList(new NumericDim(32), new NumericDim(10)));
+    TensorType t1 = TensorType.of(INT_32, 32, 10);
     // input2: shape=(16, 5, 5), dtype=float32
-    TensorType t2 =
-        new TensorType(FLOAT_32, asList(new NumericDim(16), new NumericDim(5), new NumericDim(5)));
+    TensorType t2 = TensorType.of(FLOAT_32, 16, 5, 5);
     // input3: shape=(None, 20), dtype=int32
     TensorType t3 = new TensorType(INT_32, asList(DynamicDim.INSTANCE, new NumericDim(20)));
 
@@ -11964,6 +11785,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testEyeBatchShape()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_eye_batch_shape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_3_FLOAT32)));
+  }
+
+  /**
+   * Covers the all-numeric {@link TensorType#of} factories (<a
+   * href="https://github.com/wala/ML/issues/594">wala/ML#594</a>): the {@code DType} and {@code
+   * String} cell-type overloads map {@code int} dimensions to {@link NumericDim}s, equivalent to
+   * the explicit-{@code List} construction, and compose with {@link TensorType#asSparse()}.
+   */
+  @Test
+  public void testTensorTypeNumericFactory() {
+    assertEquals(
+        new TensorType(FLOAT32, asList(new NumericDim(2), new NumericDim(3))),
+        TensorType.of(FLOAT32, 2, 3));
+    assertEquals(new TensorType(FLOAT_32, asList(new NumericDim(3))), TensorType.of(FLOAT_32, 3));
+    assertTrue(TensorType.of(FLOAT32, 2, 2).asSparse().isSparse());
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorType.java
@@ -505,6 +505,37 @@ public class TensorType implements Iterable<Dimension<?>> {
   }
 
   /**
+   * Concise factory for the common all-numeric, dense case: maps each {@code int} to a {@link
+   * NumericDim}. Chain {@link #asSparse()} for a sparse layout; use {@link #of(DType, List,
+   * Layout)} for shapes with non-numeric dimensions ({@link DynamicDim}, {@link SymbolicDim},
+   * {@link RaggedDim}, {@link CompoundDim}). wala/ML#594.
+   *
+   * @param dtype The tensor element type.
+   * @param dims The numeric dimension sizes, in order.
+   * @return A dense {@link TensorType} with the given dtype and numeric dimensions.
+   */
+  public static TensorType of(DType dtype, int... dims) {
+    List<Dimension<?>> dimensions = new ArrayList<>(dims.length);
+    for (int dim : dims) dimensions.add(new NumericDim(dim));
+    return new TensorType(dtype, dimensions);
+  }
+
+  /**
+   * String-cell-type counterpart to {@link #of(DType, int...)} (mirrors the {@link
+   * #TensorType(String, List)} constructor): maps each {@code int} to a {@link NumericDim} for the
+   * all-numeric, dense case. wala/ML#594.
+   *
+   * @param cellType The tensor cell type.
+   * @param dims The numeric dimension sizes, in order.
+   * @return A dense {@link TensorType} with the given cell type and numeric dimensions.
+   */
+  public static TensorType of(String cellType, int... dims) {
+    List<Dimension<?>> dimensions = new ArrayList<>(dims.length);
+    for (int dim : dims) dimensions.add(new NumericDim(dim));
+    return new TensorType(cellType, dimensions);
+  }
+
+  /**
    * The storage layout of this tensor: the polymorphic source of truth for sparseness. Overridden
    * by {@link SparseTensorType}; the base {@code TensorType} is always {@link Layout#DENSE}.
    *


### PR DESCRIPTION
Constructing an all-numeric `TensorType` required wrapping each dimension in `new NumericDim(...)` inside a `List`. This adds `TensorType.of(DType, int...)` (the form wala/ML#594 proposed) plus its String-cell-type counterpart `TensorType.of(String, int...)`: the test suite's cell types are `String`s (e.g. `DType.FLOAT32.name().toLowerCase()`), so the String overload is the one the boilerplate actually needs. Each maps an `int` to a `NumericDim` for the dense case; chain `.asSparse()` for sparse, and mixed-dimension shapes (`DynamicDim`, `SymbolicDim`, `RaggedDim`, `CompoundDim`) keep the explicit `List` form.

The all-numeric constructions in `TestTensorflow2Model` are migrated to the factory, and `testTensorTypeNumericFactory` covers both overloads.

Closes wala/ML#594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)