### PR TITLE
Forward constructor keyword arguments to `__init__`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2743,14 +2743,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    *
    * <p>{@code hidden} (the {@code GCN.call} return, a {@code Dense} output) is tensor-classified
    * because the modeled Keras lazy-{@code build} protocol invokes {@code GCN.build}, giving the
-   * {@code build()}-created {@code self._kernel} sublayer a points-to set. The inferred type is
-   * {@code (4, 8) float32}: the dtype and leading dimension are exact, but the trailing dimension
-   * carries the {@code matmul} input shape through the {@code Dense} instead of its {@code
-   * units=16} (the runtime shape is {@code (4, 16)}; the fixture asserts it).
+   * {@code build()}-created {@code self._kernel} sublayer a points-to set. With constructor keyword
+   * arguments forwarded to {@code __init__} (wala/ML#664), {@code units} resolves through the
+   * {@code self._units} instance-field read, so the runtime-true {@code (4, 16) float32} is
+   * inferred. The union carries a spurious {@code (4, 8)} member because both {@code GCN(...)}
+   * constructions collapse into one {@code __init__} context, unioning the {@code units} values.
    *
-   * <p>TODO: Expect {@code (4, 16) float32} once <a
-   * href="https://github.com/wala/ML/issues/664">wala/ML#664</a> resolves the {@code units} value
-   * through the {@code self._units} instance-field read.
+   * <p>TODO: Expect exactly {@code (4, 16) float32} once <a
+   * href="https://github.com/wala/ML/issues/671">wala/ML#671</a> separates {@code __init__}
+   * argument values per construction site.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2774,7 +2775,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "gcn_chain_proj",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_8_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_4_8_FLOAT32, TensorType.of(FLOAT_32, 4, 16))));
   }
 
   /**
@@ -4847,10 +4848,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * to {@code (?,)} int32.
    *
    * <p>{@code pred} types too (wala/ML#665): the model forward output is a tensor union. With
-   * {@code add_weight} consuming its {@code shape}/{@code dtype} arguments (wala/ML#667), the union
-   * gains a rank-2 float32 member (the flat logits matmul against the embedding weight before the
-   * output reshape). Analyzed statically here, like the consumer's vendoring; it runs in the
-   * perf-eval with its tfrecord/data setup.
+   * {@code add_weight} consuming its {@code shape}/{@code dtype} arguments (wala/ML#667) and
+   * constructor keyword arguments forwarded to {@code __init__} (wala/ML#664), the runtime-true
+   * vocab dimension is concrete ({@code (?, ?, 10)}) and the flat-logits matmul member carries the
+   * embedding dimension ({@code (?, 8)} float32). The {@code (?, ?, 4)} member is spurious
+   * constructor-context collapse (wala/ML#671). Analyzed statically here, like the consumer's
+   * vendoring; it runs in the perf-eval with its tfrecord/data setup.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4875,8 +4878,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             4,
             Set.of(
                 new TensorType(
-                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
-                new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
+                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
+                new TensorType(
+                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(4))),
+                new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(8))),
                 new TensorType(
                     UNKNOWN,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
@@ -10231,8 +10236,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Pins the vendored gpt-2 forward output (the wala/ML#618 {@code pred} source): with wala/ML#665
    * forwarding wildcard import bindings, the full decoder stack types and the model output is a
    * rank-3 tensor union. With {@code add_weight} consuming its {@code shape}/{@code dtype}
-   * arguments (wala/ML#667), one member carries the concrete batch/sequence dims and the float32
-   * dtype: {@code (2, 3, ?)} float32.
+   * arguments (wala/ML#667) and constructor keyword arguments forwarded to {@code __init__}
+   * (wala/ML#664), the float32 member is fully concrete ({@code (2, 3, 8)}) and the runtime-true
+   * vocab member is {@code (?, ?, 10)}; the {@code (?, ?, 4)}/{@code (?, ?, 12)} members are
+   * spurious constructor-context collapse (wala/ML#671).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10259,14 +10266,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2,
             Set.of(
-                new TensorType(
-                    FLOAT_32, asList(new NumericDim(2), new NumericDim(3), DynamicDim.INSTANCE)),
+                TensorType.of(FLOAT_32, 2, 3, 8),
                 new TensorType(
                     UNKNOWN,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
                 new TensorType(
+                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
+                new TensorType(
+                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(4))),
+                new TensorType(
                     UNKNOWN,
-                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, DynamicDim.INSTANCE)))));
+                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(12))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -15,6 +15,7 @@ import static com.ibm.wala.cast.python.types.Util.getGlobalName;
 import static com.ibm.wala.cast.python.types.Util.makeGlobalRef;
 
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
+import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.loader.DynamicCallSiteReference;
 import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
@@ -343,6 +344,30 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             ctor.addStatement(
                 new PythonInvokeInstruction(2, result, except, cref, cps, keywordParams));
             pc++;
+
+            // Declare `__init__`'s parameter names on the constructor's own formals, so a caller's
+            // keyword arguments map onto them (the keyword resolver matches callee local names) and
+            // flow through the positional forwarding above. Without this, keyword arguments to any
+            // source-class constructor were silently dropped: `GCN(units=16)` never reached
+            // `__init__`'s `units`, so `self._units`-style fields stayed empty (wala/ML#664).
+            // Constructor formal `j` feeds `__init__`'s formal `j + 1` via `cps` (`__init__` has
+            // the extra function-object formal in front).
+            if ((ctor.getValueNames() == null || ctor.getValueNames().isEmpty())
+                && init instanceof AstMethod astInit) {
+              String[][] initNames = astInit.debugInfo().getSourceNamesForValues();
+              Map<Integer, Atom> ctorValueNames = HashMapFactory.make();
+              ctorValueNames.put(1, Atom.findOrCreateUnicodeAtom("self"));
+              for (int j = 2; j < numberOfParameters; j++) {
+                int initVn = j + 1;
+                if (initNames != null
+                    && initVn < initNames.length
+                    && initNames[initVn] != null
+                    && initNames[initVn].length > 0) {
+                  ctorValueNames.put(j, Atom.findOrCreateUnicodeAtom(initNames[initVn][0]));
+                }
+              }
+              ctor.setValueNames(ctorValueNames);
+            }
           }
 
           ctor.addStatement(insts.ReturnInstruction(pc++, inst, false));


### PR DESCRIPTION
Root cause of wala/ML#664, and broader than its title: the synthesized source-class constructor declared no parameter names and passed an empty keyword array to `__init__`, so keyword arguments to **any** source-class construction were silently dropped. `GCN(units=16)` never reached `__init__`'s `units`, leaving `self._units`-style fields (and the `Dense` `units` field they feed) empty — hence the wrong `(4, 8)` shape where the runtime is `(4, 16)`.

Fix: declare `__init__`'s parameter names (from its debug info) on the constructor's formals, so the keyword resolver maps caller keywords onto them and they flow through the existing positional forwarding to `__init__`.

Encoded gains:
- `testGcnChainConsume` recovers the runtime-true `(4, 16) float32`;
- the vendored gpt-2 forward/`pred` unions carry the concrete vocab (`(?, ?, 10)`) and embedding (`8`) dims.

The unions keep spurious members because all constructions of a class collapse into one `__init__` context, unioning argument values across call sites; filed as wala/ML#671 with the tests' TODOs pointing there.

Closes wala/ML#664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
