### PR TITLE
Guard the input_signature parameter-dtype gap (wala/ML#629)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4574,7 +4574,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(3))))));
+        Map.of(2, Set.of(TensorType.of(UNKNOWN, 3))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4551,6 +4551,33 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Reproduces <a href="https://github.com/wala/ML/issues/629">wala/ML#629</a>: a parameter typed
+   * from a {@code @tf.function(input_signature=[TensorSpec(..., dtype=...)])} decorated def keeps
+   * its dtype at ⊤ when the call-site argument's dtype is unresolved, because Ariadne stores {@code
+   * input_signature} but never consumes the {@code TensorSpec} dtype to type the parameter.
+   *
+   * <p>The argument {@code np.array([1, 2, 3])} has a known shape {@code (3,)} but an unresolved
+   * dtype (no {@code dtype=}), so it reaches {@code f}'s parameter as {@code (3,)} unknown. The
+   * {@code int32} {@code input_signature} pins the dtype, but it is not consulted, so the parameter
+   * lands at {@code (3,)} unknown rather than {@code (3,)} int32 &mdash; shape reaches the
+   * parameter while the knowable int32 dtype does not, the signature of #629.
+   *
+   * <p>TODO: this pins the current under-approximation. When {@code input_signature} is consumed to
+   * type parameters, the expected type below should become {@code (3,)} int32. Tracked by <a
+   * href="https://github.com/wala/ML/issues/629">wala/ML#629</a>.
+   */
+  @Test
+  public void testInputSignatureParamDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_input_signature_dtype.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(3))))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>'s gpt-2
    * case: a callee parameter that receives a tensor argument at a direct method-call site is typed
    * by Ariadne. The {@code Gpt2} model, dataset pipeline, and {@code _train_step}/{@code

--- a/com.ibm.wala.cast.python.test/data/tf2_test_input_signature_dtype.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_input_signature_dtype.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+import numpy as np
+
+signature = [tf.TensorSpec(shape=(3,), dtype=tf.int32)]
+
+
+def consume(x):
+    # The runtime truth: the input_signature pins the parameter to int32. Ariadne
+    # should infer the same, but currently lands at unknown (wala/ML#629).
+    assert x.shape == (3,)
+    assert x.dtype == tf.int32
+
+
+@tf.function(input_signature=signature)
+def f(x):
+    consume(x)
+    return x
+
+
+# The argument is a tensor with a known shape (3,) but a dtype Ariadne cannot
+# resolve (numpy.array with no dtype= lands at unknown). The int32 input_signature
+# pins the parameter's dtype, but Ariadne does not consume input_signature, so the
+# parameter's dtype stays unknown rather than int32. wala/ML#629.
+f(np.array([1, 2, 3]))


### PR DESCRIPTION
## Root Cause

The `tf.function` summary (`tensorflow/class/function`) stores `input_signature` as a field but never consumes it, and `TensorSpec` likewise only stores its `dtype`/`shape` fields. A decorated function's parameter types come solely from its call-site argument types. So when the argument's dtype is unresolved (⊤), the parameter's dtype lands at ⊤. The shape still reaches the parameter from the argument, which is the "shape reaches, dtype ⊤" signature in wala/ML#629.

The vendored gpt-2 fixture (`testGpt2InterprocGetLoss`, `testGpt2DistributedGetLoss`) does not expose this, because its dataset argument is an int32 constant, so both reaches type `Gpt2.call`'s parameter to int32.

## This PR

`tf2_test_input_signature_dtype.py` isolates the mechanism with a minimal repro: `np.array([1, 2, 3])` (known shape `(3,)`, unresolved dtype) into an int32-`input_signature` function. `testInputSignatureParamDtype` pins the observed result, `(3,)` unknown, with a `TODO`; the Python fixture asserts the runtime truth (`(3,)` int32), since at runtime TensorFlow coerces the argument to the declared signature.

This documents and guards the observed result rather than asserting a fix. Whether Ariadne should respect a declared `input_signature` when typing a parameter is an open question that turns on TensorFlow's runtime argument-coercion semantics (and how that interacts with eager vs traced execution); it is under discussion on wala/ML#629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)