### PR TITLE
Carry summary methods on class shells and canonicalize `tf.keras.Model`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestSummaryClassShells.java
@@ -35,6 +35,9 @@ public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
    */
   private static final String MODEL_ALIAS = "Ltensorflow/keras/Model";
 
+  /** The canonical {@code TypeName} string of the {@code tf.keras.Model} instance type. */
+  private static final String MODEL = "Ltensorflow/keras/models/Model";
+
   /** The {@code TypeName} string of Python's {@code object}. */
   private static final String OBJECT = PythonTypes.object.getName().toString();
 
@@ -78,18 +81,15 @@ public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
   @Test
   public void testModelSubclassSuperclass()
       throws ClassHierarchyException, CancelException, IOException {
-    checkSuperclassChain("tf2_test_model_subclass.py", "MyModel", MODEL_ALIAS, OBJECT);
+    checkSuperclassChain("tf2_test_model_subclass.py", "MyModel", MODEL_ALIAS, MODEL, OBJECT);
   }
 
   /**
    * A subclass written against the bare name {@code Model} (under {@code from
-   * tensorflow.keras.models import Model}) still falls back to {@code object}: the canonical {@code
-   * tensorflow/keras/models/Model} instance type carries the {@code __call__}/{@code call} summary
-   * bodies, and a method-less shell under that name would shadow the bypass-registered class
-   * serving them (see the CAUTION in {@code tensorflow.xml}).
-   *
-   * <p>TODO: Expect the canonical type as the superclass once shells carry the summary's own
-   * methods per <a href="https://github.com/wala/ML/issues/106">wala/ML#106</a>.
+   * tensorflow.keras.models import Model}) has the canonical {@code tensorflow/keras/models/Model}
+   * instance type directly as its superclass. The shell carries the summary's method references (<a
+   * href="https://github.com/wala/ML/issues/106">wala/ML#106</a>), so it coexists with the
+   * bypass-served {@code __call__}/{@code call} bodies under the same name.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built
    * @throws CancelException if the analysis is canceled
@@ -98,7 +98,7 @@ public class TestSummaryClassShells extends TestPythonMLCallGraphShape {
   @Test
   public void testModelSubclassSuperclassFromImport()
       throws ClassHierarchyException, CancelException, IOException {
-    checkSuperclassChain("tf2_test_model_subclass2.py", "MyModel", OBJECT);
+    checkSuperclassChain("tf2_test_model_subclass2.py", "MyModel", MODEL, OBJECT);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2392,8 +2392,8 @@
       <class name="attribute" allocatable="true"></class>
     </package>
     <package name="tensorflow/keras/models">
-      <!-- CAUTION: this class must NOT declare a `super` (i.e., must not opt in to class-shell materialization, wala/WALA#1957): the resulting method-less shell in the Python loader would shadow the bypass-registered class that serves the `__call__`/`call` bodies below, breaking dispatch on functional-API `tf.keras.Model(...)` instances. The shell can only move here once shells carry the summary's own methods (wala/ML#106). -->
-      <class name="Model" allocatable="true">
+      <!-- Declaring a `super` opts `Model` in to class-shell materialization (wala/WALA#1957), so a source subclass such as `class MyModel(tf.keras.models.Model)` resolves its base to this canonical instance type instead of falling back to `object` (wala/ML#118, wala/ML#662). The shell carries this class's method references (`PythonLoader.defineSummaryClassShell`, wala/ML#106), so it does not shadow the bypass-served `__call__`/`call` bodies below. -->
+      <class name="Model" allocatable="true" super="Lobject">
         <method name="__call__" descriptor="()LRoot;" numArgs="5" paramNames="func self inputs training mask">
           <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/Model#call -->
           <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
@@ -2408,8 +2408,8 @@
       </class>
     </package>
     <package name="tensorflow/keras">
-      <!-- At runtime `tf.keras.Model` and `tf.keras.models.Model` are the same class under two attribute paths. Shell lookup is exact-match on the canonicalized base name (wala/ML#118), and no summary methods live under this name, so this empty shell safely covers subclasses written against the `tf.keras.Model`/`from tensorflow.keras import Model` spelling (wala/ML#662). It cannot be positioned at the canonical `Ltensorflow/keras/models/Model` instance type, nor can that type declare its own shell, until shells carry the summary's own methods (wala/ML#106); see the CAUTION on that class above. -->
-      <class name="Model" super="Lobject"></class>
+      <!-- At runtime `tf.keras.Model` and `tf.keras.models.Model` are the same class under two attribute paths. Shell lookup is exact-match on the canonicalized base name (wala/ML#118), so this empty alias shell covers subclasses written against the `tf.keras.Model`/`from tensorflow.keras import Model` spelling; positioning it at the canonical `Ltensorflow/keras/models/Model` instance type keeps one hierarchy chain, so subtype queries against the canonical type also hold for subclasses reached through this alias (wala/ML#662). -->
+      <class name="Model" super="Ltensorflow/keras/models/Model"></class>
     </package>
     <package name="tensorflow/keras/layers/class">
       <class name="Dense" allocatable="true">

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_subclass2.py
@@ -1,9 +1,6 @@
-# Test for wala/ML#662: a user subclass of `Model` imported via `from tensorflow.keras.models
-# import Model` currently still falls back to `object` in the class hierarchy: the canonical
-# `tensorflow/keras/models/Model` instance type carries the `__call__`/`call` summary bodies, and a
-# method-less shell under that name would shadow them (see the CAUTION in `tensorflow.xml`).
-# TODO: The base should resolve to the canonical type once shells carry the summary's own methods
-# per wala/ML#106 (https://github.com/wala/ML/issues/106).
+# Test for wala/ML#662 and wala/ML#106: a user subclass of `Model` imported via `from
+# tensorflow.keras.models import Model` resolves its base class (the canonical instance type) in
+# the class hierarchy instead of falling back to `object`.
 from tensorflow.keras.models import Model
 
 

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -25,6 +25,7 @@ import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.loader.IPythonClass;
+import com.ibm.wala.cast.python.loader.PythonLoader.PythonSummaryShellClass;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
@@ -360,31 +361,36 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
         || receiver instanceof BypassSyntheticClass) {
       return true;
     }
-    if (receiver instanceof SyntheticClass) {
-      if (receiver.getMethod(
-                  new Selector(
-                      Atom.findOrCreateUnicodeAtom(CALLABLE_METHOD_NAME),
-                      AstMethodReference.fnDesc))
-              != null
-          || receiver.getMethod(
-                  new Selector(
-                      Atom.findOrCreateUnicodeAtom(CALLABLE_METHOD_NAME_FOR_KERAS_MODELS),
-                      AstMethodReference.fnDesc))
-              != null
-          || receiver.getMethod(
-                  new Selector(
-                      Atom.findOrCreateUnicodeAtom(DO_METHOD_NAME), AstMethodReference.fnDesc))
-              != null) {
-        return true;
-      }
+    if (receiver instanceof SyntheticClass
+        && (receiver.getMethod(
+                    new Selector(
+                        Atom.findOrCreateUnicodeAtom(CALLABLE_METHOD_NAME),
+                        AstMethodReference.fnDesc))
+                != null
+            || receiver.getMethod(
+                    new Selector(
+                        Atom.findOrCreateUnicodeAtom(CALLABLE_METHOD_NAME_FOR_KERAS_MODELS),
+                        AstMethodReference.fnDesc))
+                != null
+            || receiver.getMethod(
+                    new Selector(
+                        Atom.findOrCreateUnicodeAtom(DO_METHOD_NAME), AstMethodReference.fnDesc))
+                != null)) {
+      return true;
+    }
 
-      if (receiver instanceof IPythonClass) {
-        for (MethodReference mr : ((IPythonClass) receiver).getMethodReferences()) {
-          String clsName = mr.getDeclaringClass().getName().toString();
-          if (clsName.endsWith("/" + CALLABLE_METHOD_NAME)
-              || clsName.endsWith("/" + CALLABLE_METHOD_NAME_FOR_KERAS_MODELS)) {
-            return true;
-          }
+    // A summary-modeled class whose method references include a `__call__`/`call` function class
+    // is callable, whether materialized as an engine-registered synthetic class (for allocatable
+    // summary types) or as a summary class shell (`PythonLoader.defineSummaryClassShell`,
+    // wala/ML#106). Source classes are deliberately excluded: their instances dispatch through
+    // constructor-wired trampolines, and substituting the receiver here instead drops those calls.
+    if ((receiver instanceof SyntheticClass || receiver instanceof PythonSummaryShellClass)
+        && receiver instanceof IPythonClass) {
+      for (MethodReference mr : ((IPythonClass) receiver).getMethodReferences()) {
+        String clsName = mr.getDeclaringClass().getName().toString();
+        if (clsName.endsWith("/" + CALLABLE_METHOD_NAME)
+            || clsName.endsWith("/" + CALLABLE_METHOD_NAME_FOR_KERAS_MODELS)) {
+          return true;
         }
       }
     }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -35,6 +35,7 @@ import com.ibm.wala.classLoader.ModuleEntry;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ipa.summaries.MethodSummary;
 import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSAInstructionFactory;
@@ -92,11 +93,31 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
   }
 
   /**
+   * A class shell materialized for a summary-modeled type (wala/WALA#1957, wala/ML#118).
+   * Distinguished from source {@link PythonClass}es by type so that machinery serving
+   * summary-modeled types (e.g. callable detection in {@code
+   * PythonInstanceMethodTrampolineTargetSelector}) can engage for shells without perturbing
+   * source-class dispatch, which flows through constructor-wired trampolines instead.
+   */
+  public class PythonSummaryShellClass extends PythonClass {
+
+    /**
+     * Creates the shell.
+     *
+     * @param name the shell's type name
+     * @param superName the shell's superclass name
+     */
+    public PythonSummaryShellClass(TypeName name, TypeName superName) {
+      super(name, superName, PythonLoader.this, null, Collections.emptySet());
+    }
+  }
+
+  /**
    * {@inheritDoc}
    *
-   * <p>The shell is a {@link PythonClass} rather than the base {@link CoreClass}, so machinery
-   * gated on {@link IPythonClass} engages for it, and its default superclass is Python's {@code
-   * object} rather than the language root.
+   * <p>The shell is a {@link PythonSummaryShellClass} rather than the base {@link CoreClass}, so
+   * machinery gated on {@link IPythonClass} (and on shell-ness specifically) engages for it, and
+   * its default superclass is Python's {@code object} rather than the language root.
    */
   @Override
   public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
