### PR TITLE
Fall back to `object` when a base-class name has no local resolution

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3950,7 +3950,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     assertTrue(
         "MyModel.call should have a call-graph node despite a colliding `class Model` in another"
             + " module (wala/ML#657).",
-        CG.stream().anyMatch(n -> n.getMethod().getSignature().contains("MyModel.call.do")));
+        CG.stream()
+            .anyMatch(
+                n ->
+                    n.getMethod()
+                        .getSignature()
+                        .contains("tf2_657_model_call.py.MyModel.call.do")));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3927,6 +3927,33 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for wala/ML#657: a {@code tf.keras.Model} subclass reached via {@code
+   * model(x)} callable dispatch keeps its call-graph node even when another module defines a
+   * same-named {@code class Model}. The subclass uses the ubiquitous bare-import idiom {@code from
+   * tensorflow.keras import Model; class MyModel(Model)}; when a second module ({@code
+   * tf2_657_collide.py}) also defines {@code class Model}, the bare base name previously
+   * mis-resolved across modules, so {@code MyModel}'s superclass came back {@code null} and {@code
+   * MyModel.call} was dropped from the call graph (which is the empty {@code getNodes(...)} that
+   * fails Hybridize's side-effect, recursion, and primitive-parameter preconditions). The fix falls
+   * back to {@code object} when the base name has no local resolution, matching the collision-free
+   * case.
+   */
+  @Test
+  public void testModelSubclassNameCollision()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine =
+        makeEngine(emptyList(), new String[] {"tf2_657_model_call.py", "tf2_657_collide.py"});
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    addPytestEntrypoints(builder);
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+    assertTrue(
+        "MyModel.call should have a call-graph node despite a colliding `class Model` in another"
+            + " module (wala/ML#657).",
+        CG.stream().anyMatch(n -> n.getMethod().getSignature().contains("MyModel.call.do")));
+  }
+
+  /**
    * Mirrors the recursion in Hybridize's {@code Function.containsPrimitive(InstanceKey, boolean,
    * PointerAnalysis, Set, IProgressMonitor)}: returns {@code true} iff a non-boolean primitive
    * {@link ConstantKey} value is reachable from {@code ik} through transitive instance field PTS

--- a/com.ibm.wala.cast.python.test/data/tf2_657_collide.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_657_collide.py
@@ -1,0 +1,9 @@
+# A second module that defines its own `class Model`, colliding by simple name with the
+# `tf.keras.Model` that `tf2_657_model_call.py` subclasses (wala/ML#657). Mirrors NLPGNN's
+# `Linear_Regression.py`, which also defines `class Model(object)`.
+class Model(object):
+    def __call__(self, inputs):
+        return inputs
+
+
+model = Model()

--- a/com.ibm.wala.cast.python.test/data/tf2_657_model_call.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_657_model_call.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+from tensorflow.keras import Model
+
+
+# The wala/ML#657 shape: a `tf.keras.Model` subclass that subclasses the *bare* imported name
+# `Model` (the ubiquitous `from tensorflow.keras import Model; class X(Model)` idiom) and is reached
+# via `model(x)` callable dispatch. Analyzed together with a second module that defines its own
+# `class Model` (`tf2_657_collide.py`), the bare base name previously mis-resolved across modules,
+# nulling `MyModel`'s superclass and dropping `MyModel.call` from the call graph.
+class MyModel(Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+        self.d = tf.keras.layers.Dense(10)
+
+    def call(self, x):
+        return self.d(x)
+
+
+model = MyModel()
+
+
+@tf.function
+def train_step(images):
+    return model(images)
+
+
+train_step(tf.ones([1, 10]))

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -157,19 +157,26 @@ public class PythonCAstToIRTranslator extends AstTranslator {
             .filter(t -> !(t instanceof MissingType))
             .collect(Collectors.toSet());
 
-    // The superclass name is the registered WALA name of the first non-missing supertype. It can be
-    // null when the base-class name mis-resolves to a same-named class in another module (e.g. a
-    // user `class Model` colliding with `from tensorflow.keras import Model; class X(Model)`): the
-    // supertype is non-missing but has no entry in this unit's `walaTypeNames`. A null superclass
-    // leaves the class unlinked in the hierarchy and breaks callable dispatch on its instances
-    // (wala/ML#657). Fall back to `object` — the same lattice point the missing/no-base case uses,
-    // and the correct one for a modeled base such as `tf.keras.Model`.
-    TypeName superName = present.isEmpty() ? null : walaTypeNames.get(present.iterator().next());
+    // The superclass is the first non-missing supertype that resolves to a class in this unit. A
+    // supertype's `walaTypeNames` entry is null when its base-class name mis-resolves to a
+    // same-named class in another module (e.g. a user `class Model` colliding with `from
+    // tensorflow.keras import Model; class X(Model)`): it is non-missing but was never registered
+    // here. Skipping the unresolved supertypes rather than taking an arbitrary first (which drops
+    // the class to a null superclass, leaving it unlinked in the hierarchy and breaking callable
+    // dispatch on its instances, wala/ML#657) keeps a locally resolvable base under multiple
+    // inheritance. Fall back to `object` when none resolve, the same lattice point the missing or
+    // no-base case uses and the correct one for a modeled base such as `tf.keras.Model`.
+    TypeName superName =
+        present.stream()
+            .map(walaTypeNames::get)
+            .filter(name -> name != null)
+            .findFirst()
+            .orElse(PythonTypes.object.getName());
 
     ((PythonLoader) loader)
         .defineType(
             typeName,
-            superName == null ? PythonTypes.object.getName() : superName,
+            superName,
             type.getPosition(),
             cls.getSupertypes().stream()
                 .filter(t -> t instanceof MissingType)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -156,14 +156,20 @@ public class PythonCAstToIRTranslator extends AstTranslator {
         cls.getSupertypes().stream()
             .filter(t -> !(t instanceof MissingType))
             .collect(Collectors.toSet());
-    ;
+
+    // The superclass name is the registered WALA name of the first non-missing supertype. It can be
+    // null when the base-class name mis-resolves to a same-named class in another module (e.g. a
+    // user `class Model` colliding with `from tensorflow.keras import Model; class X(Model)`): the
+    // supertype is non-missing but has no entry in this unit's `walaTypeNames`. A null superclass
+    // leaves the class unlinked in the hierarchy and breaks callable dispatch on its instances
+    // (wala/ML#657). Fall back to `object` — the same lattice point the missing/no-base case uses,
+    // and the correct one for a modeled base such as `tf.keras.Model`.
+    TypeName superName = present.isEmpty() ? null : walaTypeNames.get(present.iterator().next());
 
     ((PythonLoader) loader)
         .defineType(
             typeName,
-            present.isEmpty()
-                ? PythonTypes.object.getName()
-                : walaTypeNames.get(present.iterator().next()),
+            superName == null ? PythonTypes.object.getName() : superName,
             type.getPosition(),
             cls.getSupertypes().stream()
                 .filter(t -> t instanceof MissingType)


### PR DESCRIPTION
## Problem

wala/ML#657 reported that a `tf.keras.Model` subclass reached via `model(x)` inside a `@tf.function` was missing from the call graph, so its side-effect, recursion, and primitive-parameter preconditions all failed. It looked whole-project-emergent, since a faithful single-file fixture hybridized cleanly.

I reproduced it locally by driving the Ariadne call-graph builder with the evaluator's entrypoint configuration (default module entrypoints plus `PytestEntrypointBuilder`) over the real subject, then bisected the 50-file subject down to one other file and then to a two-file synthetic.

## Root Cause: A Bare-Name `class Model` Collision Across Modules

`CNN.py` subclasses the bare imported name `Model`:

```python
from tensorflow.keras import Model
class MyModel(Model): ...
```

When any other module in the project defines its own `class Model` (NLPGNN's `Linear_Regression.py` does), the bare base name mis-resolves across modules. `PythonCAstToIRTranslator.defineType` sets the superclass to the first non-missing supertype's registered WALA name, which is `null` here: the mis-resolved supertype is non-missing but has no entry in this compilation unit's `walaTypeNames`. A `null` superclass leaves `MyModel` unlinked in the class hierarchy, so `model(x)` callable dispatch finds no keras-model callable and `MyModel.call` gets no call-graph node. That empty `getNodes(...)` is what fails the preconditions.

Controls, each isolating one variable:

- Bare import is required. `class MyModel(tf.keras.Model)` (qualified) is immune; only `from tensorflow.keras import Model; class MyModel(Model)` collides.
- The name `Model` is what collides. A second module with `class Other` is harmless.
- `@tf.function` is incidental. The break occurs with or without it, so the original issue framing was a red herring.

This is general and common, since `Model` is one of the most frequent class names in Keras code and the bare-import idiom is ubiquitous.

## The Fix

Fall back to `object` when no non-missing supertype resolves to a local class. That is the same lattice point the missing/no-base case already uses, and the correct superclass for a modeled base such as `tf.keras.Model` (which is itself "missing" and yields `object` in the collision-free case). Regression guard `testModelSubclassNameCollision` asserts `MyModel.call` keeps its node with a colliding `class Model` present, and the full suite (1064 tests) stays green.

## Scope

This resolves the null-superclass symptom for the reported case. The deeper front-end limitation, the parser resolving a bare base name across modules rather than through the class's own imports, is pre-existing and unchanged. A genuine cross-module user base of a colliding name still degrades to `object`, but that path already produced a broken `null` before this change, so nothing regresses. As with wala/ML#655, evaluator confirmation on the corpus follows a release.

Closes wala/ML#657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg
