### PR TITLE
Bump `wala.version` to 1.8.0

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/client/PytestAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/client/PytestAnalysisEngine.java
@@ -42,7 +42,7 @@ public class PytestAnalysisEngine<T> extends PythonAnalysisEngine<T> {
           OrdinalSet<InstanceKey> testObjs = builder.getPointerAnalysis().getPointsToSet(test);
           testObjs.forEach(
               obj -> {
-                IField x = obj.getConcreteType().getField(Atom.findOrCreateUnicodeAtom("params"));
+                IField x = obj.concreteType().getField(Atom.findOrCreateUnicodeAtom("params"));
                 if (x != null) {
                   PointerKey ps = pkf.getPointerKeyForInstanceField(obj, x);
                   builder
@@ -51,16 +51,14 @@ public class PytestAnalysisEngine<T> extends PythonAnalysisEngine<T> {
                       .forEach(
                           p -> {
                             IField ns =
-                                p.getConcreteType()
-                                    .getField(Atom.findOrCreateUnicodeAtom("params"));
+                                p.concreteType().getField(Atom.findOrCreateUnicodeAtom("params"));
                             PointerKey names = pkf.getPointerKeyForInstanceField(p, ns);
                             OrdinalSet<InstanceKey> namesObjs =
                                 builder.getPointerAnalysis().getPointsToSet(names);
                             System.err.println("names: " + namesObjs);
 
                             IField vs =
-                                p.getConcreteType()
-                                    .getField(Atom.findOrCreateUnicodeAtom("values"));
+                                p.concreteType().getField(Atom.findOrCreateUnicodeAtom("values"));
                             PointerKey values = pkf.getPointerKeyForInstanceField(p, vs);
                             OrdinalSet<InstanceKey> valsObjs =
                                 builder.getPointerAnalysis().getPointsToSet(values);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4067,7 +4067,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     if (ik instanceof AllocationSiteInNode) {
       // Already a concrete alloc; use as-is.
     }
-    for (IField field : toProcess.getConcreteType().getAllInstanceFields()) {
+    for (IField field : toProcess.concreteType().getAllInstanceFields()) {
       InstanceFieldPointerKey fk =
           (InstanceFieldPointerKey)
               pa.getHeapModel().getPointerKeyForInstanceField(toProcess, field);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5082,10 +5082,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * targets} that flows through {@code strategy.run}'s {@code args} tuple into {@code step_fn}'s
    * {@code tar}, types to {@code (2, 2)} int32 exactly as in the direct reach. This exercises both
    * halves of the wala/ML#618 distributed-reach fix: the {@code tensorflow/distribute/run/run}
-   * model forwarding both tuple elements (see {@link #testStrategyRunTwoArgsInp()}), and {@code
-   * PythonTensorAnalysisEngine.repairSummaryParameterNames} restoring the {@code args} parameter
-   * name that WALA's {@code XMLMethodSummaryReader} strips, without which the keyword {@code args=}
-   * could not bind.
+   * model forwarding both tuple elements (see {@link #testStrategyRunTwoArgsInp()}), and the {@code
+   * args} parameter name surviving summary loading (the <a
+   * href="https://github.com/wala/WALA/pull/1972">wala/WALA#1972</a> fix to {@code
+   * XMLMethodSummaryReader}'s name filter), without which the keyword {@code args=} could not bind.
    */
   @Test
   public void testGpt2DistributedGetLoss()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -116,7 +116,7 @@ public class Concat extends TensorGenerator {
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
       if (asin == null) continue;
-      TypeReference ref = asin.getConcreteType().getReference();
+      TypeReference ref = asin.concreteType().getReference();
       if (!(ref.equals(list) || ref.equals(tuple))) continue;
 
       OrdinalSet<InstanceKey> catalog =
@@ -144,7 +144,7 @@ public class Concat extends TensorGenerator {
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
       if (asin == null) continue;
-      TypeReference ref = asin.getConcreteType().getReference();
+      TypeReference ref = asin.concreteType().getReference();
       if (!(ref.equals(list) || ref.equals(tuple))) continue;
 
       OrdinalSet<InstanceKey> catalog =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
@@ -133,8 +133,8 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -148,7 +148,7 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -259,8 +259,8 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -274,7 +274,7 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromGeneratorGenerator.java
@@ -88,8 +88,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputSignaturePts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           return true;
         }
       }
@@ -103,8 +103,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputTypesPts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           return true;
         }
       }
@@ -130,8 +130,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputSignaturePts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -174,8 +174,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputShapesPts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -231,8 +231,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         // Case 1.1: Structured signature (tuple or list of specs).
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           // We extract shapes from each component of the structure and union them.
           // This results in the dataset elements being identified as having any of
           // the types/shapes present in the signature.
@@ -315,8 +315,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputSignaturePts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -355,8 +355,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
       for (InstanceKey ik : outputTypesPts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -431,8 +431,8 @@ public class DatasetFromGeneratorGenerator extends DatasetGenerator
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         // Case 1.1: Structured signature (tuple or list of specs).
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(tuple)
-                || asin.getConcreteType().getReference().equals(list))) {
+            && (asin.concreteType().getReference().equals(tuple)
+                || asin.concreteType().getReference().equals(list))) {
           // Extract dtypes from each component and union them.
           // This results in the dataset elements being identified as having any of
           // the dtypes present in the signature.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -189,7 +189,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
     if (tensorsPTS != null && !tensorsPTS.isEmpty()) {
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           return true;
         }
       }
@@ -207,7 +207,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
       Set<List<Dimension<?>>> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -220,7 +220,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
             if (fieldIndex != null && fieldIndex == index) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -305,7 +305,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
       Set<DType> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -318,7 +318,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
             if (fieldIndex != null && fieldIndex == index) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -410,7 +410,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
 
     for (InstanceKey ik : valuePointsToSet) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin == null || !asin.getConcreteType().getReference().equals(tuple)) {
+      if (asin == null || !asin.concreteType().getReference().equals(tuple)) {
         continue;
       }
       sawTuple = true;
@@ -579,7 +579,7 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
 
     for (InstanceKey ik : valuePointsToSet) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin == null || !asin.getConcreteType().getReference().equals(tuple)) {
+      if (asin == null || !asin.concreteType().getReference().equals(tuple)) {
         continue;
       }
       sawTuple = true;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
@@ -83,7 +83,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
     if (tensorsPTS != null && !tensorsPTS.isEmpty()) {
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           return true;
         }
       }
@@ -108,7 +108,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       Set<TensorType> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -158,7 +158,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       Set<List<Dimension<?>>> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -171,7 +171,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
             if (fieldIndex != null && fieldIndex == index) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -212,7 +212,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       Set<DType> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -225,7 +225,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
             if (fieldIndex != null && fieldIndex == index) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -292,7 +292,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       Set<List<Dimension<?>>> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           // It's a structured element. We return the union of all possible shapes of its members.
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
@@ -306,7 +306,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -357,7 +357,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       for (InstanceKey ik : tensorsPTS) {
         LOGGER.fine(DatasetFromTensorsGenerator.class.getName() + ": processing ik=" + ik);
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+        if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           // It's a structured element. We return the union of all possible dtypes of its members.
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
@@ -371,7 +371,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
@@ -178,7 +178,7 @@ public class DatasetMapGenerator extends DatasetGenerator {
       for (InstanceKey ik : elementPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin == null) continue;
-        TypeReference reference = asin.getConcreteType().getReference();
+        TypeReference reference = asin.concreteType().getReference();
         if (reference.equals(tuple) || reference.equals(list)) return true;
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
@@ -134,8 +134,8 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -149,7 +149,7 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -260,8 +260,8 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -275,7 +275,7 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
             if (fieldIndex != null) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetZipGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetZipGenerator.java
@@ -64,8 +64,8 @@ public class DatasetZipGenerator extends DatasetGenerator implements TupleElemen
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()
@@ -78,7 +78,7 @@ public class DatasetZipGenerator extends DatasetGenerator implements TupleElemen
             if (fieldIndex != null && fieldIndex == targetIndex) {
               FieldReference subscript =
                   FieldReference.findOrCreate(
-                      asin.getConcreteType().getReference(),
+                      asin.concreteType().getReference(),
                       findOrCreateAsciiAtom(fieldIndex.toString()),
                       Root);
               IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -118,8 +118,8 @@ public class DatasetZipGenerator extends DatasetGenerator implements TupleElemen
       for (InstanceKey ik : datasetsPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null
-            && (asin.getConcreteType().getReference().equals(list)
-                || asin.getConcreteType().getReference().equals(tuple))) {
+            && (asin.concreteType().getReference().equals(list)
+                || asin.concreteType().getReference().equals(tuple))) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
               builder
                   .getPointerAnalysis()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -112,7 +112,7 @@ public class DenseCall extends TensorGenerator {
         // Create a field reference for the 'units' field of the Dense layer instance.
         FieldReference unitsFieldRef =
             FieldReference.findOrCreate(
-                selfASIN.getConcreteType().getReference(),
+                selfASIN.concreteType().getReference(),
                 findOrCreateAsciiAtom(DENSE_UNITS_FIELD_NAME),
                 Root);
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gradient.java
@@ -126,7 +126,7 @@ public class Gradient extends TensorGenerator implements TupleElementProvider {
       for (InstanceKey ik : sourcesPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null) {
-          TypeReference ref = asin.getConcreteType().getReference();
+          TypeReference ref = asin.concreteType().getReference();
           if (ref.equals(list) || ref.equals(tuple)) return true;
         }
       }
@@ -152,7 +152,7 @@ public class Gradient extends TensorGenerator implements TupleElementProvider {
       for (InstanceKey ik : sourcesPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin == null) continue;
-        TypeReference ref = asin.getConcreteType().getReference();
+        TypeReference ref = asin.concreteType().getReference();
         if (!ref.equals(list) && !ref.equals(tuple)) continue;
 
         OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -169,7 +169,7 @@ public class Gradient extends TensorGenerator implements TupleElementProvider {
 
           FieldReference subscript =
               FieldReference.findOrCreate(
-                  asin.getConcreteType().getReference(),
+                  asin.concreteType().getReference(),
                   findOrCreateAsciiAtom(fieldIndex.toString()),
                   Root);
           IField f = builder.getClassHierarchy().resolveField(subscript);
@@ -206,7 +206,7 @@ public class Gradient extends TensorGenerator implements TupleElementProvider {
       for (InstanceKey ik : sourcesPTS) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin == null) continue;
-        TypeReference ref = asin.getConcreteType().getReference();
+        TypeReference ref = asin.concreteType().getReference();
         if (!ref.equals(list) && !ref.equals(tuple)) continue;
 
         OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -223,7 +223,7 @@ public class Gradient extends TensorGenerator implements TupleElementProvider {
 
           FieldReference subscript =
               FieldReference.findOrCreate(
-                  asin.getConcreteType().getReference(),
+                  asin.concreteType().getReference(),
                   findOrCreateAsciiAtom(fieldIndex.toString()),
                   Root);
           IField f = builder.getClassHierarchy().resolveField(subscript);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -177,7 +177,7 @@ public class ModelCall extends TensorGenerator {
       if (selfASIN == null) continue;
 
       // Only functional-API models carry an `outputs` constructor argument.
-      if (!selfASIN.getConcreteType().getReference().equals(MODEL.getDeclaringClass())) continue;
+      if (!selfASIN.concreteType().getReference().equals(MODEL.getDeclaringClass())) continue;
 
       CGNode modelDoNode = selfASIN.getNode();
       IR ir = modelDoNode.getIR();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
@@ -220,7 +220,7 @@ public class NdarraySubscriptOperation extends TensorGenerator {
     AllocationSiteInNode tupleAsin = null;
     for (InstanceKey ik : memberPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin != null && asin.getConcreteType().getReference().equals(tuple)) {
+      if (asin != null && asin.concreteType().getReference().equals(tuple)) {
         tupleAsin = asin;
         break;
       }
@@ -230,7 +230,7 @@ public class NdarraySubscriptOperation extends TensorGenerator {
       for (InstanceKey ik : memberPts) {
         ptsDesc.append(" ").append(ik.getClass().getSimpleName());
         AllocationSiteInNode a = getAllocationSiteInNode(ik);
-        if (a != null) ptsDesc.append("@").append(a.getConcreteType().getReference().getName());
+        if (a != null) ptsDesc.append("@").append(a.concreteType().getReference().getName());
       }
       LOGGER.fine(
           () ->
@@ -307,7 +307,7 @@ public class NdarraySubscriptOperation extends TensorGenerator {
       }
       // Non-constant InstanceKey: accept it only if it's the modeled `tf.newaxis` allocation.
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin != null && asin.getConcreteType().getReference().equals(TensorFlowTypes.NEWAXIS)) {
+      if (asin != null && asin.concreteType().getReference().equals(TensorFlowTypes.NEWAXIS)) {
         sawNone = true;
         continue;
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -151,7 +151,7 @@ public class NpArray extends TensorGenerator {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin == null) return false;
 
-        TypeReference reference = asin.getConcreteType().getReference();
+        TypeReference reference = asin.concreteType().getReference();
         if (!reference.equals(list) && !reference.equals(tuple))
           // An existing array/tensor (or other non-literal): numpy would preserve its dtype rather
           // than promote, which this walk does not model. Floor to ⊤.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -26,7 +26,6 @@ import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
-import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -46,7 +45,6 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationSystem;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.nCFAContextSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
-import com.ibm.wala.ipa.summaries.MethodSummary;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
@@ -1312,44 +1310,5 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     // `NumpyTypes` constants without depending on load order side effects.
     addSummaryBypassLogic(options, "numpy.xml");
     addSummaryBypassLogic(options, "tensorflow.xml");
-  }
-
-  /** The value number of the {@code args} tuple parameter in the {@code strategy.run} summaries. */
-  private static final int STRATEGY_RUN_ARGS_VALUE_NUMBER = 3;
-
-  /**
-   * The {@code tf.distribute.Strategy.run} summary classes whose {@code args} tuple parameter name
-   * WALA strips. Both {@code run} and its legacy alias {@code experimental_run_v2} model {@code
-   * run(fn, args=(...))} and forward the {@code args} tuple's elements into {@code fn}.
-   */
-  private static final Set<String> STRATEGY_RUN_SUMMARY_CLASSES =
-      Set.of("Ltensorflow/distribute/run/run", "Ltensorflow/distribute/run/experimental_run_v2");
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p>Restores the {@code args} parameter name on the {@code tf.distribute.Strategy.run} summaries
-   * (see {@link #STRATEGY_RUN_SUMMARY_CLASSES}). Without it, the keyword form {@code
-   * strategy.run(fn, args=(inputs, targets))} that real subjects use cannot bind its tuple to the
-   * callback, dropping the tensor types of everything reached through the callback (wala/ML#618).
-   * The positional form {@code strategy.run(fn, (inputs, targets))} is unaffected, since it does
-   * not rely on parameter names.
-   *
-   * @implNote TODO: Remove this temporary workaround once the <a
-   *     href="https://github.com/wala/WALA/pull/1972">upstream WALA fix</a> that narrows the
-   *     reader's name filter to the exact {@code arg<n>} synthetic symbols ships in an adopted WALA
-   *     release. Tracked by <a href="https://github.com/wala/ML/issues/630">wala/ML#630</a>.
-   */
-  @Override
-  protected void repairSummaryParameterNames(Map<MethodReference, MethodSummary> summaries) {
-    summaries.forEach(
-        (reference, summary) -> {
-          String declaringClass = reference.getDeclaringClass().getName().toString();
-          if (STRATEGY_RUN_SUMMARY_CLASSES.contains(declaringClass)) {
-            Map<Integer, Atom> valueNames = summary.getValueNames();
-            if (valueNames != null)
-              valueNames.put(STRATEGY_RUN_ARGS_VALUE_NUMBER, Atom.findOrCreateUnicodeAtom("args"));
-          }
-        });
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -486,7 +486,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         for (InstanceKey ik : pointerAnalysis.getPointsToSet(targetKey)) {
           if (ik instanceof ConcreteTypeKey) {
             ConcreteTypeKey ctk = (ConcreteTypeKey) ik;
-            IClass type = ctk.getType();
+            IClass type = ctk.type();
             TypeReference reference = type.getReference();
 
             if (reference.equals(NEXT.getDeclaringClass())) {
@@ -679,7 +679,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     for (InstanceKey ik : pointerAnalysis.getPointsToSet(usePointerKey)) {
       if (ik instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = (AllocationSiteInNode) ik;
-        IClass concreteType = asin.getConcreteType();
+        IClass concreteType = asin.concreteType();
         TypeReference reference = concreteType.getReference();
 
         if ((reference.equals(DATASET)
@@ -727,7 +727,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             pointerAnalysis.getPointsToSet(invocationUsePointerKey)) {
           if (functionInstance instanceof ConcreteTypeKey) {
             ConcreteTypeKey typeKey = (ConcreteTypeKey) functionInstance;
-            IClass type = typeKey.getType();
+            IClass type = typeKey.type();
             TypeReference typeReference = type.getReference();
 
             if (typeReference.equals(ENUMERATE.getDeclaringClass())) {
@@ -853,7 +853,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           AllocationSiteInNode asin = getAllocationSiteInNode(ik);
 
           if (asin != null) {
-            TypeReference reference = asin.getConcreteType().getReference();
+            TypeReference reference = asin.concreteType().getReference();
 
             if (reference.getName().toString().startsWith(DATA_PACKAGE_PREFIX)) {
               LOGGER.fine(
@@ -1000,7 +1000,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // file and avoids missing tensor receivers that flow through closures or constants.
             AllocationSiteInNode asin = getAllocationSiteInNode(ik);
             if (asin != null
-                && SET_SHAPE_RECEIVER_TYPES.contains(asin.getConcreteType().getReference())) {
+                && SET_SHAPE_RECEIVER_TYPES.contains(asin.concreteType().getReference())) {
               receiverEligible = true;
               break;
             }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -163,7 +163,7 @@ public class RaggedConstant extends Constant {
 
     for (InstanceKey ik : pts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
 
       // A `list` or `tuple`.
       if (reference.equals(list) || reference.equals(tuple)) {
@@ -202,7 +202,7 @@ public class RaggedConstant extends Constant {
 
                       if (innerAsin == null) return false;
 
-                      TypeReference innerReference = innerAsin.getConcreteType().getReference();
+                      TypeReference innerReference = innerAsin.concreteType().getReference();
                       return innerReference.equals(list) || innerReference.equals(tuple);
                     });
 
@@ -221,7 +221,7 @@ public class RaggedConstant extends Constant {
 
     for (InstanceKey valueIK : valuePointsToSet) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
 
       // A `list` or `tuple`.
       if (reference.equals(list) || reference.equals(tuple)) {
@@ -243,7 +243,7 @@ public class RaggedConstant extends Constant {
     if (ik instanceof ConstantKey) return true; // Scalar value.
     else {
       AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
 
       // A nested `list`, `tuple`, or `np.ndarray`.
       if (reference.equals(list) || reference.equals(tuple)) {
@@ -283,7 +283,7 @@ public class RaggedConstant extends Constant {
     int maxDepth = 0;
 
     AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
-    TypeReference reference = asin.getConcreteType().getReference();
+    TypeReference reference = asin.concreteType().getReference();
 
     // A nested `list` or `tuple`.
     if (reference.equals(list) || reference.equals(tuple)) {
@@ -330,7 +330,7 @@ public class RaggedConstant extends Constant {
     if (valueIK instanceof ConstantKey) maxDepth = max(maxDepth, 0); // Scalar value.
     else {
       AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
 
       // A nested `list`, `tuple`, or `np.ndarray`.
       if (reference.equals(list) || reference.equals(tuple)) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
@@ -113,7 +113,7 @@ public abstract class RaggedFromNested extends RaggedTensorFromValues {
       for (InstanceKey ik : nestedRowLengthsPts) {
         if (ik instanceof AllocationSiteInNode) {
           AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-          TypeReference reference = asin.getConcreteType().getReference();
+          TypeReference reference = asin.concreteType().getReference();
 
           if (reference.equals(list) || reference.equals(tuple)) {
             OrdinalSet<InstanceKey> objectCatalogPointsToSet =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -108,7 +108,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
       for (InstanceKey ik : getEffectiveInstances(builder, nestedNrowsPts)) {
         if (ik instanceof AllocationSiteInNode) {
           AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-          TypeReference reference = asin.getConcreteType().getReference();
+          TypeReference reference = asin.concreteType().getReference();
           if (reference.equals(list) || reference.equals(tuple)) {
             // Get index 0
             FieldReference subscript =
@@ -152,7 +152,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
       for (InstanceKey ik : getEffectiveInstances(builder, nestedValueRowIdsPts)) {
         if (ik instanceof AllocationSiteInNode) {
           AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-          TypeReference reference = asin.getConcreteType().getReference();
+          TypeReference reference = asin.concreteType().getReference();
 
           if (reference.equals(list) || reference.equals(tuple)) {
             OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -179,7 +179,7 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
                   for (InstanceKey innerIk : getEffectiveInstances(builder, firstElemPts)) {
                     if (innerIk instanceof AllocationSiteInNode) {
                       AllocationSiteInNode innerAsin = getAllocationSiteInNode(innerIk);
-                      TypeReference innerRef = innerAsin.getConcreteType().getReference();
+                      TypeReference innerRef = innerAsin.concreteType().getReference();
                       if (innerRef.equals(list) || innerRef.equals(tuple)) {
                         OrdinalSet<InstanceKey> innerObjectCatalog =
                             pointerAnalysis.getPointsToSet(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -101,7 +101,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
         }
       } else if (instanceKey instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(instanceKey);
-        TypeReference reference = asin.getConcreteType().getReference();
+        TypeReference reference = asin.concreteType().getReference();
 
         if (reference.equals(list) || reference.equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -158,7 +158,7 @@ public class RaggedRange extends Range {
           for (InstanceKey ik : pts) {
             if (ik instanceof AllocationSiteInNode) {
               AllocationSiteInNode asin = (AllocationSiteInNode) ik;
-              TypeReference ref = asin.getConcreteType().getReference();
+              TypeReference ref = asin.concreteType().getReference();
               if (ref.equals(PythonTypes.list) || ref.equals(PythonTypes.tuple)) {
                 hasVector = true;
                 OrdinalSet<InstanceKey> catalog =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -181,7 +181,7 @@ public class SliceBuiltinOperation extends TensorGenerator {
       if (pts == null || pts.isEmpty()) continue;
       for (InstanceKey ik : pts) {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(TensorFlowTypes.NEWAXIS)) {
+        if (asin != null && asin.concreteType().getReference().equals(TensorFlowTypes.NEWAXIS)) {
           count++;
           break;
         }
@@ -486,7 +486,7 @@ public class SliceBuiltinOperation extends TensorGenerator {
         else return null; // integer/other — not special.
       } else {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin != null && asin.getConcreteType().getReference().equals(TensorFlowTypes.NEWAXIS))
+        if (asin != null && asin.concreteType().getReference().equals(TensorFlowTypes.NEWAXIS))
           newaxis = true;
         else return null;
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -76,7 +76,7 @@ public class SparseAdd extends ElementWiseOperation {
 
     boolean hasSparseTensor = false;
     for (InstanceKey ik : valuePointsToSet) {
-      if (ik.getConcreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
+      if (ik.concreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
         hasSparseTensor = true;
         break;
       }
@@ -90,7 +90,7 @@ public class SparseAdd extends ElementWiseOperation {
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     for (InstanceKey ik : valuePointsToSet) {
-      if (ik.getConcreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
+      if (ik.concreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
         FieldReference denseShapeFieldRef =
             FieldReference.findOrCreate(Root, findOrCreateAsciiAtom("dense_shape"), Root);
 
@@ -126,7 +126,7 @@ public class SparseAdd extends ElementWiseOperation {
 
     boolean hasSparseTensor = false;
     for (InstanceKey ik : pointsToSet) {
-      if (ik.getConcreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
+      if (ik.concreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
         hasSparseTensor = true;
         break;
       }
@@ -140,7 +140,7 @@ public class SparseAdd extends ElementWiseOperation {
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     for (InstanceKey ik : pointsToSet) {
-      if (ik.getConcreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
+      if (ik.concreteType().getReference().equals(SPARSE_TENSOR_TYPE)) {
         FieldReference valuesFieldRef =
             FieldReference.findOrCreate(Root, findOrCreateAsciiAtom("values"), Root);
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Stack.java
@@ -109,7 +109,7 @@ public class Stack extends TensorGenerator {
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
       if (asin == null) continue;
-      TypeReference ref = asin.getConcreteType().getReference();
+      TypeReference ref = asin.concreteType().getReference();
       if (!(ref.equals(list) || ref.equals(tuple))) continue;
 
       OrdinalSet<InstanceKey> catalog =
@@ -152,7 +152,7 @@ public class Stack extends TensorGenerator {
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
       if (asin == null) continue;
-      TypeReference ref = asin.getConcreteType().getReference();
+      TypeReference ref = asin.concreteType().getReference();
       if (!(ref.equals(list) || ref.equals(tuple))) continue;
 
       OrdinalSet<InstanceKey> catalog =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -307,7 +307,7 @@ public abstract class TensorGenerator {
     for (InstanceKey instanceKey : pointsToSet) {
       AllocationSiteInNode asin = getAllocationSiteInNode(instanceKey);
       if (asin == null) continue;
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
 
       if (reference.equals(list) || reference.equals(tuple)) {
         // We have a list of integers that represent the shape.
@@ -379,7 +379,7 @@ public abstract class TensorGenerator {
               tensorDimensions.add(dimension);
             } else if (instanceFieldIK instanceof AllocationSiteInNode) {
               AllocationSiteInNode innerAsin = (AllocationSiteInNode) instanceFieldIK;
-              TypeReference innerReference = innerAsin.getConcreteType().getReference();
+              TypeReference innerReference = innerAsin.concreteType().getReference();
 
               if (innerReference.equals(tuple)
                   || innerReference.equals(list)
@@ -1357,7 +1357,7 @@ public abstract class TensorGenerator {
       if (valueIK instanceof ConstantKey) ret.add(emptyList()); // Scalar value.
       else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
-        TypeReference reference = asin.getConcreteType().getReference();
+        TypeReference reference = asin.concreteType().getReference();
 
         if (reference.equals(list) || reference.equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -1491,7 +1491,7 @@ public abstract class TensorGenerator {
         }
 
         TensorGenerator generator =
-            createManualGenerator(readDataNode, asin.getConcreteType().getReference(), builder);
+            createManualGenerator(readDataNode, asin.concreteType().getReference(), builder);
 
         if (generator != null) {
           // Avoid infinite recursion for manual generators
@@ -1663,7 +1663,7 @@ public abstract class TensorGenerator {
 
       if (found) continue;
 
-      IClass concreteType = instanceKey.getConcreteType();
+      IClass concreteType = instanceKey.concreteType();
       TypeReference typeReference = concreteType.getReference();
 
       if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
@@ -2126,7 +2126,7 @@ public abstract class TensorGenerator {
         }
       } else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
-        TypeReference reference = asin.getConcreteType().getReference();
+        TypeReference reference = asin.concreteType().getReference();
 
         if (reference.equals(list) || reference.equals(tuple)) {
           OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -2233,7 +2233,7 @@ public abstract class TensorGenerator {
         }
 
         TensorGenerator generator =
-            createManualGenerator(readDataNode, asin.getConcreteType().getReference(), builder);
+            createManualGenerator(readDataNode, asin.concreteType().getReference(), builder);
 
         if (generator != null) {
           if (this.manualNode != null && this.manualNode.equals(readDataNode)) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -340,10 +340,10 @@ public class TensorGeneratorFactory {
               builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, funcVn);
           for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(funcKey)) {
             if (ik instanceof ConcreteTypeKey) {
-              return ((ConcreteTypeKey) ik).getType().getReference();
+              return ((ConcreteTypeKey) ik).type().getReference();
             }
             if (ik instanceof AllocationSiteInNode) {
-              return ((AllocationSiteInNode) ik).getConcreteType().getReference();
+              return ((AllocationSiteInNode) ik).concreteType().getReference();
             }
           }
         }
@@ -370,7 +370,7 @@ public class TensorGeneratorFactory {
     } else if (k instanceof ReturnValueKey) {
       return ((ReturnValueKey) k).getNode().getMethod().getDeclaringClass().getReference();
     } else if (k instanceof AllocationSiteInNode) {
-      return ((AllocationSiteInNode) k).getConcreteType().getReference();
+      return ((AllocationSiteInNode) k).concreteType().getReference();
     }
     return Util.getFunction(source);
   }
@@ -516,7 +516,7 @@ public class TensorGeneratorFactory {
         continue;
       }
       if (asin == null) continue;
-      TypeReference reference = asin.getConcreteType().getReference();
+      TypeReference reference = asin.concreteType().getReference();
       if (!reference.equals(PythonTypes.list) && !reference.equals(PythonTypes.tuple)) continue;
       IField field =
           builder

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPrint.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestPrint.java
@@ -68,7 +68,7 @@ public class TestPrint extends TestJythonCallGraphShape {
           assertEquals(1, read.getAccessCount());
           Access access = read.getAccess(0);
 
-          if (access.variableName.equals(PRINT_FUNCTION_VARIABLE_NAME)) {
+          if (access.variableName().equals(PRINT_FUNCTION_VARIABLE_NAME)) {
             foundPrintCall = true;
 
             // Found the print call. Let's ensure that it "points" to the built-in function.
@@ -76,13 +76,13 @@ public class TestPrint extends TestJythonCallGraphShape {
                 builder
                     .getPointerAnalysis()
                     .getHeapModel()
-                    .getPointerKeyForLocal(fNode, access.valueNumber);
+                    .getPointerKeyForLocal(fNode, access.valueNumber());
             OrdinalSet<InstanceKey> pointsToSet = builder.getPointerAnalysis().getPointsToSet(pk);
 
             for (Iterator<InstanceKey> pit = pointsToSet.iterator(); pit.hasNext(); ) {
               InstanceKey ik = pit.next();
 
-              IClass concreteType = ik.getConcreteType();
+              IClass concreteType = ik.concreteType();
               TypeReference typeReference = concreteType.getReference();
 
               if (typeReference.equals(PRINT_FUNCTION_TYPE_REFERENCE)) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -221,24 +221,6 @@ public abstract class PythonAnalysisEngine<T>
     }
   }
 
-  /**
-   * Repairs summary parameter names that WALA's {@link XMLMethodSummaryReader} discards. The reader
-   * drops the synthetic positional symbols ({@code arg0}, {@code arg1}, ...) from a summary's
-   * value-name table, but its filter is the over-broad {@code startsWith("arg")}, so it also drops
-   * legitimate parameter names beginning with {@code arg} (e.g. {@code args}, {@code argv}). A
-   * parameter so stripped has no value name, so a keyword argument of that name cannot bind to it.
-   * Subclasses override this to restore such names on the summaries they ship. The default is a
-   * no-op.
-   *
-   * @param summaries the loaded summaries, keyed by method reference, whose value-name tables may
-   *     be mutated in place
-   * @implNote TODO: Remove this temporary hook once the <a
-   *     href="https://github.com/wala/WALA/pull/1972">upstream WALA fix</a> that narrows the
-   *     reader's filter to the exact {@code arg<n>} synthetic symbols ships in an adopted WALA
-   *     release. Tracked by <a href="https://github.com/wala/ML/issues/630">wala/ML#630</a>.
-   */
-  protected void repairSummaryParameterNames(Map<MethodReference, MethodSummary> summaries) {}
-
   protected void addSummaryBypassLogic(AnalysisOptions options, String summary) {
     IClassHierarchy cha = getClassHierarchy();
     // Two distinct loader sources need to find summary XMLs, and they pull from opposite
@@ -293,7 +275,6 @@ public abstract class PythonAnalysisEngine<T>
     XMLMethodSummaryReader xml = new XMLMethodSummaryReader(xmlStream, scope);
 
     Map<MethodReference, MethodSummary> summaries = new HashMap<>(xml.getSummaries());
-    repairSummaryParameterNames(summaries);
     BypassSyntheticClassLoader ldr =
         (BypassSyntheticClassLoader) cha.getLoader(scope.getSyntheticLoader());
 

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonTurtleAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonTurtleAnalysisEngine.java
@@ -40,8 +40,6 @@ import com.ibm.wala.util.collections.EmptyIterator;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Collection;
-import com.ibm.wala.util.collections.Iterator2List;
-import com.ibm.wala.util.collections.Iterator2Set;
 import com.ibm.wala.util.collections.MapIterator;
 import com.ibm.wala.util.graph.AbstractGraph;
 import com.ibm.wala.util.graph.EdgeManager;
@@ -256,10 +254,10 @@ public class PythonTurtleAnalysisEngine
       }
       if ("**".equals(pat)) {
 
-        Iterator2List<MemberReference> pathList = Iterator2List.toList(path);
+        List<MemberReference> pathList = Iterator2Collection.toList(path);
         pathList.add(0, pe);
 
-        Iterator2List<String> patternList = Iterator2List.toList(pattern);
+        List<String> patternList = Iterator2Collection.toList(pattern);
 
         do {
           if (match(pathList.iterator(), patternList.iterator())) {
@@ -311,7 +309,7 @@ public class PythonTurtleAnalysisEngine
                 check:
                 {
                   for (InstanceKey ptr : ptrs) {
-                    if (ptr.getConcreteType().getReference().equals(TurtleSummary.turtleClassRef)) {
+                    if (ptr.concreteType().getReference().equals(TurtleSummary.turtleClassRef)) {
                       break check;
                     }
                   }
@@ -333,7 +331,7 @@ public class PythonTurtleAnalysisEngine
                           PointerKey ak = builder.getPointerKeyForLocal(node, vn);
                           PointsToSetVariable av =
                               builder.getPropagationSystem().findOrCreatePointsToSet(ak);
-                          Iterator2Set<PointerKey> back =
+                          Set<PointerKey> back =
                               Iterator2Collection.toSet(
                                   MapIterator.map(
                                       (x) -> {
@@ -582,7 +580,7 @@ public class PythonTurtleAnalysisEngine
                           OrdinalSet<? extends InstanceKey> ptrs =
                               builder.getPointerAnalysis().getPointsToSet(ak);
                           for (InstanceKey ptr : ptrs) {
-                            if (ptr.getConcreteType()
+                            if (ptr.concreteType()
                                 .getReference()
                                 .equals(TurtleSummary.turtleClassRef)) {
                               ptr.getCreationSites(CG)
@@ -683,7 +681,7 @@ public class PythonTurtleAnalysisEngine
                 OrdinalSet<? extends InstanceKey> ptrs =
                     builder.getPointerAnalysis().getPointsToSet(ak);
                 for (InstanceKey ptr : ptrs) {
-                  if (ptr.getConcreteType().getReference().equals(TurtleSummary.turtleClassRef)) {
+                  if (ptr.concreteType().getReference().equals(TurtleSummary.turtleClassRef)) {
                     ptr.getCreationSites(CG)
                         .forEachRemaining(
                             (site) -> {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonClassMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonClassMethodTrampolineTargetSelector.java
@@ -63,7 +63,7 @@ public class PythonClassMethodTrampolineTargetSelector<T>
         caller
             .getMethod()
             .getSelector()
-            .getName()
+            .name()
             .startsWith(Atom.findOrCreateAsciiAtom(TRAMPOLINE_METHOD_NAME));
 
     return classMethodReceiver

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -234,7 +234,7 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
             declaringClass.getClassLoader().getReference();
 
         // First, check the concrete type of the allocated object
-        IClass concreteType = o.getConcreteType();
+        IClass concreteType = o.concreteType();
         if (concreteType != null) {
           String concreteTypeName = "$" + concreteType.getName().toString().substring(1);
           IClass concreteCallable =

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -86,11 +86,7 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
       AnalysisOptions options,
       IAnalysisCacheView cache,
       PointerKeyFactory pointerKeyFactory) {
-    super(
-        PythonLanguage.Python.getFakeRootMethod(cha, options, cache),
-        options,
-        cache,
-        pointerKeyFactory);
+    super(PythonLanguage.Python.getFakeRootMethod(cha, cache), options, cache, pointerKeyFactory);
   }
 
   protected boolean isConstantRef(SymbolTable symbolTable, int valueNumber) {
@@ -175,7 +171,7 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
 
       if (contentsAreInvariant(symtab, du, objVn)) {
         for (InstanceKey ik : getInvariantContents(objVn)) {
-          if (!isValueForKeyType(ik.getConcreteType())) {
+          if (!isValueForKeyType(ik.concreteType())) {
             system.newConstraint(resultKey, assignOperator, eltKey);
           } else {
             newFieldRead(node, objVn, eltVn, resultVn);
@@ -193,7 +189,7 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
                     IntIterator is = rv.getValue().intIterator();
                     while (is.hasNext()) {
                       InstanceKey ik = system.getInstanceKey(is.next());
-                      if (!isValueForKeyType(ik.getConcreteType())) {
+                      if (!isValueForKeyType(ik.concreteType())) {
                         changed |= system.newConstraint(resultKey, assignOperator, eltKey);
                       } else {
                         newFieldRead(node, objVn, eltVn, resultVn);
@@ -242,9 +238,9 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
       if (contentsAreInvariant(symtab, du, objVn)) {
         system.recordImplicitPointsToSet(objKey);
         for (InstanceKey ik : getInvariantContents(objVn)) {
-          if (types.contains(ik.getConcreteType().getReference())) {
+          if (types.contains(ik.concreteType().getReference())) {
             @SuppressWarnings("unused")
-            Pair<String, TypeReference> key = Pair.make(name, ik.getConcreteType().getReference());
+            Pair<String, TypeReference> key = Pair.make(name, ik.concreteType().getReference());
             // system.newConstraint(lvalKey, new ConcreteTypeKey(getBuilder().ensure(key)));
           }
         }
@@ -259,10 +255,10 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
                       .foreach(
                           (i) -> {
                             InstanceKey ik = system.getInstanceKey(i);
-                            if (types.contains(ik.getConcreteType().getReference())) {
+                            if (types.contains(ik.concreteType().getReference())) {
                               @SuppressWarnings("unused")
                               Pair<String, TypeReference> key =
-                                  Pair.make(name, ik.getConcreteType().getReference());
+                                  Pair.make(name, ik.concreteType().getReference());
                               // system.newConstraint(lvalKey, new
                               // ConcreteTypeKey(getBuilder().ensure(key)));
                             }
@@ -818,7 +814,7 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
     OrdinalSet<InstanceKey> pointsToSet = pointerAnalysis.getPointsToSet(pointerKey);
 
     for (InstanceKey instanceKey : pointsToSet) {
-      IClass concreteType = instanceKey.getConcreteType();
+      IClass concreteType = instanceKey.concreteType();
       TypeReference reference = concreteType.getReference();
 
       // If it's an "object" method.

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonScopeMappingInstanceKeys.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonScopeMappingInstanceKeys.java
@@ -30,7 +30,7 @@ public class PythonScopeMappingInstanceKeys extends ScopeMappingInstanceKeys {
   }
 
   protected LexicalParent[] getParents(InstanceKey base) {
-    IClass cls = base.getConcreteType();
+    IClass cls = base.concreteType();
 
     if (cls instanceof PythonInstanceMethodTrampoline) {
       cls = ((PythonInstanceMethodTrampoline) cls).getRealClass();
@@ -45,7 +45,7 @@ public class PythonScopeMappingInstanceKeys extends ScopeMappingInstanceKeys {
 
   @Override
   protected boolean needsScopeMappingKey(InstanceKey base) {
-    return cha.isSubclassOf(base.getConcreteType(), codeBody) && getParents(base).length > 0;
+    return cha.isSubclassOf(base.concreteType(), codeBody) && getParents(base).length > 0;
   }
 
   @Override

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonComprehensionTrampolines.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonComprehensionTrampolines.java
@@ -46,7 +46,7 @@ public class PythonComprehensionTrampolines implements MethodTargetSelector {
                 method.getDeclaringClass(),
                 new Selector(
                     Atom.findOrCreateUnicodeAtom("__" + receiver.getName()),
-                    method.getSelector().getDescriptor()));
+                    method.getSelector().descriptor()));
 
         SSAAbstractInvokeInstruction inst = caller.getIR().getCalls(site)[0];
         int v = inst.getNumberOfUses() + 3;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSuper.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonSuper.java
@@ -245,7 +245,7 @@ public class PythonSuper {
             for (IMethod m : x.getDeclaredMethods()) {
               if (!m.isInit()
                   && !m.isClinit()
-                  && !m.getName().equals(AstMethodReference.fnSelector.getName())) {
+                  && !m.getName().equals(AstMethodReference.fnSelector.name())) {
                 methodReferences.add(m.getReference());
               }
             }
@@ -361,9 +361,8 @@ public class PythonSuper {
         CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
       if (superStub.equals(callee)) {
         if (actualParameters.length >= 3
-            && actualParameters[1].getConcreteType().getSuperclass() instanceof PythonClass) {
-          return new ExplicitSuperContext(
-              actualParameters[1].getConcreteType(), actualParameters[2]);
+            && actualParameters[1].concreteType().getSuperclass() instanceof PythonClass) {
+          return new ExplicitSuperContext(actualParameters[1].concreteType(), actualParameters[2]);
         }
         if (actualParameters.length == 1) {
           return new DelegatingContext(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonLanguage.java
@@ -35,7 +35,6 @@ import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.util.strings.Atom;
-import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
@@ -321,18 +320,7 @@ public class PythonLanguage implements Language {
   }
 
   @Override
-  public AbstractRootMethod getFakeRootMethod(
-      IClassHierarchy cha,
-      @SuppressWarnings("unused") AnalysisOptions options,
-      IAnalysisCacheView cache) {
-    // `options` is retained in the signature to satisfy the `Language.getFakeRootMethod`
-    // interface contract (the parent's signature still takes it in WALA 1.7.2) but is
-    // unused at this call site. WALA's own 1.7.2 source marks the deprecated 3-arg
-    // `FakeRootMethod(IClass, AnalysisOptions, IAnalysisCacheView)` constructor's
-    // `options` parameter with the same `@SuppressWarnings("unused")` and the
-    // deprecation Javadoc explicitly says the rationale is "to remove unused options
-    // parameter" — i.e., `options` was always vestigial in this code path. Drop the
-    // parameter on our side only if the upstream `Language` interface drops it.
+  public AbstractRootMethod getFakeRootMethod(IClassHierarchy cha, IAnalysisCacheView cache) {
     return new FakeRootMethod(new FakeRootClass(PythonTypes.pythonLoader, cha), cache);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.version>3.15.0</maven.compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build-alias>b000</build-alias>
-    <wala.version>1.7.2</wala.version>
+    <wala.version>1.8.0</wala.version>
     <spotless.version>3.7.0</spotless.version>
     <maven.surefire.version>3.5.6</maven.surefire.version>
     <parallel>both</parallel>


### PR DESCRIPTION
Bumps `wala.version` from 1.7.2 to [WALA 1.8.0](https://github.com/wala/WALA/releases/tag/v1.8.0) and adapts to its API changes, which `-Werror` promotes to build failures:
- `InstanceKey.getConcreteType()` is renamed to `concreteType()` (deprecated for removal); likewise `ConcreteTypeKey.getType()` to `type()` and `Selector.getName()`/`getDescriptor()` to `name()`/`descriptor()`.
- `Iterator2List` is deprecated for removal; `Iterator2Collection.toList()` now returns a plain `java.util.List`.
- `Language.getFakeRootMethod` drops its unused `AnalysisOptions` parameter, exactly as the comment in `PythonLanguage` anticipated.
- `AstLexicalAccess.Access` is now a record, so its fields are accessed via the record accessors.

Since WALA 1.8.0 also ships the wala/WALA#1972 fix that narrows `XMLMethodSummaryReader`'s parameter-name filter to the exact `arg<n>` synthetic symbols, a second commit removes the now-obsolete `repairSummaryParameterNames` workaround hook that restored the `args` name on the `tf.distribute.Strategy.run` summaries. The wala/ML#618 distributed-reach tests (`testGpt2DistributedGetLoss`, `testStrategyRunTwoArgs*`) cover that path against the upstream fix.

Full `mvn test` from the root passes locally.

Closes wala/ML#630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc