### PR TITLE
Add regression guards for interprocedural tensor-parameter typing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4510,6 +4510,59 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_input_sparse_pos.py", "check_input", 1, 1, Map.of(2, Set.of(t)));
   }
 
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
+   * passed interprocedurally to a callee types the callee's parameter. {@code Model.get_loss}'s
+   * {@code real} and {@code pred} receive {@code tf.constant} tensors via {@code train_step}, so
+   * both type to {@code (3,)} float32 rather than being missed.
+   */
+  @Test
+  public void testInterprocTensorParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = TensorType.of(FLOAT_32, 3);
+
+    test(
+        "tf2_test_interproc_tensor_param.py",
+        "Model.get_loss",
+        2,
+        4,
+        Map.of(3, Set.of(t), 4, Set.of(t)));
+  }
+
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
+   * passed to a Keras {@code call} method types its parameter. {@code BiLSTM.call}'s {@code inputs}
+   * receives a token-id tensor (which then feeds an {@code Embedding}), so it types to {@code (1,
+   * 3)} int32 rather than being missed.
+   */
+  @Test
+  public void testKerasCallEmbeddingParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_keras_call_embedding_param.py",
+        "BiLSTM.call",
+        1,
+        1,
+        Map.of(3, Set.of(TensorType.of(INT_32, 1, 3))));
+  }
+
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a {@code
+   * tf.data} dataset element passed to a function types its parameter. {@code target_convert}'s
+   * {@code targets} receives a dataset element, so it types to {@code (2,)} int32 rather than being
+   * missed.
+   */
+  @Test
+  public void testDatasetElementParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_element_param.py",
+        "target_convert",
+        1,
+        2,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2))));
+  }
+
   @Test
   public void testAdd54()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_element_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_element_param.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def target_convert(targets):
+    # `targets` receives a `tf.data` dataset element at the call site.
+    assert targets.shape == (2,)
+    assert targets.dtype == tf.int32
+    return targets + 1
+
+
+ds = tf.data.Dataset.from_tensor_slices(tf.constant([[1, 2], [3, 4]]))
+for batch in ds:
+    target_convert(batch)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_interproc_tensor_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_interproc_tensor_param.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+class Model:
+    def call(self, x):
+        return x * 2.0
+
+    def get_loss(self, real, pred):
+        # Both parameters receive tensors at the call site in `train_step`.
+        assert real.shape == (3,)
+        assert real.dtype == tf.float32
+        assert pred.shape == (3,)
+        assert pred.dtype == tf.float32
+        return tf.reduce_mean(tf.square(pred - real))
+
+    def train_step(self, inputs, targets):
+        predictions = self.call(inputs)
+        return self.get_loss(targets, predictions)
+
+
+Model().train_step(tf.constant([1.0, 2.0, 3.0]), tf.constant([1.0, 1.0, 1.0]))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_keras_call_embedding_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_keras_call_embedding_param.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+class BiLSTM(tf.keras.Model):
+    def __init__(self):
+        super().__init__()
+        self.embedding = tf.keras.layers.Embedding(1000, 64)
+
+    def call(self, inputs):
+        # `inputs` receives a token-id tensor at the call site, then feeds an `Embedding`.
+        assert inputs.shape == (1, 3)
+        assert inputs.dtype == tf.int32
+        return self.embedding(inputs)
+
+
+BiLSTM()(tf.constant([[1, 2, 3]]))


### PR DESCRIPTION
wala/ML#618 reports that callee parameters receiving tensors at their call sites are missed by the tensor-type analysis, across three propagation shapes. Minimal repros of each shape in fact type the parameter precisely in the current analysis, so this adds guards that lock in that behavior:

- **Interprocedural** — `Model.get_loss`'s `real`/`pred`, bound to `tf.constant` tensors via `train_step`, type to `(3,)` float32.
- **Keras `call` dispatch** — `BiLSTM.call`'s `inputs`, a token-id tensor that then feeds an `Embedding`, types to `(1, 3)` int32.
- **`tf.data` element** — `target_convert`'s `targets`, a dataset element, types to `(2,)` int32.

Each fixture also asserts the shape and dtype at the Python level so the runtime truth matches the static expectation.

Relates to wala/ML#618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)