### PR TITLE
Pin the nested layer-call forward result at five structural levels

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -9886,6 +9886,104 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins the forward result of a nested layer call ({@code self.inner(...)} inside another layer's
+   * {@code call}): the inner layer's return is tensor-typed at the nested call site and flows into
+   * a sink (<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>; enabled by the
+   * wala/ML#595 forward-result machinery).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNestedLayerCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nested_layer_call.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Pins the forward result of a nested layer call whose argument is a {@code NamedTuple} and whose
+   * inner {@code call} computes through a field read, a matmul, and an {@code unsorted_segment_sum}
+   * (<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNestedLayerCallNamedTuple()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nested_layer_call2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Pins the forward result of a nested layer call whose inner {@code call} returns through a
+   * second method hop ({@code self.propagate(...)} on the same class), the single-class form of
+   * {@code gcn_proj}'s return chain (<a href="https://github.com/wala/ML/issues/570">
+   * wala/ML#570</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNestedLayerCallPropagate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nested_layer_call3.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Pins the forward result of a nested layer call whose inner {@code call} returns through an
+   * <em>inherited</em> method ({@code self.propagate(...)} defined on a same-module base class),
+   * mirroring {@code gcn_proj}'s {@code GraphConvolution(MessagePassing)} shape (<a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNestedLayerCallInheritedPropagate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_nested_layer_call4.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
+   * Pins the forward result of a nested layer call whose inner {@code call} returns through a
+   * method inherited from a <em>cross-module</em> base ({@code Inner(MessagePassing)} with {@code
+   * MessagePassing} in another file), the deepest structural form of the {@code gcn_proj} chain (<a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>). {@code consume(x)} inside {@code
+   * Outer.call} recovers the concrete {@code (4, 8) float32}, so the frame/inheritance mechanism is
+   * not the {@code gcn_proj} residual; the remaining gap is the list-mediated aggregation inside
+   * the vendored {@code propagate} (gathers/slices/appends over the adjacency-list collection).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNestedLayerCallCrossModule()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {
+          "nested_proj/messagepassing.py",
+          "nested_proj/inner.py",
+          "nested_proj/tf2_test_nested_cross_module.py"
+        },
+        "tf2_test_nested_cross_module.py",
+        "consume",
+        "nested_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  /**
    * Verifies dtype recovery for {@code tf.linalg.matmul} on a {@code NamedTuple} field threaded in
    * as a parameter (<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>). {@code Inp}
    * is constructed in the caller and passed into {@code layer}, which reads {@code inp.x} (a {@code

--- a/com.ibm.wala.cast.python.test/data/nested_proj/inner.py
+++ b/com.ibm.wala.cast.python.test/data/nested_proj/inner.py
@@ -1,0 +1,10 @@
+# Cross-module subclass for wala/ML#570/#571.
+from messagepassing import MessagePassing
+
+
+class Inner(MessagePassing):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs):
+        return self.propagate(inputs)

--- a/com.ibm.wala.cast.python.test/data/nested_proj/messagepassing.py
+++ b/com.ibm.wala.cast.python.test/data/nested_proj/messagepassing.py
@@ -1,0 +1,14 @@
+# Cross-module base for wala/ML#570/#571: `propagate` is inherited across a module boundary.
+import tensorflow as tf
+
+
+class MessagePassing(tf.keras.layers.Layer):
+    def __init__(self):
+        super(MessagePassing, self).__init__()
+
+    def propagate(self, inputs):
+        x = inputs.node_embeddings
+        adj = inputs.adjacency_lists
+        h = tf.linalg.matmul(adj, x)
+        agg = tf.math.unsorted_segment_sum(h, tf.constant([0, 1, 2, 3]), 4)
+        return agg

--- a/com.ibm.wala.cast.python.test/data/nested_proj/tf2_test_nested_cross_module.py
+++ b/com.ibm.wala.cast.python.test/data/nested_proj/tf2_test_nested_cross_module.py
@@ -1,0 +1,35 @@
+# Test for wala/ML#570: the result of a nested layer call whose inner `call` returns through a
+# method inherited from a CROSS-MODULE base (mirroring `gcn_proj`'s
+# `GraphConvolution(MessagePassing)` with `MessagePassing` in another file) carries the
+# forward-result type.
+from typing import NamedTuple
+
+import tensorflow as tf
+
+from inner import Inner
+
+
+def consume(t):
+    pass
+
+
+class GNNInput(NamedTuple):
+    node_embeddings: tf.Tensor
+    adjacency_lists: tf.Tensor
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, node_embeddings, adjacency_lists):
+        x = self.inner(GNNInput(node_embeddings, adjacency_lists))
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 8)), tf.ones((4, 4)))
+assert out.shape == (4, 8)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call.py
@@ -1,0 +1,32 @@
+# Test for wala/ML#570: the result of a nested layer call (`self.inner(...)` inside another
+# layer's `call`) carries the inner layer's forward-result type.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class Inner(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs):
+        return tf.linalg.matmul(inputs, inputs)
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, inputs):
+        x = self.inner(inputs)
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call2.py
@@ -1,0 +1,45 @@
+# Test for wala/ML#570: the result of a nested layer call whose argument is a `NamedTuple`
+# (mirroring `gcn_proj`'s `self.gc1(GNNInput(node_embeddings, adjacency_lists))`) carries the
+# inner layer's forward-result type, where the inner `call` computes through a `NamedTuple` field
+# read, a matmul, and an `unsorted_segment_sum` aggregation.
+from typing import NamedTuple
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class GNNInput(NamedTuple):
+    node_embeddings: tf.Tensor
+    adjacency_lists: tf.Tensor
+
+
+class Inner(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs):
+        x = inputs.node_embeddings
+        adj = inputs.adjacency_lists
+        h = tf.linalg.matmul(adj, x)
+        agg = tf.math.unsorted_segment_sum(h, tf.constant([0, 1, 2, 3]), 4)
+        return agg
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, node_embeddings, adjacency_lists):
+        x = self.inner(GNNInput(node_embeddings, adjacency_lists))
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 8)), tf.ones((4, 4)))
+assert out.shape == (4, 8)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call3.py
@@ -1,0 +1,48 @@
+# Test for wala/ML#570: the result of a nested layer call whose inner `call` returns through a
+# second method hop (`self.propagate(...)`, mirroring `gcn_proj`'s
+# `GraphConvolution.call`-returns-`MessagePassing.propagate` chain) carries the forward-result
+# type.
+from typing import NamedTuple
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class GNNInput(NamedTuple):
+    node_embeddings: tf.Tensor
+    adjacency_lists: tf.Tensor
+
+
+class Inner(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def propagate(self, inputs):
+        x = inputs.node_embeddings
+        adj = inputs.adjacency_lists
+        h = tf.linalg.matmul(adj, x)
+        agg = tf.math.unsorted_segment_sum(h, tf.constant([0, 1, 2, 3]), 4)
+        return agg
+
+    def call(self, inputs):
+        return self.propagate(inputs)
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, node_embeddings, adjacency_lists):
+        x = self.inner(GNNInput(node_embeddings, adjacency_lists))
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 8)), tf.ones((4, 4)))
+assert out.shape == (4, 8)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nested_layer_call4.py
@@ -1,0 +1,52 @@
+# Test for wala/ML#570: the result of a nested layer call whose inner `call` returns through an
+# INHERITED method (`self.propagate(...)` defined on a same-module base class, mirroring
+# `gcn_proj`'s `GraphConvolution(MessagePassing)` chain) carries the forward-result type.
+from typing import NamedTuple
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class GNNInput(NamedTuple):
+    node_embeddings: tf.Tensor
+    adjacency_lists: tf.Tensor
+
+
+class MessagePassing(tf.keras.layers.Layer):
+    def __init__(self):
+        super(MessagePassing, self).__init__()
+
+    def propagate(self, inputs):
+        x = inputs.node_embeddings
+        adj = inputs.adjacency_lists
+        h = tf.linalg.matmul(adj, x)
+        agg = tf.math.unsorted_segment_sum(h, tf.constant([0, 1, 2, 3]), 4)
+        return agg
+
+
+class Inner(MessagePassing):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs):
+        return self.propagate(inputs)
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, node_embeddings, adjacency_lists):
+        x = self.inner(GNNInput(node_embeddings, adjacency_lists))
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 8)), tf.ones((4, 4)))
+assert out.shape == (4, 8)
+assert out.dtype == tf.float32


### PR DESCRIPTION
Test-only PR re-baselining wala/ML#570 after the wala/ML#118/#106/#595 machinery landed today (#495 through #499).

Five fixtures escalate from a plain nested layer call to the full structural shape of the `gcn_proj` GNN chain: a `NamedTuple` argument with field reads, a matmul, an `unsorted_segment_sum` aggregation, a second-hop return through `self.propagate(...)`, same-module inheritance, and finally a cross-module base (`Inner(MessagePassing)` with `MessagePassing` in another file). All five recover concrete types at a `consume` sink inside the outer layer's `call`, pinning the forward-result mechanism end to end as regression guards.

The diagnostic payoff: wala/ML#570's residual is NOT the frame/inheritance mechanism its description implies. The ⊤ in `gcn_proj` is localized to the list-mediated aggregation inside the vendored `MessagePassing.propagate` (`enumerate(adjacency_lists)` iteration, `[:, 0]` subscript-slices of list elements, `messages_all_type.append(...)` accumulation, and a comprehension), overlapping the wala/ML#659 subscript-slice work. I will re-scope #570 accordingly in a comment there.

Full `mvn test` from the root passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc