### PR TITLE
Model `tf.nn.dropout` as a pass-through

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -214,7 +214,7 @@
         <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
         <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="pass_through"/>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/dropout. Typing-wise an identity: the output tensor has the input's shape and dtype (elements are zeroed or scaled, never reshaped or cast), so the shared `pass_through` model applies, as with `tf.nn.relu` above. The last unmodeled op on the vendored gpt-2 forward path (wala/ML#618). -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/dropout. Typing-wise an identity: the output tensor has the input's shape and dtype (elements are zeroed or scaled, never reshaped or cast), so the shared `pass_through` model applies, as with `tf.nn.relu` above. Surfaced by the wala/ML#618 forward-path op audit. -->
         <putfield class="LRoot" field="dropout" fieldType="LRoot" ref="nn" value="pass_through"/>
         <new def="sparse_softmax_cross_entropy_with_logits" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits"/>
         <putfield class="LRoot" field="sparse_softmax_cross_entropy_with_logits" fieldType="LRoot" ref="nn" value="sparse_softmax_cross_entropy_with_logits"/>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -214,6 +214,8 @@
         <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
         <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="pass_through"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/dropout. Typing-wise an identity: the output tensor has the input's shape and dtype (elements are zeroed or scaled, never reshaped or cast), so the shared `pass_through` model applies, as with `tf.nn.relu` above. The last unmodeled op on the vendored gpt-2 forward path (wala/ML#618). -->
+        <putfield class="LRoot" field="dropout" fieldType="LRoot" ref="nn" value="pass_through"/>
         <new def="sparse_softmax_cross_entropy_with_logits" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits"/>
         <putfield class="LRoot" field="sparse_softmax_cross_entropy_with_logits" fieldType="LRoot" ref="nn" value="sparse_softmax_cross_entropy_with_logits"/>
         <new def="sigmoid" class="Ltensorflow/math/sigmoid"/>


### PR DESCRIPTION
From the wala/ML#618 forward-path op audit: every op in the vendored gpt-2 transformer layers is already modeled in `tensorflow.xml` except `tf.nn.dropout`. Typing-wise dropout is an identity (the output has the input's shape and dtype; elements are zeroed or scaled, never reshaped or cast), so it takes the shared `pass_through` model, exactly as `tf.nn.relu` does today.

No test expectations change (full `mvn test` from the root passes unchanged): the audit also showed the remaining `Gpt2.get_loss` `pred` gap is not op modeling at all. `Gpt2.call` returns the tuple `(logits, presents)` built through `zip(self.decoder_layers, pasts)` iteration, per-layer tuple unpacking, and list appends, so the residual is the same collection-mediated dataflow family as wala/ML#570's re-scoped residual and wala/ML#659; I will record that convergence on wala/ML#618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc