### PR TITLE
Add regression guards for `numpy.array` parameter propagation

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4551,6 +4551,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a>: a bare
+   * {@code numpy.array} value propagates its {@code TensorType} to a callee parameter. The issue's
+   * reproducer; {@code f}'s parameter types to {@code (3,)} unknown ({@code NpArray} infers the
+   * list-literal shape; the dtype is unknown with no {@code dtype=} argument).
+   */
+  @Test
+  public void testNpArrayBareParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_param.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(3))))));
+  }
+
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a>: the
+   * {@code tf.constant}-wrapped {@code numpy.array} form also propagates to the callee parameter.
+   * It types to {@code ⊤} unknown, coarser than the bare form's {@code (3,)} because {@code
+   * tf.constant} drops the array shape (tracked by <a
+   * href="https://github.com/wala/ML/issues/625">wala/ML#625</a>).
+   */
+  @Test
+  public void testNpArrayWrappedParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_wrapped_param.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
    * passed interprocedurally to a callee types the callee's parameter. {@code Model.get_loss}'s
    * {@code real} and {@code pred} receive {@code tf.constant} tensors via {@code train_step}, so

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4555,6 +4555,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code numpy.array} value propagates its {@code TensorType} to a callee parameter. The issue's
    * reproducer; {@code f}'s parameter types to {@code (3,)} unknown ({@code NpArray} infers the
    * list-literal shape; the dtype is unknown with no {@code dtype=} argument).
+   *
+   * <p>TODO: the unknown dtype is a recoverable-precision floor. The runtime dtype is {@code
+   * float64} (numpy promotes the Python float literals), but {@code NpArray} does not model numpy's
+   * dtype promotion, so it floors to unknown rather than infer a possibly-wrong dtype. Tracked by
+   * <a href="https://github.com/wala/ML/issues/626">wala/ML#626</a>.
    */
   @Test
   public void testNpArrayBareParam()

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 
 
 def f(t):

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
@@ -4,6 +4,9 @@ import numpy as np
 def f(t):
     # `t` is a bare `numpy.array` value. See wala/ML#598.
     assert t.shape == (3,)
+    # Runtime dtype is float64 (numpy promotes the Python floats); the static type is unknown
+    # because numpy dtype promotion is unmodeled. See wala/ML#626.
+    assert t.dtype == np.float64
     return t
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
@@ -1,0 +1,12 @@
+import numpy as np
+import tensorflow as tf
+
+
+def f(t):
+    # `t` is a bare `numpy.array` value. See wala/ML#598.
+    assert t.shape == (3,)
+    return t
+
+
+x = np.array([1.0, 2.0, 3.0])
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_wrapped_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_wrapped_param.py
@@ -1,0 +1,12 @@
+import numpy as np
+import tensorflow as tf
+
+
+def f(t):
+    # `t` is a `tf.constant`-wrapped `numpy.array` value. See wala/ML#598.
+    assert t.shape == (3,)
+    return t
+
+
+x = tf.constant(np.array([1.0, 2.0, 3.0]))
+f(x)


### PR DESCRIPTION
wala/ML#598's reproducer types the callee parameter at the Ariadne level: a bare `numpy.array([1.0, 2.0, 3.0])` flowing into `f(t)` types `t` to `(3,)` unknown (`NpArray` infers the list-literal shape; the dtype is unknown with no `dtype=` argument), exactly the issue's expected result. `NpArray`'s source typing has been stable since wala/ML#156 and interprocedural propagation already works, so the bare form propagates and the issue's symptom does not reproduce.

These guards pin both the bare and the `tf.constant`-wrapped forms. Two precision floors remain, tracked separately: the wrapped form types to a coarser `⊤` because `tf.constant` drops the array shape (wala/ML#625), and the bare form's dtype floors to unknown because numpy dtype promotion is unmodeled (wala/ML#626).

Closes wala/ML#598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)