### PR TITLE
Add the input_signature runtime matrix as test fixtures (wala/ML#634)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4550,6 +4550,95 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(3, Set.of(t), 4, Set.of(t)));
   }
 
+  // The five tests below are the wala/ML#629 input_signature runtime matrix. Each fixture asserts
+  // the actual TensorFlow runtime parameter type; the JUnit assertion pins what Ariadne computes
+  // today. The runtime ground truth was measured directly (see the issue). The matrix shows that a
+  // decorated parameter's runtime type depends on execution mode, which a static analysis cannot
+  // know -- motivating the provenance-tagged, execution-mode-complete type set proposed in #629.
+
+  /**
+   * #629 matrix, sound baseline: an undecorated function's parameter is exactly the argument. The
+   * runtime type is {@code (3,)} int32 and Ariadne agrees.
+   */
+  @Test
+  public void testInputSigNoDecorator()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_inputsig_no_decorator.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * #629 matrix, sound baseline: a {@code @tf.function} without {@code input_signature} traces on
+   * the concrete argument, so the parameter takes the argument's {@code (3,)} int32 at runtime;
+   * Ariadne agrees.
+   */
+  @Test
+  public void testInputSigNoSignature()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_inputsig_no_signature.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * #629 matrix, the headline case: a {@code @tf.function(input_signature=[TensorSpec((None,),
+   * int32)])} traced (the default) gives the parameter a <em>dynamic</em> shape {@code (None,)} at
+   * runtime -- the signature governs, not the {@code (3,)} argument.
+   *
+   * <p>TODO: Ariadne reports {@code (3,)} int32 (typing from the argument, ignoring the signature),
+   * which is <em>unsound</em> here -- the same trace serves other lengths, so the parameter is not
+   * fixed at dim 3. Under the provenance-tagged set proposed in <a
+   * href="https://github.com/wala/ML/issues/629">wala/ML#629</a>, the parameter should carry a
+   * signature-derived {@code (None,)} int32 element alongside the argument-derived one.
+   */
+  @Test
+  public void testInputSigTraced()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_inputsig_traced.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * #629 matrix: the same decorated-with-signature function as {@link #testInputSigTraced()}, but
+   * the module calls {@code tf.config.run_functions_eagerly(True)}, under which the signature is
+   * ignored and the parameter takes the argument's concrete {@code (3,)} int32. Ariadne reports
+   * {@code (3,)} int32 -- sound for this eager mode, but it is the <em>same</em> static result it
+   * gives the traced case (where it is unsound). Ariadne cannot know the execution mode, which is
+   * why #629's design is a set covering both.
+   */
+  @Test
+  public void testInputSigForcedEager()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_inputsig_forced_eager.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * #629 matrix (dtype): a {@code @tf.function(input_signature=[TensorSpec((3,), int32)])} called
+   * with an int64 {@code numpy.array} coerces the parameter to int32 at runtime.
+   *
+   * <p>TODO: Ariadne reports {@code (3,)} unknown -- it neither models {@code numpy.array}'s dtype
+   * (the argument-derived element; <a href="https://github.com/wala/ML/issues/626">wala/ML#626</a>)
+   * nor consumes the signature (the int32 graph element). Under the provenance-tagged set proposed
+   * in <a href="https://github.com/wala/ML/issues/629">wala/ML#629</a>, the signature-derived
+   * element should be int32.
+   */
+  @Test
+  public void testInputSigCoerce()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_inputsig_coerce.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(UNKNOWN, 3))));
+  }
+
   /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>'s gpt-2
    * case: a callee parameter that receives a tensor argument at a direct method-call site is typed

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4550,15 +4550,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(3, Set.of(t), 4, Set.of(t)));
   }
 
