### PR TITLE
Type a `tf.data.Dataset` read back from a list when iterated

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4769,6 +4769,40 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for wala/ML#648: a {@code tf.data.Dataset} stored in a list and read back
+   * ({@code [ds, ds][0]}) keeps its element type when iterated. The element lowers to {@code
+   * d[iterator]}, a property read whose receiver came from a list getfield, so the def-chain alone
+   * resolves the list, not the dataset; the fix recovers the dataset from the element at the
+   * constant index and seeds the read off the receiver's points-to set. {@code consume}'s parameter
+   * types to the sliced element {@code (4,)} float32.
+   */
+  @Test
+  public void testDatasetInList()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_in_list.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4))));
+  }
+
+  /**
+   * The gpt-2 {@code fit}-side shape for wala/ML#618, end to end: a mapped dataset passed in a list
+   * ({@code fit([ds, ds])}), list-unpacked, iterated with {@code enumerate} and nested unpacking,
+   * then forwarded through an indirected callback into {@code get_loss}. {@code real} (the second
+   * mapped tuple component) types to {@code (4,)} int64, exercising wala/ML#648 (dataset through a
+   * list) together with wala/ML#506 (the {@code map} tuple element). The full vendored subject
+   * ({@link #testGpt2GetLossVendored()}) additionally chains {@code padded_batch}/{@code repeat}/
+   * {@code prefetch} behind an {@code input_fn} return, which still loses the transformation chain.
+   */
+  @Test
+  public void testFitLoop()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_fit_loop.py", "consume", 1, 1, Map.of(2, Set.of(TensorType.of(INT_64, 4))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: {@code
    * strategy.run(fn, (a, b))} forwards both elements of the positional {@code args} tuple into the
    * two-parameter callback {@code step_fn(inp, tar)}, not just the first. Both {@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -400,8 +400,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               || def instanceof PythonPropertyRead
               || def instanceof PythonInvokeInstruction) {
             boolean added = false;
+
+            // When the iterated object itself came from a container read (its def is a property
+            // read, e.g. `d = [ds, other][0]`), it may point directly to a dataset. Check its
+            // points-to set before the def-chain walk below, which would otherwise climb to the
+            // container and miss the dataset. Gated to dataset instances inside, and only on this
+            // container-read shape, so attribute reads on a direct dataset are unaffected.
+            // wala/ML#648.
+            if (def instanceof PythonPropertyRead) {
+              added =
+                  processInstructionInterprocedurally(
+                      propertyRead, objectRef, localPointerKeyNode, src, sources, pointerAnalysis);
+            }
+
             // we may be invoking `next()` on a dataset.
-            if (def instanceof SSAAbstractInvokeInstruction && def.getNumberOfUses() > 1) {
+            if (!added
+                && def instanceof SSAAbstractInvokeInstruction
+                && def.getNumberOfUses() > 1) {
               SSAAbstractInvokeInstruction invokeInstruction = (SSAAbstractInvokeInstruction) def;
               added =
                   processInstruction(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -469,7 +469,8 @@ public class TensorGeneratorFactory {
    * then the container instance's field (interprocedural, when populated in another node). Mirrors
    * {@code DatasetChooseFromDatasetsGenerator}'s list-element extraction. wala/ML#648.
    *
-   * @param containerSrc The list/tuple the dataset was read from.
+   * @param node The {@link CGNode} containing the container read.
+   * @param containerVn The value number of the list/tuple the dataset was read from.
    * @param index The element index read.
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param visited The recursion guard threaded through {@link #tryGetGenerator}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -203,9 +203,11 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ZEROS_LIKE;
 import static com.ibm.wala.cast.python.types.PythonTypes.SLICE_BUILTIN;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.cast.python.util.Util.sanitize;
+import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import static java.util.Map.entry;
 import static java.util.logging.Logger.getLogger;
 
+import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
@@ -214,21 +216,26 @@ import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.python.util.Util;
 import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConcreteTypeKey;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
+import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.UnimplementedError;
@@ -449,6 +456,135 @@ public class TensorGeneratorFactory {
       LOGGER.log(Level.FINE, "Could not get points-to set for " + key, e);
       return null;
     }
+  }
+
+  /**
+   * Resolves a {@link DatasetGenerator} for a dataset stored at index {@code index} of a {@code
+   * list}/{@code tuple} and read back (e.g. {@code [ds_a, ds_b][0]} or a tuple unpack of a dataset
+   * pair). The def-chain alone misses it because the retrieved variable's def is a container
+   * getfield, not a dataset op. Unlike a points-to-set collapse (which keeps only the final dataset
+   * instance and loses the transformation chain), this recurses on the stored <em>variable</em>, so
+   * a chained dataset (e.g. {@code from_tensor_slices(...).map(...)}) keeps its full generator. Two
+   * paths: a local-IR scan of the container's property writes (intraprocedural, the precise case),
+   * then the container instance's field (interprocedural, when populated in another node). Mirrors
+   * {@code DatasetChooseFromDatasetsGenerator}'s list-element extraction. wala/ML#648.
+   *
+   * @param containerSrc The list/tuple the dataset was read from.
+   * @param index The element index read.
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param visited The recursion guard threaded through {@link #tryGetGenerator}.
+   * @return A {@link DatasetGenerator} for the stored dataset, or {@code null} if none is found.
+   */
+  private static TensorGenerator containerElementDatasetGenerator(
+      CGNode node,
+      int containerVn,
+      int index,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited) {
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+
+    // Path 1: the container was built locally; scan its property writes for the one at `index` and
+    // recurse on the stored value's variable, preserving the dataset's full generator chain. Works
+    // even when the container's pointer key is implicit (no materialized points-to set).
+    DefUse du = node.getDU();
+    if (du.getDef(containerVn) instanceof SSANewInstruction) {
+      for (Iterator<SSAInstruction> uses = du.getUses(containerVn); uses.hasNext(); ) {
+        SSAInstruction use = uses.next();
+        if (use instanceof AstPropertyWrite) {
+          AstPropertyWrite write = (AstPropertyWrite) use;
+          if (write.getObjectRef() == containerVn
+              && constantMemberEquals(node, write.getMemberRef(), index, builder)) {
+            PointsToSetVariable valueSrc =
+                getPointsToSetVariable(
+                    pa.getHeapModel().getPointerKeyForLocal(node, write.getValue()), builder);
+            TensorGenerator generator = tryGetGenerator(valueSrc, builder, visited);
+            if (generator instanceof DatasetGenerator) return generator;
+          }
+        }
+      }
+    }
+
+    // Path 2: the container was populated in another node; read its field instance directly.
+    PointerKey containerKey = pa.getHeapModel().getPointerKeyForLocal(node, containerVn);
+    for (InstanceKey ik : pa.getPointsToSet(containerKey)) {
+      AllocationSiteInNode asin;
+      try {
+        asin = getAllocationSiteInNode(ik);
+      } catch (IllegalArgumentException e) {
+        continue;
+      }
+      if (asin == null) continue;
+      TypeReference reference = asin.getConcreteType().getReference();
+      if (!reference.equals(PythonTypes.list) && !reference.equals(PythonTypes.tuple)) continue;
+      IField field =
+          builder
+              .getClassHierarchy()
+              .resolveField(
+                  FieldReference.findOrCreate(
+                      reference, findOrCreateAsciiAtom(Integer.toString(index)), PythonTypes.Root));
+      if (field == null) continue;
+      PointsToSetVariable fieldSrc =
+          getPointsToSetVariable(builder.getPointerKeyForInstanceField(asin, field), builder);
+      TensorGenerator generator = tryGetGenerator(fieldSrc, builder, visited);
+      if (generator instanceof DatasetGenerator) return generator;
+    }
+    return null;
+  }
+
+  /**
+   * Returns the constant integer the member reference of a property access resolves to, or {@code
+   * null} if it is not a single constant index.
+   *
+   * @param node The {@link CGNode} of the property access.
+   * @param memberRef The value number of the member reference.
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The constant index, or {@code null}.
+   */
+  private static Integer constantMemberIndex(
+      CGNode node, int memberRef, PropagationCallGraphBuilder builder) {
+    PointerKey memberKey =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, memberRef);
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(memberKey)) {
+      if (ik instanceof ConstantKey) {
+        Object value = ((ConstantKey<?>) ik).getValue();
+        if (value instanceof Integer) return (Integer) value;
+        if (value instanceof Long) return ((Long) value).intValue();
+        if (value instanceof String) {
+          try {
+            return Integer.parseInt((String) value);
+          } catch (NumberFormatException e) {
+            return null;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns whether the member reference of a property access resolves to the constant integer
+   * {@code index}.
+   *
+   * @param node The {@link CGNode} of the property access.
+   * @param memberRef The value number of the member reference.
+   * @param index The index to compare against.
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code true} iff the member reference is exactly the constant {@code index}.
+   */
+  private static boolean constantMemberEquals(
+      CGNode node, int memberRef, int index, PropagationCallGraphBuilder builder) {
+    PointerKey memberKey =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, memberRef);
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(memberKey)) {
+      if (ik instanceof ConstantKey) {
+        Object value = ((ConstantKey<?>) ik).getValue();
+        if (value instanceof Integer && (Integer) value == index) return true;
+        if (value instanceof Long && ((Long) value).intValue() == index) return true;
+        if (value instanceof String && ((String) value).equals(Integer.toString(index)))
+          return true;
+      }
+    }
+    return false;
   }
 
   private static boolean isNonTensorAttribute(String propertyName) {
@@ -893,6 +1029,21 @@ public class TensorGeneratorFactory {
         // from a dataset or tensor).
         PythonPropertyRead propRead = (PythonPropertyRead) def;
         int objRef = propRead.getObjectRef();
+
+        // The retrieved value may itself be a dataset stored in a list/tuple (e.g. `[ds_a,
+        // ds_b][0]`,
+        // or unpacking a `(train, test)` pair the `fit`-loop iterates). The def-chain resolves the
+        // container, not the dataset; recover the dataset's generator from the element at this
+        // constant index, preserving its transformation chain. Done before the `objSrc` guard below
+        // because a locally-built container often has an implicit (non-materialized) pointer key.
+        // wala/ML#648.
+        Integer listIndex = constantMemberIndex(node, propRead.getMemberRef(), builder);
+        if (listIndex != null) {
+          TensorGenerator elementDataset =
+              containerElementDatasetGenerator(node, objRef, listIndex, builder, visited);
+          if (elementDataset != null) return elementDataset;
+        }
+
         PointerKey objKey =
             builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, objRef);
         PointsToSetVariable objSrc = getPointsToSetVariable(objKey, builder);
@@ -1021,6 +1172,10 @@ public class TensorGeneratorFactory {
           return new NdarraySubscriptOperation(source);
         }
 
+        // The retrieved value may itself be a dataset stored in a list/tuple (e.g.
+        // `[ds_a, ds_b][0]`, or unpacking a `(train, test)` pair the `fit`-loop iterates). The
+        // def-chain resolves the container, not the dataset; recover the dataset's generator from
+        // the element at this index, preserving its transformation chain. wala/ML#648.
         // Similar to `EachElementGet`, we check if the container generator represents elements
         // (`Dataset`) or the tensor itself (peeling needed).
         if (propertyName == null || !isNonTensorAttribute(propertyName)) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_in_list.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_in_list.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# A dataset stored in a list and read back keeps its element type when iterated (wala/ML#648): each
+# sliced element of from_tensor_slices(ones([3, 4])) is (4,) float32.
+ds = tf.data.Dataset.from_tensor_slices(tf.ones([3, 4]))
+d = [ds, ds][0]
+for elem in d:
+    assert elem.shape == (4,)
+    assert elem.dtype == tf.float32
+    consume(elem)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_fit_loop.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_fit_loop.py
@@ -1,0 +1,35 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+def split(record):
+    a = tf.cast(record, tf.int32)
+    b = tf.cast(record, tf.int64)
+    return a, b
+
+
+def get_loss(real, pred):
+    assert real.shape == (4,)
+    assert real.dtype == tf.int64
+    consume(real)
+
+
+def train_step(inputs, targets):
+    get_loss(targets, inputs)
+
+
+# The gpt-2 fit-side shape (wala/ML#618): a mapped dataset passed in a list, list-unpacked, iterated
+# with enumerate and nested unpacking, then forwarded through an indirected callback into get_loss.
+# real = targets = the second mapped tuple component = (4,) int64 (wala/ML#648 + wala/ML#506).
+def fit(train_dataset):
+    train_dataset, test_dataset = train_dataset
+    train_fuc = train_step
+    for _, (inputs, targets) in enumerate(train_dataset):
+        train_fuc(inputs, targets)
+
+
+ds = tf.data.Dataset.from_tensor_slices(tf.ones([3, 4])).map(split)
+fit([ds, ds])


### PR DESCRIPTION
A dataset stored in a `list` and read back (`[ds, ds][0]`, or unpacking a `(train, test)` pair) lost its element type when iterated, so a tensor flowing out of the loop stayed untyped. This is the gpt-2 `fit`-side shape of wala/ML#618: `fit([_train, _test])` then `train_dataset, test_dataset = train_dataset`. Two coordinated gaps, both fixed.

## Generator Dispatch

`for elem in d` lowers the element to `d[iterator]`, a property read whose receiver `d` came from a list getfield, so the def-chain resolves the container, not the dataset. `TensorGeneratorFactory` now recovers the dataset's generator from the element at the constant index, recursing on the stored value's variable (a local-IR scan, then the container instance's field) so a chained dataset keeps its full generator rather than collapsing to the final instance's points-to set.

## Dataflow-Source Seeding

The iterated object's property read seeded the `EachElementGet` iterator keys, not the `d[iterator]` element the consumer reads, because it walked up `d`'s def-chain to the container instead of checking `d`'s own points-to set. `getDataflowSources` now checks the receiver's points-to set when it came from a container read, gated to that shape so attribute reads on a direct dataset are unaffected.

## Tests

- `testDatasetInList` pins the minimal case (`[ds, ds][0]`, element `(4,)` float32).
- `testFitLoop` pins the gpt-2 `fit`-side end to end: a mapped dataset in a list, list-unpack, `enumerate` with nested unpacking, an indirected callback, and `get_loss`, where `real` types to `(4,)` int64.

Advances wala/ML#618 and wala/ML#648. A dataset whose transformation chain is built behind an `input_fn` return and then listed still resolves to the base element type, so the full vendored `testGpt2GetLossVendored` subject is not yet typed; that chained-via-function-return sub-case remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)