### PR TITLE
Add a captured-gap regression guard for the wala/ML#659 GAT under-typing

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -14,6 +14,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -2592,6 +2593,70 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         4,
         Map.of(3, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Captured-gap reproduction for <a href="https://github.com/wala/ML/issues/659">wala/ML#659</a>:
+   * in the vendored GAT subject, {@code maybe_num_nodes}'s {@code index} parameter (vn=2) is
+   * currently <em>not</em> typed as a tensor, even though it receives a real tensor.
+   *
+   * <p>The chain: {@code MessagePassing._calculate_messages_all_type} computes {@code edge_targets
+   * = adjanceny_list_edge_type[:, 1]} (a subscript-slice of an {@code enumerate(adjacency_lists)}
+   * element), which flows through {@code GATConv.message_function}'s {@code edge_target} into
+   * {@code masksoftmax(alpha, edge_target)} and then {@code maybe_num_nodes(index, ...)}. In {@code
+   * propagate} the adjacency list types correctly to {@code (E, 2) int32}, but passed into {@code
+   * _calculate_messages_all_type} the {@code adjacency_lists} parameter is context-collapsed on the
+   * shared message-passing summary (merged with the {@code float32} {@code node_embeddings}),
+   * losing its {@code int32}/rank-2 type. The corrupted ⊤ makes the {@code enumerate} element
+   * empty-shaped, so the {@code [:, 1]} subscript returns ⊥ and {@code index} never types. This is
+   * a regression from 0.52.9 (bisected to the {@code SliceBuiltinOperation} empty-shape change in
+   * wala/ML#656, which unmasked the pre-existing collapse; ⊤ before, ⊥ after), and the root cause
+   * is the same context-collapse class as <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/659">wala/ML#659</a>): {@code index} should
+   * type as a tensor once the shared-summary context collapse is resolved. Flip this to assert vn=2
+   * <em>is</em> typed when it is fixed.
+   */
+  @Test
+  public void testGatMaybeNumNodesIndexUntyped()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine =
+        makeEngine(
+            getPathFiles("gat_proj"),
+            new String[] {
+              "gat_proj/nlpgnn/__init__.py",
+              "gat_proj/nlpgnn/gnn/__init__.py",
+              "gat_proj/nlpgnn/gnn/utils.py",
+              "gat_proj/nlpgnn/gnn/messagepassing.py",
+              "gat_proj/nlpgnn/gnn/GATConv.py",
+              "gat_proj/nlpgnn/models/__init__.py",
+              "gat_proj/nlpgnn/models/GAT.py",
+              "gat_proj/tf2_test_gat_call.py"
+            });
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    addPytestEntrypoints(builder);
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+    TensorTypeAnalysis analysis = engine.performAnalysis(builder);
+
+    // Collect the parameter value numbers that `maybe_num_nodes` types as tensors. Its `index`
+    // parameter is vn=2 (vn=1 is the function object).
+    Set<Integer> typedParamVns = new HashSet<>();
+    analysis.forEach(
+        pt -> {
+          if (pt.fst instanceof LocalPointerKey) {
+            LocalPointerKey lpk = (LocalPointerKey) pt.fst;
+            if (lpk.isParameter()
+                && lpk.getNode().getMethod().getSignature().contains("maybe_num_nodes"))
+              typedParamVns.add(lpk.getValueNumber());
+          }
+        });
+    assertFalse(
+        "Captured gap for wala/ML#659: `maybe_num_nodes`'s `index` (vn=2) is currently untyped"
+            + " because `adjacency_lists` is context-collapsed on the shared message-passing"
+            + " summary. Flip this assertion when the collapse is resolved.",
+        typedParamVns.contains(2));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2640,6 +2640,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     assertNotNull(CG);
     TensorTypeAnalysis analysis = engine.performAnalysis(builder);
 
+    // Guard against a vacuous pass: the captured-gap assertion below only checks that vn=2 is
+    // *absent* from the typed set, which is trivially satisfied if `maybe_num_nodes` is no longer
+    // reached at all (e.g. the entrypoint or file list changes). Require a reachable node so the
+    // test fails, rather than passing silently, when the reproduction stops exercising the target.
+    assertTrue(
+        "The reproduction must reach `maybe_num_nodes`; otherwise this captured-gap guard passes"
+            + " vacuously (wala/ML#659).",
+        CG.stream().anyMatch(n -> n.getMethod().getSignature().contains("maybe_num_nodes")));
+
     // Collect the parameter value numbers that `maybe_num_nodes` types as tensors. Its `index`
     // parameter is vn=2 (vn=1 is the function object).
     Set<Integer> typedParamVns = new HashSet<>();

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2651,6 +2651,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
     // Collect the parameter value numbers that `maybe_num_nodes` types as tensors. Its `index`
     // parameter is vn=2 (vn=1 is the function object).
+    //
+    // Coverage note: while the wala/ML#659 gap holds, no `maybe_num_nodes` parameter types, so the
+    // `isParameter() && ...maybe_num_nodes` branch is never taken and `typedParamVns.add(...)` is
+    // never reached (Codecov reports them as an uncovered line and partial branch). That is the
+    // captured gap itself; both become covered when #659 is fixed and the assertion below is
+    // flipped
+    // to expect vn=2 typed.
     Set<Integer> typedParamVns = new HashSet<>();
     analysis.forEach(
         pt -> {


### PR DESCRIPTION
## What

A committed captured-gap regression guard for wala/ML#659, using the existing 8-file `gat_proj` bed as a fast (~1s) reduced reproduction of the whole-project GAT under-typing. It asserts the current buggy behavior (`maybe_num_nodes`'s `index` parameter is untyped) with a `TODO(wala/ML#659)`, so the guard flips the day the underlying gap is fixed.

## Why the Reproduction Is `gat_proj`

#659 surfaced on the full 94-file NLPGNN subject and looked whole-project-only. Bisecting the vendored `gat_proj` (already in the suite as `testGatCall`) across the same six 0.52.9 commits shows `index` types through #487 and drops at #488, identical to the full subject, in 8 files and ~1s. So `gat_proj` is a faithful reduced reproduction.

## Root Cause (Documented in the Test Javadoc)

`MessagePassing._calculate_messages_all_type` computes `edge_targets = adjanceny_list_edge_type[:, 1]`, which flows through `masksoftmax` into `maybe_num_nodes`. In `propagate` the adjacency list types correctly to `(E, 2) int32`, but passed into `_calculate_messages_all_type` the `adjacency_lists` parameter is context-collapsed on the shared message-passing summary (merged with the `float32` `node_embeddings`), losing its type. The corrupted top makes the `enumerate` element empty-shaped, so the `[:, 1]` subscript returns bottom and `index` never types. The regression bisects to the `SliceBuiltinOperation` empty-shape change in wala/ML#656 (top before, bottom after), which only unmasked a pre-existing collapse. The root cause is the same context-collapse class as wala/ML#570, so the fix is context-sensitivity work on that summary parameter, not a slice change.

## Scope

Test-only, no behavior change. Full suite green (1065 tests). This documents and guards wala/ML#659; it does not fix it (the fix is a separate context-sensitivity change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USFp76oHfj2u3wUSCo87cg

