### PR TITLE
Add a TODO marking the `tf.eye` `batch_shape` ⊤ as a recoverable-precision floor

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11699,6 +11699,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * is unknown, so the overall rank can't be known and the result floors to ⊤ rather than throwing
    * "Batch shape argument for tf.eye() should be a list of dimensions." (which previously aborted
    * the whole analysis). The dtype stays float32.
+   *
+   * <p>TODO: ⊤ is the floor only because the batch rank is unrecoverable here (an opaque constant).
+   * When {@code batch_shape} is a tensor whose static rank is recoverable (e.g. {@code
+   * tf.shape(x)}), the result can be floored to known-rank-with-dynamic-batch, or to an exact
+   * shape, rather than ⊤. Tracked by <a
+   * href="https://github.com/wala/ML/issues/619">wala/ML#619</a>; the already-recoverable
+   * known-rank case is guarded by {@link #testEyeDynamicBatch()}.
    */
   @Test
   public void testEyeUnresolvableBatchShape()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11700,11 +11700,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * "Batch shape argument for tf.eye() should be a list of dimensions." (which previously aborted
    * the whole analysis). The dtype stays float32.
    *
-   * <p>TODO: ⊤ is the floor only because the batch rank is unrecoverable here (an opaque constant).
-   * When {@code batch_shape} is a tensor whose static rank is recoverable (e.g. {@code
-   * tf.shape(x)}), the result can be floored to known-rank-with-dynamic-batch, or to an exact
-   * shape, rather than ⊤. Tracked by <a
-   * href="https://github.com/wala/ML/issues/619">wala/ML#619</a>; the already-recoverable
+   * <p>TODO: the {@code batch_shape} value here is content-dependent (it comes from {@code
+   * json.loads}), so recovering it is the user-annotation problem tracked by <a
+   * href="https://github.com/wala/ML/issues/370">wala/ML#370</a>, the same recovery path the
+   * allocator shape floor points at. Orthogonally, a structurally-inferable tensor {@code
+   * batch_shape} (e.g. {@code tf.shape(x)}, whose rank, and often values, are statically known) can
+   * be recovered without an annotation; that is tracked by <a
+   * href="https://github.com/wala/ML/issues/619">wala/ML#619</a>. The already-recoverable
    * known-rank case is guarded by {@link #testEyeDynamicBatch()}.
    */
   @Test


### PR DESCRIPTION
Follow-up to wala/ML#451. The ⊤ in `testEyeUnresolvableBatchShape` is the floor only because the batch rank is unrecoverable for an opaque constant. A tensor-derived `batch_shape` with a recoverable static rank (e.g. `tf.shape(x)`) can do better, so this annotates the assertion with a `TODO` pointing at wala/ML#619 and at the already-precise known-rank guard `testEyeDynamicBatch`.

Javadoc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)