### PR TITLE
Recover tensor types through `append`-fed `tf.concat`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10090,6 +10090,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_list_append_constant.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
+  /**
+   * Probes the wala/ML#570 residual: a list accumulated with {@code append} in a loop feeds {@code
+   * tf.concat} (mirroring {@code MessagePassing._calculate_messages_all_type} feeding {@code
+   * _aggregate_function}). The appended values' shapes and dtype survive the list: the result keeps
+   * the rank and non-axis dims with a dynamic axis dim (the element count is not statically known)
+   * and the float32 dtype.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCollectionProbeListAppendConcat()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_list_append_concat.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2, Set.of(new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(8))))));
+  }
+
   @Test
   public void testCollectionProbeZipIterate()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -124,12 +124,11 @@ public class Concat extends TensorGenerator {
           pa.getPointsToSet(
               ((AstPointerKeyFactory) builder.getPointerKeyFactory())
                   .getPointerKeyForObjectCatalog(asin));
-      if (catalog.size() == 0) continue;
-
-      List<Dimension<?>> outShape = computeConcatenatedShape(builder, asin, catalog, axis);
-      // An append-populated list has no numeric catalog; its elements live under the synthetic
-      // append-contents field. The element count is not statically known, so the axis dim is
-      // dynamic while the rank and non-axis dims survive (wala/ML#570).
+      List<Dimension<?>> outShape =
+          catalog.size() == 0 ? null : computeConcatenatedShape(builder, asin, catalog, axis);
+      // An append-populated list has no numeric catalog entries; its elements live under the
+      // synthetic append-contents field. The element count is not statically known, so the axis
+      // dim is dynamic while the rank and non-axis dims survive (wala/ML#570).
       if (outShape == null) outShape = computeAppendedShape(builder, asin, axis);
       if (outShape != null) ret.add(outShape);
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -10,6 +10,7 @@ import static java.util.logging.Logger.getLogger;
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -126,6 +127,10 @@ public class Concat extends TensorGenerator {
       if (catalog.size() == 0) continue;
 
       List<Dimension<?>> outShape = computeConcatenatedShape(builder, asin, catalog, axis);
+      // An append-populated list has no numeric catalog; its elements live under the synthetic
+      // append-contents field. The element count is not statically known, so the axis dim is
+      // dynamic while the rank and non-axis dims survive (wala/ML#570).
+      if (outShape == null) outShape = computeAppendedShape(builder, asin, axis);
       if (outShape != null) ret.add(outShape);
     }
     return ret.isEmpty() ? null : ret;
@@ -152,11 +157,52 @@ public class Concat extends TensorGenerator {
               ((AstPointerKeyFactory) builder.getPointerKeyFactory())
                   .getPointerKeyForObjectCatalog(asin));
       OrdinalSet<InstanceKey> firstElemPts = getElementPts(builder, asin, catalog, 0);
+      // An append-populated list has no numeric catalog; union the dtypes of the values
+      // accumulated under the synthetic append-contents field instead (wala/ML#570).
+      if (firstElemPts == null) firstElemPts = getAppendedContentsPts(builder, asin);
       if (firstElemPts == null) continue;
       Set<DType> firstDTypes = this.getDTypesOfValue(builder, firstElemPts);
       if (firstDTypes != null) ret.addAll(firstDTypes);
     }
     return ret.isEmpty() ? EnumSet.of(DType.UNKNOWN) : ret;
+  }
+
+  /**
+   * Computes the concatenated shape for an append-populated list: every appended value's shape must
+   * share the rank; the output keeps the (agreeing) non-axis dims and the axis dim is {@link
+   * DynamicDim} since the element count (and each element's axis extent) is not statically known.
+   *
+   * @param builder The propagation call graph builder.
+   * @param listAsin The list allocation whose appended contents to read.
+   * @param axis The resolved concatenation axis.
+   * @return The output shape, or {@code null} if the appended values' shapes cannot be resolved or
+   *     disagree.
+   */
+  private List<Dimension<?>> computeAppendedShape(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin, int axis) {
+    OrdinalSet<InstanceKey> contentsPts = getAppendedContentsPts(builder, listAsin);
+    if (contentsPts == null) return null;
+    Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, contentsPts);
+    if (shapes == null || shapes.isEmpty()) return null;
+
+    List<Dimension<?>> template = null;
+    for (List<Dimension<?>> shape : shapes) {
+      if (template == null) template = shape;
+      else if (shape.size() != template.size()) return null; // rank mismatch — can't concat soundly
+    }
+
+    int rank = template.size();
+    int normalizedAxis = axis < 0 ? axis + rank : axis;
+    if (normalizedAxis < 0 || normalizedAxis >= rank) return null;
+
+    List<Dimension<?>> outShape = new ArrayList<>(template);
+    for (List<Dimension<?>> shape : shapes)
+      for (int d = 0; d < rank; d++)
+        if (d != normalizedAxis && !shape.get(d).equals(outShape.get(d)))
+          return null; // non-axis dim disagreement — can't pick a sound template
+
+    outShape.set(normalizedAxis, DynamicDim.INSTANCE);
+    return outShape;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -28,6 +28,7 @@ import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelect
 import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