@@ -105,7 +126,43 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
       return existing;
     }
     TypeName actualSuperName = superName == null ? PythonTypes.object.getName() : superName;
-    return new PythonClass(name, actualSuperName, this, null, Collections.emptySet());
+    return new PythonSummaryShellClass(name, actualSuperName);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The shell carries the summary's own methods as {@link PythonClass} method references, using
+   * the same function-class mapping that {@code PythonAnalysisEngine.addSummaryBypassLogic}'s
+   * method-to-function-class transformation applies (a method {@code m} of class {@code C} becomes
+   * the function class {@code C/m}, invoked through its {@code fn} selector; the {@code do}/{@code
+   * import}/{@code __init__} names are the same ones that transformation leaves in place). Without
+   * them, a shell sharing its {@link TypeName} with a bypass-served class starves {@code
+   * IPythonClass}-based callable detection (e.g. {@code
+   * PythonInstanceMethodTrampolineTargetSelector}'s {@code isCallable}), which shadows the
+   * engine-registered synthetic class and drops dispatch on the summary's instances (wala/ML#106,
+   * wala/ML#662).
+   */
+  @Override
+  public IClass defineSummaryClassShell(
+      TypeName name, TypeName superName, Collection<MethodSummary> methods) {
+    IClass existing = lookupClass(name);
+    if (existing != null) {
+      return existing;
+    }
+    PythonClass shell = (PythonClass) defineSummaryClassShell(name, superName);
+    for (MethodSummary method : methods) {
+      String methodName = method.getMethod().getName().toString();
+      if (methodName.equals(PythonTypes.DO_METHOD_NAME)
+          || methodName.equals("import")
+          || methodName.equals("__init__")) {
+        continue;
+      }
+      TypeReference funClsRef =
+          TypeReference.findOrCreate(getReference(), name.toString() + "/" + methodName);
+      shell.methodTypes.add(MethodReference.findOrCreate(funClsRef, AstMethodReference.fnSelector));
+    }
+    return shell;
   }
 
   public class DynamicMethodBody extends DynamicCodeBody {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -99,16 +99,17 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
    * PythonInstanceMethodTrampolineTargetSelector}) can engage for shells without perturbing
    * source-class dispatch, which flows through constructor-wired trampolines instead.
    */
-  public class PythonSummaryShellClass extends PythonClass {
+  public static class PythonSummaryShellClass extends PythonClass {
 
     /**
      * Creates the shell.
      *
+     * @param loader the loader to materialize the shell into
      * @param name the shell's type name
      * @param superName the shell's superclass name
      */
-    public PythonSummaryShellClass(TypeName name, TypeName superName) {
-      super(name, superName, PythonLoader.this, null, Collections.emptySet());
+    public PythonSummaryShellClass(PythonLoader loader, TypeName name, TypeName superName) {
+      loader.super(name, superName, loader, null, Collections.emptySet());
     }
   }
 
@@ -126,7 +127,7 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
       return existing;
     }
     TypeName actualSuperName = superName == null ? PythonTypes.object.getName() : superName;
-    return new PythonSummaryShellClass(name, actualSuperName);
+    return new PythonSummaryShellClass(this, name, actualSuperName);
   }
 
   /**


### PR DESCRIPTION
Lifts the constraint discovered in #496 (wala/ML#662): a class shell can now share its `TypeName` with a class whose method bodies the bypass mechanism serves, because the shell carries the summary's own method references.

Diagnosis that drove the design: dispatch on summary-allocated instances (e.g. functional-API `tf.keras.Model(...)`) flows through `PythonInstanceMethodTrampolineTargetSelector.isCallable`, which recognizes callables via `IPythonClass.getMethodReferences()`. The engine-registered synthetic class for an allocatable summary type returns its function-class references there; a method-less shell shadowing it returned nothing, so `getCalleeTarget` produced no target and the seven functional-API `Model` tests lost all typing. Three coordinated changes fix this:
- `PythonLoader` implements the method-carrying `defineSummaryClassShell` overload from wala/WALA#1962, populating the shell's method references with the same function-class mapping the engine's bypass transformation applies.
- Shells are a dedicated `PythonSummaryShellClass` subtype, so machinery can recognize them by type.
- `isCallable`'s `IPythonClass` branch, previously unreachable for shells (it was nested inside an `instanceof SyntheticClass` guard), now also covers shells. Source classes remain deliberately excluded: their instances dispatch through constructor-wired trampolines, and substituting the receiver preempts that path and drops the calls, which `testModelInit`'s subclass case catches.

Consequences encoded here: the canonical `tensorflow/keras/models/Model` opts in to shell materialization, the `tensorflow/keras/Model` alias shell is repositioned at it (restoring the one-chain design from #496's first draft: `MyModel` to `tensorflow/keras/Model` to `tensorflow/keras/models/Model` to `object`), and the `from tensorflow.keras.models import Model` subclass spelling now resolves to the canonical type; the previously pinned `object`-fallback test asserts the real chain.

Remaining for wala/ML#106 (deferred to a follow-up): tightening the blind `call`-name workaround in `getCallable` to require a hierarchy-verified Keras base, which is now possible since subclasses resolve their bases.

Full `mvn test` from the root passes locally.

Toward wala/ML#106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc