### PR TITLE
Model the `sparse`, `tensor`, `ragged`, and `type_spec` parameters in `Input`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -54,7 +54,6 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
-import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
 import java.io.IOException;
@@ -4461,47 +4460,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(t1), 3, Set.of(t2), 4, Set.of(t3)));
   }
 
+  /**
+   * The `tensor` parameter wraps an existing tensor, so the result takes that tensor's shape and
+   * dtype verbatim, with no batch dimension prepended (wala/ML#617).
+   */
   @Test
-  public void testInputUnimplemented() {
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
-                "tf2_test_input_unimplemented_tensor_kw.py",
-                "tf2_test_input_unimplemented_tensor_kw.py",
-                0,
-                0,
-                emptyMap()));
+  public void testInputTensor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = TensorType.of(FLOAT_32, 2, 3);
 
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
-                "tf2_test_input_unimplemented_ragged_kw.py",
-                "tf2_test_input_unimplemented_ragged_kw.py",
-                0,
-                0,
-                emptyMap()));
+    test("tf2_test_input_tensor_kw.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
+    test("tf2_test_input_tensor_pos.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
+  }
 
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
-                "tf2_test_input_unimplemented_type_spec_kw.py",
-                "tf2_test_input_unimplemented_type_spec_kw.py",
-                0,
-                0,
-                emptyMap()));
+  /**
+   * A ragged `Input` has the same tracked shape and dtype as a dense one, so the `ragged` parameter
+   * is modeled by treating it as transparent to shape and dtype inference (wala/ML#617).
+   */
+  @Test
+  public void testInputRagged()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(10)));
 
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
-                "tf2_test_input_unimplemented_tensor_pos.py",
-                "tf2_test_input_unimplemented_tensor_pos.py",
-                0,
-                0,
-                emptyMap()));
+    test("tf2_test_input_ragged_kw.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
+  }
+
+  /**
+   * The `type_spec` parameter supplies the full type, so the result takes the spec's shape and
+   * dtype verbatim, with no batch dimension prepended (wala/ML#617).
+   */
+  @Test
+  public void testInputTypeSpec()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = new TensorType(INT_32, asList(DynamicDim.INSTANCE, new NumericDim(4)));
+
+    test("tf2_test_input_type_spec_kw.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4467,16 +4467,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         UnimplementedError.class,
         () ->
             test(
-                "tf2_test_input_unimplemented_sparse_kw.py",
-                "tf2_test_input_unimplemented_sparse_kw.py",
-                0,
-                0,
-                emptyMap()));
-
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
                 "tf2_test_input_unimplemented_tensor_kw.py",
                 "tf2_test_input_unimplemented_tensor_kw.py",
                 0,
@@ -4507,21 +4497,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         UnimplementedError.class,
         () ->
             test(
-                "tf2_test_input_unimplemented_sparse_pos.py",
-                "tf2_test_input_unimplemented_sparse_pos.py",
+                "tf2_test_input_unimplemented_tensor_pos.py",
+                "tf2_test_input_unimplemented_tensor_pos.py",
                 0,
                 0,
                 emptyMap()));
+  }
 
