### PR TITLE
Model `complex64`/`complex128` dtypes (wala/ML#637)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TensorFlowTypesTest.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.test;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX128;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
@@ -41,6 +43,18 @@ public class TensorFlowTypesTest {
     assertTrue(FLOAT32.canConvertTo(DType.FLOAT32));
     assertFalse(FLOAT64.canConvertTo(DType.INT64));
     assertFalse(FLOAT64.canConvertTo(DType.INT32));
+
+    // Complex (wala/ML#637): a real value widens into complex, a complex never narrows back to a
+    // real, and a complex only widens to a wider complex.
+    assertTrue(COMPLEX64.canConvertTo(COMPLEX64));
+    assertTrue(COMPLEX64.canConvertTo(COMPLEX128));
+    assertFalse(COMPLEX128.canConvertTo(COMPLEX64));
+    assertTrue(FLOAT32.canConvertTo(COMPLEX64));
+    assertTrue(INT32.canConvertTo(COMPLEX64));
+    assertFalse(COMPLEX64.canConvertTo(FLOAT32));
+    assertFalse(COMPLEX64.canConvertTo(FLOAT64));
+    assertFalse(COMPLEX64.canConvertTo(INT32));
+    assertFalse(COMPLEX64.canConvertTo(STRING));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.test;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
@@ -80,6 +81,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   private static final Logger LOGGER = Logger.getLogger(TestTensorflow2Model.class.getName());
 
   private static final String FLOAT_32 = FLOAT32.name().toLowerCase();
+
+  private static final String COMPLEX_64 = COMPLEX64.name().toLowerCase();
 
   private static final String FLOAT_64 = FLOAT64.name().toLowerCase();
 
@@ -4754,6 +4757,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/637">wala/ML#637</a>: a {@code
+   * tf.constant} with an explicit {@code dtype=tf.complex64} types to {@code complex64} (now
+   * modeled by the {@code DType} enum) rather than ⊤, so {@code consume}'s parameter is {@code
+   * (2,)} complex64.
+   */
+  @Test
+  public void testConstantComplex64()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_complex64.py", "consume", 1, 1, Map.of(2, Set.of(TensorType.of(COMPLEX_64, 2))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4776,6 +4776,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * A faithful copy of <a href="https://github.com/wala/ML/issues/637">wala/ML#637</a>'s example,
+   * {@code tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)}. The complex literal ({@code 2j})
+   * currently breaks call-graph entrypoint creation, so building it aborts with an empty entrypoint
+   * set rather than typing {@code consume}'s parameter.
+   *
+   * <p>TODO: remove {@code expected = IllegalStateException.class} once the front-end translates
+   * complex literals (<a href="https://github.com/wala/ML/issues/642">wala/ML#642</a>). The dtype
+   * is already modeled, so {@code consume}'s parameter should then type to {@code (2,)} complex64
+   * (as in {@link #testConstantComplex64()}).
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testComplexLiteralEntrypoint()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_complex_literal.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(COMPLEX_64, 2))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/640">wala/ML#640</a>: the
    * constant folder evaluates a foldable expression (in an uncalled function) that raises at
    * evaluation time -- here {@code 1 / 0} ({@code ZeroDivisionError}); the original NLPGNN case was

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -718,6 +718,14 @@
         <new def="string" class="Ltensorflow/dtypes/DType"/>
         <putfield class="LRoot" field="string" fieldType="LRoot" ref="x" value="string"/>
         <putfield class="LRoot" field="string" fieldType="LRoot" ref="dtypes" value="string"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#complex64 -->
+        <new def="complex64" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="complex64" fieldType="LRoot" ref="x" value="complex64"/>
+        <putfield class="LRoot" field="complex64" fieldType="LRoot" ref="dtypes" value="complex64"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#complex128 -->
+        <new def="complex128" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="complex128" fieldType="LRoot" ref="x" value="complex128"/>
+        <putfield class="LRoot" field="complex128" fieldType="LRoot" ref="dtypes" value="complex128"/>
         <new def="ragged_constant" class="Ltensorflow/functions/ragged_constant"/>
         <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged" value="ragged_constant"/>
         <putfield class="LRoot" field="constant" fieldType="LRoot" ref="ragged_factory_ops" value="ragged_constant"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.types;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX128;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
@@ -30,28 +32,37 @@ public class TensorFlowTypes extends PythonTypes {
    *     dtypes</a>.
    */
   public enum DType {
-    FLOAT32(true, true, 32),
-    FLOAT64(true, true, 64),
-    INT32(true, false, 32),
-    INT64(true, false, 64),
-    UINT8(true, false, 8),
-    BOOL(false, false, 1),
-    STRING(false, false, 0),
+    FLOAT32(true, true, false, 32),
+    FLOAT64(true, true, false, 64),
+    INT32(true, false, false, 32),
+    INT64(true, false, false, 64),
+    UINT8(true, false, false, 8),
+    // `complex64` is 2x float32 and `complex128` is 2x float64. Modeled with a dedicated `complex`
+    // flag (rather than reusing `floatingPoint`) so that a real value can widen into a complex one
+    // but a complex value never narrows back to a real, and a complex only widens to a wider
+    // complex. See wala/ML#637.
+    COMPLEX64(true, false, true, 64),
+    COMPLEX128(true, false, true, 128),
+    BOOL(false, false, false, 1),
+    STRING(false, false, false, 0),
     // numpy `object` dtype: an ndarray of variable-length Python sequences (e.g. `reuters`/`imdb`
     // `x_train`). Non-numeric, so `canConvertTo` only matches itself — it does not auto-convert to
     // numeric dtypes, matching numpy's strict semantics. See wala/ML#488.
-    OBJECT(false, false, 0),
-    UNKNOWN(false, false, 0);
+    OBJECT(false, false, false, 0),
+    UNKNOWN(false, false, false, 0);
 
     private boolean numeric;
 
     private boolean floatingPoint;
 
+    private boolean complex;
+
     private int precision;
 
-    DType(boolean numeric, boolean floatingPoint, int precision) {
+    DType(boolean numeric, boolean floatingPoint, boolean complex, int precision) {
       this.numeric = numeric;
       this.floatingPoint = floatingPoint;
+      this.complex = complex;
       this.precision = precision;
     }
 
@@ -59,6 +70,15 @@ public class TensorFlowTypes extends PythonTypes {
       if (other == null) return false;
 
       if (!this.numeric || !other.numeric) return this == other;
+
+      // Complex is a distinct kind: a complex value never narrows to a real (int/float) one, a real
+      // value widens into any complex, and a complex only widens to a complex of at least its
+      // precision.
+      if (this.complex || other.complex) {
+        if (this.complex && !other.complex) return false;
+        if (!this.complex && other.complex) return true;
+        return this.precision <= other.precision;
+      }
 
       if (this.floatingPoint && !other.floatingPoint) return false;
 
@@ -2140,6 +2160,32 @@ public class TensorFlowTypes extends PythonTypes {
           findOrCreateAsciiAtom(DType.STRING.name().toLowerCase(Locale.ROOT)),
           D_TYPE);
 
+  /**
+   * Represents the TensorFlow complex64 data type.
+   *
+   * @see <a
+   *     href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#complex64">TensorFlow
+   *     complex64 DType</a>.
+   */
+  public static final FieldReference COMPLEX_64 =
+      FieldReference.findOrCreate(
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(COMPLEX64.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
+
+  /**
+   * Represents the TensorFlow complex128 data type.
+   *
+   * @see <a
+   *     href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#complex128">TensorFlow
+   *     complex128 DType</a>.
+   */
+  public static final FieldReference COMPLEX_128 =
+      FieldReference.findOrCreate(
+          PythonTypes.Root,
+          findOrCreateAsciiAtom(COMPLEX128.name().toLowerCase(Locale.ROOT)),
+          D_TYPE);
+
   /** A mapping from a field reference to its associated {@link DType}, if any. */
   public static final Map<FieldReference, DType> FIELD_REFERENCE_TO_DTYPE =
       Map.ofEntries(
@@ -2148,6 +2194,8 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(INT_32, INT32),
           Map.entry(INT_64, INT64),
           Map.entry(UINT_8, UINT8),
+          Map.entry(COMPLEX_64, COMPLEX64),
+          Map.entry(COMPLEX_128, COMPLEX128),
           Map.entry(STRING, DType.STRING));
 
   private TensorFlowTypes() {}

--- a/com.ibm.wala.cast.python.test/data/tf2_test_complex64.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_complex64.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# `z` is a `complex64` tensor; its dtype comes from the explicit `dtype=` argument. See wala/ML#637.
+z = tf.constant([1, 2], dtype=tf.complex64)
+assert z.shape == (2,)
+assert z.dtype == tf.complex64
+consume(z)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_complex64.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_complex64.py
@@ -5,7 +5,10 @@ def consume(x):
     pass
 
 
-# `z` is a `complex64` tensor; its dtype comes from the explicit `dtype=` argument. See wala/ML#637.
+# wala/ML#637's example is `tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)`, but a complex
+# literal (`2j`) currently breaks call-graph entrypoint creation (the separate front-end gap
+# wala/ML#642), so a faithful copy would not build at all. Use integer values cast to `complex64` to
+# isolate the dtype modeling; the dtype comes from the explicit `dtype=` argument either way.
 z = tf.constant([1, 2], dtype=tf.complex64)
 assert z.shape == (2,)
 assert z.dtype == tf.complex64

--- a/com.ibm.wala.cast.python.test/data/tf2_test_complex_literal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_complex_literal.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# wala/ML#637's example verbatim: a `complex64` constant built from complex literals. The `2j`
+# literal currently breaks call-graph entrypoint creation (wala/ML#642), so this aborts with an
+# empty entrypoint set; the companion `tf2_test_complex64.py` uses integer values to isolate the
+# dtype modeling.
+z = tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)
+assert z.shape == (2,)
+assert z.dtype == tf.complex64
+consume(z)


### PR DESCRIPTION
A `tf.complex64` `input_signature` dtype had no `DType`, so a consumer mapping the signature emptied the entrypoint set and aborted the call graph (wala/ML#637). This models complex on the Ariadne side:

- `COMPLEX64`/`COMPLEX128` in the `DType` enum, with a dedicated `complex` flag rather than reusing `floatingPoint`, so `canConvertTo` is conservative: a real value widens into complex, a complex never narrows back to a real, and a complex only widens to a wider complex.
- Their `FieldReference` constants and `FIELD_REFERENCE_TO_DTYPE` entries.
- The dtype-field declarations in `tensorflow.xml` (`<new>`+`putfield`, like `float32`) that `resolveField` needs for the dtype lookup to match.

Guards:

- `testConstantComplex64` confirms `tf.constant([1, 2], dtype=tf.complex64)` now types to `complex64` (it was falling through to int32). It uses integer values because #637's complex literals (`1 + 2j`) hit a separate front-end gap.
- `testComplexLiteralEntrypoint` is #637's example verbatim (`tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)`), marked `@Test(expected = IllegalStateException.class)`: the complex literal currently aborts entrypoint creation (wala/ML#642). Its TODO flips it to a positive `complex64` assertion once the front-end translates complex literals.
- `testCanConvertTo` covers the new complex conversion branches.

The consumer-side floor (degrade an unmodeled signature dtype to ⊤ instead of emptying the entrypoint set) is ponder-lab/Hybridize-Functions-Refactoring#701.

Part of wala/ML#637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)