### PR TITLE
Model `experimental_distribute_dataset` as a dataset pass-through

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4511,6 +4511,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a custom
+   * {@code fit} iterates an {@code experimental_distribute_dataset}-wrapped {@code tf.data} dataset
+   * and threads the yielded {@code (inputs, targets)} tuple into {@code train_step}. The strategy's
+   * {@code experimental_distribute_dataset} is a pass-through of its dataset argument, so the
+   * distributed dataset stays a recognized tensor iterable and {@code train_step}'s {@code inputs}
+   * and {@code targets} parameters type to {@code (2,)} float32 rather than being dropped (which
+   * cascaded to every downstream consumer).
+   */
+  @Test
+  public void testDistributeFitTupleParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_distribute_fit_tuple_param.py",
+        "Model.train_step",
+        2,
+        3,
+        Map.of(3, Set.of(TensorType.of(FLOAT_32, 2)), 4, Set.of(TensorType.of(FLOAT_32, 2))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
    * passed interprocedurally to a callee types the callee's parameter. {@code Model.get_loss}'s
    * {@code real} and {@code pred} receive {@code tf.constant} tensors via {@code train_step}, so

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -3142,6 +3142,8 @@
           <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
           <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
           <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <new def="edd" class="Ltensorflow/distribute/run/experimental_distribute_dataset"/>
+          <putfield class="LRoot" field="experimental_distribute_dataset" fieldType="LRoot" ref="self" value="edd"/>
           <return value="arg0"/>
         </method>
       </class>
@@ -3153,6 +3155,8 @@
           <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
           <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
           <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <new def="edd" class="Ltensorflow/distribute/run/experimental_distribute_dataset"/>
+          <putfield class="LRoot" field="experimental_distribute_dataset" fieldType="LRoot" ref="self" value="edd"/>
           <return value="arg0"/>
         </method>
       </class>
@@ -3164,6 +3168,8 @@
           <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
           <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
           <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff"/>
+          <new def="edd" class="Ltensorflow/distribute/run/experimental_distribute_dataset"/>
+          <putfield class="LRoot" field="experimental_distribute_dataset" fieldType="LRoot" ref="self" value="edd"/>
           <return value="arg0"/>
         </method>
       </class>
@@ -3195,6 +3201,12 @@
           <putfield class="LRoot" field="get_per_replica_batch_size" fieldType="LRoot" ref="ctx" value="batch_fn"/>
           <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="ctx" numArgs="2" def="v"/>
           <return value="v"/>
+        </method>
+      </class>
+      <class name="experimental_distribute_dataset" allocatable="true">
+        <!-- `strategy.experimental_distribute_dataset(ds)` returns a distributed view of `ds` with the same element structure. For tensor-type purposes it is a pass-through: return the dataset argument unchanged so it stays a recognized tensor iterable and its element types reach the iteration. wala/ML#618. -->
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self dataset">
+          <return value="arg1"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -3204,7 +3204,7 @@
         </method>
       </class>
       <class name="experimental_distribute_dataset" allocatable="true">
-        <!-- `strategy.experimental_distribute_dataset(ds)` returns a distributed view of `ds` with the same element structure. For tensor-type purposes it is a pass-through: return the dataset argument unchanged so it stays a recognized tensor iterable and its element types reach the iteration. wala/ML#618. -->
+        <!-- `strategy.experimental_distribute_dataset(ds)` returns a distributed view of `ds` with the same element structure. For tensor-type purposes it is a pass-through: return the dataset argument unchanged so it stays a recognized tensor iterable and its element types reach the iteration. wala/ML#618. Caveat: under multi-replica sharding the per-replica element's leading (batch) dimension is `global / N` for `N` replicas; the pass-through yields the global element, an upper bound on that dimension, consistent with the replica-count-agnostic modeling elsewhere (e.g. `get_per_replica_batch_size`). Tracked by wala/ML#622. -->
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self dataset">
           <return value="arg1"/>
         </method>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_distribute_fit_tuple_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_distribute_fit_tuple_param.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+class Model(tf.keras.Model):
+    def get_loss(self, real, pred):
+        return tf.reduce_mean(tf.square(pred - real))
+
+    def train_step(self, inputs, targets):
+        # `inputs` and `targets` are dataset elements threaded through a custom `fit` that iterates
+        # an `experimental_distribute_dataset`-wrapped `tf.data` dataset. See wala/ML#618.
+        assert inputs.shape == (2,)
+        assert inputs.dtype == tf.float32
+        assert targets.shape == (2,)
+        assert targets.dtype == tf.float32
+        return self.get_loss(targets, inputs)
+
+    def fit(self, dataset):
+        strategy = tf.distribute.MirroredStrategy()
+        dist = strategy.experimental_distribute_dataset(dataset)
+        for inputs, targets in dist:
+            self.train_step(inputs, targets)
+
+
+ds = tf.data.Dataset.from_tensor_slices(
+    (tf.constant([[1.0, 2.0], [3.0, 4.0]]), tf.constant([[1.0, 1.0], [1.0, 1.0]]))
+)
+Model().fit(ds)


### PR DESCRIPTION
The `tf.distribute` strategies (`MirroredStrategy`, `TPUStrategy`, `OneDeviceStrategy`) modeled `experimental_distribute_datasets_from_function` but not the plain `experimental_distribute_dataset`. So `strategy.experimental_distribute_dataset(ds)` returned an unmodeled value that was not a recognized tensor iterable. Iterating it yielded untyped elements, so a callee receiving the yielded tuple (a custom `fit` threading `(inputs, targets)` into `train_step`) got no per-parameter `TensorType`, and the absence cascaded to every downstream consumer.

Modeling it as a pass-through of its dataset argument keeps the distributed dataset a recognized tensor iterable, so its element types reach the iteration and the callee parameters type correctly. `testDistributeFitTupleParam` reproduces the exact shape (custom `fit` iterating an `experimental_distribute_dataset`-wrapped `tf.data` dataset, yielding the tuple into `train_step`) and confirms both parameters type to `(2,)` float32.

Addresses the unbatched form of wala/ML#618. The batched form is tracked by wala/ML#623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
