### PR TITLE
Model `add_weight`, wire shell-inherited methods, and pin the wildcard gap

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10058,6 +10058,274 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_zip_diag.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
+  /**
+   * Pins the gpt-2 decoder-stack shape in miniature (wala/ML#618): layers built by a list
+   * comprehension, iterated with {@code zip} against a {@code [None] * n} list, each call's tuple
+   * result destructured and the hidden state carried through the loop.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeLayerListComprehension()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_layer_list_comprehension.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Pins {@code self.add_weight(...)} (wala/ML#618): the Keras weight-creation API, called from the
+   * lazily-invoked {@code build} (wala/ML#595), creates a tensor-classified value, and a matmul
+   * against it recovers the dtype from the other operand.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeAddWeight()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_add_weight.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Pins the vendored gpt-2 {@code EmbeddingLayer} forward result (wala/ML#618): the {@code
+   * add_weight}-created weight dispatches and both {@code mode} branches contribute to the result
+   * union.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeVendoredEmbedding()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // Count-only: the parameter's type is a union across the `mode` branches whose exact
+    // members shift with modeling precision.
+    test(
+        new String[] {
+          "gpt2_vendored/layers/__init__.py",
+          "gpt2_vendored/layers/embedding_layer.py",
+          "gpt2_vendored/probe_embedding.py"
+        },
+        "probe_embedding.py",
+        "consume",
+        "gpt2_vendored",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE,
+                new TensorType(
+                    INT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
+                new TensorType(
+                    INT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+  }
+
+  /**
+   * Pins the model self-call (wala/ML#618): a method calling {@code self(...)} and destructuring
+   * the tuple result, mirroring gpt-2's {@code predictions, _ = self(inputs, training=True)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeModelSelfCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_model_self_call.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Documents the vendored gpt-2 forward output (the wala/ML#618 {@code pred} source) starving on
+   * wala/ML#665: the decoder stack builds on {@code Conv1d}, whose module takes {@code tf} from a
+   * non-forwarded wildcard import.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeVendoredForward()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {
+          "gpt2_vendored/layers/__init__.py", "gpt2_vendored/layers/embedding_layer.py",
+          "gpt2_vendored/layers/feed_forward.py", "gpt2_vendored/layers/layer_norm.py",
+          "gpt2_vendored/layers/attention_layer.py", "gpt2_vendored/utils/__init__.py",
+          "gpt2_vendored/utils/tf_utils.py", "gpt2_vendored/scripts/__init__.py",
+          "gpt2_vendored/scripts/utils.py", "gpt2_vendored/data_pipeline.py",
+          "gpt2_vendored/A.py", "gpt2_vendored/probe_forward.py"
+        },
+        "probe_forward.py",
+        "consume",
+        "gpt2_vendored",
+        0,
+        0,
+        // TODO: Expect 1 tensor parameter (the model forward output feeding wala/ML#618's `pred`)
+        // once wala/ML#665 lands (https://github.com/wala/ML/issues/665).
+        emptyMap());
+  }
+
+  /**
+   * Pins a tensor computed inside a {@code with tf.name_scope(...)} block (wala/ML#618): the
+   * unresolved context manager does not perturb the body's dataflow.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeWithNameScope()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_with_name_scope.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
+   * Documents the vendored gpt-2 {@code Conv1d} starving on wala/ML#665: {@code feed_forward.py}
+   * takes {@code tf} from a wildcard import, which is not forwarded, so every {@code tf.*} call in
+   * it is unbound.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeVendoredConv1d()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {
+          "gpt2_vendored/layers/__init__.py", "gpt2_vendored/layers/embedding_layer.py",
+          "gpt2_vendored/layers/feed_forward.py", "gpt2_vendored/layers/layer_norm.py",
+          "gpt2_vendored/layers/attention_layer.py", "gpt2_vendored/utils/__init__.py",
+          "gpt2_vendored/utils/tf_utils.py", "gpt2_vendored/scripts/__init__.py",
+          "gpt2_vendored/scripts/utils.py", "gpt2_vendored/data_pipeline.py",
+          "gpt2_vendored/A.py", "gpt2_vendored/probe_conv1d.py"
+        },
+        "probe_conv1d.py",
+        "consume",
+        "gpt2_vendored",
+        0,
+        0,
+        // TODO: Expect 1 tensor parameter once wala/ML#665 forwards `tf` through the wildcard
+        // import (https://github.com/wala/ML/issues/665).
+        emptyMap());
+  }
+
+  /**
+   * Pins {@code tf.reshape} with a literal shape list (companion to {@link
+   * #testCollectionProbeReshapeComputedShape()}).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeReshapeLiteralShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_computed_shape.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT32, 6, 8))));
+  }
+
+  /**
+   * Pins {@code tf.reshape} with a shape list built at runtime by list concatenation ({@code
+   * [tf.shape(x)[0], tf.shape(x)[1]] + [n]}, the vendored {@code Conv1d} idiom, wala/ML#618): the
+   * interpreter evaluates the expression and the output shape is concrete.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeReshapeComputedShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_computed_shape.py",
+        "consume2",
+        1,
+        1,
+        // The interpreter evaluates the concatenated shape expression to the concrete
+        // (2, 3, 16); a scalar leak rides along in the union.
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 16), SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  /**
+   * Documents wala/ML#665: {@code tf} reached through {@code from helpers import *} stays unbound,
+   * so the computation starves. Python's wildcard semantics bind every public name of the source
+   * module, including modules it imported.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeWildcardTf()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"wildcard_proj/helpers.py", "wildcard_proj/tf2_test_wildcard_tf.py"},
+        "tf2_test_wildcard_tf.py",
+        "consume",
+        "wildcard_proj",
+        0,
+        0,
+        // TODO: Expect 1 tensor parameter typed (4, 4) float32 once wala/ML#665 forwards the
+        // source module's import bindings (https://github.com/wala/ML/issues/665).
+        emptyMap());
+  }
+
+  /**
+   * Pins the vendored {@code LayerNormalization} forward result: {@code add_weight}-created {@code
+   * gamma}/{@code beta} dispatch (wala/ML#595, wala/ML#618) and the normalization body types (a
+   * union including {@code ? of float32}). Count-only: the union's exact members shift with
+   * modeling precision.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testVendoredLayerNorm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {
+          "gpt2_vendored/layers/__init__.py", "gpt2_vendored/layers/embedding_layer.py",
+          "gpt2_vendored/layers/feed_forward.py", "gpt2_vendored/layers/layer_norm.py",
+          "gpt2_vendored/layers/attention_layer.py", "gpt2_vendored/utils/__init__.py",
+          "gpt2_vendored/utils/tf_utils.py", "gpt2_vendored/scripts/__init__.py",
+          "gpt2_vendored/scripts/utils.py", "gpt2_vendored/data_pipeline.py",
+          "gpt2_vendored/A.py", "gpt2_vendored/probe_ln.py"
+        },
+        "probe_ln.py",
+        "consume",
+        "gpt2_vendored",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE, TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
   @Test
   public void testNamedTupleFieldMatmul()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2439,7 +2439,13 @@
     </package>
     <package name="tensorflow/keras/layers">
       <!-- Declaring a `super` opts `Layer` in to being materialized as a class shell before the class hierarchy is built (wala/WALA#1957), so a source subclass such as `class MyLayer(tf.keras.layers.Layer)` resolves its base to this type instead of falling back to `object` (wala/ML#118). Shell-only: the class deliberately declares no methods, since a shell shadows same-named bypass method bodies (see the CAUTION on `tensorflow/keras/models/Model`), and no `<new>` targets it, so it is not `allocatable`. -->
-      <class name="Layer" super="Lobject"></class>
+      <class name="Layer" super="Lobject">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/Layer#add_weight. The universal Keras weight-creation API: user layers call `self.add_weight(...)` (typically in `build`, wala/ML#595) to create their kernels. Modeled as a fresh dense tensor; the shape/dtype arguments are not yet consumed (a dedicated generator can refine this). The shell carries this method's reference (wala/ML#106), and source subclasses wire it through their synthesized constructors, so `self.add_weight` dispatches on any `Layer` subclass instance (wala/ML#618). -->
+        <method name="add_weight" descriptor="()LRoot;" numArgs="9" paramNames="self name shape dtype initializer regularizer trainable constraint synchronization">
+          <new def="w" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="w"/>
+        </method>
+      </class>
       <class name="Input" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_conv1d.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_conv1d.py
@@ -1,0 +1,14 @@
+# Probe driver for wala/ML#618: the vendored `Conv1d` forward output in isolation.
+# Analyzed statically, like `A.py` itself.
+import tensorflow as tf
+
+from layers.feed_forward import Conv1d
+
+
+def consume(t):
+    pass
+
+
+c = Conv1d(8, 16)
+out = c(tf.ones((2, 3, 8)))
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_embedding.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_embedding.py
@@ -1,0 +1,16 @@
+# Probe driver for wala/ML#618: the vendored `EmbeddingLayer`'s forward result in isolation.
+import tensorflow as tf
+
+from layers.embedding_layer import EmbeddingLayer
+
+
+def consume(t):
+    pass
+
+
+emb = EmbeddingLayer(10, 8)
+x = tf.constant([[1, 2, 3], [4, 5, 6]])
+out = emb(x)
+consume(out)
+assert out.shape == (2, 3, 8)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_forward.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_forward.py
@@ -1,0 +1,20 @@
+# Probe driver for wala/ML#618: the vendored `Gpt2` forward output in isolation (no training
+# loop, no `GradientTape`, no `fit` indirection). Analyzed statically, like `A.py` itself
+# (whose module-level driver needs a tfrecord setup to run).
+import tensorflow as tf
+
+from A import Gpt2
+
+
+def consume(t):
+    pass
+
+
+model = Gpt2(
+    num_layers=2, d_model=8, num_heads=2, dff=16, max_seq_len=12, vocab_size=10
+)
+inputs = tf.constant([[1, 2, 3], [4, 5, 6]])
+logits, _ = model(inputs, training=False)
+consume(logits)
+assert logits.shape == (2, 3, 10)
+assert logits.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_ln.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_ln.py
@@ -1,0 +1,14 @@
+# Probe driver for wala/ML#618: the vendored `LayerNormalization` forward output in isolation.
+# Analyzed statically, like `A.py` itself.
+import tensorflow as tf
+
+from layers.layer_norm import LayerNormalization
+
+
+def consume(t):
+    pass
+
+
+ln = LayerNormalization(8)
+out = ln(tf.ones((2, 3, 8)))
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_add_weight.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_add_weight.py
@@ -1,0 +1,29 @@
+# Probe for wala/ML#618: `self.add_weight(...)` (the Keras weight-creation API, called from the
+# lazily-invoked `build`, wala/ML#595) creates a value the analysis classifies as a tensor, so a
+# forward pass computing with the weight types.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class MyLayer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(MyLayer, self).__init__()
+
+    def build(self, input_shape):
+        self.kernel = self.add_weight(
+            "kernel", shape=[4, 4], dtype="float32", initializer=tf.zeros_initializer()
+        )
+
+    def call(self, inputs):
+        h = tf.linalg.matmul(inputs, self.kernel)
+        consume(h)
+        return h
+
+
+layer = MyLayer()
+out = layer(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_comprehension.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_comprehension.py
@@ -1,0 +1,37 @@
+# Probe for the collection-dataflow family (wala/ML#618): layers built by a LIST COMPREHENSION
+# (mirroring gpt-2's `self.decoder_layers = [DecoderLayer(...) for _ in range(num_layers)]`),
+# iterated with `zip` against a `[None] * n` list, dispatch and their forward results type.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class Inner(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Inner, self).__init__()
+
+    def call(self, inputs, past):
+        h = tf.linalg.matmul(inputs, inputs)
+        return h, past
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self):
+        super(Outer, self).__init__()
+        self.inner_layers = [Inner() for _ in range(3)]
+
+    def call(self, inputs):
+        pasts = [None] * 3
+        hidden = inputs
+        for inner_layer, past in zip(self.inner_layers, pasts):
+            hidden, present = inner_layer(hidden, past)
+        consume(hidden)
+        return hidden
+
+
+outer = Outer()
+out = outer(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_self_call.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_self_call.py
@@ -1,0 +1,29 @@
+# Probe for wala/ML#618: a model method calling `self(...)` (Keras convention: `Model.__call__`
+# routes to `call`) and unpacking the tuple result (mirroring gpt-2's
+# `predictions, _ = self(inputs, training=True)` inside `_train_step`).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class MyModel(tf.keras.Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def call(self, inputs, training=False):
+        h = tf.linalg.matmul(inputs, inputs)
+        present = tf.zeros((2, 2))
+        return h, present
+
+    def run(self, inputs):
+        predictions, _ = self(inputs, training=True)
+        consume(predictions)
+        return predictions
+
+
+model = MyModel()
+out = model.run(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_computed_shape.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_computed_shape.py
@@ -1,0 +1,24 @@
+# Probe for wala/ML#618: `tf.reshape` with (a) a literal shape list and (b) a shape list built at
+# runtime by list concatenation (`[tf.shape(x)[0], tf.shape(x)[1]] + [n]`, the vendored `Conv1d`
+# idiom).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+x = tf.ones((2, 3, 8))
+
+flat = tf.reshape(x, [-1, 8])
+consume(flat)
+assert flat.shape == (6, 8)
+
+output_shape = [tf.shape(x)[0], tf.shape(x)[1]] + [16]
+y = tf.reshape(tf.ones((2, 3, 16)), output_shape)
+consume2(y)
+assert y.shape == (2, 3, 16)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_with_name_scope.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_with_name_scope.py
@@ -1,0 +1,29 @@
+# Probe for wala/ML#618: a tensor computed inside a `with tf.name_scope(...)` block keeps its
+# type (gpt-2 wraps every stage of `Gpt2.call` in one).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class MyModel(tf.keras.Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def call(self, inputs, training=False):
+        with tf.name_scope("stage"):
+            h = tf.linalg.matmul(inputs, inputs)
+        present = tf.zeros((2, 2))
+        return h, present
+
+    def run(self, inputs):
+        predictions, _ = self(inputs, training=True)
+        consume(predictions)
+        return predictions
+
+
+model = MyModel()
+out = model.run(tf.ones((4, 4)))
+assert out.shape == (4, 4)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/wildcard_proj/helpers.py
+++ b/com.ibm.wala.cast.python.test/data/wildcard_proj/helpers.py
@@ -1,0 +1,6 @@
+# Helper module for the wildcard-import probe (wala/ML#618): `tf` is a module global here.
+import tensorflow as tf
+
+
+def shape_list(x):
+    return x

--- a/com.ibm.wala.cast.python.test/data/wildcard_proj/tf2_test_wildcard_tf.py
+++ b/com.ibm.wala.cast.python.test/data/wildcard_proj/tf2_test_wildcard_tf.py
@@ -1,0 +1,13 @@
+# Probe for wala/ML#618: `tf` reached through `from helpers import *` (the vendored
+# `feed_forward.py` never imports tensorflow directly; it takes `tf` from a wildcard import).
+from helpers import *
+
+
+def consume(t):
+    pass
+
+
+x = tf.ones((4, 4))
+h = tf.linalg.matmul(x, x)
+consume(h)
+assert h.shape == (4, 4)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -22,6 +22,7 @@ import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.loader.IPythonClass;
 import com.ibm.wala.cast.python.loader.PythonLoader;
+import com.ibm.wala.cast.python.loader.PythonLoader.PythonSummaryShellClass;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
@@ -167,6 +168,11 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
           Collection<TypeReference> innerReferences = Collections.emptyList();
           Collection<MethodReference> methodReferences = new ArrayList<>();
 
+          // Methods inherited from a summary class shell (wala/ML#118) have no function object on
+          // the source class object to read; their function classes are bypass-registered and are
+          // allocated directly below, mirroring the engine's summary-constructor rewriting.
+          Set<MethodReference> summaryDeclaredMethods = new HashSet<>();
+
           if (receiver instanceof IPythonClass) {
             IPythonClass x = (IPythonClass) receiver;
             innerReferences = x.getInnerReferences();
@@ -188,10 +194,15 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             for (IClass parent = receiver.getSuperclass();
                 parent instanceof IPythonClass;
                 parent = parent.getSuperclass()) {
+              boolean shell = parent instanceof PythonSummaryShellClass;
               ((IPythonClass) parent)
                   .getMethodReferences().stream()
                       .filter(m -> seenMethodNames.add(m.getName()))
-                      .forEach(methodReferences::add);
+                      .forEach(
+                          m -> {
+                            methodReferences.add(m);
+                            if (shell) summaryDeclaredMethods.add(m);
+                          });
             }
           } else {
             for (IMethod m : receiver.getDeclaredMethods()) {
@@ -240,12 +251,21 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             pc++;
 
             int orig_f = v++;
-            ctor.addStatement(
-                insts.GetInstruction(
-                    pc,
-                    orig_f,
-                    1,
-                    FieldReference.findOrCreate(PythonTypes.Root, r.getName(), PythonTypes.Root)));
+            if (summaryDeclaredMethods.contains(r)) {
+              // The function object of a shell-inherited summary method is not a field of the
+              // source class object; allocate its bypass-registered function class directly.
+              ctor.addStatement(
+                  insts.NewInstruction(
+                      pc, orig_f, NewSiteReference.make(pc, r.getDeclaringClass())));
+            } else {
+              ctor.addStatement(
+                  insts.GetInstruction(
+                      pc,
+                      orig_f,
+                      1,
+                      FieldReference.findOrCreate(
+                          PythonTypes.Root, r.getName(), PythonTypes.Root)));
+            }
             pc++;
 
             ctor.addStatement(


### PR DESCRIPTION
Second tranche of the collection-dataflow workstream; the wala/ML#618 `pred` bisection. Three pieces:

- **`tensorflow.xml` models `tf.keras.layers.Layer.add_weight`** (the universal Keras weight-creation API, typically called from the lazily-invoked `build`, wala/ML#595) as a fresh dense tensor. A dedicated generator consuming the `shape`/`dtype` arguments can refine this later.
- **`PythonConstructorTargetSelector` wires methods inherited from a summary class shell.** The existing wala/ML#107 superclass walk already collected them, but its `$function` hookup reads the method off the source class object, which is empty for shell-inherited methods; the synthesized constructor now allocates the bypass-registered function class directly for shell-declared references, mirroring the engine's summary-constructor rewriting. With this, any `Layer` subclass instance dispatches `self.add_weight(...)` (used by the vendored gpt-2 `EmbeddingLayer`/`LayerNormalization`/`Conv1d` and the GNN's `GraphConvolution` alike).
- **A probe battery pins the rest of the gpt-2 forward chain green:** the decoder-stack shape in miniature (comprehension-built layer list, `zip` against `[None] * n`, loop-carried hidden state, tuple destructuring), model self-calls (`predictions, _ = self(inputs, training=True)`), `with tf.name_scope(...)` blocks, computed-shape `reshape` (the interpreter recovers the concrete shape), and the vendored `EmbeddingLayer` and `LayerNormalization` end to end through real `add_weight`-built weights.

The bisection's conclusion: the single remaining hop between the analysis and the gpt-2 model forward output is wala/ML#665, `from m import *` not forwarding the source module's own import bindings. The vendored `feed_forward.py` takes `tf` from a wildcard import, so `Conv1d`, `MultiHeadAttention`, and `DecoderLayer` starve wholesale. `testCollectionProbeWildcardTf` pins the minimal form and the `probe_conv1d`/`probe_forward` drivers pin the vendored form, all with TODOs pointing at wala/ML#665; they flip when it lands.

Full `mvn test` from the root passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc