### PR TITLE
Skip folding on an eval-time interpreter error instead of aborting the hierarchy (wala/ML#640)

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -35,8 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
+import org.python.core.PyException;
 import org.python.core.PyObject;
-import org.python.core.PySyntaxError;
 import org.python.core.PyUnicode;
 import org.python.util.PythonInterpreter;
 
@@ -120,9 +120,14 @@ public class Python3Loader extends PythonLoader {
 
                 try {
                   x = ip.eval(unicode);
-                } catch (PySyntaxError e) {
-                  // Handle syntax errors gracefully.
-                  logger.log(WARNING, e, () -> "Syntax error in expression: " + unicode);
+                } catch (PyException e) {
+                  // The candidate expression may not be a compile-time constant: a free runtime
+                  // name (`NameError`), an attribute access, etc. raises during interpreter
+                  // evaluation, and a malformed fragment raises `PySyntaxError` (a `PyException`).
+                  // Skip folding this expression and leave it symbolic rather than aborting the
+                  // module's class hierarchy. See wala/ML#640 (and wala/ML#631 for the parse-error
+                  // surface).
+                  logger.log(WARNING, e, () -> "Could not evaluate expression: " + unicode);
                   return null;
                 }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4757,6 +4757,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/640">wala/ML#640</a>: the
+   * constant folder evaluates a foldable expression (in an uncalled function) that raises at
+   * evaluation time -- here {@code 1 / 0} ({@code ZeroDivisionError}); the original NLPGNN case was
+   * a {@code NameError} on a free name. Folding must skip such an eval-time error rather than abort
+   * the class hierarchy. If the hierarchy builds, {@code consume}'s parameter types normally to
+   * {@code (3,)} int32.
+   */
+  @Test
+  public void testFoldingEvalError()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_folding_eval_error.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: a tensor
    * passed to a Keras {@code call} method types its parameter. {@code BiLSTM.call}'s {@code inputs}
    * receives a token-id tensor (which then feeds an {@code Embedding}), so it types to {@code (1,

--- a/com.ibm.wala.cast.python.test/data/tf2_test_folding_eval_error.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_folding_eval_error.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+def never_called():
+    # A foldable constant binary expression that raises at evaluation time. The constant folder
+    # evaluates it in the embedded interpreter during class-hierarchy construction; division by zero
+    # raises `ZeroDivisionError` (the NLPGNN case was a `NameError` on a free name -- both are
+    # eval-time `PyException`s, not parse errors). Folding must skip an eval-time error and leave the
+    # expression symbolic rather than aborting the whole hierarchy. The function is never called, so
+    # the module still runs under `python3.10`. See wala/ML#640.
+    return 1 / 0
+
+
+t = tf.constant([1, 2, 3])
+assert t.shape == (3,)
+assert t.dtype == tf.int32
+consume(t)


### PR DESCRIPTION
The constant folder evaluates candidate expressions in the embedded interpreter during class-hierarchy construction. A foldable expression can raise at evaluation time (a free runtime name raises `NameError`, division by zero raises `ZeroDivisionError`, and so on), which the previous `catch (PySyntaxError)` did not handle, so it propagated as a `ClassHierarchyException` and aborted the whole module. This surfaced on the NLPGNN subject on 0.52.6 (a 0.52.6 regression, since the fat-jar fixes let interpreter-backed folding actually run) and gates the regen.

This broadens the catch to `PyException`, the superclass of both `PySyntaxError` and the runtime errors, so an eval-time error skips the expression and leaves it symbolic, exactly like the existing parse-error path (wala/ML#631).

Regression guard `testFoldingEvalError` uses `1 / 0` in an uncalled function (so it runs under `python3.10`) as a deterministic trigger of the folder's eval path: it aborts the class hierarchy without the fix and types `consume`'s parameter to `(3,)` int32 with it.

Closes wala/ML#640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)