### PR TITLE
Bundle `jnr-posix` in the published fat-jar (wala/ML#632)

### DIFF
--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -86,6 +86,20 @@
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
     </dependency>
+    <!-- `jython3` also references `jnr/posix/POSIXHandler` (from its
+      `org.python.modules.posix.PosixModule`) and `jnr/posix/util/Platform` (from
+      `org.python.core.PySystemState`'s file/path resolution). Same gap as
+      `jnr-constants` and `jline` above: the `jython-dev.jar`'s synthesized
+      zero-dependency POM means Maven won't pull `jnr-posix` transitively, so the
+      `fat` classifier omits it and consumers (and the standalone driver) fail with
+      `NoClassDefFoundError: jnr/posix/POSIXHandler` (or `jnr/posix/util/Platform`).
+      Declare it explicitly so the `fat` classifier bundles it and library
+      consumers receive it via the plain jar's POM (the managed `jnr-constants`
+      version takes precedence over `jnr-posix`'s own). See wala/ML#632. -->
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
         <version>2.14.6</version>
       </dependency>
       <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>3.1.19</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.21.0</version>


### PR DESCRIPTION
`jython3` references `jnr/posix/POSIXHandler` (from `org.python.modules.posix.PosixModule`) and `jnr/posix/util/Platform` (from `org.python.core.PySystemState`'s file/path resolution), but the `jython-dev.jar`'s synthesized zero-dependency POM means Maven does not pull `jnr-posix` transitively, so the `fat` classifier omitted it. Library consumers (and the standalone driver) reaching the `posix` module hit `NoClassDefFoundError: jnr/posix/POSIXHandler` (or `jnr/posix/util/Platform`).

This declares `jnr-posix` explicitly (managed at 3.1.19 in the parent), exactly mirroring `jnr-constants` (wala/ML#453) and `jline` (wala/ML#631): the `fat` classifier bundles it and library consumers receive it via the plain jar's POM. Verified the built fat-jar now contains `jnr/posix/POSIXHandler` and `jnr/posix/util/Platform` (244 `jnr/posix` classes). Full suite green; the change is pom-only.

One of the instances under the fat-jar self-containment umbrella wala/ML#633.

Closes wala/ML#632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)