### PR TITLE
Model `padded_batch` so its elements are typed

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4531,6 +4531,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/623">wala/ML#623</a>: a {@code
+   * padded_batch} element threaded through a custom {@code fit} into {@code train_step} types the
+   * parameters. {@code padded_batch} was unmodeled, so the per-element tensor type was dropped
+   * before reaching the callee; modeling it like {@code batch} recovers it. The two parameters type
+   * to {@code (2, 2)} int32 (the batch dimension prepended to the {@code (2,)} element).
+   */
+  @Test
+  public void testPaddedBatchParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    TensorType t = TensorType.of(INT_32, 2, 2);
+
+    test(
+        "tf2_test_padded_batch_param.py",
+        "Model.train_step",
+        2,
+        3,
+        Map.of(3, Set.of(t), 4, Set.of(t)));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
    * passed interprocedurally to a callee types the callee's parameter. {@code Model.get_loss}'s
    * {@code real} and {@code pred} receive {@code tf.constant} tensors via {@code train_step}, so

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2515,6 +2515,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2550,6 +2552,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2580,6 +2584,39 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
+        </method>
+      </class>
+      <class name="padded_batch" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#padded_batch — modeled like `batch` (a fresh Dataset carrying the chainable transform fields); shape inference reuses `DatasetBatchGenerator`. The field-init block is duplicated per the structural reason documented on `batch.do`. wala/ML#623. -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self batch_size padded_shapes padding_values drop_remainder name">
+          <new def="x" class="Ltensorflow/data/Dataset"/>
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2610,6 +2647,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2640,6 +2679,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2670,6 +2711,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2700,6 +2743,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2730,6 +2775,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2760,6 +2807,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2790,6 +2839,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2826,6 +2877,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2859,6 +2912,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2889,6 +2944,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2919,6 +2976,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2949,6 +3008,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -2979,6 +3040,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -3009,6 +3072,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -3039,6 +3104,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -3070,6 +3137,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
@@ -3100,6 +3169,8 @@
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
           <new def="rd_batch" class="Ltensorflow/data/batch"/>
           <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
           <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
           <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
           <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -47,6 +47,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_GEN
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_TENSORS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_TENSOR_SLICES_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_MAP_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_PADDED_BATCH_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_PREFETCH_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_RANDOM_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_RANGE_TYPE;
@@ -1133,6 +1134,10 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, DATASET_FROM_TENSORS_TYPE))
       return new DatasetFromTensorsGenerator(source);
     else if (isType(calledFunction, DATASET_BATCH_TYPE)) return new DatasetBatchGenerator(source);
+    else if (isType(calledFunction, DATASET_PADDED_BATCH_TYPE))
+      // `padded_batch` prepends a batch dimension like `batch`; reuse the batch generator. The
+      // padded inner dimensions are an upper-bound approximation. wala/ML#623.
+      return new DatasetBatchGenerator(source);
     else if (isType(calledFunction, DATASET_RANGE_TYPE)) return new DatasetRangeGenerator(source);
     else if (isType(calledFunction, TEXT_LINE_DATASET_TYPE))
       return new TextLineDatasetGenerator(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -181,6 +181,12 @@ public class TensorFlowTypes extends PythonTypes {
 
   public static final String DATASET_BATCH_SIGNATURE = "tf.data.Dataset.batch()";
 
+  public static final TypeReference DATASET_PADDED_BATCH_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/data/padded_batch"));
+
+  public static final String DATASET_PADDED_BATCH_SIGNATURE = "tf.data.Dataset.padded_batch()";
+
   public static final TypeReference DATASET_MAP_TYPE =
       TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Ltensorflow/data/map"));
 
@@ -1870,6 +1876,7 @@ public class TensorFlowTypes extends PythonTypes {
       Map.ofEntries(
           Map.entry(DATASET, DATASET_SIGNATURE),
           Map.entry(DATASET_BATCH_TYPE, DATASET_BATCH_SIGNATURE),
+          Map.entry(DATASET_PADDED_BATCH_TYPE, DATASET_PADDED_BATCH_SIGNATURE),
           Map.entry(DATASET_SHUFFLE_TYPE, DATASET_SHUFFLE_SIGNATURE),
           Map.entry(DATASET_MAP_TYPE, DATASET_MAP_SIGNATURE),
           Map.entry(DATASET_REPEAT_TYPE, DATASET_REPEAT_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_padded_batch_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_padded_batch_param.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+class Model(tf.keras.Model):
+    def get_loss(self, real, pred):
+        return tf.reduce_mean(tf.square(pred - real))
+
+    def train_step(self, inputs, targets):
+        # `inputs`/`targets` are `padded_batch` elements threaded through `fit`. See wala/ML#623.
+        assert inputs.shape == (2, 2)
+        assert inputs.dtype == tf.int32
+        assert targets.shape == (2, 2)
+        assert targets.dtype == tf.int32
+        return self.get_loss(targets, inputs)
+
+    def fit(self, dataset):
+        for inputs, targets in dataset:
+            self.train_step(inputs, targets)
+
+
+ds = tf.data.Dataset.from_tensor_slices(
+    (
+        tf.constant([[1, 2], [3, 4]], dtype=tf.int32),
+        tf.constant([[1, 1], [1, 1]], dtype=tf.int32),
+    )
+).padded_batch(2)
+Model().fit(ds)


### PR DESCRIPTION
`padded_batch` had no model (no class, no dataset-method field, no factory dispatch), so calling `.padded_batch(...)` dropped the per-element tensor type before it could reach a callee parameter.

This is the corpus blocker behind wala/ML#618. Per the consumer analysis, the failing pipeline is `TFRecordDataset -> map -> padded_batch -> repeat -> prefetch`, where the type is already gone at `padded_batch` (upstream of, and independent of, any `experimental_distribute_dataset` wrapping). So the distribute pass-through is not what unblocks the corpus; `padded_batch` is.

Modeled like `batch`: a `padded_batch` class plus a per-dataset field, dispatching to `DatasetBatchGenerator` (it prepends a batch dimension; the padded inner dimensions are an upper-bound approximation). `testPaddedBatchParam` guards it: a `(2,)` int32 element through `padded_batch(2)` threaded via a custom `fit` into `train_step` now types both parameters to `(2, 2)` int32.

Closes wala/ML#623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)