### PR TITLE
Recover `tf.io.VarLenFeature` parsed-value types through feature dicts

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4612,13 +4612,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * int32 (pinned by {@link #testParseExampleTuple()}). What remains is the {@code
    * dataset.map(parse_example)} layer itself: the {@code map} model allocates a fresh {@code
    * Dataset} but never invokes {@code map_func} nor propagates its return as the mapped dataset's
-   * element type, so the iterated {@code targets} (and {@code get_loss}'s {@code real}) stay
-   * untyped. {@code pred}'s absence is the model body. Analyzed statically here, like the
-   * consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * element type (the dataset-callback gap tracked by <a
+   * href="https://github.com/wala/ML/issues/506">wala/ML#506</a>), so the iterated {@code targets}
+   * (and {@code get_loss}'s {@code real}) stay untyped. {@code pred}'s absence is the model body.
+   * Analyzed statically here, like the consumer's vendoring; it runs in the perf-eval with its
+   * tfrecord/data setup.
    *
    * <p>TODO: pins the current absent state (0/0); {@code real} flips once the {@code dataset.map}
-   * element type is propagated from {@code map_func}'s return, {@code pred} once the model body
-   * types. Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * element type is propagated from {@code map_func}'s return (wala/ML#506), {@code pred} once the
+   * model body types. Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
   public void testGpt2GetLossVendored()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -431,6 +431,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_INT64_UNKNOWN_SHAPE = new TensorType(INT_64, null);
 
+  private static final TensorType TENSOR_DYNAMIC_INT64 =
+      new TensorType(INT_64, asList(DynamicDim.INSTANCE));
+
   private static final TensorType TENSOR_INT32_UNKNOWN_SHAPE = new TensorType(INT_32, null);
 
   private static final TensorType TENSOR_1_0_0_9_INT32 = TensorType.of(INT_32, 1, 0, 0, 9);
@@ -4599,19 +4602,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * — the dehybridization — even though the stubbed body and the in-memory minimal reaches type
    * them.
    *
-   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is dropped in {@code
-   * input_fn}'s {@code tf.data.TFRecordDataset} + {@code .map(parse_example)} element type. {@code
-   * tf.sparse.to_dense} and {@code tf.io.VarLenFeature} are now modeled (see {@link
-   * #testSparseToDense()}, {@link #testVarLenFeature()}), but the chain dies at the dict subscript:
-   * {@code parse_single_example} returns its feature dict and {@code parsed["targets"]} reads back
-   * nothing, because the SparseTensor result carries an empty points-to set that does not survive a
-   * dict {@code putfield}/{@code getfield} (wala/ML#646, pinned by {@link
-   * #testParseSingleExample()}). {@code pred}'s absence is the model body. Analyzed statically
-   * here, like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is built in {@code
+   * input_fn} as {@code tf.data.TFRecordDataset(...).map(parse_example)}, where {@code
+   * parse_example} returns {@code (inputs, targets)} with each densified from a {@code
+   * tf.io.VarLenFeature} in a feature dict. That parse-and-densify sub-chain now types end to end:
+   * the VarLenFeature SparseTensor survives the dict (wala/ML#646), {@code tf.sparse.to_dense}
+   * resolves the dict-routed operand to {@code (?,)} int64 (pinned by {@link
+   * #testParseSingleExample()}), and the int32 cast plus tuple return carry it to {@code (?,)}
+   * int32 (pinned by {@link #testParseExampleTuple()}). What remains is the {@code
+   * dataset.map(parse_example)} layer itself: the {@code map} model allocates a fresh {@code
+   * Dataset} but never invokes {@code map_func} nor propagates its return as the mapped dataset's
+   * element type, so the iterated {@code targets} (and {@code get_loss}'s {@code real}) stay
+   * untyped. {@code pred}'s absence is the model body. Analyzed statically here, like the
+   * consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: pins the current absent state (0/0); {@code real} flips once wala/ML#646 lets the
-   * SparseTensor survive the dict, {@code pred} once the model body types. Tracked by <a
-   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
+   * <p>TODO: pins the current absent state (0/0); {@code real} flips once the {@code dataset.map}
+   * element type is propagated from {@code map_func}'s return, {@code pred} once the model body
+   * types. Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4654,38 +4661,59 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for wala/ML#645: {@code tf.io.VarLenFeature(dtype)} models the SparseTensor a
    * variable-length feature parses to, so {@code tf.sparse.to_dense} of it types from the feature's
-   * dtype ({@code int64}). The {@code io}-registration fix makes {@code tf.io.*} resolve at all
-   * (they were registered under {@code tf}, not the {@code io} object).
-   *
-   * <p>TODO: the shape is unknown (⊤) rather than a dynamic rank-1 shape; only the dtype is
-   * recovered. Tracked by <a href="https://github.com/wala/ML/issues/647">wala/ML#647</a>.
+   * dtype ({@code int64}) and the API-contract shape (rank-1 with a dynamic length, {@code (?,)}).
+   * The {@code io}-registration fix makes {@code tf.io.*} resolve at all (they were registered
+   * under {@code tf}, not the {@code io} object). The rank-1 dynamic shape is the contract-model
+   * refinement of wala/ML#647 (formerly ⊤).
    */
   @Test
   public void testVarLenFeature()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_var_len_feature.py",
-        "consume",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_INT64_UNKNOWN_SHAPE)));
+    test("tf2_test_var_len_feature.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_DYNAMIC_INT64)));
   }
 
   /**
    * The realistic gpt-2 shape for wala/ML#645: a {@code VarLenFeature} in a feature dict, parsed by
-   * {@code tf.io.parse_single_example}, subscripted, and densified. {@code consume}'s parameter is
-   * currently untyped (0/0): the SparseTensor's empty points-to set does not survive the dict
-   * subscript, so {@code parsed["t"]} reads nothing (see {@link #testVarLenFeature()} for the
-   * direct case that does type).
-   *
-   * <p>TODO: pins the current untyped state; {@code consume} types once a SparseTensor result keeps
-   * a live PTS through a dict, tracked by <a
-   * href="https://github.com/wala/ML/issues/646">wala/ML#646</a>.
+   * {@code tf.io.parse_single_example}, subscripted, and densified. {@code consume}'s parameter
+   * types to {@code (?,)} int64: the VarLenFeature SparseTensor now keeps a live points-to set
+   * through the dict {@code putfield}/{@code getfield} (wala/ML#646), and {@code
+   * tf.sparse.to_dense} resolves the dict-routed operand by dispatching the {@code VarLenFeature}
+   * generator at the SparseTensor's allocation site, recovering the feature's dtype and the rank-1
+   * dynamic (contract) shape. The static shape is {@code (?,)}, not the concrete {@code (2,)} the
+   * Python runtime produces, because the example's length is lost across the serialize/parse
+   * round-trip. This is the dict-routed companion to the direct {@link #testVarLenFeature()};
+   * together they un-strand {@code get_loss}'s {@code real} in {@link #testGpt2GetLossVendored()}.
    */
   @Test
   public void testParseSingleExample()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_parse_single_example.py", "consume", 0, 0, Map.of());
+    test(
+        "tf2_test_parse_single_example.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_DYNAMIC_INT64)));
+  }
+
+  /**
+   * Mirrors gpt-2's {@code parse_example} for wala/ML#618: a tuple return over two {@code
+   * tf.cast(tf.sparse.to_dense(parsed[k]), tf.int32)} values, each parsed from a {@code
+   * VarLenFeature} in a feature dict, but called directly (no {@code dataset.map}). The recovered
+   * {@code (?,)} int64 propagates through {@code to_dense}, the int32 cast, the tuple return, and
+   * the destructuring, so {@code consume}'s parameter ({@code targets}) types to {@code (?,)}
+   * int32. Together with {@link #testParseSingleExample()} this isolates the {@code dataset.map}
+   * element-type layer as the sole remaining gap for the full {@link #testGpt2GetLossVendored()}
+   * subject.
+   */
+  @Test
+  public void testParseExampleTuple()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_parse_example_tuple.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE)))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3397,6 +3397,15 @@ public abstract class TensorGenerator {
       return new Model(node);
     } else if (type.equals(TensorFlowTypes.INPUT.getDeclaringClass())) {
       return new Input(node);
+    } else if (type.equals(TensorFlowTypes.VAR_LEN_FEATURE.getDeclaringClass())) {
+      // The SparseTensor a `tf.io.VarLenFeature` parses to is allocated in `VarLenFeature.do()`.
+      // When
+      // it reaches a consumer (e.g. `tf.sparse.to_dense`) through a feature dict, the points-to
+      // walk
+      // lands here on the allocation site rather than the `tf.io.VarLenFeature` call, so dispatch
+      // the
+      // generator that reads the feature's `dtype` and emits the contract shape. wala/ML#646.
+      return new VarLenFeature(node);
     }
     // Unregistered type: the manual-walker dispatch table doesn't know about this op, so the
     // caller will treat the null return as "no contribution" and silently lose precision on

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/VarLenFeature.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/VarLenFeature.java
@@ -1,17 +1,27 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * A generator for the SparseTensor a {@code tf.io.VarLenFeature(dtype)} represents: when a
  * variable-length feature is parsed (e.g. by {@code tf.io.parse_single_example}) it yields a {@code
- * tf.sparse.SparseTensor} whose values carry the feature's dtype and whose dense shape is dynamic
- * (⊤). Modeling it as that SparseTensor lets {@code parse_single_example} (a pass-through of its
- * feature dict) and a downstream {@code tf.sparse.to_dense} type the parsed value (wala/ML#645).
+ * tf.sparse.SparseTensor} whose values carry the feature's dtype and whose dense shape is rank-1
+ * with a dynamic length. Modeling it as that SparseTensor lets {@code parse_single_example} (a
+ * pass-through of its feature dict) and a downstream {@code tf.sparse.to_dense} type the parsed
+ * value (wala/ML#645).
  *
  * <p>{@code dtype} is the sole argument and there is no {@code shape} argument, so the base {@link
- * TensorTypeAllocator} reads the dtype slot and falls to its ⊤-shape default.
+ * TensorTypeAllocator}'s dtype slot is read while the shape comes from the API contract (see {@link
+ * #getDefaultShapes}).
  *
  * @see <a
  *     href="https://www.tensorflow.org/api_docs/python/tf/io/VarLenFeature">tf.io.VarLenFeature</a>.
@@ -39,7 +49,41 @@ public class VarLenFeature extends TensorTypeAllocator {
     super(source);
   }
 
-  /** No {@code shape} argument: a variable-length feature has a dynamic (⊤) dense shape. */
+  /**
+   * Constructs a manual-node generator for the SparseTensor allocated in {@code
+   * VarLenFeature.do()}. Used by {@link TensorGenerator#createManualGenerator(CGNode,
+   * PropagationCallGraphBuilder)} when that SparseTensor reaches a consumer (e.g. {@code
+   * tf.sparse.to_dense}) through a container such as a feature dict, where the points-to walk lands
+   * on the allocation site rather than the {@code tf.io.VarLenFeature} call. Reads the feature's
+   * {@code dtype} from the {@code do()} method's parameter (wala/ML#646).
+   *
+   * @param node The {@code VarLenFeature.do()} call-graph node that allocated the SparseTensor.
+   */
+  public VarLenFeature(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * Returns the rank-1 shape {@code (?,)} that the {@code VarLenFeature} API contract guarantees,
+   * rather than ⊤. A variable-length feature parses to a sparse tensor with one axis whose length
+   * varies per example, so the rank (1) is statically known even though the single dimension is
+   * dynamic. This is a contract-model refinement, not a recovered argument: there is no {@code
+   * shape} argument to read, but the API's documented behavior fixes the rank. {@link DynamicDim}
+   * marks the dynamic axis, the same single-dynamic-axis idiom {@code tf.range} uses (wala/ML#647).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return A single rank-1 shape with a {@link DynamicDim} length.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    List<Dimension<?>> rank1 = new ArrayList<>();
+    rank1.add(DynamicDim.INSTANCE);
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    ret.add(rank1);
+    return ret;
+  }
+
+  /** No {@code shape} argument: the dense shape comes from the API contract, not an argument. */
   @Override
   protected int getShapeParameterPosition() {
     return UNDEFINED_PARAMETER_POSITION;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_parse_example_tuple.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parse_example_tuple.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# Mirrors gpt-2's parse_example (tuple return + cast over a VarLenFeature-through-dict to_dense),
+# but called DIRECTLY (no dataset.map): the recovered (?,) int64 propagates through to_dense, the
+# int32 cast, the tuple return, and the destructuring, so targets types to (?,) int32. Isolates the
+# dataset.map element-type layer as the sole remaining gap for the full gpt-2 subject (wala/ML#618).
+# Static-analysis-only (a VarLenFeature is a parse spec, not a runtime sparse tensor).
+def parse_example(serialized):
+    data_fields = {
+        "inputs": tf.io.VarLenFeature(tf.int64),
+        "targets": tf.io.VarLenFeature(tf.int64),
+    }
+    parsed = tf.io.parse_single_example(serialized, data_fields)
+    inputs = tf.sparse.to_dense(parsed["inputs"])
+    targets = tf.sparse.to_dense(parsed["targets"])
+    inputs = tf.cast(inputs, tf.int32)
+    targets = tf.cast(targets, tf.int32)
+    return inputs, targets
+
+
+inp, tar = parse_example("")
+consume(tar)


### PR DESCRIPTION
A `tf.io.VarLenFeature(dtype)` models the `SparseTensor` a variable-length feature parses to. Two refinements let its recovered type reach a downstream `tf.sparse.to_dense`, including when the SparseTensor is routed through a feature dict (the realistic gpt-2 shape from wala/ML#618).

## Rank-1 Dynamic Contract Shape (Closes wala/ML#647)

`VarLenFeature.getDefaultShapes` now emits `(?,)`, a single `DynamicDim`, instead of falling to the `TensorTypeAllocator` top-shape default. The API contract fixes the rank (1) even though the one axis varies per example, so the rank-1 dynamic shape is the right floor, not top. `testVarLenFeature` now types `(?,)` int64.

## Dict-Routed Dispatch (Advances wala/ML#618)

When the VarLenFeature SparseTensor reaches `to_dense` through a feature dict, the points-to walk lands on the `VarLenFeature.do()` allocation site rather than the `tf.io.VarLenFeature` call. `createManualGenerator` had no case for that declaring class, so it returned null and the feature's dtype was lost. Adding the case (plus a `CGNode` constructor) lets the dict-routed operand recover the dtype and the rank-1 shape.

- `testParseSingleExample` now types `(?,)` int64 (was untyped), the `VarLenFeature`/feature-dict/`parse_single_example`/subscript/`to_dense` chain.
- `testParseExampleTuple` pins the `tf.cast` and tuple-return layer at `(?,)` int32 and isolates the `dataset.map` element-type propagation as the sole remaining gap for `get_loss`'s `real` in `testGpt2GetLossVendored`.

The static shape is `(?,)`, not the concrete `(2,)` the runtime produces, because the example length is lost across the serialize/parse round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)