### PR TITLE
Model `GlobalAveragePooling1D` and unstall the weight walk

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10270,6 +10270,27 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins wala/ML#670's fixes directly: {@code GlobalAveragePooling1D} is modeled (rank-3 input,
+   * temporal axis dropped), so the functional model's weight walk resolves the downstream {@code
+   * Dense} kernel {@code (8, 5)} and bias {@code (5,)} concretely.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGap1dWeights()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gap1d_weights.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 8, 5), TENSOR_5_FLOAT32)));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/669">wala/ML#669</a>: {@code
    * build_model} is vendored verbatim from {@code LongmaoTeamTf/deep_recommenders} ({@code
    * examples/train_transformer_on_imdb_keras.py}), a functional {@code tf.keras.Model} whose

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10301,11 +10301,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * which this harness does not enable, so this guard pins that the walk completes; the {@code
    * getConstantValues} degrade contract is exercised structurally.
    *
-   * <p>The walk currently yields no weight shapes for this topology (the head {@code Dense}'s input
-   * is an unmodeled {@code GlobalAveragePooling1D}, and the unresolvable input also stops the
-   * upstream trace-back), so the sink parameter has no tensor types despite the runtime weights
-   * asserted in the fixture. TODO: expect the concrete weight-shape union once <a
-   * href="https://github.com/wala/ML/issues/670">wala/ML#670</a> is fixed.
+   * <p>With wala/ML#670 fixed, the walk traverses past the head {@code Dense} into the transformer
+   * (an unresolvable input no longer stops the trace-back, and {@code GlobalAveragePooling1D} is
+   * modeled — see {@link #testGap1dWeights()}), but it still yields no weight shapes here: the
+   * pooling input is the vendored transformer's forward output, whose shape is the wala/ML#570
+   * residual. TODO: expect the concrete weight-shape union once <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a> is fixed.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -431,6 +431,8 @@
         <putfield class="LRoot" field="Dense" fieldType="LRoot" ref="layers" value="Dense"/>
         <new def="FlattenLayerCls" class="Ltensorflow/keras/layers/class/Flatten"/>
         <putfield class="LRoot" field="Flatten" fieldType="LRoot" ref="layers" value="FlattenLayerCls"/>
+        <new def="GlobalAveragePooling1DCls" class="Ltensorflow/keras/layers/class/GlobalAveragePooling1D"/>
+        <putfield class="LRoot" field="GlobalAveragePooling1D" fieldType="LRoot" ref="layers" value="GlobalAveragePooling1DCls"/>
         <new def="DropoutLayerCls" class="Ltensorflow/keras/layers/class/Dropout"/>
         <putfield class="LRoot" field="Dropout" fieldType="LRoot" ref="layers" value="DropoutLayerCls"/>
         <new def="Model" class="Ltensorflow/keras/models/class/Model"/>
@@ -2436,6 +2438,13 @@
           <return value="res"/>
         </method>
       </class>
+      <class name="GlobalAveragePooling1D" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/GlobalAveragePooling1D. Rank-reducing pooling: the `GlobalAveragePooling1DCall` generator drops the temporal axis (wala/ML#670). -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data_format keepdims">
+          <new def="res" class="Ltensorflow/keras/layers/GlobalAveragePooling1D"/>
+          <return value="res"/>
+        </method>
+      </class>
       <class name="Dropout" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dropout -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self rate noise_shape seed">
@@ -2474,6 +2483,17 @@
       </class>
       <class name="Flatten" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Flatten#__call__ -->
+        <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
+        </method>
+        <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
+        </method>
+      </class>
+      <class name="GlobalAveragePooling1D" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/GlobalAveragePooling1D. The output type is computed by `GlobalAveragePooling1DCall` (wala/ML#670). -->
         <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
           <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="out"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GlobalAveragePooling1DCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GlobalAveragePooling1DCall.java
@@ -1,0 +1,123 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for the {@code __call__} on a {@code tf.keras.layers.GlobalAveragePooling1D} instance.
+ * Given an input of shape {@code (B, steps, features)}, returns a tensor of shape {@code (B,
+ * features)} (the temporal axis is averaged away); dtype passes through unchanged. See <a
+ * href="https://github.com/wala/ML/issues/670">wala/ML#670</a>.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/GlobalAveragePooling1D">tf.keras.layers.GlobalAveragePooling1D</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class GlobalAveragePooling1DCall extends TensorGenerator {
+
+  /**
+   * Constructs a {@code GlobalAveragePooling1DCall} from a caller-side {@link PointsToSetVariable}
+   * (the result of the {@code __call__} invoke).
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the {@code
+   *     __call__} invoke on a {@code tf.keras.layers.GlobalAveragePooling1D} instance.
+   */
+  public GlobalAveragePooling1DCall(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs a {@code GlobalAveragePooling1DCall} anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the {@code __call__} synthetic method.
+   */
+  public GlobalAveragePooling1DCall(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * Resolves the output shapes by reading the {@code inputs} argument's shapes and dropping the
+   * temporal (middle) axis of each rank-3 input.
+   *
+   * @param builder The propagation call graph builder.
+   * @return A set of output shapes, one per rank-3 input shape, or {@code null} if the input has no
+   *     known shape.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> inputPts = this.getArgumentPointsToSet(builder, 1, "inputs");
+    if (inputPts == null || inputPts.isEmpty()) return null;
+    Set<List<Dimension<?>>> inputShapes = this.getShapesOfValue(builder, inputPts);
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      if (inputShape.size() == 3) {
+        List<Dimension<?>> newShape = new ArrayList<>();
+        newShape.add(inputShape.get(0));
+        newShape.add(inputShape.get(2));
+        ret.add(newShape);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Resolves the output dtypes by passing the {@code inputs} argument's dtypes through unchanged.
+   *
+   * @param builder The propagation call graph builder.
+   * @return The set of dtypes observed on the input, or {@code {UNKNOWN\}} if none can be resolved.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> inputPts = this.getArgumentPointsToSet(builder, 1, "inputs");
+    if (inputPts == null || inputPts.isEmpty()) return EnumSet.of(DType.UNKNOWN);
+    Set<DType> dtypes = this.getDTypesOfValue(builder, inputPts);
+    return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+  }
+
+  /**
+   * @return {@link #UNDEFINED_PARAMETER_POSITION}; {@code GlobalAveragePooling1D.__call__} takes no
+   *     explicit shape parameter.
+   */
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  /**
+   * @return {@code null}; {@code GlobalAveragePooling1D.__call__} takes no explicit shape
+   *     parameter.
+   */
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  /**
+   * @return {@link #UNDEFINED_PARAMETER_POSITION}; {@code GlobalAveragePooling1D.__call__} takes no
+   *     explicit dtype parameter.
+   */
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  /**
+   * @return {@code null}; {@code GlobalAveragePooling1D.__call__} takes no explicit dtype
+   *     parameter.
+   */
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Model.java
@@ -126,23 +126,27 @@ public class Model extends TensorGenerator {
                 DenseCall.Parameters.INPUTS.getName(),
                 false);
         Set<List<Dimension<?>>> inputShapes = denseCall.getShapes(builder, valNum);
-        if (inputShapes == null) continue;
-        Set<Long> unitsValues = denseCall.getPossibleUnits(builder);
+        // An unresolvable input skips only this node's kernel/bias contribution; the trace-back
+        // below still runs, so one unmodeled layer input does not stop the upstream walk
+        // (wala/ML#670).
+        if (inputShapes != null) {
+          Set<Long> unitsValues = denseCall.getPossibleUnits(builder);
 
-        for (List<Dimension<?>> inputShape : inputShapes) {
-          if (inputShape.isEmpty()) continue;
-          Dimension<?> lastDim = inputShape.get(inputShape.size() - 1);
-          for (Long units : unitsValues) {
-            // Kernel shape: (input_dim, units)
-            List<Dimension<?>> kernelShape = new ArrayList<>();
-            kernelShape.add(lastDim);
-            kernelShape.add(new NumericDim(units.intValue()));
-            weightShapes.add(kernelShape);
+          for (List<Dimension<?>> inputShape : inputShapes) {
+            if (inputShape.isEmpty()) continue;
+            Dimension<?> lastDim = inputShape.get(inputShape.size() - 1);
+            for (Long units : unitsValues) {
+              // Kernel shape: (input_dim, units)
+              List<Dimension<?>> kernelShape = new ArrayList<>();
+              kernelShape.add(lastDim);
+              kernelShape.add(new NumericDim(units.intValue()));
+              weightShapes.add(kernelShape);
 
-            // Bias shape: (units,)
-            List<Dimension<?>> biasShape = new ArrayList<>();
-            biasShape.add(new NumericDim(units.intValue()));
-            weightShapes.add(biasShape);
+              // Bias shape: (units,)
+              List<Dimension<?>> biasShape = new ArrayList<>();
+              biasShape.add(new NumericDim(units.intValue()));
+              weightShapes.add(biasShape);
+            }
           }
         }
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3414,6 +3414,8 @@ public abstract class TensorGenerator {
       return new Placeholder(node);
     } else if (type.equals(TensorFlowTypes.DENSE_CALL.getDeclaringClass())) {
       return new DenseCall(node);
+    } else if (type.equals(TensorFlowTypes.GLOBAL_AVERAGE_POOLING_1D_CALL.getDeclaringClass())) {
+      return new GlobalAveragePooling1DCall(node);
     } else if (type.equals(TensorFlowTypes.MODEL_CALL.getDeclaringClass())) {
       return new ModelCall(node);
     } else if (type.equals(TensorFlowTypes.MODEL.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -94,6 +94,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWID
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER_ND;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GLOBAL_AVERAGE_POOLING_1D_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GREATER_EQUAL;
@@ -1533,6 +1534,8 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, FLATTEN.getDeclaringClass())) return new Flatten(source);
     else if (isType(calledFunction, FLATTEN_LAYER_CALL.getDeclaringClass()))
       return new FlattenCall(source);
+    else if (isType(calledFunction, GLOBAL_AVERAGE_POOLING_1D_CALL.getDeclaringClass()))
+      return new GlobalAveragePooling1DCall(source);
     else if (isType(calledFunction, MAX_POOL.getDeclaringClass())) return new MaxPool(source);
     else if (isType(calledFunction, SLICE_BUILTIN)) return new SliceBuiltinOperation(source);
     else {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1877,6 +1877,24 @@ public class TensorFlowTypes extends PythonTypes {
               TypeName.string2TypeName("Ltensorflow/keras/layers/Flatten/" + CALLABLE_METHOD_NAME)),
           AstMethodReference.fnSelector);
 
+  /**
+   * The {@code __call__} synthetic method on a {@code tf.keras.layers.GlobalAveragePooling1D}
+   * instance.
+   *
+   * @see <a
+   *     href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/GlobalAveragePooling1D">tf.keras.layers.GlobalAveragePooling1D</a>
+   */
+  public static final MethodReference GLOBAL_AVERAGE_POOLING_1D_CALL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName(
+                  "Ltensorflow/keras/layers/GlobalAveragePooling1D/" + CALLABLE_METHOD_NAME)),
+          AstMethodReference.fnSelector);
+
+  private static final String GLOBAL_AVERAGE_POOLING_1D_CALL_SIGNATURE =
+      "tf.keras.layers.GlobalAveragePooling1D." + CALLABLE_METHOD_NAME + "()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/nn/max_pool. */
   public static final MethodReference MAX_POOL =
       MethodReference.findOrCreate(
@@ -2128,6 +2146,9 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(GRADIENT.getDeclaringClass(), GRADIENT_SIGNATURE),
           Map.entry(SOFTMAX.getDeclaringClass(), SOFTMAX_SIGNATURE),
           Map.entry(DENSE_CALL.getDeclaringClass(), DENSE_CALL_SIGNATURE),
+          Map.entry(
+              GLOBAL_AVERAGE_POOLING_1D_CALL.getDeclaringClass(),
+              GLOBAL_AVERAGE_POOLING_1D_CALL_SIGNATURE),
           Map.entry(ADD_WEIGHT.getDeclaringClass(), ADD_WEIGHT_SIGNATURE),
           Map.entry(FLATTEN.getDeclaringClass(), FLATTEN_SIGNATURE),
           Map.entry(MAX_POOL.getDeclaringClass(), MAX_POOL_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gap1d_weights.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gap1d_weights.py
@@ -1,0 +1,21 @@
+# Pins wala/ML#670's fixes directly: `GlobalAveragePooling1D` is modeled (rank-3 input, temporal
+# axis dropped), so the functional model's weight walk resolves the downstream `Dense` kernel and
+# bias concretely.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+a = tf.keras.Input(shape=(10, 8))
+b = tf.keras.layers.GlobalAveragePooling1D()(a)
+c = tf.keras.layers.Dense(5)(b)
+model = tf.keras.Model(a, c)
+
+for w in model.trainable_weights:
+    consume(w)
+
+assert tuple(model.trainable_weights[0].shape) == (8, 5)
+assert tuple(model.trainable_weights[1].shape) == (5,)
+assert all(w.dtype == tf.float32 for w in model.trainable_weights)


### PR DESCRIPTION
Fixes both causes of wala/ML#670:
- **`GlobalAveragePooling1D` modeled**: constructor and `__call__` summaries in `tensorflow.xml` plus a `GlobalAveragePooling1DCall` generator that drops the temporal axis of rank-3 inputs and passes the dtype through, dispatched by call site and via the manual registry the weight walk uses.
- **Walk no longer stalls**: in `Model.getWeightShapes`, an unresolvable `Dense` input now skips only that node's kernel/bias contribution; the trace-back still extends the frontier, so one unmodeled layer no longer stops the upstream walk.

`testGap1dWeights` pins the fixes end to end: a functional `Input(10, 8)`→`GlobalAveragePooling1D`→`Dense(5)` model's weight union types exactly `{(8, 5) float32, (5,) float32}`, matching the runtime weights. The vendored transformer guard (`testTransformerWeights`) now traverses the full model; its remaining empty result is the vendored transformer's forward-output shape, which is the wala/ML#570 residual (its TODO is repointed there).

Closes wala/ML#670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
