### PR TITLE
Model `tf.sparse.to_dense` to type its dense result from the `SparseTensor` operand

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4599,15 +4599,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * — the dehybridization — even though the stubbed body and the in-memory minimal reaches type
    * them.
    *
-   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped by {@code
-   * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type, which
-   * flows through the unmodeled {@code tf.sparse.to_dense} / {@code VarLenFeature} (the modeled
-   * {@code from_tensor_slices} the negative ladder used types it; see {@link
-   * #testSparseToDense()}). {@code pred}'s absence is the model body. Analyzed statically here,
-   * like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped in {@code
+   * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type. {@code
+   * tf.sparse.to_dense} is now modeled (see {@link #testSparseToDense()}), but the chain still dies
+   * one step earlier, at {@code tf.io.parse_single_example} / {@code VarLenFeature}, which Ariadne
+   * does not type as a SparseTensor — so {@code to_dense} reads ⊤ there (wala/ML#645). {@code
+   * pred}'s absence is the model body. Analyzed statically here, like the consumer's vendoring; it
+   * runs in the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: pins the current absent state (0/0); flips when wala/ML#618's residual is fixed.
-   * Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * <p>TODO: pins the current absent state (0/0); {@code real} flips once wala/ML#645 types the
+   * parsed SparseTensor, {@code pred} once the model body does. Tracked by <a
+   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4630,20 +4632,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Confirms wala/ML#618's data-pipeline localization: a {@code tf.sparse.to_dense} of a {@code
-   * SparseTensor} (the construct {@code parse_example} feeds the dataset element through) is
-   * untyped, so {@code consume}'s parameter is absent (0 tensor parameters). The unmodeled sparse
-   * densification path is therefore the type-dropper that strands {@code get_loss}'s {@code real}
-   * (the dataset-sourced {@code targets}) in {@link #testGpt2GetLossVendored()}.
-   *
-   * <p>TODO: pins the current absent state (0/0); flips when {@code tf.sparse.to_dense} (and/or
-   * {@code VarLenFeature}) is modeled. Tracked by <a
-   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * Regression guard for wala/ML#618's data-pipeline fix: {@code tf.sparse.to_dense} of a {@code
+   * SparseTensor} types its dense result from the operand's {@code dense_shape} field (shape) and
+   * {@code values} field (dtype), so {@code consume}'s parameter types to {@code (2,2)} int32.
+   * Modeling this is what un-strands {@code get_loss}'s {@code real} (the dataset-sourced {@code
+   * targets}) in {@link #testGpt2GetLossVendored()}.
    */
   @Test
   public void testSparseToDense()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_sparse_to_dense.py", "consume", 0, 0, Map.of());
+    test(
+        "tf2_test_sparse_to_dense.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2, 2))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -742,6 +742,9 @@
         <new def="sparse_from_dense" class="Ltensorflow/functions/sparse_from_dense"/>
         <putfield class="LRoot" field="from_dense" fieldType="LRoot" ref="sparse" value="sparse_from_dense"/>
         <putfield class="LRoot" field="sparse_from_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_from_dense"/>
+        <new def="sparse_to_dense" class="Ltensorflow/functions/sparse_to_dense"/>
+        <putfield class="LRoot" field="to_dense" fieldType="LRoot" ref="sparse" value="sparse_to_dense"/>
+        <putfield class="LRoot" field="sparse_to_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_to_dense"/>
         <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor"/>
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor"/>
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops" value="convert_to_tensor"/>
@@ -1804,6 +1807,13 @@
       <class name="sparse_from_dense" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/from_dense. Fresh allocation, not pass-through; shape and dtype inheritance from the `tensor` argument lives in the `SparseFromDense` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="sparse_to_dense" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense. Fresh allocation, not pass-through; the dense result's shape (from `dense_shape`) and dtype (from `values`) of the `sp_input` SparseTensor are inferred in the `SparseToDense` generator. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self sp_input default_value validate_indices name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
@@ -1,0 +1,82 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A generator for the dense tensor produced by {@code tf.sparse.to_dense}. The dense result has the
+ * same shape and dtype as the {@code sp_input} SparseTensor operand (the operand's {@code
+ * dense_shape} and {@code values} dtype), so they are read from the operand's value number via the
+ * recursive {@link #getShapes}/{@link #getDTypes} resolution — which, unlike a direct points-to-set
+ * read, is unaffected by the operand's frequently-empty PTS. Unlike its operand, the result is
+ * dense.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense">tf.sparse.to_dense</a>.
+ */
+public class SparseToDense extends TensorTypeAllocator {
+
+  protected enum Parameters {
+    SP_INPUT,
+    DEFAULT_VALUE,
+    VALIDATE_INDICES,
+    NAME;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public SparseToDense(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /** The dense result's shape is the {@code sp_input} SparseTensor's (its {@code dense_shape}). */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    int spValueNumber =
+        this.getArgumentValueNumber(
+            builder, Parameters.SP_INPUT.getIndex(), Parameters.SP_INPUT.getName(), false);
+    return this.getShapes(builder, spValueNumber);
+  }
+
+  /** The dense result's dtype is the {@code sp_input} SparseTensor's (its {@code values} dtype). */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    int spValueNumber =
+        this.getArgumentValueNumber(
+            builder, Parameters.SP_INPUT.getIndex(), Parameters.SP_INPUT.getName(), false);
+    return this.getDTypes(builder, spValueNumber);
+  }
+
+  /** No explicit shape argument; the shape comes from the {@code sp_input} operand. */
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  /** No explicit dtype argument; the dtype comes from the {@code sp_input} operand. */
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -170,6 +170,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_FROM_DENSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TO_DENSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQRT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUARE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUEEZE;
@@ -1119,6 +1120,8 @@ public class TensorGeneratorFactory {
     } else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
     else if (isType(calledFunction, SPARSE_FROM_DENSE.getDeclaringClass()))
       return new SparseFromDense(source);
+    else if (isType(calledFunction, SPARSE_TO_DENSE.getDeclaringClass()))
+      return new SparseToDense(source);
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);
     else if (isType(calledFunction, TENSOR.getDeclaringClass())
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -570,6 +570,16 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String SPARSE_FROM_DENSE_SIGNATURE = "tf.sparse.from_dense()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense. */
+  public static final MethodReference SPARSE_TO_DENSE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/sparse_to_dense")),
+          AstMethodReference.fnSelector);
+
+  private static final String SPARSE_TO_DENSE_SIGNATURE = "tf.sparse.to_dense()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gamma. */
   public static final MethodReference GAMMA =
       MethodReference.findOrCreate(
@@ -1934,6 +1944,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SPARSE_EYE.getDeclaringClass(), SPARSE_EYE_SIGNATURE),
           Map.entry(SPARSE_ADD.getDeclaringClass(), SPARSE_ADD_SIGNATURE),
           Map.entry(SPARSE_FROM_DENSE.getDeclaringClass(), SPARSE_FROM_DENSE_SIGNATURE),
+          Map.entry(SPARSE_TO_DENSE.getDeclaringClass(), SPARSE_TO_DENSE_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONE_HOT.getDeclaringClass(), ONE_HOT_SIGNATURE),


### PR DESCRIPTION
`tf.sparse.to_dense` produces a dense tensor with the same shape and dtype as its `sp_input` SparseTensor operand (the operand's `dense_shape` and `values` dtype). This adds the `tensorflow.xml` summary, the `SPARSE_TO_DENSE` method reference and factory dispatch, and the `SparseToDense` generator, which reads the operand's shape/dtype via `getShapes`/`getDTypes` on its value number. That path is robust to the operand's frequently-empty points-to set, where a direct field read returns empty.

`testSparseToDense` flips from 0/0 to `(2,2)` int32. This is the first half of wala/ML#618's real-half data-pipeline gap. The gpt-2 subject (`testGpt2GetLossVendored`) still strands `real` because the chain dies one step earlier, at `tf.io.parse_single_example`/`VarLenFeature` (filed wala/ML#645).

Part of wala/ML#618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)