### PR TITLE
Degrade an unmodeled dtype to UNKNOWN instead of throwing (wala/ML#637)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1673,7 +1673,8 @@ public abstract class TensorGenerator {
         // creation from an `input_signature`, throwing empties the entrypoint set and aborts the
         // whole call graph (wala/ML#637). Lose dtype precision for this one value rather than
         // killing the analysis, but log it so the modeling gap is still visible.
-        LOGGER.warning(() -> "Unmodeled dtype: " + instanceKey + "; degrading to UNKNOWN.");
+        LOGGER.warning(
+            () -> "Unmodeled dtype: " + instanceKey + "; degrading to " + DType.UNKNOWN + ".");
         ret.add(DType.UNKNOWN);
       } else if (asin != null
           && asin.getNode()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1672,7 +1672,8 @@ public abstract class TensorGenerator {
         // dtype) rather than throwing. When this resolves a parameter dtype during entrypoint
         // creation from an `input_signature`, throwing empties the entrypoint set and aborts the
         // whole call graph (wala/ML#637). Lose dtype precision for this one value rather than
-        // killing the analysis.
+        // killing the analysis, but log it so the modeling gap is still visible.
+        LOGGER.warning(() -> "Unmodeled dtype: " + instanceKey + "; degrading to UNKNOWN.");
         ret.add(DType.UNKNOWN);
       } else if (asin != null
           && asin.getNode()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1667,7 +1667,13 @@ public abstract class TensorGenerator {
       TypeReference typeReference = concreteType.getReference();
 
       if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
-        throw new IllegalStateException("Unknown dtype: " + instanceKey + ".");
+        // An unmodeled dtype: a `tf.DType` instance with no entry in `FIELD_REFERENCE_TO_DTYPE`
+        // (e.g. a half-precision or quantized dtype not yet enumerated). Degrade to UNKNOWN (the ⊤
+        // dtype) rather than throwing. When this resolves a parameter dtype during entrypoint
+        // creation from an `input_signature`, throwing empties the entrypoint set and aborts the
+        // whole call graph (wala/ML#637). Lose dtype precision for this one value rather than
+        // killing the analysis.
+        ret.add(DType.UNKNOWN);
       } else if (asin != null
           && asin.getNode()
               .getMethod()


### PR DESCRIPTION
The general robustness half of wala/ML#637 (the priority — it unblocks the held 0.52.6 consumer bump regardless of which dtypes get modeled).

`TensorGenerator.getDTypesFromDTypeArgument` resolves a `tf.DType` instance to a `DType` via `FIELD_REFERENCE_TO_DTYPE`. On a miss it threw `IllegalStateException`, which — when resolving a parameter's dtype during entrypoint creation from an `input_signature` — empties the entrypoint set so `PropagationCallGraphBuilder.makeCallGraph` aborts the whole call graph. This degrades the miss to `DType.UNKNOWN` (the ⊤ dtype) and logs a `WARNING`, so an unmodeled dtype loses precision for that one parameter instead of killing the analysis.

This complements but is independent of the complex64/complex128 modeling in #472: modeling makes the *specific* complex64 case match the map; this fallback handles *any* future unmodeled dtype.

Validation note: this path isn't reachable from Ariadne's own pytest-entrypoint test harness (every currently-declared dtype is mapped, so line 1670 is unreachable in-suite), so there is no in-suite regression fixture; the validation is the consumer's `testSuppliedInputSignatureUnmodeledDType`. Full suite green.

Part of wala/ML#637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)