### PR TITLE
Type a `tf.io.FixedLenFeature` parsed value as a dense tensor

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1738,6 +1738,44 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(3, Set.of(TENSOR_20_28_28_INT32)));
   }
 
+  /**
+   * Regression guard for wala/ML#655: a {@code tf.io.FixedLenFeature} value, parsed by {@code
+   * tf.io.parse_single_example} and read back through a dict subscript, types as a dense tensor
+   * whose shape comes from the feature's {@code dims} argument and whose dtype comes from its
+   * {@code type} argument. Previously {@code FixedLenFeature.do} allocated an {@code
+   * Ltensorflow/objects/ feature} that the manual tensor walker ignores, so the parsed value never
+   * typed.
+   */
+  @Test
+  public void testFixedLenFeature()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_fixed_len_feature.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 128))));
+  }
+
+  /**
+   * Regression guard for wala/ML#655, end to end: the NLPGNN {@code TFLoader.load_valid} input
+   * pipeline — a {@code TFRecordDataset} mapped by a {@code parse_single_example} decoder returning
+   * a 4-tuple of {@code FixedLenFeature} dict-subscripts, then {@code prefetch}ed, then iterated
+   * with a 4-way tuple unpack — types its first parsed field {@code X} ({@code input_ids}) to
+   * {@code (128,)} int64. Before the {@code FixedLenFeature} fix, the mapped element was
+   * non-tensor, so {@code X} (and any model parameter fed from it) came back non-tensor.
+   */
+  @Test
+  public void testTfrecordLoader()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_tfrecord_loader.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 128))));
+  }
+
   @Test
   public void testModelAttributes()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2221,8 +2221,9 @@
         </method>
       </class>
       <class name="FixedLenFeature" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/io/FixedLenFeature. A fixed-length feature parses to a dense tensor; allocate a `Tensor` so the `FixedLenFeature` generator can type the parsed value (shape from the `dims` argument, dtype from the `type` argument). Previously this allocated an `Ltensorflow/objects/feature`, which the manual tensor walker explicitly ignores (`TensorFlowTypes.FEATURE`), so a `parse_single_example` result read back through a feature dict never typed. See wala/ML#655. The `set_shape` field is retained so a subsequent `x.set_shape(...)` still dispatches. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self dims type">
-          <new def="x" class="Ltensorflow/objects/feature"/>
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
           <new def="y" class="Ltensorflow/functions/set_shape"/>
           <putfield class="LRoot" field="set_shape" fieldType="LRoot" ref="x" value="y"/>
           <return value="x"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FixedLenFeature.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FixedLenFeature.java
