### PR TITLE
Model `tf.io.VarLenFeature` and register the `tf.io.*` parsing APIs under `io`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4654,8 +4654,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for wala/ML#645: {@code tf.io.VarLenFeature(dtype)} models the SparseTensor a
    * variable-length feature parses to, so {@code tf.sparse.to_dense} of it types from the feature's
-   * dtype (dynamic shape, {@code int64}). The {@code io}-registration fix makes {@code tf.io.*}
-   * resolve at all (they were registered under {@code tf}, not the {@code io} object).
+   * dtype ({@code int64}). The {@code io}-registration fix makes {@code tf.io.*} resolve at all
+   * (they were registered under {@code tf}, not the {@code io} object).
+   *
+   * <p>TODO: the shape is unknown (⊤) rather than a dynamic rank-1 shape; only the dtype is
+   * recovered. Tracked by <a href="https://github.com/wala/ML/issues/647">wala/ML#647</a>.
    */
   @Test
   public void testVarLenFeature()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4601,14 +4601,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    *
    * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped in {@code
    * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type. {@code
-   * tf.sparse.to_dense} is now modeled (see {@link #testSparseToDense()}), but the chain still dies
-   * one step earlier, at {@code tf.io.parse_single_example} / {@code VarLenFeature}, which Ariadne
-   * does not type as a SparseTensor — so {@code to_dense} reads ⊤ there (wala/ML#645). {@code
-   * pred}'s absence is the model body. Analyzed statically here, like the consumer's vendoring; it
-   * runs in the perf-eval with its tfrecord/data setup.
+   * tf.sparse.to_dense} and {@code tf.io.VarLenFeature} are now modeled (see {@link
+   * #testSparseToDense()}, {@link #testVarLenFeature()}), but the chain dies at the dict subscript:
+   * {@code parse_single_example} returns its feature dict and {@code parsed["targets"]} reads back
+   * nothing, because the SparseTensor result carries an empty points-to set that does not survive a
+   * dict {@code putfield}/{@code getfield} (wala/ML#646, pinned by {@link
+   * #testParseSingleExample()}). {@code pred}'s absence is the model body. Analyzed statically
+   * here, like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: pins the current absent state (0/0); {@code real} flips once wala/ML#645 types the
-   * parsed SparseTensor, {@code pred} once the model body does. Tracked by <a
+   * <p>TODO: pins the current absent state (0/0); {@code real} flips once wala/ML#646 lets the
+   * SparseTensor survive the dict, {@code pred} once the model body types. Tracked by <a
    * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
@@ -4647,6 +4649,40 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(INT_32, 2, 2))));
+  }
+
+  /**
+   * Regression guard for wala/ML#645: {@code tf.io.VarLenFeature(dtype)} models the SparseTensor a
+   * variable-length feature parses to, so {@code tf.sparse.to_dense} of it types from the feature's
+   * dtype (dynamic shape, {@code int64}). The {@code io}-registration fix makes {@code tf.io.*}
+   * resolve at all (they were registered under {@code tf}, not the {@code io} object).
+   */
+  @Test
+  public void testVarLenFeature()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_var_len_feature.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+  }
+
+  /**
+   * The realistic gpt-2 shape for wala/ML#645: a {@code VarLenFeature} in a feature dict, parsed by
+   * {@code tf.io.parse_single_example}, subscripted, and densified. {@code consume}'s parameter is
+   * currently untyped (0/0): the SparseTensor's empty points-to set does not survive the dict
+   * subscript, so {@code parsed["t"]} reads nothing (see {@link #testVarLenFeature()} for the
+   * direct case that does type).
+   *
+   * <p>TODO: pins the current untyped state; {@code consume} types once a SparseTensor result keeps
+   * a live PTS through a dict, tracked by <a
+   * href="https://github.com/wala/ML/issues/646">wala/ML#646</a>.
+   */
+  @Test
+  public void testParseSingleExample()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_parse_single_example.py", "consume", 0, 0, Map.of());
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4599,15 +4599,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * — the dehybridization — even though the stubbed body and the in-memory minimal reaches type
    * them.
    *
