### PR TITLE
Pin the `tf.constant`-wrapped `numpy.array` shape imprecision with a wala/ML#625 TODO

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4613,9 +4613,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a>: the
    * {@code tf.constant}-wrapped {@code numpy.array} form also propagates to the callee parameter.
-   * It types to {@code ⊤} unknown, coarser than the bare form's {@code (3,)} because {@code
-   * tf.constant} drops the array shape (tracked by <a
-   * href="https://github.com/wala/ML/issues/625">wala/ML#625</a>).
+   * It currently types to {@code ⊤} unknown, coarser than the bare form's {@code (3,)} because
+   * {@code tf.constant} drops the array shape.
+   *
+   * <p>TODO: This pins the current imprecise shape. Once <a
+   * href="https://github.com/wala/ML/issues/625">wala/ML#625</a> lands, the parameter should type
+   * to {@code (3,)} unknown (the bare form's shape; the dtype stays unknown pending <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>), and this assertion should be
+   * updated accordingly.
    */
   @Test
   public void testNpArrayWrappedParam()


### PR DESCRIPTION
Upgrades the existing `testNpArrayWrappedParam` guard's prose reference to wala/ML#625 into an explicit captured-behavior TODO, so the assertion-flip to `(3,)` is unambiguous once the shape gap lands. The parameter currently pins `⊤` unknown; the TODO records that it should become `(3,)` unknown after wala/ML#625 (dtype still unknown pending wala/ML#626).

The #625 root cause is diagnosed on the issue: the `Lnumpy/ndarray` allocation's shape is unrecoverable through the implicit-def path in `getShapesFromTensor`, and the documented `isImplicit`-guard shortcut throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)