### PR TITLE
Don't type a subscript-slice of a non-tensor as a tensor

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3775,6 +3775,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
+  @Test
+  public void testSliceOpaque()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_slice_opaque.py", "consume", 0, 0);
+  }
+
+  @Test
+  public void testSliceOpaqueIter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_slice_opaque_iter.py", "consume", 0, 0);
+  }
+
   /**
    * Regression test for wala/ML#451 (reopen): asserts the underlying PA state that Hybridize's
    * {@code Function.inferPrimitiveParameters} consumes &mdash; specifically, that no primitive

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -90,7 +90,12 @@ public class SliceBuiltinOperation extends TensorGenerator {
                 + view.receiverVn
                 + " receiverShapes="
                 + capturedReceiverShapes);
-    if (receiverShapes == null || receiverShapes.isEmpty()) return null;
+    // A `null` receiver shape means the receiver is a tensor of unknown shape (⊤), so the slice is
+    // ⊤. An empty set means the receiver is not a tensor (⊥): a subscript-slice of a non-tensor
+    // (e.g. `x[1::2]` of an opaque `argparse` attribute) is not a tensor either, so propagate ⊥
+    // rather than over-typing it to ⊤. wala/ML#656.
+    if (receiverShapes == null) return null;
+    if (receiverShapes.isEmpty()) return Set.of();
 
     // Multi-dim subscript: `slice(receiver, dim0, dim1, ...)` where each dimension is a
     // `slice(lower, upper, step)` object or an integer index (wala/ML#406). Distinguished from the

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1179,7 +1179,13 @@ public class TensorGeneratorFactory {
         // the element at this index, preserving its transformation chain. wala/ML#648.
         // Similar to `EachElementGet`, we check if the container generator represents elements
         // (`Dataset`) or the tensor itself (peeling needed).
-        if (propertyName == null || !isNonTensorAttribute(propertyName)) {
+        // Only treat a subscript/slice as a tensor-element extraction when the container is a
+        // recognized tensor/dataset producer. A `null` container generator means the base is not a
+        // tensor (e.g. a subscript-slice `x[1::2]` of an opaque `argparse` attribute), so the
+        // result is not a tensor either; dispatching `TensorElementGenerator` here would over-type
+        // it. wala/ML#656.
+        if (containerGenerator != null
+            && (propertyName == null || !isNonTensorAttribute(propertyName))) {
           return (containerGenerator instanceof DatasetGenerator)
               ? new DatasetElementGenerator(objSrc, containerGenerator)
               : new TensorElementGenerator(source, containerGenerator);

--- a/com.ibm.wala.cast.python.test/data/tf2_test_slice_opaque.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_slice_opaque.py
@@ -1,0 +1,15 @@
+import argparse
+
+
+def consume(value):
+    pass
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--data", nargs="*", default=[])
+args = parser.parse_args([])
+
+# `args.data` is an opaque (argparse) attribute, not a tensor. A subscript-slice of it is still not
+# a tensor, so `value` should not be typed as a tensor. wala/ML#656.
+sliced = args.data[1::2]
+consume(sliced)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_slice_opaque_iter.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_slice_opaque_iter.py
@@ -1,0 +1,15 @@
+import argparse
+
+
+def consume(value):
+    pass
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--data", nargs="*", default=[])
+args = parser.parse_args([])
+
+# `args.data` is opaque; a subscript-slice of it is not a tensor, and neither is an element iterated
+# from that slice. `value` should not be typed as a tensor. wala/ML#656.
+for value in args.data[1::2]:
+    consume(value)


### PR DESCRIPTION
## Summary

A subscript-slice of an opaque, non-tensor value — e.g. `args.data[1::2]` where `args.data` is an `argparse` attribute — was typed as a tensor, so a parameter fed such a value (or an element iterated from it) was wrongly classified as a tensor parameter. The same value unsliced is correctly non-tensor, so the slice was the trigger (wala/ML#656). Distilled from `is_float_between_0_and_1` in `TensorFlow2.0-Examples` (`mAP/main.py`).

## Root cause

Two coupled over-typings:

1. **`TensorGeneratorFactory`** dispatched `TensorElementGenerator` for any non-attribute property read, even when the container had no recognized tensor generator (`TensorElementGenerator(null)` in the trace) — so the opaque base `args.data` itself typed as a tensor.
2. **`SliceBuiltinOperation.getDefaultShapes`** then collapsed both "receiver is a tensor of unknown shape" (`null`) and "receiver is not a tensor" (empty set) to `null` (⊤), so the slice of the (now ⊤) base stayed ⊤.

## Fix

- Gate the `TensorElementGenerator` dispatch on a non-null container generator. A `list`-of-tensors subscript at a constant index is unaffected — it's recovered earlier by the wala/ML#648 element path (verified).
- In `SliceBuiltinOperation`, distinguish the two cases: a `null` receiver shape stays ⊤ (a real tensor of unknown shape), but an **empty** receiver shape yields the empty set (⊥), which pairs with any dtype to a non-tensor in `getTensorTypes`.

## Tests

`testSliceOpaque` (the slice passed directly) and `testSliceOpaqueIter` (the slice iterated, matching the corpus pattern). Full suite green (924); the existing slice/subscript and list-of-tensors paths are unaffected.

Closes wala/ML#656. (Detector: ponder-lab/Hybridize-Functions-Refactoring#708 flips its #656 half on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg