### PR TITLE
Recover tensor types through `append`, `zip`, and `for`-destructuring

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -1967,24 +1967,92 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
 
         String tempName = "temp " + ++tmpIndex;
 
-        CAstNode test =
-            Ast.makeNode(
-                CAstNode.BINARY_EXPR,
-                CAstOperator.OP_NE,
-                Ast.makeConstant(null),
-                Ast.makeNode(
-                    CAstNode.BLOCK_EXPR,
-                    Ast.makeNode(
-                        CAstNode.ASSIGN,
-                        c.getInternalTarget().accept(this),
-                        Ast.makeNode(
-                            CAstNode.EACH_ELEMENT_GET,
-                            Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
-                            c.getInternalTarget().accept(this)))));
+        // The iteration key must survive to drive the element-value read (`temp[key]`) and the
+        // next-key step (`EACH_ELEMENT_GET(temp, key)`). A simple-name target serves as its own
+        // key variable, but a destructuring target (`for x, y in ...`) would tear the key apart
+        // before the value read, so the read's reconstructed composite key can never match and
+        // every destructured element starves (wala/ML#618, surfaced by `zip`). Route the key
+        // through a dedicated scalar temporary instead; the target is then assigned (and
+        // destructured) from the element VALUE.
+        boolean scalarTarget = c.getInternalTarget() instanceof Name;
+        String keyName = scalarTarget ? null : "temp key " + ++tmpIndex;
 
-        result =
-            notePosition(
+        CAstNode test;
+        CAstNode firstKeyAssign;
+        CAstNode bodyValueAssign;
+        {
+          if (scalarTarget) {
+            test =
                 Ast.makeNode(
+                    CAstNode.BINARY_EXPR,
+                    CAstOperator.OP_NE,
+                    Ast.makeConstant(null),
+                    Ast.makeNode(
+                        CAstNode.BLOCK_EXPR,
+                        Ast.makeNode(
+                            CAstNode.ASSIGN,
+                            c.getInternalTarget().accept(this),
+                            Ast.makeNode(
+                                CAstNode.EACH_ELEMENT_GET,
+                                Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                                c.getInternalTarget().accept(this)))));
+            firstKeyAssign =
+                Ast.makeNode(
+                    CAstNode.ASSIGN,
+                    c.getInternalTarget().accept(this),
+                    Ast.makeNode(
+                        CAstNode.EACH_ELEMENT_GET,
+                        Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                        Ast.makeConstant(null)));
+            bodyValueAssign =
+                Ast.makeNode(
+                    CAstNode.ASSIGN,
+                    c.getInternalTarget().accept(this),
+                    Ast.makeNode(
+                        CAstNode.OBJECT_REF,
+                        Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                        c.getInternalTarget().accept(this)));
+          } else {
+            test =
+                Ast.makeNode(
+                    CAstNode.BINARY_EXPR,
+                    CAstOperator.OP_NE,
+                    Ast.makeConstant(null),
+                    Ast.makeNode(
+                        CAstNode.BLOCK_EXPR,
+                        Ast.makeNode(
+                            CAstNode.ASSIGN,
+                            Ast.makeNode(CAstNode.VAR, Ast.makeConstant(keyName)),
+                            Ast.makeNode(
+                                CAstNode.EACH_ELEMENT_GET,
+                                Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                                Ast.makeNode(CAstNode.VAR, Ast.makeConstant(keyName))))));
+            firstKeyAssign =
+                Ast.makeNode(
+                    CAstNode.ASSIGN,
+                    Ast.makeNode(CAstNode.VAR, Ast.makeConstant(keyName)),
+                    Ast.makeNode(
+                        CAstNode.EACH_ELEMENT_GET,
+                        Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                        Ast.makeConstant(null)));
+            bodyValueAssign =
+                Ast.makeNode(
+                    CAstNode.ASSIGN,
+                    c.getInternalTarget().accept(this),
+                    Ast.makeNode(
+                        CAstNode.OBJECT_REF,
+                        Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
+                        Ast.makeNode(CAstNode.VAR, Ast.makeConstant(keyName))));
+          }
+        }
+
+        CAstNode decls =
+            scalarTarget
+                ? Ast.makeNode(
+                    CAstNode.DECL_STMT,
+                    Ast.makeConstant(new CAstSymbolImpl(tempName, PythonCAstToIRTranslator.Any)),
+                    c.getInternalIter().accept(this))
+                : Ast.makeNode(
                     CAstNode.BLOCK_EXPR,
                     Ast.makeNode(
                         CAstNode.DECL_STMT,
@@ -1992,25 +2060,20 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
                             new CAstSymbolImpl(tempName, PythonCAstToIRTranslator.Any)),
                         c.getInternalIter().accept(this)),
                     Ast.makeNode(
-                        CAstNode.ASSIGN,
-                        c.getInternalTarget().accept(this),
-                        Ast.makeNode(
-                            CAstNode.EACH_ELEMENT_GET,
-                            Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
-                            Ast.makeConstant(null))),
+                        CAstNode.DECL_STMT,
+                        Ast.makeConstant(new CAstSymbolImpl(keyName, PythonCAstToIRTranslator.Any)),
+                        Ast.makeConstant(null)));
+
+        result =
+            notePosition(
+                Ast.makeNode(
+                    CAstNode.BLOCK_EXPR,
+                    decls,
+                    firstKeyAssign,
                     Ast.makeNode(
                         CAstNode.LOOP,
                         test,
-                        Ast.makeNode(
-                            CAstNode.BLOCK_EXPR,
-                            Ast.makeNode(
-                                CAstNode.ASSIGN,
-                                c.getInternalTarget().accept(this),
-                                Ast.makeNode(
-                                    CAstNode.OBJECT_REF,
-                                    Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)),
-                                    c.getInternalTarget().accept(this))),
-                            result))),
+                        Ast.makeNode(CAstNode.BLOCK_EXPR, bodyValueAssign, result))),
                 c);
       }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1606,11 +1606,18 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testTensorList3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // `list.append` is modeled (wala/ML#136): both appended tensors reach `add` through the
+    // iteration, so each parameter carries the union of the two shapes, as in testTensorList.
     test(
         "tf2_test_tensor_list3.py",
         "add",
-        0,
-        0); // NOTE: Change to 2, 2, 2, 3 once https://github.com/wala/ML/issues/136 is fixed.
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TENSOR_1_2_FLOAT32, TENSOR_2_2_FLOAT32),
+            3,
+            Set.of(TENSOR_1_2_FLOAT32, TENSOR_2_2_FLOAT32)));
   }
 
   @Test
@@ -6562,18 +6569,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * href="https://github.com/wala/ML/issues/196">wala/ML#196</a>'s {@link
    * com.ibm.wala.cast.python.ml.client.ReadDataFallback}.
    *
-   * <p>The current assertion is {@code (0, 3)} &mdash; 0 tensor parameters because the parameter (a
-   * list of tensors) is dropped from classification per <a
-   * href="https://github.com/wala/ML/issues/136">wala/ML#136</a>.
-   *
-   * <p>TODO: Once wala/ML#136 (losing tensors in lists) lands, change the assertion to {@code (1,
-   * 3)} (one tensor parameter &mdash; the {@code tower_grads} list-of-tensors), with the parameter
-   * at {@code vn=2} typed as the appropriate list-of-tensors type.
+   * <p>With `list.append` modeled (<a
+   * href="https://github.com/wala/ML/issues/136">wala/ML#136</a>), the loop's element values reach
+   * classification and the local-tensor count is 8 (the loop variable {@code g}, the per-iteration
+   * {@code expand_dims} results, and the {@code concat} chain). The parameter count stays 0: {@code
+   * tower_grads} is the list <em>container</em>, which is not itself a tensor; its elements are
+   * classified where they are read.
    */
   @Test
   public void testMultiGPUTraining2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("multigpu_training.py", "average_gradients", 0, 3);
+    test("multigpu_training.py", "average_gradients", 0, 8);
   }
 
   @Test
@@ -10004,6 +10010,54 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
+  @Test
+  public void testCollectionProbeTupleReturnUnpack()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_tuple_return_unpack.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  @Test
+  public void testCollectionProbeLayerTupleReturn()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_layer_tuple_return.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  @Test
+  public void testCollectionProbeListAppendIterate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_list_append_iterate.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  @Test
+  public void testCollectionProbeZipIterate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_zip_iterate.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  @Test
+  public void testCollectionProbeListElemSlice()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_list_elem_slice.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 4))));
+  }
+
+  @Test
+  public void testCollectionProbeListLiteralIterate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_list_literal_iterate.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
+  @Test
+  public void testCollectionProbeZipDiag()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_zip_diag.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+  }
+
   @Test
   public void testNamedTupleFieldMatmul()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_tuple_return.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_tuple_return.py
@@ -1,0 +1,34 @@
+# Probe for the collection-dataflow family (wala/ML#618): a user layer whose `call` returns a
+# TUPLE (mirroring gpt-2's `return logits, presents`), unpacked at the nested call site.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class Inner(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs):
+        logits = tf.linalg.matmul(inputs, inputs)
+        present = tf.zeros((2, 2))
+        return logits, present
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner = Inner()
+
+    def call(self, inputs):
+        x, present = self.inner(inputs)
+        consume(x)
+        return x
+
+
+outer = Outer()
+out = outer(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_append_iterate.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_append_iterate.py
@@ -1,0 +1,17 @@
+# Probe for the collection-dataflow family (wala/ML#570): a tensor appended to a list in a loop
+# and read back by iteration keeps its type (mirroring `messages_all_type.append(messages)`).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+tensors = []
+for i in range(3):
+    tensors.append(tf.ones((4, 8)))
+
+for t in tensors:
+    consume(t)
+    assert t.shape == (4, 8)
+    assert t.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_append_iterate.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_append_iterate.py
@@ -8,7 +8,7 @@ def consume(t):
 
 
 tensors = []
-for i in range(3):
+for _ in range(3):
     tensors.append(tf.ones((4, 8)))
 
 for t in tensors:

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_elem_slice.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_elem_slice.py
@@ -1,0 +1,17 @@
+# Probe for the collection-dataflow family (wala/ML#570/#659): a column slice of a tensor taken
+# from a list element keeps a tensor type (mirroring `adjacency_type_list[:, 1]` over
+# `adjacency_lists`).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+adjacency_lists = [tf.constant([[0, 1], [1, 2], [2, 3], [3, 0]])]
+
+for adjacency_type_list in adjacency_lists:
+    targets = adjacency_type_list[:, 1]
+    consume(targets)
+    assert targets.shape == (4,)
+    assert targets.dtype == tf.int32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_literal_iterate.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_literal_iterate.py
@@ -1,0 +1,15 @@
+# Probe for the collection-dataflow family (wala/ML#570/#618): a tensor read back by iterating a
+# LIST LITERAL keeps its type (differential probe against the `append` and `zip` forms).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+tensors = [tf.ones((4, 8)), tf.ones((4, 8))]
+
+for t in tensors:
+    consume(t)
+    assert t.shape == (4, 8)
+    assert t.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tuple_return_unpack.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tuple_return_unpack.py
@@ -1,0 +1,19 @@
+# Probe for the collection-dataflow family (wala/ML#570/#618/#659): a function returning a tuple
+# of tensors, unpacked at the call site, keeps each element's tensor type.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def produce():
+    logits = tf.ones((4, 8))
+    presents = tf.zeros((2, 2))
+    return logits, presents
+
+
+a, b = produce()
+consume(a)
+assert a.shape == (4, 8)
+assert a.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_zip_diag.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_zip_diag.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+xs = [tf.ones((4, 8))]
+ys = [tf.zeros((2, 2))]
+
+for p in zip(xs, ys):
+    consume(p[0])
+
+for x, y in zip(xs, ys):
+    consume2(x)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_zip_iterate.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_zip_iterate.py
@@ -1,0 +1,16 @@
+# Probe for the collection-dataflow family (wala/ML#618): tensors iterated through `zip` keep
+# their types (mirroring gpt-2's `for decoder_layer, past in zip(self.decoder_layers, pasts)`).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+xs = [tf.ones((4, 8)), tf.ones((4, 8))]
+ys = [tf.zeros((2, 2)), tf.zeros((2, 2))]
+
+for x, y in zip(xs, ys):
+    consume(x)
+    assert x.shape == (4, 8)
+    assert x.dtype == tf.float32

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -78,6 +78,14 @@ import java.util.logging.Logger;
 
 public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraphBuilder {
 
+  /**
+   * The synthetic property key under which {@code xs.append(v)} stores {@code v} on {@code xs}; see
+   * {@code PythonConstraintVisitor.processListAppend}. Value-iteration surfaces the property's
+   * values regardless of its name, so the name only needs to avoid colliding with real program
+   * properties.
+   */
+  public static final String LIST_APPEND_CONTENTS_FIELD = "__list_append_contents__";
+
   private static final Logger logger =
       Logger.getLogger(PythonSSAPropagationCallGraphBuilder.class.getName());
 
@@ -291,6 +299,40 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
     @Override
     public void visitPythonInvoke(PythonInvokeInstruction inst) {
       visitInvokeInternal(inst, new DefaultInvariantComputer());
+      processListAppend(inst);
+    }
+
+    /**
+     * Models {@code xs.append(v)} as a property write of {@code v} onto {@code xs} under the
+     * synthetic {@value #LIST_APPEND_CONTENTS_FIELD} key, so values accumulated through {@code
+     * append} surface when the collection is iterated ({@code visitForElementGet} reads the
+     * cataloged properties of value-iterated collections). Nothing else models {@code list.append},
+     * so without this the appended values are unreachable from the collection and every value
+     * flowing through an append-accumulate-iterate chain unravels (wala/ML#570, wala/ML#618).
+     *
+     * <p>Detection is syntactic on the du-chain: an invoke whose callee value is a property read of
+     * the constant name {@code append}. The property write coexists with the invoke's normal
+     * dispatch, so a user-defined {@code append} method still dispatches; such a receiver merely
+     * gains a stray property under the synthetic key, which is only observable if that same object
+     * is also value-iterated.
+     *
+     * @param inst the invoke instruction to examine
+     */
+    private void processListAppend(PythonInvokeInstruction inst) {
+      if (inst.getNumberOfPositionalParameters() != 2) return;
+
+      SSAInstruction calleeDef = du.getDef(inst.getUse(0));
+      if (!(calleeDef instanceof AstPropertyRead)) return;
+
+      AstPropertyRead read = (AstPropertyRead) calleeDef;
+      SymbolTable symtab = ir.getSymbolTable();
+      if (!symtab.isConstant(read.getMemberRef())
+          || !"append".equals(symtab.getConstantValue(read.getMemberRef()))) return;
+
+      InstanceKey contentsKey =
+          getBuilder().getInstanceKeyForConstant(PythonTypes.string, LIST_APPEND_CONTENTS_FIELD);
+      PointerKey valueKey = getPointerKeyForLocal(inst.getUse(1));
+      newFieldWrite(node, read.getObjectRef(), new InstanceKey[] {contentsKey}, valueKey);
     }
 
     /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -96,6 +96,55 @@ public class BuiltinFunctions {
     return x;
   }
 
+  /**
+   * Builds the summary for {@code zip}: a freshly-allocated list holding one tuple whose field
+   * {@code j} is an element of {@code zip}'s argument {@code j}. Iterating the result and unpacking
+   * each element (the {@code for a, b in zip(xs, ys)} idiom) then recovers the input lists' element
+   * values. Up to four arguments are wired; an unbound argument's element read has an empty
+   * points-to set and contributes nothing. Without this, {@code zip} returned an <em>empty</em>
+   * list and every value flowing through it unraveled (wala/ML#618; the same starvation shape as
+   * {@code range}, wala/ML#599).
+   *
+   * @param cls The builtin function class whose summary this is.
+   * @param name The builtin's name ({@code zip}).
+   * @return The populated summary.
+   */
+  private static IMethod zipSummary(IClass cls, String name) {
+    TypeReference type = builtinFunction(name);
+    MethodReference ref = MethodReference.findOrCreate(type, AstMethodReference.fnSelector);
+    PythonSummary x = new PythonSummary(ref, 10);
+
+    AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
+    int container = 11;
+    int tuple = 12;
+    int nullKey = 13;
+    int containerKey = 14;
+    int v = 15;
+    int idx = 0;
+
+    x.addStatement(
+        factory.NewInstruction(idx++, container, NewSiteReference.make(0, PythonTypes.list)));
+    x.addStatement(
+        factory.NewInstruction(idx++, tuple, NewSiteReference.make(1, PythonTypes.tuple)));
+    x.addConstant(nullKey, new ConstantValue(null));
+
+    for (int arg = 2; arg <= 5; arg++) {
+      int elementKey = v++;
+      int element = v++;
+      int fieldKey = v++;
+      x.addStatement(factory.EachElementGetInstruction(idx++, elementKey, arg, nullKey));
+      x.addStatement(factory.PropertyRead(idx++, element, arg, elementKey));
+      x.addConstant(fieldKey, new ConstantValue(arg - 2));
+      x.addStatement(factory.PropertyWrite(idx++, tuple, fieldKey, element));
+    }
+
+    x.addConstant(containerKey, new ConstantValue(0));
+    x.addStatement(factory.PropertyWrite(idx++, container, containerKey, tuple));
+    x.addStatement(factory.ReturnInstruction(idx++, container, false));
+
+    return new PythonSummarizedFunction(ref, x, cls);
+  }
+
   private static IMethod argSummary(IClass cls, String name, int arg) {
     PythonSummary S = argSummary(cls, builtinFunction(name), arg);
     return new PythonSummarizedFunction(S.getMethod(), S, cls);
@@ -141,7 +190,11 @@ public class BuiltinFunctions {
               // comprehensions over it can recover element keys. See wala/ML#599.
               : name.equals("range")
                   ? iterableSummary(this, name, returnedType, TypeReference.Int)
-                  : typeSummary(this, name, returnedType);
+                  // `zip` must return a list of tuples wiring the inputs' elements through;
+                  // see `zipSummary` (wala/ML#618).
+                  : name.equals("zip")
+                      ? zipSummary(this, name)
+                      : typeSummary(this, name, returnedType);
     }
 
     private BuiltinFunction(IClassHierarchy cha, String name, int arg) {


### PR DESCRIPTION
First tranche of the collection-dataflow workstream shared by wala/ML#570, wala/ML#618, and wala/ML#659. A six-probe battery bisected the family; three of the six idioms starved tensor types and are fixed here, and all six are pinned by new `testCollectionProbe*` regression guards.

- **`list.append`** was modeled by nothing, so values accumulated through it were unreachable from the collection. `PythonConstraintVisitor.processListAppend` detects the idiom on the du-chain (an invoke whose callee is a property read of the constant `append`) and writes the value onto the receiver under a synthetic property key, which value-iteration surfaces. The write coexists with the invoke's normal dispatch, so a user-defined `append` method still dispatches.
- **`zip`** returned a freshly-allocated EMPTY list. It now has a real summary in `BuiltinFunctions`: a list holding a tuple whose field `j` carries the elements of argument `j` (up to four arguments); the same starvation shape `range` had (wala/ML#599).
- **`for x, y in ...` destructuring** tore the iteration key apart before the element-value read (`temp[key]`), so the reconstructed composite key never matched and every destructured element starved, regardless of producer. `doGenerators` now routes the key through a dedicated scalar temporary for non-name targets; the simple-name path is byte-identical to before.

Consequences in existing tests: `testTensorList3` (the wala/ML#136 pin, literally `append`+iterate) flips to its documented post-fix expectations, with both `add` parameters carrying the union of the appended shapes, and `testMultiGPUTraining2`'s gradient-averaging loop gains five typed locals (its #136 TODO retires; the parameter count stays 0 because the parameter is the list container, not a tensor). The enumerate-sensitive `testTensorboardExample` (wala/ML#409) is unaffected.

Full `mvn test` from the root passes locally.

Closes wala/ML#136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc