### PR TITLE
Keep the mapped element type through a pass-through dataset transform

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4803,6 +4803,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for wala/ML#649: a pass-through transform after {@code map} keeps the mapped
+   * element type. {@code map(split).repeat(2)} yields the same {@code (int32, int64)} tuple
+   * elements as {@code map(split)}, so {@code y} types to {@code (4,)} int64. Before the fix,
+   * {@code repeat}'s receiver-inheritance resolved the {@code map} receiver to a plain {@code
+   * DatasetGenerator} (inheriting the upstream base), dropping {@code map_func}'s return; it now
+   * resolves to a {@code DatasetMapGenerator} reading the {@code element} field off the receiver
+   * instance.
+   */
+  @Test
+  public void testDatasetMapRepeat()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_map_repeat.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 4))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>: {@code
    * strategy.run(fn, (a, b))} forwards both elements of the positional {@code args} tuple into the
    * two-parameter callback {@code step_fn(inp, tar)}, not just the first. Both {@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
@@ -151,6 +151,20 @@ public class DatasetGenerator extends TensorGenerator implements TupleElementPro
       for (InstanceKey valueIK : receiverPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
         if (asin != null) {
+          // A mapped-dataset receiver is allocated in `map.do()` as a generic `Dataset`, so the
+          // default dispatch below would resolve it to a plain `DatasetGenerator` that inherits
+          // from
+          // `map.do()`'s own receiver (the upstream base), dropping `map_func`'s return. Resolve it
+          // to a `DatasetMapGenerator` reading the `element` field off this receiver instance so
+          // the
+          // mapped type survives a downstream pass-through transform. wala/ML#649.
+          if (asin.getNode()
+              .getMethod()
+              .getDeclaringClass()
+              .getReference()
+              .equals(TensorFlowTypes.DATASET_MAP_TYPE)) {
+            return new DatasetMapGenerator(asin.getNode(), asin);
+          }
           int vn = findDefinition(asin.getNode(), asin);
           if (vn > 0) {
             PointerKey pk =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
@@ -18,6 +18,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -35,12 +36,56 @@ public class DatasetMapGenerator extends DatasetGenerator {
   /** The field {@code map.do()} stores {@code map_func}'s return (the mapped element) into. */
   private static final String ELEMENT_FIELD = "element";
 
+  /**
+   * The specific mapped-dataset instance whose {@code element} field carries the mapped type, when
+   * this generator is resolved from a receiver instance rather than a source variable (e.g. a
+   * downstream {@code repeat}/{@code prefetch} inheriting from a {@code map} receiver). {@code
+   * null} for the source- and node-based constructions.
+   */
+  private final AllocationSiteInNode mapResultInstance;
+
   public DatasetMapGenerator(PointsToSetVariable source) {
     super(source);
+    this.mapResultInstance = null;
   }
 
   public DatasetMapGenerator(CGNode node) {
     super(node);
+    this.mapResultInstance = null;
+  }
+
+  /**
+   * Constructs a generator for a specific mapped-dataset instance, used when a downstream
+   * pass-through transform inherits its element type from a {@code map} receiver. The {@code
+   * element} field is read off {@code mapResultInstance} directly, so the mapped type survives the
+   * pass-through. wala/ML#649.
+   *
+   * @param node The {@code map.do()} node that allocated the instance.
+   * @param mapResultInstance The mapped-dataset instance carrying the {@code element} field.
+   */
+  public DatasetMapGenerator(CGNode node, AllocationSiteInNode mapResultInstance) {
+    super(node);
+    this.mapResultInstance = mapResultInstance;
+  }
+
+  /**
+   * Returns the instances whose {@code element} field holds the mapped type: the source variable's
+   * points-to set, or the single {@code mapResultInstance} when this generator was resolved from a
+   * receiver instance.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The mapped-dataset instances, or {@code null} if neither is available.
+   */
+  private OrdinalSet<InstanceKey> selfInstances(PropagationCallGraphBuilder builder) {
+    if (this.getSource() != null) {
+      return builder.getPointerAnalysis().getPointsToSet(this.getSource().getPointerKey());
+    }
+    if (this.mapResultInstance != null) {
+      return OrdinalSet.toOrdinalSet(
+          Collections.singleton((InstanceKey) this.mapResultInstance),
+          builder.getPointerAnalysis().getInstanceKeyMapping());
+    }
+    return null;
   }
 
   /**
@@ -51,9 +96,8 @@ public class DatasetMapGenerator extends DatasetGenerator {
    * @return The points-to set of the mapped element, or {@code null} if it cannot be resolved.
    */
   private OrdinalSet<InstanceKey> getMappedElementPointsToSet(PropagationCallGraphBuilder builder) {
-    if (this.getSource() == null) return null;
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
-    OrdinalSet<InstanceKey> selfPTS = pa.getPointsToSet(this.getSource().getPointerKey());
+    OrdinalSet<InstanceKey> selfPTS = selfInstances(builder);
     if (selfPTS == null || selfPTS.isEmpty()) return null;
 
     IField field =

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_map_repeat.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_map_repeat.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+def split(record):
+    a = tf.cast(record, tf.int32)
+    b = tf.cast(record, tf.int64)
+    return a, b
+
+
+ds = tf.data.Dataset.from_tensor_slices(tf.ones([3, 4])).map(split).repeat(2)
+for x, y in ds:
+    assert y.shape == (4,)
+    assert y.dtype == tf.int64
+    consume(y)


### PR DESCRIPTION
A pass-through transform (`repeat`, `prefetch`, ...) after `map` dropped the mapped element type. `DatasetGenerator`'s receiver-inheritance resolves the receiver to a generator, but a mapped-dataset receiver is allocated in `map.do()` as a generic `Dataset`, so it resolved to a plain `DatasetGenerator` that inherits from `map.do()`'s own receiver (the upstream base), discarding `map_func`'s return.

`getReceiverGenerator` now resolves a map-allocation receiver to a `DatasetMapGenerator` that reads the `element` field off that receiver instance, so the mapped type (and its per-index tuple components) survives downstream pass-through transforms, including chains. `DatasetMapGenerator` gains an instance-key construction for this, reading the `element` field from the given instance rather than a source variable's points-to set.

`testDatasetMapRepeat` pins `map(split).repeat(2)`, where the tuple element's second component still types to `(4,)` int64.

Advances wala/ML#649 and wala/ML#618. The full vendored `testGpt2GetLossVendored` subject (whose `input_fn` adds `padded_batch`/`prefetch` over a `TFRecordDataset` with a `VarLenFeature` `parse_example`) is still untyped; remaining layers are being localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)