### PR TITLE
Model `tf.data.TFRecordDataset` as a chainable dataset (types gpt-2 `get_loss`'s `real`)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4595,35 +4595,29 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Reproduces wala/ML#618's residual: the full subject from {@code akanyaani/gpt-2-tensorflow2.0}
-   * (a perf-eval corpus subject) vendored verbatim with the REAL transformer layers and {@code
-   * input_fn}, unlike the stubbed {@link #testGpt2InterprocGetLoss()}. Both {@code get_loss}'s
-   * {@code real} and {@code pred} are absent from the analysis (0 tensor parameters and variables)
-   * — the dehybridization — even though the stubbed body and the in-memory minimal reaches type
-   * them.
+   * The full subject from {@code akanyaani/gpt-2-tensorflow2.0} (a perf-eval corpus subject)
+   * vendored verbatim with the REAL transformer layers and {@code input_fn}, unlike the stubbed
+   * {@link #testGpt2InterprocGetLoss()}. {@code get_loss}'s {@code real} now types end to end
+   * (wala/ML#618), resolving the whole dataset-sourced chain that previously dehybridized it.
    *
-   * <p>The localization: {@code real} (the dataset-sourced {@code targets}) is built in {@code
-   * input_fn} as {@code tf.data.TFRecordDataset(...).map(parse_example)}, where {@code
-   * parse_example} returns {@code (inputs, targets)} with each densified from a {@code
-   * tf.io.VarLenFeature} in a feature dict. That parse-and-densify sub-chain now types end to end:
-   * the VarLenFeature SparseTensor survives the dict (wala/ML#646), {@code tf.sparse.to_dense}
-   * resolves the dict-routed operand to {@code (?,)} int64 (pinned by {@link
-   * #testParseSingleExample()}), and the int32 cast plus tuple return carry it to {@code (?,)}
-   * int32 (pinned by {@link #testParseExampleTuple()}). The {@code dataset.map(parse_example)}
-   * layer now types too (wala/ML#506): the mapped element is {@code map_func}'s {@code (inputs,
-   * targets)} return, and {@code enumerate} with nested unpacking resolves {@code targets} (pinned
-   * by {@link #testDatasetMap()}, {@link #testDatasetMapTuple()}, {@link
-   * #testDatasetMapEnumerate()}). What remains is the {@code fit}-side chain past the dataset:
-   * {@code input_fn}'s result is passed as a list {@code _model.fit([_train, _test], ...)} and
-   * list-unpacked, then forwarded through an indirected {@code train_fuc} into {@code train_step} →
-   * {@code _train_step} → {@code get_loss}; one of those hops still drops {@code targets} before it
-   * reaches {@code real}. {@code pred}'s absence is the model body. Analyzed statically here, like
+   * <p>The chain: {@code real} (the dataset-sourced {@code targets}) is built in {@code input_fn}
+   * as {@code
+   * tf.data.TFRecordDataset(...).map(parse_example).padded_batch(...).repeat(...).prefetch(...)},
+   * passed as a list {@code _model.fit([_train, _test], ...)}, list-unpacked, iterated with {@code
+   * enumerate} and nested unpacking, and forwarded through an indirected {@code train_fuc} into
+   * {@code train_step} → {@code _train_step} → {@code get_loss}. Each layer is modeled: {@code
+   * parse_example} densifies a {@code tf.io.VarLenFeature} through a dict to {@code (?,)} int32
+   * (wala/ML#646, pinned by {@link #testParseExampleTuple()}); {@code map} types the element from
+   * {@code map_func}'s return (wala/ML#506, {@link #testDatasetMapTuple()}); a pass-through
+   * transform after {@code map} keeps the mapped type (wala/ML#649, {@link
+   * #testDatasetMapRepeat()}); {@code TFRecordDataset} is chainable ({@link #testTfrecordMap()});
+   * the dataset survives the list (wala/ML#648, {@link #testFitLoop()}). So {@code real} resolves
+   * to {@code (?,)} int32.
+   *
+   * <p>{@code pred}'s absence (it stays a function-local, hence locals 1 not 2) is the model {@code
+   * __call__} body, tracked separately under <a
+   * href="https://github.com/wala/ML/issues/618">wala/ML#618</a>. Analyzed statically here, like
    * the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
-   *
-   * <p>TODO: pins the current absent state (0/0); {@code real} flips once the {@code fit}-side
-   * list-unpack and {@code train_fuc} forwarding carry the now-typed dataset element to {@code
-   * get_loss} (wala/ML#506 modeled the {@code map} layer), {@code pred} once the model body types.
-   * Tracked by <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a>.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4640,9 +4634,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "A.py",
         "Gpt2.get_loss",
         "gpt2_vendored",
-        0,
-        0,
-        Map.of());
+        1,
+        1,
+        Map.of(3, Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE)))));
   }
 
   /**
@@ -4820,6 +4814,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(INT_64, 4))));
+  }
+
+  /**
+   * Regression guard for wala/ML#618: {@code tf.data.TFRecordDataset(...)} is a chainable dataset,
+   * so {@code .map(parse_example)} resolves and the VarLenFeature-parsed {@code targets} types to
+   * {@code (?,)} int32. Previously {@code TFRecordDataset} was a bare {@code Dataset} field with no
+   * {@code do()}, so the chain did not resolve.
+   */
+  @Test
+  public void testTfrecordMap()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_tfrecord_map.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE)))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -166,7 +166,8 @@
         <new def="TextLineDataset" class="Ltensorflow/data/TextLineDataset"/>
         <putfield class="LRoot" field="TextLineDataset" fieldType="LRoot" ref="data" value="TextLineDataset"/>
         <!--https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset -->
-        <new def="TFRecordDataset" class="Ltensorflow/data/Dataset"/> <!-- FIXME: Should *extend* `Dataset` -->
+        <!-- Distinct class with a `do()` that allocates a fresh chainable dataset, so `tf.data.TFRecordDataset(...).map(...)` resolves the chain (it was a bare `Dataset` field with no `do()`). Mirrors `TextLineDataset`. wala/ML#618. -->
+        <new def="TFRecordDataset" class="Ltensorflow/data/TFRecordDataset"/>
         <putfield class="LRoot" field="TFRecordDataset" fieldType="LRoot" ref="data" value="TFRecordDataset"/>
         <new def="MirroredStrategy" class="Ltensorflow/distribute/MirroredStrategy"/>
         <putfield class="LRoot" field="MirroredStrategy" fieldType="LRoot" ref="distribute" value="MirroredStrategy"/>
@@ -2538,6 +2539,43 @@
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self filenames compression_type">
           <new def="x" class="Ltensorflow/data/TextLineDataset"/>
+          <!-- NOTE: This block of dataset field initializations is duplicated intentionally. See shuffle/do() for rationale. -->
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <return value="x"/>
+        </method>
+        <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="it" class="Ltensorflow/data/iterator"/>
+          <putfield class="LRoot" field="dataset" fieldType="LRoot" ref="it" value="self"/>
+          <return value="it"/>
+        </method>
+      </class>
+      <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset. A fresh chainable dataset per call site (parallel to TextLineDataset); its elements are serialized records, typically consumed by a `map(parse_*)` that derives its own types. The chain-method fields are bound on the new instance so `tf.data.TFRecordDataset(...).map(...).padded_batch(...)` chains resolve. wala/ML#618. -->
+      <class name="TFRecordDataset" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self filenames compression_type buffer_size num_parallel_reads name">
+          <new def="x" class="Ltensorflow/data/TFRecordDataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. See shuffle/do() for rationale. -->
           <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+def parse_example(serialized):
+    data_fields = {
+        "inputs": tf.io.VarLenFeature(tf.int64),
+        "targets": tf.io.VarLenFeature(tf.int64),
+    }
+    parsed = tf.io.parse_single_example(serialized, data_fields)
+    inputs = tf.cast(tf.sparse.to_dense(parsed["inputs"]), tf.int32)
+    targets = tf.cast(tf.sparse.to_dense(parsed["targets"]), tf.int32)
+    return inputs, targets
+
+
+# The gpt-2 input pipeline shape (wala/ML#618): a TFRecordDataset mapped by a VarLenFeature parser.
+# TFRecordDataset is now a chainable dataset, so .map resolves and the parsed targets type to
+# (?,) int32. Static-analysis-only (no real tfrecord at runtime).
+ds = tf.data.TFRecordDataset("x").map(parse_example)
+for inputs, targets in ds:
+    consume(targets)


### PR DESCRIPTION
`TFRecordDataset` was a bare `Dataset` field with no `do()` method, so `tf.data.TFRecordDataset(...).map(...)` did not resolve the transform chain. This gives it a distinct class with a `do()` that allocates a fresh chainable dataset and binds the transform-method fields, mirroring `TextLineDataset`.

## Completes the gpt-2 `real` Chain

This is the final piece of `get_loss`'s `real` for the vendored gpt-2 subject (wala/ML#618). `testGpt2GetLossVendored` now types `real` to `(?,)` int32 (1 tensor parameter, 1 local), where it was absent before. The full chain:

- wala/ML#479 — `VarLenFeature` densified through a feature dict.
- wala/ML#506 — the `map` callback's return becomes the element type.
- wala/ML#648 — the dataset survives storage in a list.
- wala/ML#649 — a pass-through transform after `map` keeps the mapped type.
- This PR — `TFRecordDataset` is a chainable base.

`pred` stays absent pending the model `__call__` body, tracked separately under wala/ML#618.

`testTfrecordMap` guards `TFRecordDataset.map(parse_example)` in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)