### PR TITLE
Ship `jline` in the published fat-jar (wala/ML#631)

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -10,7 +10,6 @@
  */
 package com.ibm.wala.cast.python.loader;
 
-import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 
 import com.ibm.wala.cast.ir.translator.ConstantFoldingRewriter;
@@ -35,7 +34,6 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import org.python.core.PyObject;
 import org.python.core.PySyntaxError;
@@ -45,19 +43,6 @@ import org.python.util.PythonInterpreter;
 public class Python3Loader extends PythonLoader {
 
   private static final Logger logger = Logger.getLogger(Python3Loader.class.getName());
-
-  /**
-   * Memoizes whether the "parser unavailable" warning has already been emitted from constant
-   * folding. When the embedded interpreter compiles a non-constant expression it hits a parse
-   * error, and Jython's {@link org.python.core.ParserFacade#fixParseError} references {@code jline}
-   * to format it. Under a minimal runtime classpath (the published {@code
-   * com.ibm.wala.cast.python.ml} fat-jar, which ships no {@code jline} classes) that reference
-   * throws {@link NoClassDefFoundError} instead of producing a {@link PySyntaxError}. Folding
-   * catches it and degrades (skips that expression), but every non-constant subexpression would
-   * otherwise re-log; this flag keeps it to one WARNING, FINE thereafter. See <a
-   * href="https://github.com/wala/ML/issues/631">wala/ML#631</a>.
-   */
-  private static final AtomicBoolean parserUnavailableWarned = new AtomicBoolean(false);
 
   public Python3Loader(IClassHierarchy cha, IClassLoader parent, List<File> pythonPath) {
     super(cha, parent, pythonPath);
@@ -138,29 +123,6 @@ public class Python3Loader extends PythonLoader {
                 } catch (PySyntaxError e) {
                   // Handle syntax errors gracefully.
                   logger.log(WARNING, e, () -> "Syntax error in expression: " + unicode);
-                  return null;
-                } catch (LinkageError e) {
-                  // A non-constant expression hits a parse error during eval, and Jython's
-                  // ParserFacade.fixParseError references jline to format it. Under a minimal
-                  // runtime classpath (the published fat-jar, which ships no jline classes) that
-                  // reference throws NoClassDefFoundError (a LinkageError) before a PySyntaxError
-                  // is
-                  // produced, so the catch above never sees it. Treat it like the syntax error it
-                  // stands in for: skip folding this expression. Catching LinkageError (not Error)
-                  // keeps serious failures (OOM, stack overflow) propagating. The first occurrence
-                  // is logged at WARNING so operators see folding is degraded; the rest at FINE to
-                  // avoid one entry per non-constant subexpression. See wala/ML#631.
-                  if (parserUnavailableWarned.compareAndSet(false, true))
-                    logger.log(
-                        WARNING,
-                        e,
-                        () ->
-                            "Cannot format a parse error during constant folding (jline missing"
-                                + " from the runtime classpath); skipping folding for this and any"
-                                + " subsequent non-constant expression. First skipped: "
-                                + unicode);
-                  else
-                    logger.log(FINE, e, () -> "Skipping folding (parser unavailable): " + unicode);
                   return null;
                 }
 

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.cast.python.loader;
 
+import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
 
 import com.ibm.wala.cast.ir.translator.ConstantFoldingRewriter;
@@ -34,6 +35,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import org.python.core.PyObject;
 import org.python.core.PySyntaxError;
@@ -43,6 +45,19 @@ import org.python.util.PythonInterpreter;
 public class Python3Loader extends PythonLoader {
 
   private static final Logger logger = Logger.getLogger(Python3Loader.class.getName());
+
+  /**
+   * Memoizes whether the "parser unavailable" warning has already been emitted from constant
+   * folding. When the embedded interpreter compiles a non-constant expression it hits a parse
+   * error, and Jython's {@link org.python.core.ParserFacade#fixParseError} references {@code jline}
+   * to format it. Under a minimal runtime classpath (the published {@code
+   * com.ibm.wala.cast.python.ml} fat-jar, which ships no {@code jline} classes) that reference
+   * throws {@link NoClassDefFoundError} instead of producing a {@link PySyntaxError}. Folding
+   * catches it and degrades (skips that expression), but every non-constant subexpression would
+   * otherwise re-log; this flag keeps it to one WARNING, FINE thereafter. See <a
+   * href="https://github.com/wala/ML/issues/631">wala/ML#631</a>.
+   */
+  private static final AtomicBoolean parserUnavailableWarned = new AtomicBoolean(false);
 
   public Python3Loader(IClassHierarchy cha, IClassLoader parent, List<File> pythonPath) {
     super(cha, parent, pythonPath);
@@ -123,6 +138,29 @@ public class Python3Loader extends PythonLoader {
                 } catch (PySyntaxError e) {
                   // Handle syntax errors gracefully.
                   logger.log(WARNING, e, () -> "Syntax error in expression: " + unicode);
+                  return null;
+                } catch (LinkageError e) {
+                  // A non-constant expression hits a parse error during eval, and Jython's
+                  // ParserFacade.fixParseError references jline to format it. Under a minimal
+                  // runtime classpath (the published fat-jar, which ships no jline classes) that
+                  // reference throws NoClassDefFoundError (a LinkageError) before a PySyntaxError
+                  // is
+                  // produced, so the catch above never sees it. Treat it like the syntax error it
+                  // stands in for: skip folding this expression. Catching LinkageError (not Error)
+                  // keeps serious failures (OOM, stack overflow) propagating. The first occurrence
+                  // is logged at WARNING so operators see folding is degraded; the rest at FINE to
+                  // avoid one entry per non-constant subexpression. See wala/ML#631.
+                  if (parserUnavailableWarned.compareAndSet(false, true))
+                    logger.log(
+                        WARNING,
+                        e,
+                        () ->
+                            "Cannot format a parse error during constant folding (jline missing"
+                                + " from the runtime classpath); skipping folding for this and any"
+                                + " subsequent non-constant expression. First skipped: "
+                                + unicode);
+                  else
+                    logger.log(FINE, e, () -> "Skipping folding (parser unavailable): " + unicode);
                   return null;
                 }
 

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -71,6 +71,21 @@
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
     </dependency>
+    <!-- `jython3` references `jline/console/UserInterruptException` from its
+      parser error formatter (`org.python.core.ParserFacade.fixParseError`) and
+      its site import (`importSiteIfSelected`). As with `jnr-constants` above,
+      the `jython-dev.jar`'s synthesized zero-dependency POM means Maven won't
+      pull `jline` transitively, so the `fat` classifier omits it and reaches
+      under a minimal runtime classpath fail with `NoClassDefFoundError:
+      jline/console/UserInterruptException`. Declare it explicitly so consumers
+      receive it via the plain jar's POM and the `fat` classifier bundles it.
+      Without this, constant folding aborts the module's analysis when it
+      evaluates a non-constant (parse-erroring) expression. See wala/ML#631 (and
+      wala/ML#628, the site-import surface of the same missing dependency). -->
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
         <version>0.10.4</version>
       </dependency>
       <dependency>
+        <groupId>jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>2.14.6</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.21.0</version>


### PR DESCRIPTION
Under a minimal runtime classpath (the published `com.ibm.wala.cast.python.ml` fat-jar, which shipped no `jline` classes), constant folding threw `NoClassDefFoundError: jline/console/UserInterruptException` on 0.52.5, aborting the module's analysis. Folding compiles each candidate expression with the embedded interpreter; a non-constant expression hits a parse error, and Jython's `ParserFacade.fixParseError` references `jline` to format it.

## Root Cause

The `jython-dev.jar` is installed with a synthesized zero-dependency POM, so Maven does not pull `jline` transitively and the `fat` classifier omits it. This is the same situation already handled for `jnr-constants`, which the ml pom declares explicitly for the identical reason (`jython3` references `jnr/constants/Constant`). The site-import surface of this missing dependency was wala/ML#628; the parser surface is this issue, exposed once #628 let the interpreter initialize and folding actually reach `ip.eval`.

## Fix

Declare `jline:jline:2.14.6` the same way as `jnr-constants`, so consumers receive it via the plain jar's POM and the `fat` classifier bundles it. This cures every `jline` surface at once and restores the pre-0.52.5 behavior where a parse error formats into a `PySyntaxError` that folding's existing `catch (PySyntaxError)` handles. The freshly built fat-jar bundles `jline/console/UserInterruptException` and the rest of `jline` (85 classes).

The net change is the two dependency declarations (parent `dependencyManagement` plus the ml pom). The suite is unaffected because `jline` was already on the test classpath. Surfaced downstream in ponder-lab/Hybridize-Functions-Refactoring#699.

Closes wala/ML#631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)