### PR TITLE
Probe input_signature parameter typing via a multi-depth call (wala/ML#638)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4725,6 +4725,38 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * A {@code @tf.function} without {@code input_signature} creates {@code tf.constant(5)} and
+   * passes it to {@code g} (the FUT), so {@code g}'s parameter is that scalar. At runtime {@code g}
+   * receives {@code ()} int32 and Ariadne agrees: a positive guard that a value flowing through a
+   * decorated body to a callee types the callee's parameter correctly.
+   */
+  @Test
+  public void testDecoratedCallDepth()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_decorated_call_depth.py", "g", 1, 1, Map.of(2, Set.of(TensorType.of(INT_32))));
+  }
+
+  /**
+   * A {@code @tf.function(input_signature=[(None,) int32])} passes its parameter to {@code g} (the
+   * FUT). At runtime {@code g} receives the signature's {@code (None,)} int32, since the signature
+   * governs the parameter and propagates to the callee.
+   *
+   * <p>TODO: Ariadne ignores {@code input_signature} and types {@code g}'s parameter from the
+   * call-site argument {@code (3,)} int32, which is <em>unsound</em> here. Tracked by <a
+   * href="https://github.com/wala/ML/issues/638">wala/ML#638</a>.
+   */
+  @Test
+  public void testDecoratedCallDepthInputSig()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_decorated_call_depth_input_sig.py",
+        "g",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
    * passed to a Keras {@code call} method types its parameter. {@code BiLSTM.call}'s {@code inputs}
    * receives a token-id tensor (which then feeds an {@code Embedding}), so it types to {@code (1,

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_call_depth.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_call_depth.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def g(b):
+    pass
+
+
+@tf.function
+def f():
+    a = tf.constant(5)
+    # `a` is `g`'s argument here (calling context for the FUT `g`).
+    assert a.shape == ()
+    assert a.dtype == tf.int32
+    g(a)
+
+
+f()

--- a/com.ibm.wala.cast.python.test/data/tf2_test_decorated_call_depth_input_sig.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_decorated_call_depth_input_sig.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def g(b):
+    pass
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(None,), dtype=tf.int32)])
+def f(x):
+    # `input_signature` governs `x`, so at `g`'s call site the argument is (None,) int32,
+    # NOT the (3,) of the value passed to `f` below.
+    assert x.shape.as_list() == [None]
+    assert x.dtype == tf.int32
+    g(x)
+
+
+f(tf.constant([1, 2, 3], dtype=tf.int32))


### PR DESCRIPTION
A multi-depth probe that settles, in the test suite, what `@tf.function`/`input_signature` does under Ariadne. A decorated `f` passes its parameter (or an internally-created tensor) to a callee `g`, and `g` is the FUT — so `g`'s parameter is exactly what `f` hands down, and the characterizing asserts live in `g`'s calling context (inside `f`), per convention.

| fixture | runtime `g` receives | Ariadne types `g`'s param | verdict |
|---|---|---|---|
| no `input_signature` | `()` int32 | `()` int32 | sound |
| `input_signature=[(None,) int32]` | `(None,)` int32 | `(3,)` int32 | unsound |

Without a signature, a value flowing through the decorated body to `g` is typed correctly (positive guard). With a signature, Ariadne ignores it and types `g`'s parameter from the call-site argument `(3,)`, while at runtime the signature governs the parameter and `g` receives `(None,)`. The unsound case is pinned to current behavior with a `TODO` to wala/ML#638 (whether Ariadne should consume `input_signature`).

Both fixtures run under `python3.10`; the JUnit expectations match the observed analysis output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)