@@ -1,0 +1,77 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import java.util.Locale;
+
+/**
+ * A generator for the dense tensor a {@code tf.io.FixedLenFeature(shape, dtype)} represents: when a
+ * fixed-length feature is parsed (e.g. by {@code tf.io.parse_single_example}) it yields a dense
+ * tensor whose shape is the feature's declared {@code shape} and whose dtype is the feature's
+ * {@code dtype}. Modeling it as that tensor lets {@code parse_single_example} (a pass-through of
+ * its feature dict) type the parsed value, so a dataset whose {@code map_func} returns such values
+ * (the gpt-2 / NLPGNN input-pipeline shape) types its elements (wala/ML#655).
+ *
+ * <p>Unlike {@link VarLenFeature} (whose parsed value is a {@code tf.sparse.SparseTensor} with a
+ * contract shape and only a {@code dtype} argument), a fixed-length feature carries both an
+ * explicit {@code shape} ({@code dims}, the first argument) and a {@code dtype} ({@code type}, the
+ * second argument), and parses to a dense tensor.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/io/FixedLenFeature">tf.io.FixedLenFeature</a>.
+ */
+public class FixedLenFeature extends TensorTypeAllocator {
+
+  protected enum Parameters {
+    DIMS,
+    TYPE;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public FixedLenFeature(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs a manual-node generator for the dense tensor allocated in {@code
+   * FixedLenFeature.do()}. Used by {@link TensorGenerator#createManualGenerator(CGNode,
+   * PropagationCallGraphBuilder)} when that tensor reaches a consumer through a container such as a
+   * feature dict, where the points-to walk lands on the allocation site rather than the {@code
+   * tf.io.FixedLenFeature} call. Reads the feature's {@code dims} and {@code type} from the {@code
+   * do()} method's parameters (wala/ML#655).
+   *
+   * @param node The {@code FixedLenFeature.do()} call-graph node that allocated the tensor.
+   */
+  public FixedLenFeature(CGNode node) {
+    super(node);
+  }
+
+  /** The shape is the first argument ({@code dims}). */
+  @Override
+  protected int getShapeParameterPosition() {
+    return Parameters.DIMS.getIndex();
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return Parameters.DIMS.getName();
+  }
+
+  /** The dtype is the second argument ({@code type}). */
+  @Override
+  protected int getDTypeParameterPosition() {
+    return Parameters.TYPE.getIndex();
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return Parameters.TYPE.getName();
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3406,6 +3406,14 @@ public abstract class TensorGenerator {
       // the
       // generator that reads the feature's `dtype` and emits the contract shape. wala/ML#646.
       return new VarLenFeature(node);
+    } else if (type.equals(TensorFlowTypes.FIXED_LEN_FEATURE.getDeclaringClass())) {
+      // The dense tensor a `tf.io.FixedLenFeature` parses to is allocated in
+      // `FixedLenFeature.do()`.
+      // When it reaches a consumer through a feature dict (e.g. a `parse_single_example` result
+      // subscripted by feature name), the points-to walk lands here on the allocation site rather
+      // than the `tf.io.FixedLenFeature` call, so dispatch the generator that reads the feature's
+      // `dims` (shape) and `type` (dtype). wala/ML#655.
+      return new FixedLenFeature(node);
     }
     // Unregistered type: the manual-walker dispatch table doesn't know about this op, so the
     // caller will treat the null return as "no contribution" and silently lose precision on

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -78,6 +78,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FASHION_MNIST_X_
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FASHION_MNIST_Y_TEST;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FASHION_MNIST_Y_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FIXED_LEN_FEATURE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FLATTEN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FLATTEN_LAYER_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FLOOR;
@@ -1281,6 +1282,8 @@ public class TensorGeneratorFactory {
       return new SparseToDense(source);
     else if (isType(calledFunction, VAR_LEN_FEATURE.getDeclaringClass()))
       return new VarLenFeature(source);
+    else if (isType(calledFunction, FIXED_LEN_FEATURE.getDeclaringClass()))
+      return new FixedLenFeature(source);
     else if (isType(calledFunction, MODEL.getDeclaringClass())) return new Model(source);
     else if (isType(calledFunction, TENSOR.getDeclaringClass())
         || isType(calledFunction, NDARRAY.getDeclaringClass())) return new TensorCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -590,6 +590,16 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String VAR_LEN_FEATURE_SIGNATURE = "tf.io.VarLenFeature()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/io/FixedLenFeature. */
+  public static final MethodReference FIXED_LEN_FEATURE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/FixedLenFeature")),
+          AstMethodReference.fnSelector);
+
+  private static final String FIXED_LEN_FEATURE_SIGNATURE = "tf.io.FixedLenFeature()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gamma. */
   public static final MethodReference GAMMA =
       MethodReference.findOrCreate(
@@ -1956,6 +1966,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SPARSE_FROM_DENSE.getDeclaringClass(), SPARSE_FROM_DENSE_SIGNATURE),
           Map.entry(SPARSE_TO_DENSE.getDeclaringClass(), SPARSE_TO_DENSE_SIGNATURE),
           Map.entry(VAR_LEN_FEATURE.getDeclaringClass(), VAR_LEN_FEATURE_SIGNATURE),
+          Map.entry(FIXED_LEN_FEATURE.getDeclaringClass(), FIXED_LEN_FEATURE_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONE_HOT.getDeclaringClass(), ONE_HOT_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_fixed_len_feature.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_fixed_len_feature.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# Isolates wala/ML#655: a `FixedLenFeature` value, parsed by `parse_single_example` and read back
+# through a dict subscript, should type as a dense tensor (shape from `dims`, dtype from `type`).
+# The corpus `decode_record` returns such values; before the fix they were non-tensor.
+example = tf.train.Example(
+    features=tf.train.Features(
+        feature={
+            "input_ids": tf.train.Feature(
+                int64_list=tf.train.Int64List(value=[0] * 128)
+            )
+        }
+    )
+).SerializeToString()
+feature_description = {
+    "input_ids": tf.io.FixedLenFeature([128], tf.int64),
+}
+parsed = tf.io.parse_single_example(example, feature_description)
+v = parsed["input_ids"]
+assert v.shape == (128,)
+assert v.dtype == tf.int64
+consume(v)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_loader.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_loader.py
@@ -1,0 +1,43 @@
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+# Faithful distillation of the wala/ML#655 NLPGNN `TFLoader.load_valid` input pipeline: a
+# `TFRecordDataset` mapped (via a lambda wrapping a method) by a `parse_single_example` decoder
+# returning a 4-tuple of `FixedLenFeature` dict-subscripts, then `prefetch`ed, then iterated with a
+# 4-way tuple unpack. `X` (the first parsed field, `input_ids`) should type to `(128,)` int64. The
+# corpus also `batch`es between `map` and `prefetch`; that prepends a batch dimension (modeled by
+# `DatasetBatchGenerator`) and is orthogonal to the element-typing this guards. Static-analysis-only
+# (no real tfrecord at runtime).
+class TFLoader(object):
+    def __init__(self, maxlen):
+        self.maxlen = maxlen
+
+    def decode_record(self, record):
+        feature_description = {
+            "input_ids": tf.io.FixedLenFeature([128], tf.int64),
+            "label_id": tf.io.FixedLenFeature([], tf.int64),
+            "segment_ids": tf.io.FixedLenFeature([128], tf.int64),
+            "input_mask": tf.io.FixedLenFeature([128], tf.int64),
+        }
+        example = tf.io.parse_single_example(record, feature_description)
+        return (
+            example["input_ids"],
+            example["segment_ids"],
+            example["input_mask"],
+            example["label_id"],
+        )
+
+    def load_valid(self):
+        raw_dataset = tf.data.TFRecordDataset("valid.tfrecords")
+        dataset = raw_dataset.map(lambda record: self.decode_record(record))
+        dataset = dataset.prefetch(1)
+        return dataset
+
+
+load = TFLoader(128)
+for X, token_type_id, input_mask, Y in load.load_valid():
+    consume(X)


### PR DESCRIPTION
## Problem

wala/ML#655 reports that `tf.keras.Model`/`Layer` `call`/`predict` methods reached through `model(x)`/`model.predict(x)` forwarding stopped typing their tensor parameters. The issue hypothesized a `__call__`-dispatch regression.

That hypothesis is incorrect. A nested user-`Layer` reached through a `predict`/`__call__`/`call` chain — even with a second positional `training` argument — types its parameter correctly. The `__call__` forwarding is not broken.

The actual cause for the parameter-untyped cases (`BiLSTM.call`, `TextCNN.predict`, `BilstmAttention.predict`) is the **tensor source**, not the forwarding. Those methods are fed from the NLPGNN `TFLoader` input pipeline:

```python
raw = tf.data.TFRecordDataset(f)
ds = raw.map(lambda r: self.decode_record(r))  # returns a 4-tuple of FixedLenFeature dict-subscripts
ds = ds.batch(...).prefetch(...)
for X, ... in ds:
    model.predict(X)
```

`decode_record` returns `tf.io.parse_single_example(...)` values keyed by `tf.io.FixedLenFeature`. `FixedLenFeature.do` allocated an `Ltensorflow/objects/feature` object, which the manual tensor walker explicitly ignores (`TensorFlowTypes.FEATURE`). So the parsed value was never a tensor. Once dataset elements began typing precisely from the `map_func` return (rather than coarsely as ⊤), the mapped element became non-tensor, and `X` — and every parameter fed from it — came back non-tensor. That is the regression.

## Fix

Model `tf.io.FixedLenFeature` like `tf.io.VarLenFeature`:

- `FixedLenFeature.do` allocates a dense `Ltensorflow/python/framework/ops/Tensor` (the `set_shape` field is retained so a later `x.set_shape(...)` still dispatches).
- A new `FixedLenFeature` generator types it from the `dims` (shape) and `type` (dtype) arguments.
- Dispatch is wired from both the factory direct-call path and the manual-walker feature-dict-container path.

## Reproduction and guards

- `tf2_test_fixed_len_feature.py` / `testFixedLenFeature` — a `FixedLenFeature` parsed through `parse_single_example` and a dict subscript types to `(128,)` int64. Failed before the fix (non-tensor).
- `tf2_test_tfrecord_loader.py` / `testTfrecordLoader` — the end-to-end `TFRecordDataset.map(...).prefetch(...)` + 4-way tuple-unpack corpus shape types its first parsed field to `(128,)` int64. Failed before the fix (non-tensor).

## Scope

This addresses wala/ML#655's parameter-untyped cases (symptom A). The remaining case — `MyModel.call` types but its call graph is incomplete inside a `@tf.function` (symptom B) — is a distinct call-graph-completeness concern with a different cause, split out to wala/ML#657 per the issue's own suggestion.

Closes wala/ML#655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg