### PR TITLE
Document why the Keras `call` convention stays hierarchy-unchecked

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -297,14 +297,17 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
 
         // The Keras `call` convention (https://github.com/wala/ML/issues/106) applies to ANY
         // class with a `call` method, without checking its hierarchy. Although a subclass's
-        // summary-modeled base has been resolvable since wala/ML#118 (class shells), gating this
-        // on a shell ancestor drops sound dispatch for every subclass whose base does NOT resolve
-        // (cross-module imports, wala/ML#571; bare-name collisions, wala/ML#657; unmodeled
-        // spellings) and empirically loses 18 tests' worth of forward-pass coverage. Tighten only
-        // once unresolved-base metadata is complete enough that a hierarchy check has the same
-        // recall.
+        // summary-modeled base has been resolvable since the class shells of
+        // https://github.com/wala/ML/issues/118, gating this on a shell ancestor drops sound
+        // dispatch for every subclass whose base does NOT resolve (cross-module imports,
+        // https://github.com/wala/ML/issues/571; bare-name collisions,
+        // https://github.com/wala/ML/issues/657; unmodeled spellings) and empirically loses 18
+        // tests' worth of forward-pass coverage. Tightening is tracked by
+        // https://github.com/wala/ML/issues/663.
         if (callable == null) {
-          LOGGER.finer("Attempting callable workaround for https://github.com/wala/ML/issues/118.");
+          LOGGER.finer(
+              "Attempting the Keras `call` convention for"
+                  + " https://github.com/wala/ML/issues/106.");
 
           callable =
               cha.lookupClass(
@@ -321,7 +324,9 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
           }
 
           if (callable != null)
-            LOGGER.info("Applying callable workaround for https://github.com/wala/ML/issues/118.");
+            LOGGER.info(
+                "Applying the Keras `call` convention for"
+                    + " https://github.com/wala/ML/issues/106.");
         }
 
         if (callable != null) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -295,10 +295,15 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
           }
         }
 
-        // TODO: Remove this code once https://github.com/wala/ML/issues/118 is completed.
+        // The Keras `call` convention (https://github.com/wala/ML/issues/106) applies to ANY
+        // class with a `call` method, without checking its hierarchy. Although a subclass's
+        // summary-modeled base has been resolvable since wala/ML#118 (class shells), gating this
+        // on a shell ancestor drops sound dispatch for every subclass whose base does NOT resolve
+        // (cross-module imports, wala/ML#571; bare-name collisions, wala/ML#657; unmodeled
+        // spellings) and empirically loses 18 tests' worth of forward-pass coverage. Tighten only
+        // once unresolved-base metadata is complete enough that a hierarchy check has the same
+        // recall.
         if (callable == null) {
-          // try the workaround for https://github.com/wala/ML/issues/106. NOTE: We cannot verify
-          // that the super class is tf.keras.Model due to https://github.com/wala/ML/issues/118.
           LOGGER.finer("Attempting callable workaround for https://github.com/wala/ML/issues/118.");
 
           callable =


### PR DESCRIPTION
Comment-only change. The stale TODO on the `call` workaround in `PythonInstanceMethodTrampolineTargetSelector.getCallable` said to remove it "once wala/ML#118 is completed". #118 is now complete (ponder-lab/ML#495 through #497), and I ran the experiment the TODO implies: gating the `call`-name lookups on the receiver descending from a summary class shell.

The result was 18 test failures across the Model/Layer forward-pass suites (`testGcnCall`, `testGatCall`, `testTransformerCall`, `testNeuralNetwork*`, `testModelCall2`, `testModelSubclassNameCollision`, ...): every subclass whose framework base does NOT resolve to a shell (cross-module imports, wala/ML#571; bare-name collisions, wala/ML#657; unmodeled base spellings) falls back to `object` under the gate and silently loses all call dispatch. The blind treatment is carrying that recall today, so it stays, and the comment now records the finding and the precondition for tightening (unresolved-base metadata complete enough that a hierarchy check has equal recall) instead of a removal instruction that would reintroduce the regressions.

Per the skip-local-tests convention this is a non-behavioral change, but the reverted experiment ran the full suite (18 failures with the gate, green without it) and the touched dispatch tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc