### PR TITLE
Add a vendored functional-model guard for the wala/ML#669 frames

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10263,6 +10263,49 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Regression guard for <a href="https://github.com/wala/ML/issues/669">wala/ML#669</a>: {@code
+   * build_model} is vendored verbatim from {@code LongmaoTeamTf/deep_recommenders} ({@code
+   * examples/train_transformer_on_imdb_keras.py}), a functional {@code tf.keras.Model} whose
+   * weight-graph walk ({@code Model.getWeightShapes}) resolves {@code Dense}/{@code MatMul} weight
+   * shapes — the exact frames that crashed with {@code IllegalStateException} on 0.52.12 when a
+   * WALA 1.8.0 non-constant key reached {@code getConstantValues}. The crash's non-constant {@code
+   * units} key itself arises only under the consumer-side speculative call-graph configuration,
+   * which this harness does not enable, so this guard pins that the walk completes; the {@code
+   * getConstantValues} degrade contract is exercised structurally.
+   *
+   * <p>The walk currently yields no weight shapes for this topology (the head {@code Dense}'s input
+   * is an unmodeled {@code GlobalAveragePooling1D}, and the unresolvable input also stops the
+   * upstream trace-back), so the sink parameter has no tensor types despite the runtime weights
+   * asserted in the fixture. TODO: expect the concrete weight-shape union once <a
+   * href="https://github.com/wala/ML/issues/670">wala/ML#670</a> is fixed.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTransformerWeights()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {
+          "tr_proj/deep_recommenders/__init__.py",
+          "tr_proj/deep_recommenders/keras/__init__.py",
+          "tr_proj/deep_recommenders/keras/models/__init__.py",
+          "tr_proj/deep_recommenders/keras/models/nlp/__init__.py",
+          "tr_proj/deep_recommenders/keras/models/nlp/multi_head_attention.py",
+          "tr_proj/deep_recommenders/keras/models/nlp/transformer.py",
+          "tr_proj/tf2_test_transformer_weights.py"
+        },
+        "tf2_test_transformer_weights.py",
+        "consume",
+        "tr_proj",
+        0,
+        0,
+        emptyMap());
+  }
+
+  /**
    * Pins a tensor computed inside a {@code with tf.name_scope(...)} block (wala/ML#618): the
    * unresolved context manager does not perturb the body's dataflow.
    *

--- a/com.ibm.wala.cast.python.test/data/tr_proj/tf2_test_transformer_weights.py
+++ b/com.ibm.wala.cast.python.test/data/tr_proj/tf2_test_transformer_weights.py
@@ -1,0 +1,41 @@
+# Regression guard for wala/ML#669. The model topology is adapted from
+# `LongmaoTeamTf/deep_recommenders` (`examples/train_transformer_on_imdb_keras.py`, `build_model`
+# inlined at module level): a functional `tf.keras.Model` whose weight graph walks back through
+# `Dense` and the transformer's `K.dot` kernels. Resolving those weight shapes
+# (`Model.getWeightShapes`) meets a WALA 1.8.0 `ScopeMappingInstanceKey` in the `units` slot,
+# which crashed `getConstantValues` with `IllegalStateException` on 0.52.12; it must instead
+# degrade to "not statically resolvable".
+import tensorflow as tf
+
+from deep_recommenders.keras.models.nlp import Transformer
+
+vocab_size = 5000
+max_len = 128
+model_dim = 8
+
+
+def consume(t):
+    pass
+
+
+encoder_inputs = tf.keras.Input(shape=(max_len,), name="encoder_inputs")
+decoder_inputs = tf.keras.Input(shape=(max_len,), name="decoder_inputs")
+outputs = Transformer(
+    vocab_size,
+    model_dim,
+    n_heads=2,
+    encoder_stack=2,
+    decoder_stack=2,
+    feed_forward_size=50,
+)(encoder_inputs, decoder_inputs)
+outputs = tf.keras.layers.GlobalAveragePooling1D()(outputs)
+outputs = tf.keras.layers.Dense(2, activation="softmax")(outputs)
+model = tf.keras.Model(inputs=[encoder_inputs, decoder_inputs], outputs=outputs)
+
+for w in model.weights:
+    consume(w)
+
+# The classifier head's kernel: the transformer outputs vocab-size logits, so after pooling the
+# head consumes a 5000-dim feature.
+assert any(tuple(w.shape) == (5000, 2) for w in model.weights)
+assert all(w.dtype == tf.float32 for w in model.weights)


### PR DESCRIPTION
Follow-up to ponder-lab/ML#508 (wala/ML#669): a multi-file guard over the vendored deep_recommenders transformer. The fixture adapts `build_model` from `examples/train_transformer_on_imdb_keras.py` (inlined at module level) and iterates `model.weights` into a sink, which drives `Model.getWeightShapes` through the exact frames that crashed on 0.52.12 (`ModelWeightsGenerator` → `DenseCall` units resolution). The guard pins that the analysis completes.

Two scope notes:
- The crash's non-constant `units` key arises under the consumer-side speculative call-graph configuration (`useSpeculativeAnalysis`), which is not an Ariadne option and is not enabled by this test harness, so the guard exercises the frames structurally rather than reproducing the `ScopeMappingInstanceKey` itself.
- The walk currently yields no weight shapes for this topology: the head `Dense`'s input is an unmodeled `GlobalAveragePooling1D`, and the unresolvable input also stops the upstream trace-back. Filed as wala/ML#670; the test carries a TODO to expect the concrete weight-shape union once fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
