### PR TITLE
Handle dict-structured dtype argument in `from_generator`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1539,6 +1539,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Test a dataset created with {@code tf.data.Dataset.from_generator} using a <em>dict</em>
+   * -structured legacy {@code output_types} argument (https://github.com/wala/ML/issues/615). The
+   * dtype specification is a mapping, not a scalar {@code tf.DType} or a tuple/list of them, so the
+   * dtype helper must recurse into the dict's values rather than asserting a single {@code DType}.
+   */
+  @Test
+  public void testDataset72()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_dataset72.py", "consume", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  /**
    * Test enumerating a dataset (https://github.com/wala/ML/issues/140). The first element of the
    * tuple returned isn't a tensor.
    *

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1732,7 +1732,8 @@ public abstract class TensorGenerator {
         // A dict-structured dtype specification, e.g. `output_types={"feature": tf.int32, ...}`.
         // `tf.data.Dataset.from_generator` accepts a nested structure of dtypes; the values (keyed
         // by arbitrary string names) are the per-leaf dtype specs. Recurse into each value and
-        // union the results, mirroring the tuple/list handling above. See wala/ML#615.
+        // union the results, mirroring the tuple/list handling above. See
+        // https://github.com/wala/ML/issues/615.
         OrdinalSet<InstanceKey> objectCatalogPointsToSet =
             pointerAnalysis.getPointsToSet(
                 ((AstPointerKeyFactory) builder.getPointerKeyFactory())

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -15,6 +15,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORFLOW_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TYPE_REFERENCE_TO_SIGNATURE;
 import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
+import static com.ibm.wala.cast.python.types.PythonTypes.dict;
 import static com.ibm.wala.cast.python.types.PythonTypes.list;
 import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
 import static com.ibm.wala.cast.python.util.Util.findDefinition;
@@ -1719,6 +1720,32 @@ public abstract class TensorGenerator {
 
           FieldReference subscript =
               FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldIndex.toString()), Root);
+
+          IField f = builder.getClassHierarchy().resolveField(subscript);
+          if (f != null) {
+            PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
+            OrdinalSet<InstanceKey> fieldPts = pointerAnalysis.getPointsToSet(pk);
+            ret.addAll(this.getDTypesFromDTypeArgument(builder, fieldPts));
+          }
+        }
+      } else if (typeReference.equals(dict)) {
+        // A dict-structured dtype specification, e.g. `output_types={"feature": tf.int32, ...}`.
+        // `tf.data.Dataset.from_generator` accepts a nested structure of dtypes; the values (keyed
+        // by arbitrary string names) are the per-leaf dtype specs. Recurse into each value and
+        // union the results, mirroring the tuple/list handling above. See wala/ML#615.
+        OrdinalSet<InstanceKey> objectCatalogPointsToSet =
+            pointerAnalysis.getPointsToSet(
+                ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                    .getPointerKeyForObjectCatalog(asin));
+
+        for (InstanceKey catalogIK : objectCatalogPointsToSet) {
+          ConstantKey<?> constantKey = (ConstantKey<?>) catalogIK;
+          Object keyValue = constantKey.getValue();
+          // Dict keys are strings; the value is stored as an instance field named by the key.
+          if (!(keyValue instanceof String)) continue;
+
+          FieldReference subscript =
+              FieldReference.findOrCreate(Root, findOrCreateAsciiAtom((String) keyValue), Root);
 
           IField f = builder.getClassHierarchy().resolveField(subscript);
           if (f != null) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset72.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset72.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def gen():
+    yield {"feature": tf.constant(42), "label": tf.constant(1)}
+
+
+def consume(a):
+    return a
+
+
+dataset = tf.data.Dataset.from_generator(
+    gen, output_types={"feature": tf.int32, "label": tf.int32}
+)
+
+for element in dataset:
+    f = element["feature"]
+    assert isinstance(f, tf.Tensor)
+    assert f.dtype == tf.int32
+    consume(f)


### PR DESCRIPTION
## Problem

`tf.data.Dataset.from_generator` accepts a *structured* dtype specification: `output_types` (and the dtype of `output_signature`) can be a nested structure, e.g. a `dict` or tuple/list of dtypes, not only a scalar `tf.DType`.

`TensorGenerator.getDTypesFromDTypeArgument` recognized tuple/list structures but fell through to its single-`DType` assertion on a `dict`, throwing:

```
java.lang.IllegalStateException: Expected a <PythonLoader,Ltensorflow/dtypes/DType> for the dtype, but got: <PythonLoader,Ldict>.
	at com.ibm.wala.cast.python.ml.client.TensorGenerator.getDTypesFromDTypeArgument(TensorGenerator.java:1755)
	at com.ibm.wala.cast.python.ml.client.DatasetFromGeneratorGenerator.getDefaultDTypes(DatasetFromGeneratorGenerator.java:476)
```

This aborted tensor-type analysis on otherwise-valid programs.

## Fix

Add a `dict` branch to `getDTypesFromDTypeArgument` that recurses into each value (keyed by the dict's string keys) and unions the resulting dtypes, mirroring the existing tuple/list handling. The parallel shapes helper (`getShapesFromShapeArgument`) already degrades to `⊤` on an unrecognized top-level form, so no symmetric fix is needed there.

## Test

New `tf2_test_dataset72.py` exercises `from_generator(gen, output_types={"feature": tf.int32, "label": tf.int32})`; `testDataset72` confirms the analysis no longer crashes and recovers the per-leaf `int32` dtype. The full `TestTensorflow2Model` suite (843 tests) passes.

Closes wala/ML#615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)