### PR TITLE
Add an end-to-end regression guard for the `FixedLenFeature` de-typing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1778,6 +1778,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(TensorType.of(INT_64, 128))));
   }
 
+  /**
+   * Regression guard for wala/ML#655, the full symptom-A chain in one fixture: the NLPGNN {@code
+   * BilstmAttention} model (whose {@code predict} forwards to {@code self(inputs, training)} and
+   * whose {@code call} delegates to a user-defined child {@code BiLSTM} layer built from unmodeled
+   * sublayers) fed from the {@code TFLoader} {@code FixedLenFeature}/{@code TFRecordDataset}
+   * source. The child {@code BiLSTM.call}'s {@code inputs} parameter types to {@code (128,)} int64,
+   * flowing the parsed {@code input_ids} field through {@code model.predict(X)} → {@code __call__}
+   * → {@code call} → {@code self.bilstm(inputs, training)}. This demonstrates that the symptom-A
+   * cases are unit-reproducible via the source pipeline (not the affected file, which carries no
+   * call site or source) and that the cause was the source typing, not the {@code __call__}
+   * forwarding the issue title hypothesized. Before the {@code FixedLenFeature} fix, {@code inputs}
+   * came back non-tensor.
+   */
+  @Test
+  public void testBilstmLoaderE2e()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_bilstm_loader_e2e.py",
+        "BiLSTM.call",
+        1,
+        1,
+        Map.of(3, Set.of(TensorType.of(INT_64, 128))));
+  }
+
   @Test
   public void testModelAttributes()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_bilstm_loader_e2e.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_bilstm_loader_e2e.py
@@ -1,0 +1,75 @@
+import tensorflow as tf
+
+# End-to-end symptom-A reproduction for wala/ML#655: the full NLPGNN `BilstmAttention` structure
+# (a `tf.keras.Model` whose `predict` forwards to `self(inputs, training)`, whose `call` delegates to
+# a user-defined child `BiLSTM` layer built from unmodeled sublayers) fed from the real `TFLoader`
+# `FixedLenFeature`/`TFRecordDataset` source. `BiLSTM.call`'s `inputs` parameter should type to
+# `(128,)` int64, flowing the whole chain: the parsed `input_ids` field -> `model.predict(X)` ->
+# `__call__` -> `call` -> `self.bilstm(inputs, training)` -> `BiLSTM.call`. Before the
+# `FixedLenFeature` fix the source was non-tensor, so `inputs` came back non-tensor. The `__call__`
+# forwarding itself was never the cause (the title hypothesis); the source was.
+# Static-analysis-only (no real tfrecord at runtime).
+
+
+class TFLoader(object):
+    def __init__(self, maxlen):
+        self.maxlen = maxlen
+
+    def decode_record(self, record):
+        feature_description = {
+            "input_ids": tf.io.FixedLenFeature([128], tf.int64),
+            "label_id": tf.io.FixedLenFeature([], tf.int64),
+            "segment_ids": tf.io.FixedLenFeature([128], tf.int64),
+            "input_mask": tf.io.FixedLenFeature([128], tf.int64),
+        }
+        example = tf.io.parse_single_example(record, feature_description)
+        return (
+            example["input_ids"],
+            example["segment_ids"],
+            example["input_mask"],
+            example["label_id"],
+        )
+
+    def load_valid(self):
+        raw_dataset = tf.data.TFRecordDataset("valid.tfrecords")
+        dataset = raw_dataset.map(lambda record: self.decode_record(record))
+        dataset = dataset.prefetch(1)
+        return dataset
+
+
+class BiLSTM(tf.keras.layers.Layer):
+    def __init__(self, maxlen, vocab_size, embedding_dims, hidden_dim, **kwargs):
+        super(BiLSTM, self).__init__(**kwargs)
+        self.embedding = tf.keras.layers.Embedding(
+            vocab_size, embedding_dims, input_length=maxlen
+        )
+        self.bilstm = tf.keras.layers.Bidirectional(
+            tf.keras.layers.LSTM(hidden_dim, return_sequences=True)
+        )
+
+    def call(self, inputs, training):
+        embed = self.embedding(inputs)
+        logits = self.bilstm(embed, training=training)
+        return logits
+
+
+class BilstmAttention(tf.keras.Model):
+    def __init__(self, maxlen, vocab_size, embedding_dims, hidden_dim, **kwargs):
+        super(BilstmAttention, self).__init__(**kwargs)
+        self.bilstm = BiLSTM(maxlen, vocab_size, embedding_dims, hidden_dim)
+        self.dense = tf.keras.layers.Dense(2, activation="softmax")
+
+    def call(self, inputs, training=True):
+        logits = self.bilstm(inputs, training)
+        logits = self.dense(logits)
+        return logits
+
+    def predict(self, inputs, training=False):
+        out = self(inputs, training)
+        return out
+
+
+model = BilstmAttention(128, 30522, 100, 50)
+load = TFLoader(128)
+for X, token_type_id, input_mask, Y in load.load_valid():
+    predict = model.predict(X)


### PR DESCRIPTION
Follow-up to ponder-lab/ML#489 (wala/ML#655).

#489 fixed the de-typing root cause (`tf.io.FixedLenFeature` parsed values now type as dense tensors) and guarded it with a unit test (`testFixedLenFeature`) and a dataset-pipeline test (`testTfrecordLoader`). This adds the **full symptom-A chain in one fixture** as a higher-level guard.

`tf2_test_bilstm_loader_e2e.py` reconstructs the NLPGNN `BilstmAttention` structure — a `tf.keras.Model` whose `predict` forwards to `self(inputs, training)`, whose `call` delegates to a user-defined child `BiLSTM` layer built from unmodeled sublayers (`Embedding`, `Bidirectional`/`LSTM`) — fed from the `TFLoader` `FixedLenFeature`/`TFRecordDataset` source. The child `BiLSTM.call`'s `inputs` parameter types to `(128,)` int64, flowing the parsed `input_ids` field through `model.predict(X)` → `__call__` → `call` → `self.bilstm(inputs, training)` → `BiLSTM.call`.

Why it is worth keeping:

- It demonstrates the symptom-A cases **are** unit-reproducible — via the *source pipeline*, not the affected file. Vendoring `bilstm.py` alone carries no call site and no tensor source, which is why file-level vendoring did not reproduce the de-hybridization; the source pipeline is the missing ingredient.
- It pins the corrected diagnosis: the cause was the dataset source typing, not the `__call__`/`predict` forwarding the issue title hypothesized (the forwarding resolves correctly).

Before #489, `BiLSTM.call`'s `inputs` came back non-tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg