### PR TITLE
Model the Keras lazy-`build` protocol in the `call` trampoline

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2696,6 +2696,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * parameter in an inferred signature is the downstream consumer's job; this confirms the typed
    * input it needs is available.
    *
+   * <p>The local-tensor count rose from 4 to 7 when the Keras lazy-{@code build} protocol was
+   * modeled (<a href="https://github.com/wala/ML/issues/595">wala/ML#595</a>): {@code self._kernel}
+   * now dispatches, so {@code outputs} (the {@code Dense} result), the residual {@code outputs +=
+   * features} value, and the return alias gained tensor types &mdash; a precision gain.
+   *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
@@ -2717,30 +2722,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "GCN.call",
         "gcn_sparse_proj",
         2,
-        4,
+        7,
         Map.of(3, Set.of(TENSOR_4_8_FLOAT32), 4, Set.of(SPARSE_TENSOR_4_4_FLOAT32)));
   }
 
   /**
-   * Documents the chained-layer coverage gap (<a href="https://github.com/wala/ML/issues/595">
-   * wala/ML#595</a>): a value bound to a user-defined Keras {@code Layer}'s call is not
-   * tensor-typed at the call site, so it does not flow as a tensor into a downstream function. The
-   * fixture chains two {@code GCN} layers (vendored from {@code deep_recommenders}), mirroring
-   * {@code train_gcn_on_cora_keras.py}'s {@code x = GCN(32)(feats, g); GCN(num_classes)(x, g)}, and
-   * sinks the first layer's output through {@code consume(hidden)}.
+   * Pins the chained-layer forward result (<a href="https://github.com/wala/ML/issues/595">
+   * wala/ML#595</a>): a value bound to a user-defined Keras {@code Layer}'s call is tensor-typed at
+   * the call site, so it flows as a tensor into a downstream function. The fixture chains two
+   * {@code GCN} layers (vendored from {@code deep_recommenders}), mirroring {@code
+   * train_gcn_on_cora_keras.py}'s {@code x = GCN(32)(feats, g); GCN(num_classes)(x, g)}, and sinks
+   * the first layer's output through {@code consume(hidden)}.
    *
-   * <p>Observed: {@code consume} has <em>zero</em> tensor parameters &mdash; {@code hidden} (the
-   * {@code GCN.call} return, a {@code Dense} output) is not tensor-classified. The consequence is
-   * that the second layer's {@code features} parameter, fed {@code hidden}, is dropped: per calling
-   * context the first call has {@code features}+{@code adj} (2 tensor params) while the second has
-   * only {@code adj}. Under the input-signature consumer's abandon-on-non-tensor rule, that second
-   * decorated layer would yield ⊥. This is a coverage loss in the {@code __call__}-body codepath,
-   * distinct from the chained-shape gaps (<a href="https://github.com/wala/ML/issues/358">
-   * wala/ML#358</a>/<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>).
+   * <p>{@code hidden} (the {@code GCN.call} return, a {@code Dense} output) is tensor-classified
+   * because the modeled Keras lazy-{@code build} protocol invokes {@code GCN.build}, giving the
+   * {@code build()}-created {@code self._kernel} sublayer a points-to set. The inferred type is
+   * {@code (4, 8) float32}: the dtype and leading dimension are exact, but the trailing dimension
+   * carries the {@code matmul} input shape through the {@code Dense} instead of its {@code
+   * units=16} (the runtime shape is {@code (4, 16)}; the fixture asserts it).
    *
-   * <p>TODO: When <a href="https://github.com/wala/ML/issues/595">wala/ML#595</a> lands (the
-   * layer-call result becomes tensor-typed), {@code consume}'s parameter will recover the concrete
-   * {@code hidden} type; update this fixture to a positive assertion then.
+   * <p>TODO: Expect {@code (4, 16) float32} once <a
+   * href="https://github.com/wala/ML/issues/664">wala/ML#664</a> resolves the {@code units} value
+   * through the {@code self._units} instance-field read.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2762,9 +2765,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_gcn_chain_call.py",
         "consume",
         "gcn_chain_proj",
-        0,
-        0,
-        emptyMap());
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonInstanceMethodTrampolineTargetSelector.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.python.ipa.callgraph;
 import static com.ibm.wala.cast.python.types.PythonTypes.CALLABLE_METHOD_NAME;
 import static com.ibm.wala.cast.python.types.PythonTypes.CALLABLE_METHOD_NAME_FOR_KERAS_MODELS;
 import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
+import static com.ibm.wala.cast.python.types.PythonTypes.KERAS_BUILD_METHOD_NAME;
 import static com.ibm.wala.cast.python.types.PythonTypes.STATIC_METHOD;
 import static com.ibm.wala.cast.python.types.Util.getDeclaringClassTypeReference;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
@@ -147,6 +148,39 @@ public class PythonInstanceMethodTrampolineTargetSelector<T>
                   1,
                   FieldReference.findOrCreate(
                       PythonTypes.Root, Atom.findOrCreateUnicodeAtom("$self"), PythonTypes.Root)));
+
+      // The Keras layer-call protocol builds lazily: `Layer.__call__` invokes `self.build(...)`
+      // before the first `call`, and user subclasses commonly create their sublayers there (e.g.
+      // `self._kernel = tf.keras.layers.Dense(...)`). Nothing else in the analysis invokes
+      // `build`, so without this the sublayers those bodies create have empty points-to sets and
+      // every value flowing through them unravels (wala/ML#595). Emitting the invocation
+      // unconditionally is safe: a class without a `build` method yields an empty points-to set
+      // for the field read, and the invoke has no targets.
+      if (filter
+          .getReference()
+          .getName()
+          .toString()
+          .endsWith("/" + CALLABLE_METHOD_NAME_FOR_KERAS_MODELS)) {
+        int buildFunction = v1 + 3;
+        x.addStatement(
+            PythonLanguage.Python.instructionFactory()
+                .GetInstruction(
+                    2,
+                    buildFunction,
+                    v1,
+                    FieldReference.findOrCreate(
+                        PythonTypes.Root,
+                        Atom.findOrCreateUnicodeAtom(KERAS_BUILD_METHOD_NAME),
+                        PythonTypes.Root)));
+        x.addStatement(
+            new PythonInvokeInstruction(
+                3,
+                v1 + 4,
+                v1 + 5,
+                new DynamicCallSiteReference(call.getCallSite().getDeclaredTarget(), 3),
+                new int[] {buildFunction, v1},
+                new Pair[0]));
+      }
     } else if (classMethodReceiver) {
       // Add a class reference.
       v1 = v + 2;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/types/PythonTypes.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/types/PythonTypes.java
@@ -49,6 +49,17 @@ public class PythonTypes extends AstTypeReference {
    */
   public static final String CALLABLE_METHOD_NAME_FOR_KERAS_MODELS = "call";
 
+  /**
+   * The method name of the Keras lazy-build hook: {@code Layer.__call__} invokes {@code
+   * self.build(input_shape)} before the first {@link #CALLABLE_METHOD_NAME_FOR_KERAS_MODELS call},
+   * and user subclasses commonly create their sublayers there (wala/ML#595).
+   *
+   * @see <a
+   *     href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/Layer#build">TensorFlow
+   *     documentation</a>.
+   */
+  public static final String KERAS_BUILD_METHOD_NAME = "build";
+
   /** The method name that is used for summarized methods . */
   public static final String DO_METHOD_NAME = "do";
 


### PR DESCRIPTION
Closes wala/ML#595, the next link in the dependency chain unblocked by WALA 1.8.0 (#495-#498 preceded this).

Root cause, matching the original diagnosis: `Layer.__call__` invokes `self.build(input_shape)` before the first `call`, and user subclasses commonly create their sublayers there (`self._kernel = tf.keras.layers.Dense(...)` in the vendored `deep_recommenders` GCN). Nothing in the analysis invoked `build`, so those sublayers had empty points-to sets and the layer-call result was untyped, dropping chained-layer parameters downstream.

The fix is one trampoline emission: `PythonInstanceMethodTrampolineTargetSelector.populate` for a Keras-`call`-convention trampoline now also reads `self.build` and invokes it before the main call. Classes without a `build` method are unaffected (empty points-to set for the field read; the invoke has no targets), so the emission is unconditional.

Test changes:
- `testGcnChainConsume` flips from documenting the gap to a positive assertion per its TODO: `consume(hidden)` recovers `(4, 8) float32`. The dtype and leading dimension are exact; the trailing dimension carries the matmul input shape through the `Dense` instead of its `units=16` (runtime is `(4, 16)`), a shape imprecision I filed as wala/ML#664 with a TODO in the test.
- `testGcnSparseCall`'s local-tensor count rises 4 to 7: `self._kernel` now dispatches, so the `Dense` result, the residual `outputs += features` value, and the return alias gained tensor types, a precision gain.

Full `mvn test` from the root passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc