### PR TITLE
Degrade non-constant keys to not statically resolvable

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
@@ -17,6 +17,7 @@ import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -121,6 +122,9 @@ public class DatasetBatchGenerator extends DatasetGenerator {
         getPossibleLongValues(
             this.getArgumentPointsToSet(
                 builder, Parameters.BATCH_SIZE.getIndex(), Parameters.BATCH_SIZE.getName()));
+    // A null result means `batch_size` is not statically resolvable (wala/ML#669); treat it like
+    // an unspecified batch size (the symbolic-batching path below).
+    if (batchSizes == null) batchSizes = Collections.emptySet();
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetRangeGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetRangeGenerator.java
@@ -77,6 +77,12 @@ public class DatasetRangeGenerator extends DatasetGenerator {
             this.getArgumentPointsToSet(
                 builder, Parameters.STEP.getIndex(), Parameters.STEP.getName()));
 
+    // A null result means the argument is not statically resolvable (wala/ML#669); treat it like
+    // an unspecified argument (the size stays unknown below).
+    if (starts == null) starts = Collections.emptySet();
+    if (stops == null) stops = Collections.emptySet();
+    if (steps == null) steps = Collections.emptySet();
+
     if (stops.isEmpty() && starts.isEmpty()) {
       return Collections.emptySet();
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -130,7 +130,9 @@ public class DenseCall extends TensorGenerator {
           LOGGER.finer(
               "Possible `units` values: " + unitValues + " for points-to set: " + unitsPTS + ".");
 
-          ret.addAll(unitValues);
+          // A null result means `units` is not statically resolvable (wala/ML#669); skip it
+          // rather than crashing or claiming a partial value.
+          if (unitValues != null) ret.addAll(unitValues);
         }
       }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/FlowFromDirectoryGenerator.java
@@ -36,7 +36,9 @@ public class FlowFromDirectoryGenerator extends DatasetGenerator {
     OrdinalSet<InstanceKey> batchSizePts = this.getArgumentPointsToSet(builder, 5, "batch_size");
     if (batchSizePts != null && !batchSizePts.isEmpty()) {
       Set<Long> batchSizes = getPossibleLongValues(batchSizePts);
-      if (!batchSizes.isEmpty() && !batchSizes.contains(null)) {
+      // A null set means `batch_size` is not statically resolvable (wala/ML#669); fall through to
+      // the default, as for an unspecified argument.
+      if (batchSizes != null && !batchSizes.isEmpty() && !batchSizes.contains(null)) {
         batchSize = batchSizes.iterator().next();
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -176,7 +176,10 @@ public class Input extends TensorTypeAllocator {
                 + this.getSource()
                 + "; assuming unknown.");
       } else {
-        batchSizes.addAll(getPossibleLongValues(batchSizePts));
+        Set<Long> values = getPossibleLongValues(batchSizePts);
+        // A null result means `batch_size` is not statically resolvable (wala/ML#669); leave
+        // `batchSizes` empty so the unknown-batch (dynamic-dim) path below applies.
+        if (values != null) batchSizes.addAll(values);
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -29,6 +29,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -536,7 +537,10 @@ public class RaggedConstant extends Constant {
     OrdinalSet<InstanceKey> pointsToSet =
         this.getArgumentPointsToSet(
             builder, this.getRaggedRankParameterPosition(), getRaggedRankParameterName());
-    return getPossibleLongValues(pointsToSet);
+    Set<Long> values = getPossibleLongValues(pointsToSet);
+    // A null result means `ragged_rank` is not statically resolvable (wala/ML#669); treat it like
+    // an unspecified argument (callers fall back to depth-based rank inference).
+    return values == null ? Collections.emptySet() : values;
   }
 
   protected Set<List<Dimension<?>>> getPossibleInnerShapeArguments(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -24,6 +24,7 @@ import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -163,7 +164,10 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
         this.getArgumentPointsToSet(
             builder, this.getNrowsParameterPosition(), this.getNrowsParameterName());
 
-    return getPossibleLongValues(pointsToSet);
+    Set<Long> values = getPossibleLongValues(pointsToSet);
+    // A null result means `nrows` is not statically resolvable (wala/ML#669); treat it like an
+    // unspecified argument (the caller infers `nrows` from `value_rowids`).
+    return values == null ? Collections.emptySet() : values;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -226,10 +226,10 @@ public class RaggedRange extends Range {
       boolean deltaProvided) {
     if (!limitProvided) return null;
 
-    // `getPossibleDoubleValues` throws `IllegalStateException` on non-`ConstantKey<Number>` PTS
-    // contents (via `getConstantValues(..., requireConstants=true)`); catch and degrade to
-    // RaggedDim instead of crashing the analysis. Mirrors the established "modeling gap → soft
-    // fallback" pattern in e.g. `Reshape.getShapes`.
+    // `getPossibleDoubleValues` returns null on a non-constant PTS key (not statically
+    // resolvable, wala/ML#669) and throws `IllegalStateException` on a non-numeric constant;
+    // degrade both to RaggedDim instead of crashing the analysis. Mirrors the established
+    // "modeling gap → soft fallback" pattern in e.g. `Reshape.getShapes`.
     Set<Double> limits;
     Set<Double> starts;
     Set<Double> deltas;
@@ -240,6 +240,8 @@ public class RaggedRange extends Range {
     } catch (IllegalStateException e) {
       return null;
     }
+
+    if (limits == null || starts == null || deltas == null) return null;
 
     if (limits.isEmpty() || limits.contains(null)) return null;
     if (startProvided && (starts.isEmpty() || starts.contains(null))) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -159,11 +159,16 @@ public class Range extends TensorGenerator {
         }
 
         Set<Double> starts = getPossibleDoubleValues(startPts);
-        if (starts.isEmpty()) starts.add(0.0);
-
         Set<Double> limits = getPossibleDoubleValues(limitPts);
-
         Set<Double> deltas = getPossibleDoubleValues(deltaPts);
+
+        // A null set means the argument is not statically resolvable (wala/ML#669); with no
+        // resolvable `limit`, no concrete shape is produced below.
+        if (starts == null) starts = HashSetFactory.make();
+        if (limits == null) limits = HashSetFactory.make();
+        if (deltas == null) deltas = HashSetFactory.make();
+
+        if (starts.isEmpty()) starts.add(0.0);
         if (deltas.isEmpty()) deltas.add(1.0);
 
         for (Double s : starts) {
@@ -232,11 +237,16 @@ public class Range extends TensorGenerator {
     }
 
     Set<Double> starts = getPossibleDoubleValues(builder, caller, startVN);
-    if (starts.isEmpty()) starts.add(0.0);
-
     Set<Double> limits = getPossibleDoubleValues(builder, caller, limitVN);
-
     Set<Double> deltas = getPossibleDoubleValues(builder, caller, deltaVN);
+
+    // A null set means the argument is not statically resolvable (wala/ML#669); with no
+    // resolvable `limit`, no concrete shape is produced below.
+    if (starts == null) starts = HashSetFactory.make();
+    if (limits == null) limits = HashSetFactory.make();
+    if (deltas == null) deltas = HashSetFactory.make();
+
+    if (starts.isEmpty()) starts.add(0.0);
     if (deltas.isEmpty()) deltas.add(1.0);
 
     for (Double s : starts) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3110,7 +3110,8 @@ public abstract class TensorGenerator {
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param caller The {@link CGNode} calling the function.
    * @param vn The value number of the argument.
-   * @return A set of possible double values.
+   * @return A set of possible double values, or {@code null} if the argument's points-to set
+   *     contains a non-constant key (the value is not statically resolvable, wala/ML#669).
    */
   protected static Set<Double> getPossibleDoubleValues(
       PropagationCallGraphBuilder builder, CGNode caller, int vn) {
@@ -3127,7 +3128,11 @@ public abstract class TensorGenerator {
 
     // 2. Try points-to analysis
     PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, vn);
-    vals.addAll(getPossibleDoubleValues(builder.getPointerAnalysis().getPointsToSet(pk)));
+    Set<Double> fromPts = getPossibleDoubleValues(builder.getPointerAnalysis().getPointsToSet(pk));
+    // A non-constant key means the value is not statically resolvable (wala/ML#669); a partial
+    // result would falsely claim exhaustiveness.
+    if (fromPts == null) return null;
+    vals.addAll(fromPts);
 
     return vals;
   }
@@ -3136,12 +3141,16 @@ public abstract class TensorGenerator {
    * Returns the possible double values for the given points-to set.
    *
    * @param pts The points-to set of the argument.
-   * @return A set of possible double values.
+   * @return A set of possible double values, or {@code null} if the points-to set contains a
+   *     non-constant key (the value is not statically resolvable, wala/ML#669).
    */
   protected static Set<Double> getPossibleDoubleValues(OrdinalSet<InstanceKey> pts) {
+    Set<Object> constants = getConstantValues(pts, true);
+    if (constants == null) return null;
+
     Set<Double> ret = HashSetFactory.make();
 
-    for (Object val : getConstantValues(pts, true)) {
+    for (Object val : constants) {
       if (val instanceof Number) {
         ret.add(((Number) val).doubleValue());
       } else if (val == null) {
@@ -3159,13 +3168,17 @@ public abstract class TensorGenerator {
    * null value will be contained within the returned set.
    *
    * @param pointsToSet The points-to set of the value.
-   * @return A set of possible long values. If the value is `None`, then a null value will be
-   *     contained within the returned set.
+   * @return A set of possible long values, or {@code null} if the points-to set contains a
+   *     non-constant key (the value is not statically resolvable, wala/ML#669). If the value is
+   *     `None`, then a null value will be contained within the returned set.
    */
   protected static Set<Long> getPossibleLongValues(OrdinalSet<InstanceKey> pointsToSet) {
+    Set<Object> constants = getConstantValues(pointsToSet, true);
+    if (constants == null) return null;
+
     Set<Long> ret = HashSetFactory.make();
 
-    for (Object val : getConstantValues(pointsToSet, true)) {
+    for (Object val : constants) {
       if (val instanceof Number) {
         ret.add(((Number) val).longValue());
       } else if (val == null) {
@@ -3182,10 +3195,14 @@ public abstract class TensorGenerator {
    * Returns a set of constant values derived from the given points-to set.
    *
    * @param pts The points-to set to analyze.
-   * @param requireConstants If true, throws an exception if a non-constant key is encountered.
-   * @return A set of constant values (which may contain nulls).
-   * @throws IllegalStateException If {@code requireConstants} is true and a non-constant key is
-   *     found.
+   * @param requireConstants If true, a non-constant key makes the whole set non-static: {@code
+   *     null} is returned instead of the partial constants. If false, non-constant keys are
+   *     skipped.
+   * @return A set of constant values (which may contain nulls), or {@code null} if {@code
+   *     requireConstants} is true and a non-constant key is found (the value is not statically
+   *     resolvable). Previously this case threw {@link IllegalStateException}, which aborted the
+   *     whole analysis when WALA 1.8.0 supplied a {@code ScopeMappingInstanceKey} (<a
+   *     href="https://github.com/wala/ML/issues/669">wala/ML#669</a>).
    */
   protected static Set<Object> getConstantValues(
       OrdinalSet<InstanceKey> pts, boolean requireConstants) {
@@ -3196,8 +3213,12 @@ public abstract class TensorGenerator {
         if (ik instanceof ConstantKey) {
           ret.add(((ConstantKey<?>) ik).getValue());
         } else if (requireConstants) {
-          throw new IllegalStateException(
-              "Expected a constant key but found: " + ik.getClass() + ".");
+          LOGGER.fine(
+              () ->
+                  "Non-constant key: "
+                      + ik.getClass()
+                      + " in points-to set; the value is not statically resolvable (wala/ML#669).");
+          return null;
         }
       }
     }


### PR DESCRIPTION
On 0.52.12, tensor analysis aborts on `deep_recommenders` with `IllegalStateException`: `TensorGenerator.getConstantValues` asserts every points-to key is a `ConstantKey`, and WALA 1.8.0 supplies a `ScopeMappingInstanceKey` while a `Dense`/`MatMul` weight shape resolves through `Model.getWeightShapes`.

Fix: `getConstantValues(pts, requireConstants=true)` now returns null (the value is not statically resolvable) instead of throwing, and every caller of `getPossibleLongValues`/`getPossibleDoubleValues` maps null onto its documented unknown path:
- `DenseCall.getPossibleUnits` skips the unresolvable value instead of crashing or claiming a partial one;
- `Input`/`DatasetBatchGenerator`/`FlowFromDirectoryGenerator` treat an unresolvable `batch_size` like an unspecified one (dynamic/symbolic batch, default);
- `DatasetRangeGenerator`/`Range`/`RaggedRange` produce no concrete size/shape when a bound is unresolvable;
- `RaggedConstant`/`RaggedFromValueRowIds` fall back to their inference paths for `ragged_rank`/`nrows`;
- a partial constant set is never reported as exhaustive (soundness: a mixed constant/non-constant PTS degrades to unknown rather than pretending the constants are all possible values).

The crash branch itself only manifests under whole-project pointer-analysis imprecision (a scope-mapped closure key aliased into the `units` slot), which a minimal fixture cannot force; the fix is validated at the contract level, with every caller's unknown path already pinned by existing tests (969 green). The evaluation re-run against the next release will confirm on the reporting subject.

Closes wala/ML#669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
