### PR TITLE
Cover the `tf.keras.Model` subclass spelling with an alias class shell

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
@@ -19,14 +19,24 @@ import org.junit.Test;
 /**
  * Tests for the summary-modeled class shells of <a
  * href="https://github.com/wala/ML/issues/118">wala/ML#118</a>: a source class subclassing a
- * framework base modeled only by an XML method summary (e.g. {@code tf.keras.layers.Layer})
- * resolves that base in the class hierarchy instead of falling back to {@code object}.
+ * framework base modeled only by an XML method summary (e.g. {@code tf.keras.layers.Layer} or
+ * {@code tf.keras.Model}) resolves that base in the class hierarchy instead of falling back to
+ * {@code object}.
  */
 public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
 
-  /** The canonical {@link TypeReference} of the {@code tf.keras.layers.Layer} summary shell. */
-  private static final TypeReference LAYER =
-      TypeReference.findOrCreate(PythonTypes.pythonLoader, "Ltensorflow/keras/layers/Layer");
+  /** The canonical {@code TypeName} string of the {@code tf.keras.layers.Layer} summary shell. */
+  private static final String LAYER = "Ltensorflow/keras/layers/Layer";
+
+  /**
+   * The {@code TypeName} string of the {@code tensorflow/keras/Model} alias shell covering the
+   * {@code tf.keras.Model} subclass spelling (<a
+   * href="https://github.com/wala/ML/issues/662">wala/ML#662</a>).
+   */
+  private static final String MODEL_ALIAS = "Ltensorflow/keras/Model";
+
+  /** The {@code TypeName} string of Python's {@code object}. */
+  private static final String OBJECT = PythonTypes.object.getName().toString();
 
   /**
    * A subclass written against the aliased attribute path {@code tf.keras.layers.Layer} (under
@@ -39,7 +49,7 @@ public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
   @Test
   public void testLayerSubclassSuperclass()
       throws ClassHierarchyException, CancelException, IOException {
-    checkLayerSubclass("tf2_test_layer_subclass.py");
+    checkSuperclassChain("tf2_test_layer_subclass.py", "MyLayer", LAYER, OBJECT);
   }
 
   /**
@@ -53,43 +63,81 @@ public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
   @Test
   public void testLayerSubclassSuperclassFromImport()
       throws ClassHierarchyException, CancelException, IOException {
-    checkLayerSubclass("tf2_test_layer_subclass2.py");
+    checkSuperclassChain("tf2_test_layer_subclass2.py", "MyLayer", LAYER, OBJECT);
   }
 
   /**
-   * Asserts that {@code MyLayer} in {@code filename} has the {@code Layer} summary shell as its
-   * superclass, that the shell engages {@link PythonLoader.PythonClass}-gated machinery, and that
-   * the shell itself is positioned at {@code object}.
+   * A subclass written against the aliased attribute path {@code tf.keras.Model} has the {@code
+   * tensorflow/keras/Model} alias shell as its superclass (<a
+   * href="https://github.com/wala/ML/issues/662">wala/ML#662</a>).
    *
-   * @param filename the test file defining {@code MyLayer}
    * @throws ClassHierarchyException if the class hierarchy cannot be built
    * @throws CancelException if the analysis is canceled
    * @throws IOException if the test file cannot be read
    */
-  private void checkLayerSubclass(String filename)
+  @Test
+  public void testModelSubclassSuperclass()
+      throws ClassHierarchyException, CancelException, IOException {
+    checkSuperclassChain("tf2_test_model_subclass.py", "MyModel", MODEL_ALIAS, OBJECT);
+  }
+
+  /**
+   * A subclass written against the bare name {@code Model} (under {@code from
+   * tensorflow.keras.models import Model}) still falls back to {@code object}: the canonical {@code
+   * tensorflow/keras/models/Model} instance type carries the {@code __call__}/{@code call} summary
+   * bodies, and a method-less shell under that name would shadow the bypass-registered class
+   * serving them (see the CAUTION in {@code tensorflow.xml}).
+   *
+   * <p>TODO: Expect the canonical type as the superclass once shells carry the summary's own
+   * methods per <a href="https://github.com/wala/ML/issues/106">wala/ML#106</a>.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built
+   * @throws CancelException if the analysis is canceled
+   * @throws IOException if the test file cannot be read
+   */
+  @Test
+  public void testModelSubclassSuperclassFromImport()
+      throws ClassHierarchyException, CancelException, IOException {
+    checkSuperclassChain("tf2_test_model_subclass2.py", "MyModel", OBJECT);
+  }
+
+  /**
+   * Asserts that {@code className} in {@code filename} has exactly the given superclass chain above
+   * it, and that each shell on the chain engages {@link PythonLoader.PythonClass}-gated machinery.
+   *
+   * @param filename the test file defining {@code className}
+   * @param className the source class whose chain to check
+   * @param expectedChain the expected superclass {@code TypeName} strings, from the immediate
+   *     superclass upward (ending at {@code Lobject})
+   * @throws ClassHierarchyException if the class hierarchy cannot be built
+   * @throws CancelException if the analysis is canceled
+   * @throws IOException if the test file cannot be read
+   */
+  private void checkSuperclassChain(String filename, String className, String... expectedChain)
       throws ClassHierarchyException, CancelException, IOException {
     PythonAnalysisEngine<TensorTypeAnalysis> engine = makeEngine(filename);
     engine.defaultCallGraphBuilder();
     IClassHierarchy cha = engine.getClassHierarchy();
 
-    IClass subclass =
+    IClass current =
         cha.lookupClass(
             TypeReference.findOrCreate(
-                PythonTypes.pythonLoader, "Lscript " + filename + "/MyLayer"));
-    assertNotNull("expected the source subclass in the hierarchy", subclass);
+                PythonTypes.pythonLoader, "Lscript " + filename + "/" + className));
+    assertNotNull("expected the source subclass in the hierarchy", current);
 
-    IClass superclass = subclass.getSuperclass();
-    assertNotNull("expected the Layer summary shell as the superclass", superclass);
-    assertEquals(LAYER, superclass.getReference());
+    for (String expected : expectedChain) {
+      IClass superclass = current.getSuperclass();
+      assertNotNull("expected a superclass named " + expected, superclass);
+      assertEquals(expected, superclass.getReference().getName().toString());
 
-    // The shell engages `IPythonClass`-gated machinery.
-    assertTrue(
-        "expected the shell to be a PythonLoader class",
-        superclass instanceof PythonLoader.PythonClass);
+      if (!expected.equals(OBJECT)) {
+        // The shell engages `IPythonClass`-gated machinery.
+        assertTrue(
+            "expected the " + expected + " shell to be a PythonLoader class",
+            superclass instanceof PythonLoader.PythonClass);
+      }
 
-    // The shell itself is positioned at `object`, per its `super` declaration in tensorflow.xml.
-    IClass shellSuper = superclass.getSuperclass();
-    assertNotNull("expected the shell to link to object", shellSuper);
-    assertEquals(PythonTypes.object, shellSuper.getReference());
+      current = superclass;
+    }
   }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2392,6 +2392,7 @@
       <class name="attribute" allocatable="true"></class>
     </package>
     <package name="tensorflow/keras/models">
