### PR TITLE
Allocate `tf.sparse.SparseTensor` directly in `do()` so its result keeps a live PTS

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12706,4 +12706,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             })
         .collect(toList());
   }
+
+  /**
+   * Regression guard for wala/ML#646: a SparseTensor flows through a dict subscript ({@code
+   * features["t"]}) and keeps its type. {@code tf.sparse.SparseTensor} allocates directly in {@code
+   * do()} (the former {@code read_data} call was inlined), so the result carries a live points-to
+   * set that survives the dict {@code putfield}/{@code getfield}; the earlier empty PTS dropped it.
+   */
+  @Test
+  public void testSparseTensorThroughDict()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dict_subscript.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2, 2).asSparse())));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1771,12 +1771,9 @@
         </method>
       </class>
       <class name="SparseTensor" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor"/>
-          <return value="x"/>
-        </method>
+        <!-- Allocate directly in do() (inlining the former read_data synthetic call) so the result carries a live points-to set: the read_data call indirection left the do() result with an empty PTS, so a SparseTensor could not flow through a container such as a dict subscript (wala/ML#646). The alloc flows straight out via do()'s return, so inlining is seeding-safe (wala/ML#380). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self indices values dense_shape">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="x"/>
+          <new def="x" class="Ltensorflow/python/framework/sparse_tensor/SparseTensor"/>
           <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="indices"/>
           <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="values"/>
           <putfield class="LRoot" field="dense_shape" fieldType="LRoot" ref="x" value="dense_shape"/>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dict_subscript.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dict_subscript.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+sp = tf.sparse.SparseTensor(indices=[[0, 0], [1, 1]], values=[1, 2], dense_shape=[2, 2])
+features = {"t": sp}
+y = features["t"]
+consume(y)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dict_subscript.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dict_subscript.py
@@ -8,4 +8,6 @@ def consume(x):
 sp = tf.sparse.SparseTensor(indices=[[0, 0], [1, 1]], values=[1, 2], dense_shape=[2, 2])
 features = {"t": sp}
 y = features["t"]
+assert y.shape == (2, 2)
+assert y.dtype == tf.int32
 consume(y)


### PR DESCRIPTION
`tf.sparse.SparseTensor`'s `do()` called a separate `read_data` synthetic method to allocate the SparseTensor and then returned it. That call indirection left the `do()` result with an empty points-to set, so a SparseTensor could not flow through a container such as a dict subscript (`features["t"]`): the value the `putfield` stored was empty. Inlining the allocation into `do()` (like the sibling `sparse_eye`) gives the result a live PTS that survives the dict. `testSparseTensorThroughDict` guards it (`consume(features["t"])` types to `(2,2)` int32 sparse). The alloc flows straight out via `do()`'s return, so inlining is seeding-safe (wala/ML#380).

This is necessary but not sufficient for the gpt-2 `real`-half (wala/ML#618 via #645): the SparseTensor now survives the dict, but `VarLenFeature`'s SparseTensor still allocates bare (no `dense_shape`/`values` fields), so its dtype is lost through the dict subscript. That remaining piece is tracked separately.

Fixes wala/ML#646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)