### PR TITLE
Handle invariant appended values in `processListAppend`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10065,6 +10065,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test("tf2_test_list_append_iterate.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
+  /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/668">wala/ML#668</a>: appending
+   * a constant (an invariant-contents value whose pointer key the invoke's own argument processing
+   * records as implicitly represented) must not crash call-graph construction with {@code
+   * UnimplementedError}. The tensor appended alongside still types through the iteration.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeListAppendConstant()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_list_append_constant.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
   @Test
   public void testCollectionProbeZipIterate()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_append_constant.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_append_constant.py
@@ -1,0 +1,17 @@
+# Reproduces wala/ML#668: appending a constant (an invariant-contents value) must not crash
+# call-graph construction. The invoke's own argument processing records the constant's pointer
+# key as implicitly represented; the append model must use the invariant-contents path instead
+# of a raw constraint on that key. The tensor appended alongside still types through iteration.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+xs = []
+xs.append(1)
+xs.append(tf.ones((4, 4)))
+
+for x in xs:
+    consume(x)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -332,8 +332,24 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
 
       InstanceKey contentsKey =
           getBuilder().getInstanceKeyForConstant(PythonTypes.string, LIST_APPEND_CONTENTS_FIELD);
-      PointerKey valueKey = getPointerKeyForLocal(inst.getUse(1));
-      newFieldWrite(node, read.getObjectRef(), new InstanceKey[] {contentsKey}, valueKey);
+      int valueVn = inst.getUse(1);
+
+      if (contentsAreInvariant(symtab, du, valueVn)) {
+        // The invoke's own argument processing records an invariant value's pointer key as
+        // implicitly represented, so a raw constraint on that key crashes
+        // `findOrCreatePointsToSet` (wala/ML#668). Write the invariant instance keys directly.
+        system.recordImplicitPointsToSet(getPointerKeyForLocal(valueVn));
+        newFieldWrite(
+            node,
+            read.getObjectRef(),
+            new InstanceKey[] {contentsKey},
+            getInvariantContents(symtab, du, node, valueVn));
+      } else
+        newFieldWrite(
+            node,
+            read.getObjectRef(),
+            new InstanceKey[] {contentsKey},
+            getPointerKeyForLocal(valueVn));
     }
 
     /**


### PR DESCRIPTION
On 0.52.12, call-graph construction throws `UnimplementedError` when a program appends an invariant-contents value (e.g. `xs.append(1)`): the invoke's own argument processing records the value's pointer key as implicitly represented, and the append model (ponder-lab/ML#502) then issued a raw constraint on that key, which `PropagationSystem.findOrCreatePointsToSet` refuses. Reproduced with a two-line fixture; this is the crash reported for three of the six evaluation subjects.

Fix: mirror the field-write handling in `AstSSAPropagationCallGraphBuilder`. When `contentsAreInvariant` holds for the appended value, record the implicit points-to set and pass the invariant instance keys to the `InstanceKey[]`-values `newFieldWrite` overload; otherwise keep the pointer-key path.

`testCollectionProbeListAppendConstant` pins the non-crash and that a tensor appended alongside the constant still types through the iteration (`(4, 4)` float32, with the constant not polluting the union).

Closes wala/ML#668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
