### PR TITLE
Skip constant-folding complex literals instead of crashing the front end

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3Loader.java
@@ -132,9 +132,18 @@ public class Python3Loader extends PythonLoader {
                 }
 
                 if (x.isNumberType()) {
-                  // If the result is a number, return its integer value.
-                  logger.info(() -> s + " -> " + x.asInt());
-                  return x.asInt();
+                  // A complex result is a number but not integer-foldable: PyComplex.asInt() raises
+                  // a TypeError (a PyException). Catch it and skip folding rather than letting it
+                  // abort the module's front-end translation, which would empty its entrypoint set
+                  // and crash the call graph. See wala/ML#642.
+                  try {
+                    int value = x.asInt();
+                    logger.info(() -> s + " -> " + value);
+                    return value;
+                  } catch (PyException e) {
+                    logger.log(WARNING, e, () -> "Could not fold to an integer: " + s);
+                    return null;
+                  }
                 }
                 return null;
               }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4831,17 +4831,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * A faithful copy of <a href="https://github.com/wala/ML/issues/637">wala/ML#637</a>'s example,
+   * Regression guard for <a href="https://github.com/wala/ML/issues/642">wala/ML#642</a>: a
+   * faithful copy of <a href="https://github.com/wala/ML/issues/637">wala/ML#637</a>'s example,
    * {@code tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)}. The complex literal ({@code 2j})
-   * currently breaks call-graph entrypoint creation, so building it aborts with an empty entrypoint
-   * set rather than typing {@code consume}'s parameter.
-   *
-   * <p>TODO: remove {@code expected = IllegalStateException.class} once the front-end translates
-   * complex literals (<a href="https://github.com/wala/ML/issues/642">wala/ML#642</a>). The dtype
-   * is already modeled, so {@code consume}'s parameter should then type to {@code (2,)} complex64
-   * (as in {@link #testConstantComplex64()}).
+   * folds to a {@code PyComplex} whose {@code asInt()} raises a TypeError; before wala/ML#642 that
+   * uncaught exception aborted the module's front-end translation and emptied its entrypoint set.
+   * The front end now skips folding it, so the constant builds and types {@code consume}'s
+   * parameter to complex64. The shape is unknown (⊤) rather than {@code (2,)}: skipping the fold
+   * leaves the list elements non-constant, so the size isn't recovered (the integer-valued {@link
+   * #testConstantComplex64()} still gets {@code (2,)}). TODO: recover the shape, tracked by <a
+   * href="https://github.com/wala/ML/issues/644">wala/ML#644</a>.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testComplexLiteralEntrypoint()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -4849,7 +4850,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TensorType.of(COMPLEX_64, 2))));
+        Map.of(2, Set.of(new TensorType(COMPLEX64, null))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_complex_literal.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_complex_literal.py
@@ -5,10 +5,10 @@ def consume(x):
     pass
 
 
-# wala/ML#637's example verbatim: a `complex64` constant built from complex literals. The `2j`
-# literal currently breaks call-graph entrypoint creation (wala/ML#642), so this aborts with an
-# empty entrypoint set; the companion `tf2_test_complex64.py` uses integer values to isolate the
-# dtype modeling.
+# wala/ML#637's example verbatim: a `complex64` constant built from complex literals. The front end
+# skips constant-folding the `2j` literal (wala/ML#642) instead of aborting the module, so this
+# builds and types normally; the companion `tf2_test_complex64.py` uses integer values to isolate
+# the dtype modeling.
 z = tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)
 assert z.shape == (2,)
 assert z.dtype == tf.complex64


### PR DESCRIPTION
The constant folder evaluated a complex literal (`1 + 2j`) to a `PyComplex` and called `asInt()` on it, which raises a TypeError (`can't convert complex to long`). That call sat outside the try, so the uncaught `PyException` aborted the module's front-end translation and emptied its entrypoint set, crashing the call graph with `Could not create a entrypoint callsites`. Catch it and skip folding the literal, degrading like the eval-error path (wala/ML#640).

This is the actual cause of the entrypoint crash reported against a complex64 `input_signature` (wala/ML#637): the subject's `tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64)` crashes on the `1 + 2j` literal, not the dtype. The same `input_signature` with non-complex literals builds fine.

`testComplexLiteralEntrypoint` flips from a crash guard to a positive guard: the constant now types `consume`'s parameter to complex64. Its shape is unknown (⊤) rather than `(2,)` because the unfolded list size isn't recovered, tracked separately by wala/ML#644.

Fixes wala/ML#642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)