### PR TITLE
Floor untraceable values in `getShapes`/`getDTypes` to ⊥ instead of throwing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2382,7 +2382,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_masked_sparse_ce.py",
         "MaskSparseCategoricalCrossentropy.__call__",
         3,
-        5,
+        6,
         Map.of(
             3, Set.of(TENSOR_4_INT32),
             4, Set.of(TENSOR_4_10_FLOAT32),
@@ -2766,7 +2766,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_unary_score",
         3,
-        14,
+        18,
         Map.of(
             2, Set.of(TENSOR_2_3_INT32),
             3, Set.of(TENSOR_2_INT32),
@@ -2790,7 +2790,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_binary_score",
         3,
-        13,
+        14,
         Map.of(
             2, Set.of(TENSOR_2_3_INT32),
             3, Set.of(TENSOR_2_INT32),
@@ -2814,7 +2814,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_sequence_score",
         4,
-        6,
+        9,
         Map.of(
             2, Set.of(TENSOR_2_3_4_FLOAT32),
             3, Set.of(TENSOR_2_3_INT32),
@@ -3478,7 +3478,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "autoencoder.py",
         "mean_square",
         2,
-        4,
+        5,
         Map.of(2, Set.of(TENSOR_256_784_FLOAT32), 3, Set.of(TENSOR_256_784_FLOAT32)));
   }
 
@@ -3499,7 +3499,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testAutoencoder3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("autoencoder.py", "run_optimization", 1, 4, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
+    test("autoencoder.py", "run_optimization", 1, 5, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -927,12 +927,19 @@ public abstract class TensorGenerator {
       }
     }
 
-    throw new IllegalArgumentException(
-        "Empty points-to set and could not trace properties for value number: "
-            + valueNumber
-            + " in: "
-            + node
-            + ".");
+    // The value is untraceable (empty points-to set and no recoverable def/parameter chain). Floor
+    // to ⊥ (not a tensor) rather than throwing: this preserves the behavior from when the throw was
+    // caught upstream and treated as not-a-tensor, but removes the abort risk for any caller that
+    // doesn't catch it. wala/ML#620, mirroring the non-aborting floors in wala/ML#604 and
+    // wala/ML#611.
+    LOGGER.fine(
+        () ->
+            "Could not trace shape for value number "
+                + valueNumber
+                + " in "
+                + node
+                + "; flooring to ⊥ (not a tensor). wala/ML#620.");
+    return Collections.emptySet();
   }
 
   /**
@@ -1963,12 +1970,18 @@ public abstract class TensorGenerator {
       }
     }
 
-    throw new IllegalArgumentException(
-        "Empty points-to set and could not trace properties for value number: "
-            + valueNumber
-            + " in: "
-            + node
-            + ".");
+    // The value is untraceable (empty points-to set and no recoverable def/parameter chain). Floor
+    // to ⊥ (not a tensor), paired with the shape floor above, rather than throwing: this preserves
+    // the behavior from when the throw was caught upstream and treated as not-a-tensor, but removes
+    // the abort risk for any caller that doesn't catch it. wala/ML#620.
+    LOGGER.fine(
+        () ->
+            "Could not trace dtype for value number "
+                + valueNumber
+                + " in "
+                + node
+                + "; flooring to ⊥ (not a tensor). wala/ML#620.");
+    return Collections.emptySet();
   }
 
   /**


### PR DESCRIPTION
The shape and dtype value-tracing methods (`computeShapes`/`computeDTypes`) threw `IllegalArgumentException` when a value could not be traced (empty points-to set, no recoverable def/parameter chain). In practice that throw was caught upstream and the value degraded to ⊥ (not-a-tensor), but the catch sometimes sat high enough to drop a whole source mid-traversal, discarding intermediate tensors. This returns ⊥ directly at the trace failure, so the analysis completes and those intermediates are recovered, and the abort risk is removed for any caller that does not catch.

Flooring to ⊤ instead over-approximates the previously-⊥ values to unknown-tensor and regresses 14 tests, so ⊥ is the correct floor (it matches the established caught behavior).

## Effect

Recovers intermediate tensors previously dropped to ⊥. Six model tests gain local-tensor-variable counts, purely additive (no parameter-type changes). Deep-verified on `crf_sequence_score`: the three recovered value numbers are `unary_scores`, `binary_scores`, and `sequence_scores` (the `crf_unary_score`/`crf_binary_score` results and their sum). These are genuine tensors that the `crf_*` helpers' internal untraceable-value throw had been discarding. The six model tests are the regression coverage; a minimal fixture cannot serve, because in simple cases the throw is already caught and degraded to the same ⊥.

Closes wala/ML#620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)