### PR TITLE
Floor `tf.eye`'s unresolvable `batch_shape` to ⊤ instead of throwing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11677,6 +11677,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guards the {@code tf.eye} unresolvable-{@code batch_shape} floor (<a
+   * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): when {@code batch_shape} is
+   * present but unresolvable (here from {@code json.loads}), the number of leading batch dimensions
+   * is unknown, so the overall rank can't be known and the result floors to ⊤ rather than throwing
+   * "Batch shape argument for tf.eye() should be a list of dimensions." (which previously aborted
+   * the whole analysis). The dtype stays float32.
+   */
+  @Test
+  public void testEyeUnresolvableBatchShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_eye_unresolvable_batch_shape.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Guards the {@code tf.random.gamma} unresolvable-{@code shape} floor (<a
    * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): when the {@code shape} argument
    * is unresolvable (here from {@code json.loads}) the output rank can't be known, so the result

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11677,6 +11677,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Complements {@link #testEyeUnresolvableBatchShape()}: when {@code batch_shape} is a list
+   * literal whose length (and hence the output rank) is statically known but whose element is
+   * unresolvable (here from {@code json.loads}), precision is preserved rather than floored to ⊤.
+   * The single leading batch dimension is dynamic and the {@code (num_rows, num_columns)} suffix
+   * stays exact, so {@code tf.eye(3, batch_shape=[<unknown>])} types to {@code (Dynamic, 3, 3)}
+   * float32. See <a href="https://github.com/wala/ML/issues/611">wala/ML#611</a>.
+   */
+  @Test
+  public void testEyeDynamicBatch()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t =
+        new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(3)));
+    test("tf2_test_eye_dynamic_batch.py", "consume", 1, 1, Map.of(2, Set.of(t)));
+  }
+
+  /**
    * Guards the {@code tf.eye} unresolvable-{@code batch_shape} floor (<a
    * href="https://github.com/wala/ML/issues/611">wala/ML#611</a>): when {@code batch_shape} is
    * present but unresolvable (here from {@code json.loads}), the number of leading batch dimensions

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Eye.java
@@ -58,6 +58,12 @@ public class Eye extends EyeBase {
     Set<List<Dimension<?>>> ret = super.getShapes(builder);
     Set<List<Dimension<?>>> batchShapes = this.getBatchShapes(builder);
 
+    if (batchShapes == null)
+      // `batch_shape` is present but unresolvable (content-dependent), so the number of leading
+      // batch dimensions is unknown and the overall rank can't be known: floor to ⊤ rather than
+      // throwing (which aborted the whole analysis). wala/ML#611.
+      return null;
+
     if (batchShapes.isEmpty()) return ret;
 
     // Prepend each batch shape to each base shape, building a fresh list per combination. Mutating
@@ -75,6 +81,14 @@ public class Eye extends EyeBase {
     return withBatchShapes;
   }
 
+  /**
+   * Returns the possible leading {@code batch_shape} dimensions to prepend to the identity matrix.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return An empty set when {@code batch_shape} is absent (no leading dimensions); the resolved
+   *     batch shapes when it is present and resolvable; or {@code null} (⊤) when it is present but
+   *     unresolvable (content-dependent), since the leading rank is then unknown. wala/ML#611.
+   */
   private Set<List<Dimension<?>>> getBatchShapes(PropagationCallGraphBuilder builder) {
     int valNum = this.getBatchShapesArgumentValueNumber(builder);
     if (valNum <= 0) return emptySet();
@@ -88,8 +102,10 @@ public class Eye extends EyeBase {
     Set<List<Dimension<?>>> shapesFromShapeArgument = this.getShapesFromShapeArgument(builder, pts);
 
     if (shapesFromShapeArgument == null || shapesFromShapeArgument.isEmpty())
-      throw new IllegalStateException(
-          "Batch shape argument for tf.eye() should be a list of dimensions.");
+      // `batch_shape` is present but its contents are unresolvable (content-dependent). Signal ⊤ to
+      // the caller with `null` rather than throwing; an empty set would instead mean "no batch
+      // shape" and wrongly drop the (definitely-present) leading dimensions. wala/ML#611.
+      return null;
 
     return shapesFromShapeArgument;
   }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_dynamic_batch.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_dynamic_batch.py
@@ -1,0 +1,14 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `batch_shape` is a 1-element list literal: its length (and so the output rank) is statically 1,
+# but its element is content-dependent (`json.loads`). The rank is known, so precision is preserved
+# rather than floored to ⊤: the leading batch axis is dynamic and the `(3, 3)` identity-matrix
+# suffix stays exact, giving `(None, 3, 3)`. See https://github.com/wala/ML/issues/611.
+consume(tf.eye(3, batch_shape=[json.loads("2")]))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_eye_unresolvable_batch_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_eye_unresolvable_batch_shape.py
@@ -1,0 +1,14 @@
+import json
+
+import tensorflow as tf
+
+
+def consume(z):
+    pass
+
+
+# `tf.eye`'s `batch_shape` is a tensor whose contents are unresolvable here (`json.loads`), so the
+# number of leading batch dimensions is unknown and the overall rank can't be known: the result
+# floors to ⊤. Regression guard for wala/ML#611: `Eye` previously threw "Batch shape argument for
+# tf.eye() should be a list of dimensions." here, aborting the whole analysis.
+consume(tf.eye(3, batch_shape=tf.constant(json.loads("[2]"))))


### PR DESCRIPTION
The remaining throws listed in wala/ML#611 (the standard allocators, `tf.range`, `gamma`, `poisson`, and `tf.eye`'s `num_rows`) are already floored on `master`. This finishes the family. `Eye.getBatchShapes` still threw an `IllegalStateException` ("Batch shape argument for tf.eye() should be a list of dimensions.") when `batch_shape` was present but its contents were unresolvable (content-dependent, e.g. a tensor built from `json.loads(...)`), aborting the whole analysis. That is the same anti-pattern wala/ML#604 and wala/ML#606 fixed.

An unresolvable `batch_shape` leaves the number of leading batch dimensions unknown, so the overall rank cannot be known. `getBatchShapes` now returns `null` (⊤) in that case and `getShapes` propagates it. An empty set stays reserved for "no batch shape"; using it here would wrongly drop the definitely-present leading dimensions.

`testEyeUnresolvableBatchShape` guards the floor. The fixture's `batch_shape` is a `tf.constant` whose value is unresolvable, giving the non-empty-but-unparseable points-to set that reaches the former throw.

Closes wala/ML#611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)