### PR TITLE
Skip importing site.py when initializing the analysis interpreter

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/util/Python3Interpreter.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.util;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.python.core.Options;
 import org.python.core.PyException;
 import org.python.core.PyInteger;
 import org.python.core.PyLong;
@@ -44,6 +45,18 @@ public class Python3Interpreter extends com.ibm.wala.cast.python.util.PythonInte
     if (interp == null) {
       try {
         PySystemState.initialize();
+        // Skip importing site.py when constructing the interpreter. The PythonInterpreter
+        // constructor calls Py.importSiteIfSelected(), which (when Options.importSite is true)
+        // loads site.py, whose interactive-console setup references jline
+        // (jline/console/UserInterruptException). Under a minimal runtime classpath — e.g. the
+        // published com.ibm.wala.cast.python.ml fat-jar, which ships no jline classes — that load
+        // throws NoClassDefFoundError. Being an Error rather than an Exception, it bypasses the
+        // catch below and aborts the module's analysis. site.py is unnecessary for static
+        // analysis, so we disable its import (the equivalent of the -S flag or
+        // python.import.site=false). The flag is set after PySystemState.initialize() — which runs
+        // Options.setOptions() and could otherwise reset it from the registry — and before
+        // new PythonInterpreter(), which reads it. See wala/ML#628.
+        Options.importSite = false;
         interp = new PythonInterpreter();
       } catch (Exception t) {
         // Jython init can fail when bootstrap resources (e.g., the embedded

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/Python3InterpreterTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/Python3InterpreterTest.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeNotNull;
 
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.python.core.Options;
 
 /** Unit tests for {@link Python3Interpreter}. */
 public class Python3InterpreterTest {
@@ -61,5 +63,25 @@ public class Python3InterpreterTest {
 
     // Cannot be evaluated at all (an undefined name, as a runtime-shaped dimension would be): null.
     assertNull(interpreter.evalAsInteger("undefined_name_xyz[0]"));
+  }
+
+  /**
+   * Verifies that initializing the analysis interpreter disables the {@code site.py} import. The
+   * {@code PythonInterpreter} constructor imports {@code site.py} when {@link Options#importSite}
+   * is set, and {@code site.py}'s interactive-console setup references {@code jline}. Under a
+   * minimal runtime classpath (e.g. the published fat-jar, which ships no {@code jline} classes)
+   * that import throws {@code NoClassDefFoundError} — an {@code Error}, so it bypasses the
+   * recoverable-failure handling in {@link Python3Interpreter#getInterp()} and aborts the module's
+   * analysis. Pins the fix for wala/ML#628: the interpreter must not pull in {@code site.py}.
+   */
+  @Test
+  public void testSiteImportDisabled() {
+    Python3Interpreter interpreter = new Python3Interpreter();
+
+    // Skip where the embedded Jython interpreter is unavailable despite the setup above (e.g.,
+    // under Tycho-OSGi): getInterp() never reaches the flag in that case.
+    assumeNotNull(interpreter.evalAsInteger("3"));
+
+    assertFalse(Options.importSite);
   }
 }


### PR DESCRIPTION
`Python3Interpreter.getInterp()` constructs a Jython `PythonInterpreter`, whose constructor calls `Py.importSiteIfSelected()`. When `Options.importSite` is set (the default), that loads `site.py`, whose interactive-console setup references `jline` (`jline/console/UserInterruptException`). Under a minimal runtime classpath, such as the published `com.ibm.wala.cast.python.ml` fat-jar that ships no `jline` classes, the load throws `NoClassDefFoundError`. Because that is an `Error` rather than an `Exception`, it bypasses the `catch (Exception)` recoverable-failure handling in `getInterp()` and aborts the module's analysis.

`site.py` (REPL/console setup) is unnecessary for static analysis. This disables its import, the equivalent of the `-S` flag or `python.import.site=false`, by setting `Options.importSite` to `false` after `PySystemState.initialize()` (which runs `Options.setOptions()` and could otherwise reset it from the registry) and before constructing the interpreter. Setting the flag directly is robust to initialization ordering, holding even if `PySystemState` was already initialized elsewhere.

`testReshape` and the other interpreter-folding tests confirm constant folding still produces tensor types with `site.py` disabled, so the import is not load-bearing.

Closes wala/ML#628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)