-   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped by {@code
-   * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type, which
-   * flows through the unmodeled {@code tf.sparse.to_dense} / {@code VarLenFeature} (the modeled
-   * {@code from_tensor_slices} the negative ladder used types it; see {@link
-   * #testSparseToDense()}). {@code pred}'s absence is the model body. Analyzed statically here,
-   * like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped in {@code
+   * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type. {@code
+   * tf.sparse.to_dense} is now modeled (see {@link #testSparseToDense()}), but the chain still dies
+   * one step earlier, at {@code tf.io.parse_single_example} / {@code VarLenFeature}, which Ariadne
+   * does not type as a SparseTensor — so {@code to_dense} reads ⊤ there (wala/ML#645). {@code
+   * pred}'s absence is the model body. Analyzed statically here, like the consumer's vendoring; it
+   * runs in the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: pins the current absent state (0/0); flips when wala/ML#618's residual is fixed.
-   * Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * <p>TODO: pins the current absent state (0/0); {@code real} flips once wala/ML#645 types the
+   * parsed SparseTensor, {@code pred} once the model body does. Tracked by <a
+   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4630,20 +4632,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Confirms wala/ML#618's data-pipeline localization: a {@code tf.sparse.to_dense} of a {@code
-   * SparseTensor} (the construct {@code parse_example} feeds the dataset element through) is
-   * untyped, so {@code consume}'s parameter is absent (0 tensor parameters). The unmodeled sparse
-   * densification path is therefore the type-dropper that strands {@code get_loss}'s {@code real}
-   * (the dataset-sourced {@code targets}) in {@link #testGpt2GetLossVendored()}.
-   *
-   * <p>TODO: pins the current absent state (0/0); flips when {@code tf.sparse.to_dense} (and/or
-   * {@code VarLenFeature}) is modeled. Tracked by <a
-   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * Regression guard for wala/ML#618's data-pipeline fix: {@code tf.sparse.to_dense} of a {@code
+   * SparseTensor} types its dense result from the operand's {@code dense_shape} field (shape) and
+   * {@code values} field (dtype), so {@code consume}'s parameter types to {@code (2,2)} int32.
+   * Modeling this is what un-strands {@code get_loss}'s {@code real} (the dataset-sourced {@code
+   * targets}) in {@link #testGpt2GetLossVendored()}.
    */
   @Test
   public void testSparseToDense()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_sparse_to_dense.py", "consume", 0, 0, Map.of());
+    test(
+        "tf2_test_sparse_to_dense.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2, 2))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -742,6 +742,9 @@
         <new def="sparse_from_dense" class="Ltensorflow/functions/sparse_from_dense"/>
         <putfield class="LRoot" field="from_dense" fieldType="LRoot" ref="sparse" value="sparse_from_dense"/>
         <putfield class="LRoot" field="sparse_from_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_from_dense"/>
+        <new def="sparse_to_dense" class="Ltensorflow/functions/sparse_to_dense"/>
+        <putfield class="LRoot" field="to_dense" fieldType="LRoot" ref="sparse" value="sparse_to_dense"/>
+        <putfield class="LRoot" field="sparse_to_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_to_dense"/>
         <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor"/>
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor"/>
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops" value="convert_to_tensor"/>
@@ -1804,6 +1807,13 @@
       <class name="sparse_from_dense" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/from_dense. Fresh allocation, not pass-through; shape and dtype inheritance from the `tensor` argument lives in the `SparseFromDense` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="sparse_to_dense" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense. Fresh allocation, not pass-through; the dense result's shape (from `dense_shape`) and dtype (from `values`) of the `sp_input` SparseTensor are inferred in the `SparseToDense` generator. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self sp_input default_value validate_indices name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -68,6 +68,8 @@
         <putfield class="LRoot" field="parse_single_example" fieldType="LRoot" ref="x" value="parse_single_example"/>
         <new def="FixedLenFeature" class="Ltensorflow/functions/FixedLenFeature"/>
         <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="x" value="FixedLenFeature"/>
+        <new def="VarLenFeature" class="Ltensorflow/functions/VarLenFeature"/>
+        <putfield class="LRoot" field="VarLenFeature" fieldType="LRoot" ref="x" value="VarLenFeature"/>
         <new def="pass_through" class="Ltensorflow/functions/pass_through"/>
         <putfield class="LRoot" field="decode_raw" fieldType="LRoot" ref="x" value="pass_through"/>
         <new def="pass_through_rhs" class="Ltensorflow/functions/pass_through_rhs"/>
@@ -104,6 +106,10 @@
         <putfield class="LRoot" field="image" fieldType="LRoot" ref="x" value="image"/>
         <new def="io" class="Lobject"/>
         <putfield class="LRoot" field="io" fieldType="LRoot" ref="x" value="io"/>
+        <!-- The parsing APIs are `tf.io.*` (wala/ML#645); also expose them under the `io` object, not just `tf`. -->
+        <putfield class="LRoot" field="parse_single_example" fieldType="LRoot" ref="io" value="parse_single_example"/>
+        <putfield class="LRoot" field="FixedLenFeature" fieldType="LRoot" ref="io" value="FixedLenFeature"/>
+        <putfield class="LRoot" field="VarLenFeature" fieldType="LRoot" ref="io" value="VarLenFeature"/>
         <new def="strings" class="Lobject"/>
         <putfield class="LRoot" field="strings" fieldType="LRoot" ref="x" value="strings"/>
         <new def="as_string" class="Ltensorflow/strings/as_string"/>
@@ -2222,6 +2228,13 @@
           <new def="y" class="Ltensorflow/functions/set_shape"/>
           <putfield class="LRoot" field="set_shape" fieldType="LRoot" ref="x" value="y"/>
           <return value="x"/>
+        </method>
+      </class>
+      <class name="VarLenFeature" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/io/VarLenFeature. A variable-length feature parses to a sparse tensor; allocate a SparseTensor so the `VarLenFeature` generator can type the parsed value (dynamic shape, dtype from the `dtype` argument). See wala/ML#645. -->
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self dtype">
+          <new def="res" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="conv2d" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
@@ -1,0 +1,82 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A generator for the dense tensor produced by {@code tf.sparse.to_dense}. The dense result has the
+ * same shape and dtype as the {@code sp_input} SparseTensor operand (the operand's {@code
+ * dense_shape} and {@code values} dtype), so they are read from the operand's value number via the
+ * recursive {@link #getShapes}/{@link #getDTypes} resolution — which, unlike a direct points-to-set
+ * read, is unaffected by the operand's frequently-empty PTS. Unlike its operand, the result is
+ * dense.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense">tf.sparse.to_dense</a>.
+ */
+public class SparseToDense extends TensorTypeAllocator {
+
+  protected enum Parameters {
+    SP_INPUT,
+    DEFAULT_VALUE,
+    VALIDATE_INDICES,
+    NAME;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public SparseToDense(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /** The dense result's shape is the {@code sp_input} SparseTensor's (its {@code dense_shape}). */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    int spValueNumber =
+        this.getArgumentValueNumber(
+            builder, Parameters.SP_INPUT.getIndex(), Parameters.SP_INPUT.getName(), false);
+    return this.getShapes(builder, spValueNumber);
+  }
+
+  /** The dense result's dtype is the {@code sp_input} SparseTensor's (its {@code values} dtype). */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    int spValueNumber =
+        this.getArgumentValueNumber(
+            builder, Parameters.SP_INPUT.getIndex(), Parameters.SP_INPUT.getName(), false);
+    return this.getDTypes(builder, spValueNumber);
+  }
+
+  /** No explicit shape argument; the shape comes from the {@code sp_input} operand. */
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  /** No explicit dtype argument; the dtype comes from the {@code sp_input} operand. */
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -196,6 +196,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT_MEAN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.UNSORTED_SEGMENT_SUM;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.VARIABLE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.VAR_LEN_FEATURE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.WHERE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS_LIKE;
@@ -1122,6 +1123,8 @@ public class TensorGeneratorFactory {
       return new SparseFromDense(source);
     else if (isType(calledFunction, SPARSE_TO_DENSE.getDeclaringClass()))
       return new SparseToDense(source);
+    else if (isType(calledFunction, VAR_LEN_FEATURE.getDeclaringClass()))
+      return new VarLenFeature(source);
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);
     else if (isType(calledFunction, TENSOR.getDeclaringClass())
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -170,6 +170,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_EYE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_FROM_DENSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TO_DENSE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQRT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUARE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUEEZE;
@@ -1119,6 +1120,8 @@ public class TensorGeneratorFactory {
     } else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
     else if (isType(calledFunction, SPARSE_FROM_DENSE.getDeclaringClass()))
       return new SparseFromDense(source);
+    else if (isType(calledFunction, SPARSE_TO_DENSE.getDeclaringClass()))
+      return new SparseToDense(source);
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);
     else if (isType(calledFunction, TENSOR.getDeclaringClass())
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/VarLenFeature.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/VarLenFeature.java
@@ -1,0 +1,84 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A generator for the SparseTensor a {@code tf.io.VarLenFeature(dtype)} represents: when a
+ * variable-length feature is parsed (e.g. by {@code tf.io.parse_single_example}) it yields a {@code
+ * tf.sparse.SparseTensor} whose values carry the feature's dtype and whose dense shape is dynamic
+ * (⊤). Modeling it as that SparseTensor lets {@code parse_single_example} (a pass-through of its
+ * feature dict) and a downstream {@code tf.sparse.to_dense} type the parsed value (wala/ML#645).
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/io/VarLenFeature">tf.io.VarLenFeature</a>.
+ */
+public class VarLenFeature extends TensorTypeAllocator {
+
+  @Override
+  protected boolean producesSparseTensor() {
+    return true;
+  }
+
+  protected enum Parameters {
+    DTYPE;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public VarLenFeature(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /** Variable-length: the dense shape is dynamic (⊤). */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return null;
+  }
+
+  /** The dtype comes from the {@code dtype} argument. */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> pointsToSet =
+        this.getArgumentPointsToSet(
+            builder, Parameters.DTYPE.getIndex(), Parameters.DTYPE.getName());
+
+    if (pointsToSet == null || pointsToSet.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+
+    return this.getDTypesFromDTypeArgument(builder, pointsToSet);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return Parameters.DTYPE.getIndex();
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return Parameters.DTYPE.getName();
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -570,6 +570,16 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String SPARSE_FROM_DENSE_SIGNATURE = "tf.sparse.from_dense()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/sparse/to_dense. */
+  public static final MethodReference SPARSE_TO_DENSE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/sparse_to_dense")),
+          AstMethodReference.fnSelector);
+
+  private static final String SPARSE_TO_DENSE_SIGNATURE = "tf.sparse.to_dense()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gamma. */
   public static final MethodReference GAMMA =
       MethodReference.findOrCreate(
@@ -1934,6 +1944,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SPARSE_EYE.getDeclaringClass(), SPARSE_EYE_SIGNATURE),
           Map.entry(SPARSE_ADD.getDeclaringClass(), SPARSE_ADD_SIGNATURE),
           Map.entry(SPARSE_FROM_DENSE.getDeclaringClass(), SPARSE_FROM_DENSE_SIGNATURE),
+          Map.entry(SPARSE_TO_DENSE.getDeclaringClass(), SPARSE_TO_DENSE_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONE_HOT.getDeclaringClass(), ONE_HOT_SIGNATURE),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -580,6 +580,16 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String SPARSE_TO_DENSE_SIGNATURE = "tf.sparse.to_dense()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/io/VarLenFeature. */
+  public static final MethodReference VAR_LEN_FEATURE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/VarLenFeature")),
+          AstMethodReference.fnSelector);
+
+  private static final String VAR_LEN_FEATURE_SIGNATURE = "tf.io.VarLenFeature()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gamma. */
   public static final MethodReference GAMMA =
       MethodReference.findOrCreate(
@@ -1945,6 +1955,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SPARSE_ADD.getDeclaringClass(), SPARSE_ADD_SIGNATURE),
           Map.entry(SPARSE_FROM_DENSE.getDeclaringClass(), SPARSE_FROM_DENSE_SIGNATURE),
           Map.entry(SPARSE_TO_DENSE.getDeclaringClass(), SPARSE_TO_DENSE_SIGNATURE),
+          Map.entry(VAR_LEN_FEATURE.getDeclaringClass(), VAR_LEN_FEATURE_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONE_HOT.getDeclaringClass(), ONE_HOT_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
@@ -7,8 +7,14 @@ def consume(x):
 
 # The gpt-2 shape (wala/ML#645): a VarLenFeature in a feature dict, parsed, subscripted, densified.
 # Currently untyped: the SparseTensor's empty PTS does not survive the dict subscript (wala/ML#646).
+example = tf.train.Example(
+    features=tf.train.Features(
+        feature={"t": tf.train.Feature(int64_list=tf.train.Int64List(value=[1, 2]))}
+    )
+).SerializeToString()
 features = {"t": tf.io.VarLenFeature(tf.int64)}
-parsed = tf.io.parse_single_example(b"", features)
+parsed = tf.io.parse_single_example(example, features)
 d = tf.sparse.to_dense(parsed["t"])
+assert d.shape == (2,)
 assert d.dtype == tf.int64
 consume(d)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
@@ -10,4 +10,5 @@ def consume(x):
 features = {"t": tf.io.VarLenFeature(tf.int64)}
 parsed = tf.io.parse_single_example(b"", features)
 d = tf.sparse.to_dense(parsed["t"])
+assert d.dtype == tf.int64
 consume(d)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parse_single_example.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# The gpt-2 shape (wala/ML#645): a VarLenFeature in a feature dict, parsed, subscripted, densified.
+# Currently untyped: the SparseTensor's empty PTS does not survive the dict subscript (wala/ML#646).
+features = {"t": tf.io.VarLenFeature(tf.int64)}
+parsed = tf.io.parse_single_example(b"", features)
+d = tf.sparse.to_dense(parsed["t"])
+consume(d)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_var_len_feature.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_var_len_feature.py
@@ -5,7 +5,11 @@ def consume(x):
     pass
 
 
-# tf.io.VarLenFeature parses to a sparse tensor; densify it and check the dtype propagates (int64).
+# Static-analysis-only fixture: a VarLenFeature is a parse spec, not a sparse tensor, so
+# tf.sparse.to_dense(vf) is not valid at TF runtime and this file does not run to completion. It
+# exercises only Ariadne's modeling of the VarLenFeature -> SparseTensor -> to_dense path directly
+# (the runnable, realistic form is tf2_test_parse_single_example.py), so it carries no runtime
+# asserts. The modeled dtype propagates (int64).
 vf = tf.io.VarLenFeature(tf.int64)
 d = tf.sparse.to_dense(vf)
 consume(d)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_var_len_feature.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_var_len_feature.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# tf.io.VarLenFeature parses to a sparse tensor; densify it and check the dtype propagates (int64).
+vf = tf.io.VarLenFeature(tf.int64)
+d = tf.sparse.to_dense(vf)
+consume(d)


### PR DESCRIPTION
`tf.io.VarLenFeature(dtype)` now models the SparseTensor a variable-length feature parses to (the feature's dtype, a dynamic shape), so `tf.sparse.to_dense` of it types from the dtype (`testVarLenFeature`, ⊤ int64). It also registers `tf.io.parse_single_example`, `FixedLenFeature`, and `VarLenFeature` under the `io` object; they were registered under `tf` only, so `tf.io.*` did not resolve at all.

This is groundwork for wala/ML#645's gpt-2 real-half. It types the direct `to_dense(VarLenFeature)` case, but the realistic dict-based chain (`parse_single_example` then `parsed["t"]`) stays untyped (`testParseSingleExample`, 0/0) because a SparseTensor result carries an empty points-to set that does not survive a dict subscript. That is the actual blocker, filed as wala/ML#646.

Stacked on #476 (`tf.sparse.to_dense`); review/merge that first.

Part of wala/ML#645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)