-    assertThrows(
-        UnimplementedError.class,
-        () ->
-            test(
-                "tf2_test_input_unimplemented_tensor_pos.py",
-                "tf2_test_input_unimplemented_tensor_pos.py",
-                0,
-                0,
-                emptyMap()));
+  /**
+   * A sparse `Input` has the same logical shape and dtype as a dense one, so the `sparse` parameter
+   * is modeled by treating it as transparent to shape and dtype inference (wala/ML#616).
+   */
+  @Test
+  public void testInputSparse()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(10)));
+
+    test("tf2_test_input_sparse_kw.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
+    test("tf2_test_input_sparse_pos.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -166,9 +166,17 @@ public class Input extends TensorTypeAllocator {
     return newShapes;
   }
 
+  /**
+   * Throws if the modeled `Input()` call uses a parameter whose semantics this generator does not
+   * model. `sparse` is intentionally absent: a sparse `Input()` has the same logical shape and
+   * dtype as a dense one (sparseness only affects storage), so it is transparent to this shape and
+   * dtype analysis. See <a href="https://github.com/wala/ML/issues/616">wala/ML#616</a>.
+   *
+   * @param builder The call graph builder supplying the modeled call's arguments.
+   */
   private void checkUnimplementedParameters(PropagationCallGraphBuilder builder) {
     Parameters[] unimplementedParameters = {
-      Parameters.SPARSE, Parameters.TENSOR, Parameters.RAGGED, Parameters.TYPE_SPEC
+      Parameters.TENSOR, Parameters.RAGGED, Parameters.TYPE_SPEC
     };
 
     for (Parameters p : unimplementedParameters) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -11,7 +11,6 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +57,32 @@ public class Input extends TensorTypeAllocator {
 
   @Override
   protected Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
+    // `tensor`: the layer wraps an existing tensor, so its dtype passes through verbatim
+    // (wala/ML#617). A non-empty points-to set is what signals the argument was actually supplied:
+    // in the synthetic `do`-method context every formal parameter has a value number, so the value
+    // number alone is not a presence test.
+    int tensorValNum =
+        this.getArgumentValueNumber(
+            builder, this.getTensorParameterPosition(), this.getTensorParameterName(), true);
+    if (tensorValNum > 0) {
+      OrdinalSet<InstanceKey> tensorPts =
+          this.getArgumentPointsToSet(
+              builder, this.getTensorParameterPosition(), this.getTensorParameterName());
+      if (tensorPts != null && !tensorPts.isEmpty()) return this.getDTypes(builder, tensorValNum);
+    }
+
+    // `type_spec`: the dtype comes from the supplied `TypeSpec` object (wala/ML#617).
+    int typeSpecValNum =
+        this.getArgumentValueNumber(
+            builder, this.getTypeSpecParameterPosition(), this.getTypeSpecParameterName(), true);
+    if (typeSpecValNum > 0) {
+      OrdinalSet<InstanceKey> typeSpecPts =
+          this.getArgumentPointsToSet(
+              builder, this.getTypeSpecParameterPosition(), this.getTypeSpecParameterName());
+      if (typeSpecPts != null && !typeSpecPts.isEmpty())
+        return this.getDTypesFromDTypeArgument(builder, typeSpecPts);
+    }
+
     int valNum =
         this.getArgumentValueNumber(
             builder, this.getDTypeParameterPosition(), this.getDTypeParameterName(), true);
@@ -77,7 +102,35 @@ public class Input extends TensorTypeAllocator {
 
   @Override
   protected Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
-    this.checkUnimplementedParameters(builder);
+    // `tensor`: the layer wraps an existing tensor, so its shape passes through verbatim with no
+    // batch dimension prepended (wala/ML#617). A non-empty points-to set is what signals the
+    // argument was actually supplied: in the synthetic `do`-method context every formal parameter
+    // has a value number, so the value number alone is not a presence test.
+    int tensorValNum =
+        this.getArgumentValueNumber(
+            builder, this.getTensorParameterPosition(), this.getTensorParameterName(), true);
+    if (tensorValNum > 0) {
+      OrdinalSet<InstanceKey> tensorPts =
+          this.getArgumentPointsToSet(
+              builder, this.getTensorParameterPosition(), this.getTensorParameterName());
+      if (tensorPts != null && !tensorPts.isEmpty()) {
+        LOGGER.fine("Reading shape from `tensor` argument for source: " + this.getSource() + ".");
+        return this.getShapes(builder, tensorValNum);
+      }
+    }
+
+    // `type_spec`: the shape comes from the supplied `TypeSpec` object, again with no batch
+    // dimension prepended (wala/ML#617).
+    int typeSpecValNum =
+        this.getArgumentValueNumber(
+            builder, this.getTypeSpecParameterPosition(), this.getTypeSpecParameterName(), true);
+    if (typeSpecValNum > 0) {
+      OrdinalSet<InstanceKey> typeSpecPts =
+          this.getArgumentPointsToSet(
+              builder, this.getTypeSpecParameterPosition(), this.getTypeSpecParameterName());
+      if (typeSpecPts != null && !typeSpecPts.isEmpty())
+        return this.getShapesFromShapeArgument(builder, typeSpecPts);
+    }
 
     int shapeValNum =
         this.getArgumentValueNumber(
@@ -166,28 +219,6 @@ public class Input extends TensorTypeAllocator {
     return newShapes;
   }
 
-  /**
-   * Throws if the modeled `Input()` call uses a parameter whose semantics this generator does not
-   * model. `sparse` is intentionally absent: a sparse `Input()` has the same logical shape and
-   * dtype as a dense one (sparseness only affects storage), so it is transparent to this shape and
-   * dtype analysis. See <a href="https://github.com/wala/ML/issues/616">wala/ML#616</a>.
-   *
-   * @param builder The call graph builder supplying the modeled call's arguments.
-   */
-  private void checkUnimplementedParameters(PropagationCallGraphBuilder builder) {
-    Parameters[] unimplementedParameters = {
-      Parameters.TENSOR, Parameters.RAGGED, Parameters.TYPE_SPEC
-    };
-
-    for (Parameters p : unimplementedParameters) {
-      if (this.getNumberOfPossiblePositionalArguments(builder).stream()
-              .anyMatch(n -> n >= p.getIndex() + 1)
-          || this.isKeywordArgumentPresent(builder, p.getName()))
-        throw new UnimplementedError(
-            "Unimplemented parameter " + p.getName() + " at position " + p.getIndex());
-    }
-  }
-
   @Override
   protected int getShapeParameterPosition() {
     return Parameters.SHAPE.getIndex();
@@ -212,5 +243,21 @@ public class Input extends TensorTypeAllocator {
 
   protected String getDTypeParameterName() {
     return Parameters.DTYPE.getName();
+  }
+
+  protected int getTensorParameterPosition() {
+    return Parameters.TENSOR.getIndex();
+  }
+
+  protected String getTensorParameterName() {
+    return Parameters.TENSOR.getName();
+  }
+
+  protected int getTypeSpecParameterPosition() {
+    return Parameters.TYPE_SPEC.getIndex();
+  }
+
+  protected String getTypeSpecParameterName() {
+    return Parameters.TYPE_SPEC.getName();
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_ragged_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_ragged_kw.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# A ragged `Input` has the same tracked shape and dtype as a dense one; raggedness only affects the
+# tensor's row structure, not its `.shape` or `.dtype`. See https://github.com/wala/ML/issues/617.
+input1 = tf.keras.Input(shape=(10,), ragged=True)
+assert input1.shape == (None, 10)
+assert input1.dtype == tf.float32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_sparse_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_sparse_kw.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# A sparse `Input` has the same logical shape and dtype as a dense one; `sparse` only affects
+# storage. See https://github.com/wala/ML/issues/616.
+input1 = tf.keras.Input(shape=(10,), sparse=True)
+assert input1.shape == (None, 10)
+assert input1.dtype == tf.float32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_sparse_pos.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_sparse_pos.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# Input(shape, batch_size, name, dtype, sparse); sparse is the 5th arg (index 4).
+# A sparse `Input` has the same logical shape and dtype as a dense one; `sparse` only affects
+# storage. See https://github.com/wala/ML/issues/616.
+input1 = tf.keras.Input((10,), None, None, None, True)
+assert input1.shape == (None, 10)
+assert input1.dtype == tf.float32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_tensor_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_tensor_kw.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# `tensor` wraps an existing tensor: the result has that tensor's shape and dtype verbatim, with no
+# batch dimension prepended. See https://github.com/wala/ML/issues/617.
+t = tf.ones((2, 3))
+input1 = tf.keras.Input(tensor=t)
+assert input1.shape == (2, 3)
+assert input1.dtype == tf.float32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_tensor_pos.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_tensor_pos.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# Input(shape, batch_size, name, dtype, sparse, tensor); tensor is the 6th arg (index 5).
+# When `tensor` is given it wraps that existing tensor, so the declared `shape` is ignored and the
+# result takes the wrapped tensor's shape and dtype. See https://github.com/wala/ML/issues/617.
+t = tf.ones((2, 3))
+input1 = tf.keras.Input((10,), None, None, None, False, t)
+assert input1.shape == (2, 3)
+assert input1.dtype == tf.float32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_type_spec_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_type_spec_kw.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def check_input(i1):
+    pass
+
+
+# `type_spec` supplies the full type: the result takes the spec's shape and dtype verbatim, with no
+# batch dimension prepended. See https://github.com/wala/ML/issues/617.
+spec = tf.TensorSpec(shape=(None, 4), dtype=tf.int32)
+input1 = tf.keras.Input(type_spec=spec)
+assert input1.shape == (None, 4)
+assert input1.dtype == tf.int32
+
+check_input(input1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_ragged_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_ragged_kw.py
@@ -1,3 +1,0 @@
-import tensorflow as tf
-
-tf.keras.Input(shape=(10,), ragged=True)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_sparse_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_sparse_kw.py
@@ -1,3 +1,0 @@
-import tensorflow as tf
-
-tf.keras.Input(shape=(10,), sparse=True)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_sparse_pos.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_sparse_pos.py
@@ -1,5 +1,0 @@
-import tensorflow as tf
-
-# Input(shape, batch_size, name, dtype, sparse)
-# sparse is 5th arg (index 4)
-tf.keras.Input((10,), None, None, None, True)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_tensor_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_tensor_kw.py
@@ -1,3 +1,0 @@
-import tensorflow as tf
-
-tf.keras.Input(shape=(10,), tensor=1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_tensor_pos.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_tensor_pos.py
@@ -1,5 +1,0 @@
-import tensorflow as tf
-
-# Input(shape, batch_size, name, dtype, sparse, tensor)
-# tensor is 6th arg (index 5)
-tf.keras.Input((10,), None, None, None, False, 1)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_type_spec_kw.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_unimplemented_type_spec_kw.py
@@ -1,3 +1,0 @@
-import tensorflow as tf
-
-tf.keras.Input(shape=(10,), type_spec=1)


### PR DESCRIPTION
`Input.checkUnimplementedParameters` threw an `UnimplementedError` (a `java.lang.Error`, so it escaped Exception-based isolation in clients and aborted the analysis) on any `tf.keras.Input` call using `sparse`, `tensor`, `ragged`, or `type_spec`. This models all four, after which no `Input` parameter is unmodeled and the `UnimplementedError` path is removed entirely.

- `sparse` and `ragged` are transparent to the tracked shape and dtype: they only affect storage and row structure, not `.shape` or `.dtype`, so the result matches the dense form.
- `tensor` wraps an existing tensor, so the result takes that tensor's shape and dtype verbatim, with no batch dimension prepended.
- `type_spec` supplies the full type, so the result takes the spec's shape and dtype from the `TypeSpec` object (read via the existing `TensorSpec`/`RaggedTensorSpec` field extraction), again with no batch dimension.

Presence of `tensor`/`type_spec` is detected via a non-empty points-to set rather than the argument's value number: in the synthetic `do`-method context every formal parameter has a value number, so the value number alone is not a presence test.

The `UnimplementedError` fixtures become positive shape and dtype assertions (`testInputSparse`, `testInputTensor`, `testInputRagged`, `testInputTypeSpec`) and are renamed accordingly; `checkUnimplementedParameters` and its `testInputUnimplemented` guard are removed.

Closes wala/ML#616.
Closes wala/ML#617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)