@@ -2346,6 +2347,31 @@ public abstract class TensorGenerator {
     result = 31 * result + System.identityHashCode(this.source);
     result = 31 * result + System.identityHashCode(this.manualNode);
     return result;
+  }
+
+  /**
+   * Resolves the points-to set of the synthetic {@code __list_append_contents__} field on the given
+   * list allocation: the union of all values accumulated onto the list through {@code append}
+   * (modeled in {@code PythonSSAPropagationCallGraphBuilder.processListAppend}). Element order and
+   * multiplicity are not represented; generators reading elements through this helper should treat
+   * the result as an unordered value union (wala/ML#570).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param listAsin The list allocation whose appended contents to read.
+   * @return The union points-to set of the appended values, or {@code null} if the list has none.
+   */
+  protected static OrdinalSet<InstanceKey> getAppendedContentsPts(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin) {
+    FieldReference contentsRef =
+        FieldReference.findOrCreate(
+            PythonTypes.Root,
+            findOrCreateAsciiAtom(PythonSSAPropagationCallGraphBuilder.LIST_APPEND_CONTENTS_FIELD),
+            PythonTypes.Root);
+    IField f = builder.getClassHierarchy().resolveField(contentsRef);
+    if (f == null) return null;
+    PointerKey pk = builder.getPointerKeyForInstanceField(listAsin, f);
+    OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
+    return pts == null || pts.isEmpty() ? null : pts;
   }
 
   protected CGNode getNode() {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_append_concat.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_append_concat.py
@@ -11,7 +11,7 @@ def consume(t):
 
 
 xs = []
-for i in range(3):
+for _ in range(3):
     xs.append(tf.ones((2, 8)))
 
 y = tf.concat(xs, axis=0)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_append_concat.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_append_concat.py
@@ -1,0 +1,21 @@
+# Probe for the wala/ML#570 residual: a list accumulated with `append` in a loop feeds
+# `tf.concat`, mirroring `MessagePassing._calculate_messages_all_type` feeding
+# `_aggregate_function`. The appended values' shapes and dtype survive the list: the concat
+# result keeps the rank and non-axis dims with a dynamic axis dim (the element count is not
+# statically known) and the float32 dtype.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+xs = []
+for i in range(3):
+    xs.append(tf.ones((2, 8)))
+
+y = tf.concat(xs, axis=0)
+consume(y)
+
+assert y.shape == (6, 8)
+assert y.dtype == tf.float32


### PR DESCRIPTION
A slice of the re-scoped wala/ML#570 residual (list-mediated aggregation in `MessagePassing.propagate`): generators read list elements through the numeric object catalog, which an append-populated list does not have — its values live only under the synthetic append-contents field (ponder-lab/ML#502), and nothing on the generator side read it.

Adds a shared `TensorGenerator.getAppendedContentsPts` helper and uses it in `Concat`:
- dtypes union the appended values' dtypes;
- the shape keeps the rank and agreeing non-axis dims with a dynamic axis dim, since the element count (and per-element axis extent) is not statically known.

`testCollectionProbeListAppendConcat` pins the loop-append-then-concat idiom at `(?, 8) float32`, mirroring `MessagePassing._calculate_messages_all_type` feeding `_aggregate_function`.

This does not close wala/ML#570: in the vendored fixture the appended `messages` value (the `self.message_function(...)` result) has an empty pointer-analysis points-to set, so the append-contents field carries no instance keys there — even though the parallel `TensorTypeAnalysis` dataflow carries `(4, ?)` on that very field key. That source-method-return points-to gap is the next residual; findings posted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