-  // The five tests below are the wala/ML#629 input_signature runtime matrix. Each fixture asserts
-  // the actual TensorFlow runtime parameter type; the JUnit assertion pins what Ariadne computes
-  // today. The runtime ground truth was measured directly (see the issue). The matrix shows that a
-  // decorated parameter's runtime type depends on execution mode, which a static analysis cannot
-  // know -- motivating the provenance-tagged, execution-mode-complete type set proposed in #629.
+  // The five tests below are the input_signature runtime matrix for
+  // https://github.com/wala/ML/issues/634. Each fixture asserts the actual TensorFlow runtime
+  // parameter type; the JUnit assertion pins what Ariadne computes today. The runtime ground truth
+  // was measured directly. The matrix shows that a decorated parameter's runtime type depends on
+  // execution mode, which a static analysis cannot know, motivating the provenance-tagged,
+  // execution-mode-complete type set proposed there.
 
   /**
-   * #629 matrix, sound baseline: an undecorated function's parameter is exactly the argument. The
-   * runtime type is {@code (3,)} int32 and Ariadne agrees.
+   * Matrix sound baseline: an undecorated function's parameter is exactly the argument. The runtime
+   * type is {@code (3,)} int32 and Ariadne agrees.
    */
   @Test
   public void testInputSigNoDecorator()
@@ -4572,9 +4573,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * #629 matrix, sound baseline: a {@code @tf.function} without {@code input_signature} traces on
-   * the concrete argument, so the parameter takes the argument's {@code (3,)} int32 at runtime;
-   * Ariadne agrees.
+   * Matrix sound baseline: a {@code @tf.function} without {@code input_signature} traces on the
+   * concrete argument, so the parameter takes the argument's {@code (3,)} int32 at runtime; Ariadne
+   * agrees.
    */
   @Test
   public void testInputSigNoSignature()
@@ -4588,14 +4589,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * #629 matrix, the headline case: a {@code @tf.function(input_signature=[TensorSpec((None,),
-   * int32)])} traced (the default) gives the parameter a <em>dynamic</em> shape {@code (None,)} at
-   * runtime -- the signature governs, not the {@code (3,)} argument.
+   * Matrix headline case: a {@code @tf.function(input_signature=[TensorSpec((None,), int32)])}
+   * traced (the default) gives the parameter a <em>dynamic</em> shape {@code (None,)} at runtime;
+   * the signature governs, not the {@code (3,)} argument.
    *
    * <p>TODO: Ariadne reports {@code (3,)} int32 (typing from the argument, ignoring the signature),
-   * which is <em>unsound</em> here -- the same trace serves other lengths, so the parameter is not
+   * which is <em>unsound</em> here—the same trace serves other lengths, so the parameter is not
    * fixed at dim 3. Under the provenance-tagged set proposed in <a
-   * href="https://github.com/wala/ML/issues/629">wala/ML#629</a>, the parameter should carry a
+   * href="https://github.com/wala/ML/issues/634">wala/ML#634</a>, the parameter should carry a
    * signature-derived {@code (None,)} int32 element alongside the argument-derived one.
    */
   @Test
@@ -4605,12 +4606,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * #629 matrix: the same decorated-with-signature function as {@link #testInputSigTraced()}, but
-   * the module calls {@code tf.config.run_functions_eagerly(True)}, under which the signature is
+   * Matrix: the same decorated-with-signature function as {@link #testInputSigTraced()}, but the
+   * module calls {@code tf.config.run_functions_eagerly(True)}, under which the signature is
    * ignored and the parameter takes the argument's concrete {@code (3,)} int32. Ariadne reports
-   * {@code (3,)} int32 -- sound for this eager mode, but it is the <em>same</em> static result it
-   * gives the traced case (where it is unsound). Ariadne cannot know the execution mode, which is
-   * why #629's design is a set covering both.
+   * {@code (3,)} int32, sound for this eager mode but the <em>same</em> static result it gives the
+   * traced case (where it is unsound). Ariadne cannot know the execution mode, which is why the <a
+   * href="https://github.com/wala/ML/issues/634">wala/ML#634</a> design is a set covering both.
    */
   @Test
   public void testInputSigForcedEager()
@@ -4624,13 +4625,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * #629 matrix (dtype): a {@code @tf.function(input_signature=[TensorSpec((3,), int32)])} called
-   * with an int64 {@code numpy.array} coerces the parameter to int32 at runtime.
+   * Matrix (dtype): a {@code @tf.function(input_signature=[TensorSpec((3,), int32)])} called with
+   * an int64 {@code numpy.array} coerces the parameter to int32 at runtime.
    *
-   * <p>TODO: Ariadne reports {@code (3,)} unknown -- it neither models {@code numpy.array}'s dtype
-   * (the argument-derived element; <a href="https://github.com/wala/ML/issues/626">wala/ML#626</a>)
+   * <p>TODO: Ariadne reports {@code (3,)} unknown; it neither models {@code numpy.array}'s dtype
+   * (the argument-derived element, <a href="https://github.com/wala/ML/issues/626">wala/ML#626</a>)
    * nor consumes the signature (the int32 graph element). Under the provenance-tagged set proposed
-   * in <a href="https://github.com/wala/ML/issues/629">wala/ML#629</a>, the signature-derived
+   * in <a href="https://github.com/wala/ML/issues/634">wala/ML#634</a>, the signature-derived
    * element should be int32.
    */
   @Test

--- a/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_coerce.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_coerce.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+import numpy as np
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(3,), dtype=tf.int32)])
+def f(x):
+    # The numpy argument is int64, but the signature coerces the parameter to
+    # int32 (traced). So the parameter's dtype comes from the signature.
+    assert x.dtype == tf.int32
+    assert x.shape.as_list() == [3]
+    return x
+
+
+f(np.array([1, 2, 3]))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_forced_eager.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_forced_eager.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+tf.config.run_functions_eagerly(True)
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(None,), dtype=tf.int32)])
+def f(x):
+    # Same decorated-with-signature function as the traced case, but under
+    # run_functions_eagerly the signature is ignored: the parameter takes the
+    # argument's concrete shape (3,), not the signature's (None,).
+    assert x.dtype == tf.int32
+    assert x.shape.as_list() == [3]
+    return x
+
+
+f(tf.constant([1, 2, 3], dtype=tf.int32))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_no_decorator.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_no_decorator.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def f(x):
+    # Eager, no decorator: the parameter is exactly the argument.
+    assert x.dtype == tf.int32
+    assert x.shape.as_list() == [3]
+    return x
+
+
+f(tf.constant([1, 2, 3], dtype=tf.int32))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_no_signature.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_no_signature.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+@tf.function
+def f(x):
+    # Decorated, no input_signature: traced on the concrete argument, so the
+    # parameter takes the argument's shape and dtype.
+    assert x.dtype == tf.int32
+    assert x.shape.as_list() == [3]
+    return x
+
+
+f(tf.constant([1, 2, 3], dtype=tf.int32))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_traced.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_inputsig_traced.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(None,), dtype=tf.int32)])
+def f(x):
+    # Decorated with a signature, traced (default): the signature governs the
+    # parameter, so its shape is dynamic (None,) -- NOT the argument's (3,).
+    assert x.dtype == tf.int32
+    assert x.shape.as_list() == [None]
+    return x
+
+
+f(tf.constant([1, 2, 3], dtype=tf.int32))


### PR DESCRIPTION
Establishes the ground truth behind wala/ML#634 as committed, executable fixtures. Five Python files assert TensorFlow's actual runtime parameter type across {no decorator, decorator without signature, decorator with signature} under {traced, forced-eager}; the paired JUnit tests pin what Ariadne computes today.

| fixture | runtime parameter | Ariadne now | verdict |
|---|---|---|---|
| `no_decorator` | `(3,) int32` | `(3,) int32` | sound |
| `no_signature` | `(3,) int32` | `(3,) int32` | sound |
| `traced` (`input_signature=[TensorSpec((None,), int32)]`) | `(None,) int32` | `(3,) int32` | unsound |
| `forced_eager` (same plus `run_functions_eagerly(True)`) | `(3,) int32` | `(3,) int32` | sound |
| `coerce` (int32 sig, int64 numpy arg) | `(3,) int32` | `(3,) unknown` | dtype unknown |

The headline is `traced`: a decorated parameter with a dynamic-shape signature has runtime shape `(None,)`, but the same function under `run_functions_eagerly(True)` takes the argument's concrete `(3,)`. Ariadne reports `(3,)` for both, which is sound for the eager case but unsound for the traced one (the same trace serves other lengths). A static analysis cannot know the execution mode, which is why #634's direction is a provenance-tagged set covering both. The `coerce` row is the dtype analog: the signature coerces int64 to int32 at runtime while Ariadne reports unknown.

The three undecorated or unsignatured rows are sound baselines Ariadne already matches. The `traced` and `coerce` tests pin current behavior with `TODO`s toward the #634 tagged-set design. Supersedes the narrower `np.array` repro in #463 (which conflated with wala/ML#626).

Part of wala/ML#634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)