+      <!-- CAUTION: this class must NOT declare a `super` (i.e., must not opt in to class-shell materialization, wala/WALA#1957): the resulting method-less shell in the Python loader would shadow the bypass-registered class that serves the `__call__`/`call` bodies below, breaking dispatch on functional-API `tf.keras.Model(...)` instances. The shell can only move here once shells carry the summary's own methods (wala/ML#106). -->
       <class name="Model" allocatable="true">
         <method name="__call__" descriptor="()LRoot;" numArgs="5" paramNames="func self inputs training mask">
           <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/Model#call -->
@@ -2405,6 +2406,10 @@
           <return value="out"/>
         </method>
       </class>
+    </package>
+    <package name="tensorflow/keras">
+      <!-- At runtime `tf.keras.Model` and `tf.keras.models.Model` are the same class under two attribute paths. Shell lookup is exact-match on the canonicalized base name (wala/ML#118), and no summary methods live under this name, so this empty shell safely covers subclasses written against the `tf.keras.Model`/`from tensorflow.keras import Model` spelling (wala/ML#662). It cannot be positioned at the canonical `Ltensorflow/keras/models/Model` instance type, nor can that type declare its own shell, until shells carry the summary's own methods (wala/ML#106); see the CAUTION on that class above. -->
+      <class name="Model" super="Lobject"></class>
     </package>
     <package name="tensorflow/keras/layers/class">
       <class name="Dense" allocatable="true">
@@ -2431,12 +2436,8 @@
       </class>
     </package>
     <package name="tensorflow/keras/layers">
-      <!-- Declaring a `super` opts `Layer` in to being materialized as a class shell before the class hierarchy is built (wala/WALA#1957), so a source subclass such as `class MyLayer(tf.keras.layers.Layer)` resolves its base to this type instead of falling back to `object` (wala/ML#118). -->
-      <class name="Layer" super="Lobject" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
-          <return value="self"/>
-        </method>
-      </class>
+      <!-- Declaring a `super` opts `Layer` in to being materialized as a class shell before the class hierarchy is built (wala/WALA#1957), so a source subclass such as `class MyLayer(tf.keras.layers.Layer)` resolves its base to this type instead of falling back to `object` (wala/ML#118). Shell-only: the class deliberately declares no methods, since a shell shadows same-named bypass method bodies (see the CAUTION on `tensorflow/keras/models/Model`), and no `<new>` targets it, so it is not `allocatable`. -->
+      <class name="Layer" super="Lobject"></class>
       <class name="Input" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass.py
@@ -1,0 +1,16 @@
+# Test for wala/ML#662: a user subclass of `tf.keras.Model` resolves its base class in the class
+# hierarchy (through the `tensorflow/keras/Model` alias shell) instead of falling back to `object`.
+import tensorflow as tf
+
+
+class MyModel(tf.keras.Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def call(self, inputs):
+        return inputs
+
+
+model = MyModel()
+assert isinstance(model, tf.keras.Model)
+assert isinstance(model, tf.keras.models.Model)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass2.py
@@ -1,0 +1,19 @@
+# Test for wala/ML#662: a user subclass of `Model` imported via `from tensorflow.keras.models
+# import Model` currently still falls back to `object` in the class hierarchy: the canonical
+# `tensorflow/keras/models/Model` instance type carries the `__call__`/`call` summary bodies, and a
+# method-less shell under that name would shadow them (see the CAUTION in `tensorflow.xml`).
+# TODO: The base should resolve to the canonical type once shells carry the summary's own methods
+# per wala/ML#106 (https://github.com/wala/ML/issues/106).
+from tensorflow.keras.models import Model
+
+
+class MyModel(Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def call(self, inputs):
+        return inputs
+
+
+model = MyModel()
+assert isinstance(model, Model)


### PR DESCRIPTION
At runtime `tf.keras.Model` and `tf.keras.models.Model` are one class under two attribute paths, but shell lookup (wala/ML#118, ponder-lab/ML#495) is exact-match, so subclasses written as `class MyModel(tf.keras.Model)` (the dominant subclassing-API spelling) fell back to `object`. An empty `tensorflow/keras/Model` shell now covers that spelling.

The key constraint discovered while implementing this: **a class-shell declaration must not share a `TypeName` with a class whose method bodies the bypass mechanism serves.** The method-less shell materializes into the Python loader and shadows the bypass-registered class, killing dispatch. Declaring `super=` directly on the canonical `tensorflow/keras/models/Model` (which carries the `__call__`/`call` summaries) broke seven functional-API `Model` tests (`testModelInit`, `testGanTutorial*`, `testModelCall*`). Consequences encoded in this PR:
- The alias shell is positioned at `Lobject` rather than at the canonical instance type, and the canonical type carries a CAUTION comment against opting in.
- The `from tensorflow.keras.models import Model` subclass spelling keeps the `object` fallback for now; `testModelSubclassSuperclassFromImport` pins that behavior with a TODO pointing at wala/ML#106, since method-carrying shells are exactly what lifts the constraint.
- The `Layer` shell from #495 is now shell-only: its `do` summary was dead (shadowed by its own shell, and the `tf.keras.layers.Layer` value is never wired), and nothing allocates it.

`TestSummaryClassShells` covers `Layer` and `Model` in both import spellings with fixtures verified under Python 3.10. Full `mvn test` from the root passes locally.

Closes wala/ML#662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc