### PR TITLE
Don't type Python list repetition (`[0] * n`) as a tensor

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3776,6 +3776,19 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression test for <a href="https://github.com/wala/ML/issues/653">wala/ML#653</a>: Python
+   * list repetition ({@code [0] * 3}) is not a tensor. The {@code *} binop has a {@code list}
+   * operand and an {@code int} operand, so it is list repetition (producing a list), not tensor
+   * scalar-multiplication. The binop operand-tensor gate must not treat the bare {@code list}
+   * operand as tensor evidence, so {@code consume}'s parameter is not classified as a tensor.
+   */
+  @Test
+  public void testListRepetition()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_list_repetition.py", "consume", 0, 0);
+  }
+
+  /**
    * Regression test for wala/ML#451 (reopen): asserts the underlying PA state that Hybridize's
    * {@code Function.inferPrimitiveParameters} consumes &mdash; specifically, that no primitive
    * {@link ConstantKey} is reachable through the parameter's points-to set when traversed

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -766,6 +766,22 @@ public class TensorGeneratorFactory {
     // the propagation system — most commonly summary-method returns. Treat
     // those as potential tensors so legitimate chained tensor binops (e.g.
     // `tf.constant(...) - some_summary_op_result`) aren't over-rejected.
+    // A bare Python `list`/`tuple` operand is not a tensor: a `*` binop over it is list repetition
+    // (`[0] * 3`) and a `+` is concatenation, neither of which is a tensor op. A list literal's
+    // local
+    // pointer key is often implicit (its PTS isn't materialised), which the check below would
+    // otherwise read as a summary-return tensor, so detect the container structurally from its
+    // allocating `new`. Only the companion operand (a tensor or `np.ndarray`) carries tensor
+    // evidence. wala/ML#653.
+    SSAInstruction operandDef = node.getDU().getDef(operandVn);
+    if (operandDef instanceof SSANewInstruction) {
+      TypeReference allocated = ((SSANewInstruction) operandDef).getConcreteType();
+      if (allocated.equals(PythonTypes.list) || allocated.equals(PythonTypes.tuple)) return false;
+    }
+    // Implicit pointer keys flag values whose PTS hasn't been materialised by
+    // the propagation system — most commonly summary-method returns. Treat
+    // those as potential tensors so legitimate chained tensor binops (e.g.
+    // `tf.constant(...) - some_summary_op_result`) aren't over-rejected.
     if (builder.getPropagationSystem().isImplicit(pk)) return true;
     PointsToSetVariable operandSrc = getPointsToSetVariable(pk, builder);
     if (operandSrc != null && tryGetGenerator(operandSrc, builder, visited) != null) return true;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_repetition.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_repetition.py
@@ -1,0 +1,7 @@
+def consume(value):
+    pass
+
+
+# `[0] * 3` is Python list repetition (produces a list), not tensor scalar-multiplication. `value`
+# should not be typed as a tensor. wala/ML#653.
+consume([0] * 3)


### PR DESCRIPTION
## Summary

`[0] * 3` is Python list repetition — it produces a list, not a tensor — yet the tensor-type analysis classified its result as a tensor, and a parameter fed such a value was typed as a tensor parameter. This is a false-positive tensor classification (wala/ML#653).

## Root cause

The binop operand-tensor gate (`isBinopWithoutTensorOperand` → `operandHasTensorEvidence`, wala/ML#451) counted the bare `list` operand of `*` as tensor evidence. A list literal's local pointer key is **implicit** (its points-to set isn't materialized by the propagation system), so the gate's implicit-pointer-key heuristic — intended for summary-method returns — treated the list as a potential tensor. The `*` binop was then dispatched to `ElementWiseOperation` (it maps to `tensorflow/math/multiply`) and typed `int32`.

## Fix

Detect a directly-allocated `list`/`tuple` operand structurally from its `new` instruction and exclude it from tensor evidence, *before* the implicit-pointer-key check. A `*` over a bare list is repetition and a `+` is concatenation — neither is a tensor op — so only the companion operand (an actual tensor or `np.ndarray`) carries evidence. With no real tensor operand, the gate rejects the `ElementWiseOperation` dispatch.

A list-of-tensors that reaches a binop through a variable rather than a literal (`testTensorList2`: `add(a, b)` over a list-of-tensors param) is unaffected — its operand's def is not a `new list`, so it still resolves via the existing PTS path.

## Tests

`testListRepetition` (`consume([0] * 3)` → 0 tensor parameters). Full suite green; the `#451` binop gate tests (`testRecursionTensorOnly`/`testRecursionIntOnly`) and `testTensorList2`/`3` are unchanged.

Closes wala/ML#653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg