### PR TITLE
Infer the numpy-promoted dtype of a literal `numpy.array`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -84,6 +84,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final String COMPLEX_64 = COMPLEX64.name().toLowerCase();
 
+  private static final String COMPLEX_128 = DType.COMPLEX128.name().toLowerCase();
+
   private static final String FLOAT_64 = FLOAT64.name().toLowerCase();
 
   private static final String INT_32 = INT32.name().toLowerCase();
@@ -4917,12 +4919,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testNpArrayBareParam()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_nparray_param.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(new TensorType(FLOAT_64, asList(new NumericDim(3))))));
+    test("tf2_test_nparray_param.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_64, 3))));
   }
 
   /**
@@ -4934,12 +4931,82 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testNpArrayIntParam()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nparray_int_param.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(INT_64, 3))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the boolean path of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: an all-boolean literal array
+   * types to {@code (2,)} {@code bool}.
+   */
+  @Test
+  public void testNpArrayBoolParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nparray_bool_param.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(BOOL, 2))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the string path of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: an all-string literal array types
+   * to {@code (2,)} {@code string} (a string leaf subsumes the array in numpy's promotion).
+   */
+  @Test
+  public void testNpArrayStringParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_nparray_int_param.py",
+        "tf2_test_nparray_string_param.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(STRING, 2))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the nested-literal promotion path of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: a nested literal mixing ints and
+   * a float promotes to {@code (2, 2)} {@code float64}, exercising the walk's descent through
+   * nested lists and the float-over-int promotion.
+   */
+  @Test
+  public void testNpArrayNestedParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_nested_param.py",
         "f",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(INT_64, asList(new NumericDim(3))))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_64, 2, 2))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the complex path of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: an all-complex literal array
+   * types to {@code (2,)} {@code complex128} (numpy promotes Python {@code complex} to {@code
+   * complex128}).
+   */
+  @Test
+  public void testNpArrayComplexParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_complex_param.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(COMPLEX_128, 2))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the non-literal-source floor of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: when {@code x} is itself an
+   * {@code np.ndarray} rather than a Python literal, numpy preserves the source's dtype, which the
+   * walk does not model, so it floors to ⊤. The nested-array shape does not propagate through the
+   * outer {@code np.array} either, so both axes are ⊤.
+   */
+  @Test
+  public void testNpArrayArraySource()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_array_source.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
   }
 
   /**
@@ -4950,9 +5017,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    *
    * <p>TODO: This pins the current imprecise shape. Once <a
    * href="https://github.com/wala/ML/issues/625">wala/ML#625</a> lands, the parameter should type
-   * to {@code (3,)} unknown (the bare form's shape; the dtype stays unknown pending <a
-   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>), and this assertion should be
-   * updated accordingly.
+   * to {@code (3,)} {@code float64} (the bare form's result now that <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a> models numpy dtype promotion), and
+   * this assertion should be updated accordingly.
    */
   @Test
   public void testNpArrayWrappedParam()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4908,13 +4908,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a>: a bare
    * {@code numpy.array} value propagates its {@code TensorType} to a callee parameter. The issue's
-   * reproducer; {@code f}'s parameter types to {@code (3,)} unknown ({@code NpArray} infers the
-   * list-literal shape; the dtype is unknown with no {@code dtype=} argument).
-   *
-   * <p>TODO: the unknown dtype is a recoverable-precision floor. The runtime dtype is {@code
-   * float64} (numpy promotes the Python float literals), but {@code NpArray} does not model numpy's
-   * dtype promotion, so it floors to unknown rather than infer a possibly-wrong dtype. Tracked by
-   * <a href="https://github.com/wala/ML/issues/626">wala/ML#626</a>.
+   * reproducer; {@code f}'s parameter types to {@code (3,)} {@code float64}: {@code NpArray} infers
+   * the list-literal shape, and the dtype from numpy's promotion of the Python float literals (<a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>). The runtime dtype is {@code
+   * float64} (numpy promotes Python {@code float} to {@code float64}, not the {@code float32}
+   * TF-literal convention).
    */
   @Test
   public void testNpArrayBareParam()
@@ -4924,7 +4922,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(3))))));
+        Map.of(2, Set.of(new TensorType(FLOAT_64, asList(new NumericDim(3))))));
+  }
+
+  /**
+   * Companion to {@link #testNpArrayBareParam()} for the integer-promotion path of <a
+   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: a bare {@code numpy.array} of
+   * Python ints types to {@code (3,)} {@code int64}, because numpy promotes Python {@code int} to
+   * {@code int64} (not the {@code int32} TF-literal convention).
+   */
+  @Test
+  public void testNpArrayIntParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_int_param.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, asList(new NumericDim(3))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -142,6 +142,10 @@ public class NpArray extends TensorGenerator {
         else if (value instanceof Boolean) leaves.add(DType.BOOL);
         else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
         else if (value instanceof String) leaves.add(DType.STRING);
+        else if (value != null && "org.python.core.PyComplex".equals(value.getClass().getName()))
+          // A Python complex literal, which the Jython front-end represents as a `PyComplex`.
+          // Matched by class name to avoid a compile-time dependency on the Jython runtime.
+          leaves.add(DType.COMPLEX128);
         else return false; // Unrecognized scalar.
       } else {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -1,9 +1,26 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.types.PythonTypes.Root;
+import static com.ibm.wala.cast.python.types.PythonTypes.list;
+import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
+import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
+import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
+
+import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.types.FieldReference;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -13,7 +30,9 @@ import java.util.logging.Logger;
  * Modeling of the function-style {@code numpy.array(x, dtype)} call. Preserves the shape of the
  * first positional argument ({@code x}) and applies the second positional argument as the output
  * dtype, mirroring {@link AstypeOperation}'s shape-preserving / dtype-changing semantics for the
- * method-style {@code x.astype(dtype)} counterpart.
+ * method-style {@code x.astype(dtype)} counterpart. When no explicit {@code dtype} argument is
+ * given, the dtype is inferred from the contents of {@code x} using numpy's promotion rules (<a
+ * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>).
  */
 public class NpArray extends TensorGenerator {
   private static final Logger LOGGER = Logger.getLogger(NpArray.class.getName());
@@ -53,7 +72,109 @@ public class NpArray extends TensorGenerator {
         return dTypes;
       }
     }
+
+    // No explicit `dtype` argument: infer from the contents of `x` (arg 0) using numpy's promotion
+    // rules. numpy promotes Python `int` to `int64` and `float` to `float64` (not the `int32` /
+    // `float32` TF-literal convention), so a numpy-specific walk is needed. wala/ML#626.
+    int sourceVn = getArgumentValueNumber(0);
+    if (sourceVn > 0) {
+      PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+      PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(getNode(), sourceVn);
+      OrdinalSet<InstanceKey> sourcePTS = pa.getPointsToSet(pk);
+      Set<DType> inferred = numpyPromotedDTypes(builder, sourcePTS);
+      if (!inferred.isEmpty()) {
+        LOGGER.fine(() -> "NpArray.getDefaultDTypes: inferred " + inferred + " from sourceVn.");
+        return inferred;
+      }
+    }
+
     return Set.of(DType.UNKNOWN);
+  }
+
+  /**
+   * Infers the numpy-promoted dtype of a literal {@code x} argument from its leaf scalar values.
+   * The widest leaf kind wins, following numpy's promotion order (a string anywhere yields a string
+   * array; otherwise complex {@literal >} float {@literal >} int {@literal >} bool). Returns the
+   * empty set when no leaf type is recoverable, and {@code {UNKNOWN}} when {@code x} (or a nested
+   * element) is not a literal the walk can promote (e.g. an existing array or tensor, whose dtype
+   * numpy would preserve rather than promote) &mdash; ⊤ is the sound floor there. wala/ML#626.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param sourcePTS The points-to set of the {@code x} argument.
+   * @return The promoted dtype, an {@code {UNKNOWN}} floor, or the empty set.
+   */
+  private Set<DType> numpyPromotedDTypes(
+      PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> sourcePTS) {
+    if (sourcePTS == null || sourcePTS.isEmpty()) return Set.of();
+
+    EnumSet<DType> leaves = EnumSet.noneOf(DType.class);
+    if (!collectNumpyLeaves(builder, sourcePTS, leaves)) return Set.of(DType.UNKNOWN);
+
+    // Promotion order: a string array subsumes everything; otherwise widen numerically.
+    if (leaves.contains(DType.STRING)) return Set.of(DType.STRING);
+    if (leaves.contains(DType.COMPLEX128)) return Set.of(DType.COMPLEX128);
+    if (leaves.contains(DType.FLOAT64)) return Set.of(DType.FLOAT64);
+    if (leaves.contains(DType.INT64)) return Set.of(DType.INT64);
+    if (leaves.contains(DType.BOOL)) return Set.of(DType.BOOL);
+    return Set.of();
+  }
+
+  /**
+   * Recursively collects the numpy base dtypes of the leaf scalars reachable from {@code pts},
+   * descending through nested {@code list}/{@code tuple} allocations.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param pts The points-to set to walk.
+   * @param leaves Accumulator for the leaf numpy base dtypes ({@code BOOL}, {@code INT64}, {@code
+   *     FLOAT64}, {@code COMPLEX128}, {@code STRING}).
+   * @return {@code true} if every element was a literal scalar or a nested list/tuple of literals;
+   *     {@code false} if an element is not a promotable literal (e.g. an existing array/tensor), in
+   *     which case the caller floors to ⊤.
+   */
+  private boolean collectNumpyLeaves(
+      PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> pts, EnumSet<DType> leaves) {
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+
+    for (InstanceKey ik : pts) {
+      if (ik instanceof ConstantKey) {
+        Object value = ((ConstantKey<?>) ik).getValue();
+        if (value instanceof Float || value instanceof Double) leaves.add(DType.FLOAT64);
+        else if (value instanceof Boolean) leaves.add(DType.BOOL);
+        else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
+        else if (value instanceof String) leaves.add(DType.STRING);
+        else return false; // Unrecognized scalar.
+      } else {
+        AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+        if (asin == null) return false;
+
+        TypeReference reference = asin.getConcreteType().getReference();
+        if (!reference.equals(list) && !reference.equals(tuple))
+          // An existing array/tensor (or other non-literal): numpy would preserve its dtype rather
+          // than promote, which this walk does not model. Floor to ⊤.
+          return false;
+
+        OrdinalSet<InstanceKey> catalogPTS =
+            pa.getPointsToSet(
+                ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                    .getPointerKeyForObjectCatalog(asin));
+
+        for (InstanceKey catalogIK : catalogPTS) {
+          Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
+          if (fieldIndex == null) continue; // Skip non-integer attribute keys. wala/ML#603.
+
+          FieldReference subscript =
+              FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldIndex.toString()), Root);
+          IField f = builder.getClassHierarchy().resolveField(subscript);
+          if (f == null) continue;
+
+          OrdinalSet<InstanceKey> fieldPTS =
+              pa.getPointsToSet(builder.getPointerKeyForInstanceField(asin, f));
+          if (!collectNumpyLeaves(builder, fieldPTS, leaves)) return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_array_source.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_array_source.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# The source is itself an `np.ndarray`, not a Python literal. numpy preserves the source's dtype
+# rather than promoting, which the static analysis does not model, so it floors to ⊤ (the sound
+# result). The nested-array shape does not propagate through the outer `np.array` either, so the
+# static result is ⊤ on both axes. See wala/ML#626.
+x = np.array(np.array([1, 2]))
+assert x.shape == (2,)
+assert x.dtype == np.int64
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_bool_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_bool_param.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# numpy infers `bool` for an all-boolean literal array. The static analysis models this. See
+# wala/ML#626.
+x = np.array([True, False])
+assert x.shape == (2,)
+assert x.dtype == np.bool_
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_complex_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_complex_param.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# numpy infers complex128 for a complex literal array. See wala/ML#626.
+x = np.array([1j, 2j])
+assert x.shape == (2,)
+assert x.dtype == np.complex128
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_int_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_int_param.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# `x` is a bare `numpy.array` of Python ints. numpy promotes Python `int` to `int64` (not the
+# `int32` TF-literal convention), and the static analysis models this promotion. See wala/ML#626.
+x = np.array([1, 2, 3])
+assert x.shape == (3,)
+assert x.dtype == np.int64
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_nested_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_nested_param.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# A nested literal mixing ints and a float: numpy promotes to `float64`, and the static walk
+# descends through the nested lists to find the float leaf. See wala/ML#626.
+x = np.array([[1, 2.0], [3, 4]])
+assert x.shape == (2, 2)
+assert x.dtype == np.float64
+f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_param.py
@@ -8,7 +8,7 @@ def f(t):
 # `x` is a bare `numpy.array` value. See wala/ML#598.
 x = np.array([1.0, 2.0, 3.0])
 assert x.shape == (3,)
-# Runtime dtype is float64 (numpy promotes the Python floats); the static type is unknown
-# because numpy dtype promotion is unmodeled. See wala/ML#626.
+# Runtime dtype is float64 (numpy promotes the Python floats); the static analysis models this
+# promotion. See wala/ML#626.
 assert x.dtype == np.float64
 f(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_string_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_string_param.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def f(t):
+    return t
+
+
+# numpy infers a string dtype for an all-string literal array. The static analysis models this. See
+# wala/ML#626.
+x = np.array(["a", "b"])
+assert x.shape == (2,)
+assert x.dtype.kind == "U"
+f(x)


### PR DESCRIPTION
## Summary

`NpArray.getDefaultDTypes` only read an explicit `dtype=` argument and otherwise returned ⊤, so a literal `np.array([1.0, 2.0, 3.0])` typed to `(3,)` unknown even though the shape was concrete (the dtype axis lagged the shape axis).

Infer the dtype from the contents of `x` when no explicit `dtype` is given, applying numpy's promotion rules:

- Walk the literal's leaf scalars and pick the widest kind: a string anywhere yields a string array; otherwise complex over float over int over bool.
- Map Python `int` to `int64` and `float` to `float64` — numpy's promotion, not the `int32`/`float32` TF-literal convention. This is the soundness subtlety #626 flagged: a naive source-dtype read would infer the wrong `float32`/`int32`.
- A non-literal source (an existing array or tensor, whose dtype numpy would *preserve* rather than promote) floors to ⊤, which stays the sound result there.

## Tests

`testNpArrayBareParam` now expects `(3,)` `float64` (was ⊤ dtype); `testNpArrayIntParam` is new for the `int64` path. Both fixtures assert the runtime dtype under python3.10. The `tf.constant`-wrapped form (`testNpArrayWrappedParam`) is unaffected — its shape loss is the separate wala/ML#625.

Closes wala/ML#626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg