### PR TITLE
Resolve summary-modeled base classes via WALA 1.8.0 class shells

### DIFF
--- a/com.ibm.wala.cast.python.jython/source/com/ibm/wala/cast/python/loader/Python2LoaderFactory.java
+++ b/com.ibm.wala.cast.python.jython/source/com/ibm/wala/cast/python/loader/Python2LoaderFactory.java
@@ -1,12 +1,11 @@
 package com.ibm.wala.cast.python.loader;
 
-import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 
 public class Python2LoaderFactory extends PythonLoaderFactory {
 
   @Override
-  protected IClassLoader makeTheLoader(IClassHierarchy cha) {
+  protected PythonLoader makePythonLoader(IClassHierarchy cha) {
     return new Python2Loader(cha);
   }
 }

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/PytestLoaderFactory.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/PytestLoaderFactory.java
@@ -1,6 +1,5 @@
 package com.ibm.wala.cast.python.loader;
 
-import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import java.io.File;
 import java.util.List;
@@ -21,7 +20,7 @@ public class PytestLoaderFactory extends PythonLoaderFactory {
   }
 
   @Override
-  protected IClassLoader makeTheLoader(IClassHierarchy cha) {
+  protected PythonLoader makePythonLoader(IClassHierarchy cha) {
     return new PytestLoader(cha, this.getPythonPath());
   }
 

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3LoaderFactory.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/loader/Python3LoaderFactory.java
@@ -1,6 +1,5 @@
 package com.ibm.wala.cast.python.loader;
 
-import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import java.io.File;
 import java.util.List;
@@ -21,7 +20,7 @@ public class Python3LoaderFactory extends PythonLoaderFactory {
   }
 
   @Override
-  protected IClassLoader makeTheLoader(IClassHierarchy cha) {
+  protected PythonLoader makePythonLoader(IClassHierarchy cha) {
     return new Python3Loader(cha, this.getPythonPath());
   }
 

--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.python.antlr.PythonTree;
 import org.python.antlr.ast.AnnAssign;
 import org.python.antlr.ast.Assert;
@@ -294,6 +295,35 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     public Map<CAstNode, Collection<CAstEntity>> getScopedEntities() {
       return fun.getAllScopedEntities();
     }
+  }
+
+  /**
+   * Maps an in-scope import binding to the fully qualified dotted module path it imports. Populated
+   * by {@link CAstVisitor#visitImport} ({@code import tensorflow as tf} maps {@code tf} to {@code
+   * tensorflow}) and {@link CAstVisitor#visitImportFrom} ({@code from tensorflow.keras.layers
+   * import Layer} maps {@code Layer} to {@code tensorflow.keras.layers.Layer}). Held on the parser
+   * rather than the visitor so that class definitions in nested scopes (visited by child {@link
+   * CAstVisitor}s) see the file's top-level imports.
+   */
+  private final Map<String, String> importedNames = HashMapFactory.make();
+
+  /**
+   * Expands the root identifier of a dotted name through {@link #importedNames} to the fully
+   * qualified module path it is bound to (e.g. {@code tf.keras.layers.Layer} to {@code
+   * tensorflow.keras.layers.Layer} under {@code import tensorflow as tf}).
+   *
+   * @param dotted a dotted source-level name whose root may be an import binding
+   * @return the expanded dotted name, or {@code dotted} unchanged if the root is not an import
+   *     binding
+   */
+  private String expandImportedName(String dotted) {
+    int dot = dotted.indexOf('.');
+    String root = dot < 0 ? dotted : dotted.substring(0, dot);
+    String qualifiedRoot = importedNames.get(root);
+    if (qualifiedRoot == null) {
+      return dotted;
+    }
+    return dot < 0 ? qualifiedRoot : qualifiedRoot + dotted.substring(dot);
   }
 
   public class CAstVisitor extends AbstractParser.CAstVisitor implements VisitorIF<CAstNode> {
@@ -757,6 +787,11 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
               @Override
               public String getName() {
                 return name;
+              }
+
+              @Override
+              public String qualifiedName() {
+                return expandImportedName(name);
               }
 
               @Override
@@ -1627,6 +1662,7 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
       int i = 0;
       CAstNode[] elts = new CAstNode[arg0.getInternalNames().size()];
       for (alias n : arg0.getInternalNames()) {
+        importedNames.put(name(n), n.getInternalName());
         CAstNode obj = importAst(arg0, n.getInternalNameNodes());
         elts[i++] =
             notePosition(
@@ -1658,10 +1694,16 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
               arg0);
 
       int i = 1;
+      String moduleName =
+          arg0.getInternalModuleNames().stream()
+              .map(Name::getInternalId)
+              .collect(Collectors.joining("."));
       for (alias n : arg0.getInternalNames()) {
         java.util.List<Name> nn = n.getInternalNameNodes();
         if (nn == null) {
           assert n.getInternalName().equals("*");
+        } else {
+          importedNames.put(name(n), moduleName + "." + n.getInternalName());
         }
         elts[i++] =
             notePosition(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
@@ -1,0 +1,95 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
+import com.ibm.wala.cast.python.loader.PythonLoader;
+import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
+import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Tests for the summary-modeled class shells of <a
+ * href="https://github.com/wala/ML/issues/118">wala/ML#118</a>: a source class subclassing a
+ * framework base modeled only by an XML method summary (e.g. {@code tf.keras.layers.Layer})
+ * resolves that base in the class hierarchy instead of falling back to {@code object}.
+ */
+public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
+
+  /** The canonical {@link TypeReference} of the {@code tf.keras.layers.Layer} summary shell. */
+  private static final TypeReference LAYER =
+      TypeReference.findOrCreate(PythonTypes.pythonLoader, "Ltensorflow/keras/layers/Layer");
+
+  /**
+   * A subclass written against the aliased attribute path {@code tf.keras.layers.Layer} (under
+   * {@code import tensorflow as tf}) has the {@code Layer} summary shell as its superclass.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built
+   * @throws CancelException if the analysis is canceled
+   * @throws IOException if the test file cannot be read
+   */
+  @Test
+  public void testLayerSubclassSuperclass()
+      throws ClassHierarchyException, CancelException, IOException {
+    checkLayerSubclass("tf2_test_layer_subclass.py");
+  }
+
+  /**
+   * A subclass written against the bare name {@code Layer} (under {@code from
+   * tensorflow.keras.layers import Layer}) has the {@code Layer} summary shell as its superclass.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built
+   * @throws CancelException if the analysis is canceled
+   * @throws IOException if the test file cannot be read
+   */
+  @Test
+  public void testLayerSubclassSuperclassFromImport()
+      throws ClassHierarchyException, CancelException, IOException {
+    checkLayerSubclass("tf2_test_layer_subclass2.py");
+  }
+
+  /**
+   * Asserts that {@code MyLayer} in {@code filename} has the {@code Layer} summary shell as its
+   * superclass, that the shell engages {@link PythonLoader.PythonClass}-gated machinery, and that
+   * the shell itself is positioned at {@code object}.
+   *
+   * @param filename the test file defining {@code MyLayer}
+   * @throws ClassHierarchyException if the class hierarchy cannot be built
+   * @throws CancelException if the analysis is canceled
+   * @throws IOException if the test file cannot be read
+   */
+  private void checkLayerSubclass(String filename)
+      throws ClassHierarchyException, CancelException, IOException {
+    PythonAnalysisEngine<TensorTypeAnalysis> engine = makeEngine(filename);
+    engine.defaultCallGraphBuilder();
+    IClassHierarchy cha = engine.getClassHierarchy();
+
+    IClass subclass =
+        cha.lookupClass(
+            TypeReference.findOrCreate(
+                PythonTypes.pythonLoader, "Lscript " + filename + "/MyLayer"));
+    assertNotNull("expected the source subclass in the hierarchy", subclass);
+
+    IClass superclass = subclass.getSuperclass();
+    assertNotNull("expected the Layer summary shell as the superclass", superclass);
+    assertEquals(LAYER, superclass.getReference());
+
+    // The shell engages `IPythonClass`-gated machinery.
+    assertTrue(
+        "expected the shell to be a PythonLoader class",
+        superclass instanceof PythonLoader.PythonClass);
+
+    // The shell itself is positioned at `object`, per its `super` declaration in tensorflow.xml.
+    IClass shellSuper = superclass.getSuperclass();
+    assertNotNull("expected the shell to link to object", shellSuper);
+    assertEquals(PythonTypes.object, shellSuper.getReference());
+  }
+}

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2431,6 +2431,12 @@
       </class>
     </package>
     <package name="tensorflow/keras/layers">
+      <!-- Declaring a `super` opts `Layer` in to being materialized as a class shell before the class hierarchy is built (wala/WALA#1957), so a source subclass such as `class MyLayer(tf.keras.layers.Layer)` resolves its base to this type instead of falling back to `object` (wala/ML#118). -->
+      <class name="Layer" super="Lobject" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <return value="self"/>
+        </method>
+      </class>
       <class name="Input" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -63,6 +63,7 @@ import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1310,5 +1311,17 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     // `NumpyTypes` constants without depending on load order side effects.
     addSummaryBypassLogic(options, "numpy.xml");
     addSummaryBypassLogic(options, "tensorflow.xml");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>{@code tensorflow.xml} declares class shells (via {@code <class super="...">}) for the
+   * subclassable Keras framework bases (e.g. {@code tf.keras.layers.Layer}), so user subclasses
+   * resolve their base in the class hierarchy (wala/ML#118).
+   */
+  @Override
+  protected Collection<String> getSummaryClassShellSummaries() {
+    return List.of("tensorflow.xml");
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_subclass.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_subclass.py
@@ -1,0 +1,15 @@
+# Test for wala/ML#118: a user subclass of `tf.keras.layers.Layer` resolves its base class in the
+# class hierarchy instead of falling back to `object`.
+import tensorflow as tf
+
+
+class MyLayer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(MyLayer, self).__init__()
+
+    def call(self, inputs):
+        return inputs
+
+
+layer = MyLayer()
+assert isinstance(layer, tf.keras.layers.Layer)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_subclass2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_subclass2.py
@@ -1,0 +1,15 @@
+# Test for wala/ML#118: a user subclass of `Layer` imported via `from tensorflow.keras.layers
+# import Layer` resolves its base class in the class hierarchy instead of falling back to `object`.
+from tensorflow.keras.layers import Layer
+
+
+class MyLayer(Layer):
+    def __init__(self):
+        super(MyLayer, self).__init__()
+
+    def call(self, inputs):
+        return inputs
+
+
+layer = MyLayer()
+assert isinstance(layer, Layer)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -193,8 +193,25 @@ public abstract class PythonAnalysisEngine<T>
     }
   }
 
+  /**
+   * The summary XMLs whose {@code <class name="..." super="...">} declarations should be
+   * materialized as class shells in the Python loader before source translation, so a source class
+   * subclassing a summary-modeled type resolves its base at definition time instead of falling back
+   * to {@code object} (wala/ML#118). Subclasses override this to name the summaries they ship that
+   * declare shells (e.g. {@code tensorflow.xml}); the default is empty.
+   *
+   * @return the summary XML resource names declaring class shells
+   */
+  protected Collection<String> getSummaryClassShellSummaries() {
+    return Collections.emptyList();
+  }
+
   @Override
   public IClassHierarchy buildClassHierarchy() {
+    for (String summary : getSummaryClassShellSummaries()) {
+      loader.addSummaryClassShells(new XMLMethodSummaryReader(openSummaryStream(summary), scope));
+    }
+
     IClassHierarchy cha = null;
     try {
       cha = SeqClassHierarchyFactory.make(scope, loader);
@@ -221,40 +238,49 @@ public abstract class PythonAnalysisEngine<T>
     }
   }
 
-  protected void addSummaryBypassLogic(AnalysisOptions options, String summary) {
-    IClassHierarchy cha = getClassHierarchy();
-    // Two distinct loader sources need to find summary XMLs, and they pull from opposite
-    // directions under OSGi/module isolation:
-    //
-    //   1. *Subclass-shipped summaries* (numpy.xml, tensorflow.xml, etc.) live in the subclass's
-    //      module (e.g., `com.ibm.wala.cast.python.ml`'s `PythonTensorAnalysisEngine`). Only the
-    //      subclass's classloader sees them; the base engine's classloader can't.
-    //   2. *Base-shipped summaries* (the LIBRARIES array — `pytest.xml`, `flask.xml`, etc.) live
-    //      in the base module (`com.ibm.wala.cast.python`'s `PythonAnalysisEngine`). When a
-    //      cross-module subclass like `PytestAnalysisEngine` (in
-    // `com.ibm.wala.cast.python.jython3`)
-    //      calls this inherited helper, the subclass's classloader doesn't see them; only the
-    //      base's does.
-    //
-    // Try `getClass()` first, then fall back to `PythonAnalysisEngine.class` if the resource
-    // wasn't found through the runtime class's loader. The fallback handles case (2) without
-    // breaking case (1). The broader `Class.getResourceAsStream`-vs-`getClassLoader()` choice
-    // is for OSGi reliability per wala/ML#419: the former uses the class's own classloader,
-    // while `getClassLoader()` can return a parent classloader that doesn't see the bundle's
-    // resources. Leading `/` makes the lookup absolute — matches where the summary XMLs live in
-    // the JAR (classpath root). CodeQL's "Unsafe use of getResource" rule fires on the first
-    // line below; that alert is dismissed as a false positive — the rule's mental model assumes
-    // a single resource source, but the API design intentionally has two.
+  /**
+   * Opens a summary XML as a classpath resource stream.
+   *
+   * <p>Two distinct loader sources need to find summary XMLs, and they pull from opposite
+   * directions under OSGi/module isolation:
+   *
+   * <ol>
+   *   <li><em>Subclass-shipped summaries</em> (numpy.xml, tensorflow.xml, etc.) live in the
+   *       subclass's module (e.g., {@code com.ibm.wala.cast.python.ml}'s {@code
+   *       PythonTensorAnalysisEngine}). Only the subclass's classloader sees them; the base
+   *       engine's classloader can't.
+   *   <li><em>Base-shipped summaries</em> (the LIBRARIES array — {@code pytest.xml}, {@code
+   *       flask.xml}, etc.) live in the base module ({@code com.ibm.wala.cast.python}'s {@code
+   *       PythonAnalysisEngine}). When a cross-module subclass like {@code PytestAnalysisEngine}
+   *       (in {@code com.ibm.wala.cast.python.jython3}) calls this inherited helper, the subclass's
+   *       classloader doesn't see them; only the base's does.
+   * </ol>
+   *
+   * <p>Try {@code getClass()} first, then fall back to {@code PythonAnalysisEngine.class} if the
+   * resource wasn't found through the runtime class's loader. The fallback handles case (2) without
+   * breaking case (1). The broader {@code Class.getResourceAsStream}-vs-{@code getClassLoader()}
+   * choice is for OSGi reliability per wala/ML#419: the former uses the class's own classloader,
+   * while {@code getClassLoader()} can return a parent classloader that doesn't see the bundle's
+   * resources. Leading {@code /} makes the lookup absolute — matches where the summary XMLs live in
+   * the JAR (classpath root). CodeQL's "Unsafe use of getResource" rule fires on the first lookup
+   * below; that alert is dismissed as a false positive — the rule's mental model assumes a single
+   * resource source, but the API design intentionally has two.
+   *
+   * @param summary the summary XML resource name (e.g. {@code tensorflow.xml})
+   * @return the opened resource stream
+   * @throws IllegalStateException if the resource is not found through either classloader; without
+   *     this check, the downstream {@link XMLMethodSummaryReader} constructor throws an {@code
+   *     IllegalArgumentException: null xmlFile} that doesn't name the missing resource — exactly
+   *     the unhelpful diagnostic that motivated wala/ML#419
+   */
+  protected InputStream openSummaryStream(String summary) {
     String resourcePath = "/" + summary;
     InputStream xmlStream = getClass().getResourceAsStream(resourcePath);
     if (xmlStream == null) {
       xmlStream = PythonAnalysisEngine.class.getResourceAsStream(resourcePath);
     }
     if (xmlStream == null) {
-      // Without this check, the downstream `XMLMethodSummaryReader` constructor throws an
-      // `IllegalArgumentException: null xmlFile` that doesn't name the missing resource — exactly
-      // the unhelpful diagnostic that motivated wala/ML#419. Surface the actual context. The
-      // message is intentionally generic — `addSummaryBypassLogic` is reused for caller-supplied
+      // The message is intentionally generic — this helper is reused for caller-supplied
       // summaries (e.g., test fixtures resolving via a subclass), so the diagnostic should help
       // contributors identify whether the resource is one of Ariadne's bundled XMLs (which need
       // to be on either the subclass's or the base engine's classpath) or a caller-supplied one
@@ -272,7 +298,12 @@ public abstract class PythonAnalysisEngine<T>
               + " layout). If this is a caller-supplied summary, verify it is on the consumer's"
               + " classpath at the expected absolute path.");
     }
-    XMLMethodSummaryReader xml = new XMLMethodSummaryReader(xmlStream, scope);
+    return xmlStream;
+  }
+
+  protected void addSummaryBypassLogic(AnalysisOptions options, String summary) {
+    IClassHierarchy cha = getClassHierarchy();
+    XMLMethodSummaryReader xml = new XMLMethodSummaryReader(openSummaryStream(summary), scope);
 
     Map<MethodReference, MethodSummary> summaries = new HashMap<>(xml.getSummaries());
     BypassSyntheticClassLoader ldr =

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -74,6 +74,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.Consumer;
@@ -164,14 +165,15 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     // here. Skipping the unresolved supertypes rather than taking an arbitrary first (which drops
     // the class to a null superclass, leaving it unlinked in the hierarchy and breaking callable
     // dispatch on its instances, wala/ML#657) keeps a locally resolvable base under multiple
-    // inheritance. Fall back to `object` when none resolve, the same lattice point the missing or
-    // no-base case uses and the correct one for a modeled base such as `tf.keras.Model`.
+    // inheritance. When none resolve, prefer a summary-modeled class shell matching a missing
+    // supertype (wala/ML#118) before falling back to `object`, the lattice point the missing and
+    // no-base cases share.
     TypeName superName =
         present.stream()
             .map(walaTypeNames::get)
             .filter(name -> name != null)
             .findFirst()
-            .orElse(PythonTypes.object.getName());
+            .orElseGet(() -> summaryShellSuperName(cls).orElse(PythonTypes.object.getName()));
 
     ((PythonLoader) loader)
         .defineType(
@@ -183,6 +185,27 @@ public class PythonCAstToIRTranslator extends AstTranslator {
                 .collect(Collectors.toSet()));
 
     return true;
+  }
+
+  /**
+   * Resolves a missing (imported) supertype of {@code cls} against the summary-modeled class shells
+   * registered in the loader (see {@code PythonLoader.defineSummaryClassShell}, wala/ML#118). A
+   * missing supertype's fully qualified dotted name (e.g. {@code tensorflow.keras.layers.Layer})
+   * canonicalizes to the shell's {@link TypeName} (e.g. {@code Ltensorflow/keras/layers/Layer}) by
+   * slashing the dots, so a shell registered under the summary's canonical name is found exactly,
+   * with no fuzzy matching.
+   *
+   * @param cls the class type whose missing supertypes to resolve
+   * @return the first missing supertype's shell {@link TypeName}, or empty if no missing supertype
+   *     matches a registered shell
+   */
+  private Optional<TypeName> summaryShellSuperName(CAstType cls) {
+    return cls.getSupertypes().stream()
+        .filter(t -> t instanceof MissingType)
+        .map(t -> ((MissingType) t).qualifiedName())
+        .map(name -> TypeName.findOrCreate("L" + name.replace('.', '/')))
+        .filter(name -> loader.lookupClass(name) != null)
+        .findFirst();
   }
 
   @Override

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -33,7 +33,9 @@ import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.ModuleEntry;
 import com.ibm.wala.core.util.strings.Atom;
+import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.ssa.SymbolTable;
@@ -56,10 +58,54 @@ import java.util.stream.Collectors;
 @SuppressWarnings("this-escape")
 public abstract class PythonLoader extends CAstAbstractModuleLoader {
 
+  /**
+   * Summary readers whose {@code <class name="..." super="...">} declarations should be
+   * materialized as class shells in this loader before source translation. Set by {@link
+   * PythonLoaderFactory#makeTheLoader} from the readers the engine registers.
+   */
+  private List<XMLMethodSummaryReader> summaryClassShellReaders = Collections.emptyList();
+
+  /**
+   * Sets the summary readers whose class shells to materialize at {@link #init} time.
+   *
+   * @param summaryClassShellReaders the readers whose {@code <class super="...">} declarations
+   *     should become shells
+   */
+  public void setSummaryClassShellReaders(List<XMLMethodSummaryReader> summaryClassShellReaders) {
+    this.summaryClassShellReaders = summaryClassShellReaders;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Registers the summary-modeled class shells before translating source, so a source class
+   * subclassing a summary-modeled type (e.g. {@code class MyLayer(tf.keras.layers.Layer)}) resolves
+   * its base at definition time instead of falling back to {@code object} (wala/ML#118, via
+   * wala/WALA#1957).
+   */
   @Override
   public void init(List<Module> modules) {
-    // TODO Auto-generated method stub
+    for (XMLMethodSummaryReader summaries : summaryClassShellReaders) {
+      Util.addSummaryClassShells(this, summaries);
+    }
     super.init(modules);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The shell is a {@link PythonClass} rather than the base {@link CoreClass}, so machinery
+   * gated on {@link IPythonClass} engages for it, and its default superclass is Python's {@code
+   * object} rather than the language root.
+   */
+  @Override
+  public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
+    IClass existing = lookupClass(name);
+    if (existing != null) {
+      return existing;
+    }
+    TypeName actualSuperName = superName == null ? PythonTypes.object.getName() : superName;
+    return new PythonClass(name, actualSuperName, this, null, Collections.emptySet());
   }
 
   public class DynamicMethodBody extends DynamicCodeBody {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoaderFactory.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoaderFactory.java
@@ -12,9 +12,53 @@ package com.ibm.wala.cast.python.loader;
 
 import com.ibm.wala.cast.loader.SingleClassLoaderFactory;
 import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.types.ClassLoaderReference;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class PythonLoaderFactory extends SingleClassLoaderFactory {
+
+  /**
+   * Summary readers whose {@code <class name="..." super="...">} declarations should be
+   * materialized as class shells in the loader before source translation (wala/ML#118). Registered
+   * by the engine via {@link #addSummaryClassShells} before the class hierarchy is built.
+   */
+  private final List<XMLMethodSummaryReader> summaryClassShellReaders = new ArrayList<>();
+
+  /**
+   * Registers a summary reader whose {@code <class super="...">} declarations should become class
+   * shells in the loader this factory creates. Must be called before the class hierarchy is built,
+   * since the shells are materialized when the loader initializes.
+   *
+   * @param summaries the reader whose class-shell declarations to materialize
+   */
+  public void addSummaryClassShells(XMLMethodSummaryReader summaries) {
+    summaryClassShellReaders.add(summaries);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Hands the registered summary class-shell readers to the loader, so {@link PythonLoader#init}
+   * can materialize the shells before source translation.
+   */
+  @Override
+  protected final IClassLoader makeTheLoader(IClassHierarchy cha) {
+    PythonLoader loader = makePythonLoader(cha);
+    loader.setSummaryClassShellReaders(summaryClassShellReaders);
+    return loader;
+  }
+
+  /**
+   * Creates the concrete {@link PythonLoader} for this factory's Python front end.
+   *
+   * @param cha the class hierarchy under construction
+   * @return the loader
+   */
+  protected abstract PythonLoader makePythonLoader(IClassHierarchy cha);
 
   @Override
   public ClassLoaderReference getTheReference() {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/parser/AbstractParser.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/parser/AbstractParser.java
@@ -13,7 +13,22 @@ import java.util.Collection;
 
 public abstract class AbstractParser {
 
-  public interface MissingType extends CAstType {}
+  public interface MissingType extends CAstType {
+
+    /**
+     * The fully qualified dotted name of this type, with any import alias at the root expanded to
+     * the module path it is bound to (e.g. {@code tensorflow.keras.layers.Layer} for a base written
+     * as {@code tf.keras.layers.Layer} under {@code import tensorflow as tf}). Falls back to {@link
+     * #getName()} when the root is not an import binding, so consumers keyed on the source-level
+     * name (e.g. {@link com.ibm.wala.cast.python.loader.PythonLoader.PythonClass} missing-type
+     * bookkeeping) are unaffected.
+     *
+     * @return the fully qualified dotted name, or {@link #getName()} if no import binding applies
+     */
+    default String qualifiedName() {
+      return getName();
+    }
+  }
 
   public interface PythonGlobalsEntity {
     java.util.Set<String> downwardGlobals();


### PR DESCRIPTION
Consumes the wala/WALA#1957 class-shell mechanism that shipped in WALA 1.8.0 (adopted in #493), so a source class subclassing a framework base modeled only by an XML method summary resolves that base in the class hierarchy instead of falling back to `object`. This is the first half of wala/ML#118 and the root of the dependency chain unblocked by the release (wala/ML#106, wala/ML#595, wala/ML#570, wala/ML#618).

How it works, following the consumption plan on wala/ML#118:
- `tensorflow.xml` opts `tf.keras.layers.Layer` in to shell materialization by declaring `<class name="Layer" super="Lobject">`.
- `PythonAnalysisEngine.buildClassHierarchy` parses the shell-declaring summaries (named by the new `getSummaryClassShellSummaries` hook, overridden in `PythonTensorAnalysisEngine` to name `tensorflow.xml`) and registers the readers with the loader factory before the CHA is built.
- `PythonLoaderFactory.makeTheLoader` becomes a template method that hands the readers to the loader; the concrete factories now implement `makePythonLoader`.
- `PythonLoader.init` materializes the shells (via `Util.addSummaryClassShells`) before source translation, and its `defineSummaryClassShell` override produces a `PythonClass` so `IPythonClass`-gated machinery engages and the shell defaults to Python's `object` rather than the language root.
- `PythonParser` records import bindings (`import tensorflow as tf`, `from tensorflow.keras.layers import Layer`), and `MissingType` gains a `qualifiedName()` that expands the alias root, so `PythonCAstToIRTranslator.defineType` resolves a missing base to a registered shell by exact canonical `TypeName` (no fuzzy matching), falling back to `object` exactly as before when no shell matches.

`TestSummaryClassShells` covers both import forms with fixtures that run under Python 3.10. Full `mvn test` from the root passes locally.

The `tf.keras.Model` case additionally needs its dual-name canonicalization (`keras/models/Model` vs `tensorflow/keras/Model`, cf. the wala/ML#657 collision fix) and is a follow-on, as is carrying the shell's own method declarations for inherited-call resolution (wala/ML#106).

Toward wala/ML#118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc