### PR TITLE
Run the `parse_example` tuple fixture with a real example and assert its types

### DIFF
--- a/com.ibm.wala.cast.python.test/data/tf2_test_parse_example_tuple.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parse_example_tuple.py
@@ -6,10 +6,9 @@ def consume(x):
 
 
 # Mirrors gpt-2's parse_example (tuple return + cast over a VarLenFeature-through-dict to_dense),
-# but called DIRECTLY (no dataset.map): the recovered (?,) int64 propagates through to_dense, the
-# int32 cast, the tuple return, and the destructuring, so targets types to (?,) int32. Isolates the
+# but called DIRECTLY (no dataset.map): the recovered dynamic int64 propagates through to_dense, the
+# int32 cast, the tuple return, and the destructuring, so targets types to int32. Isolates the
 # dataset.map element-type layer as the sole remaining gap for the full gpt-2 subject (wala/ML#618).
-# Static-analysis-only (a VarLenFeature is a parse spec, not a runtime sparse tensor).
 def parse_example(serialized):
     data_fields = {
         "inputs": tf.io.VarLenFeature(tf.int64),
@@ -23,5 +22,18 @@ def parse_example(serialized):
     return inputs, targets
 
 
-inp, tar = parse_example("")
+example = tf.train.Example(
+    features=tf.train.Features(
+        feature={
+            "inputs": tf.train.Feature(int64_list=tf.train.Int64List(value=[1, 2])),
+            "targets": tf.train.Feature(int64_list=tf.train.Int64List(value=[3, 4, 5])),
+        }
+    )
+).SerializeToString()
+inp, tar = parse_example(example)
+# The runtime shape is the concrete (3,) from the example; the static analysis recovers only the
+# rank-1 dynamic (?,), since the variable-length feature's length is lost across the serialize/parse
+# round-trip. The dtype is int32 after the cast.
+assert tar.shape == (3,)
+assert tar.dtype == tf.int32
 consume(tar)


### PR DESCRIPTION
Follow-up to #479. The `tf2_test_parse_example_tuple.py` fixture was mislabeled static-only and called `parse_example("")`, so it carried no tensor-type assertions (flagged in review).

A `tf.io.VarLenFeature` parsed by `tf.io.parse_single_example` does yield a runnable sparse tensor, as `tf2_test_parse_single_example.py` already shows. The fixture now feeds a real `tf.train.Example` with `inputs` and `targets` features, runs to completion under `python3.10`, and asserts that `targets` densifies and casts to `(3,)` int32 at runtime.

The static analysis still recovers `(?,)` int32, since the variable-length feature's length is lost across the serialize/parse round-trip, matching `testParseExampleTuple`. This is the same documented static-versus-runtime divergence as `tf2_test_parse_single_example.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)