### PR TITLE
Pin the Keras default float32 dtype for `dtype`-less `add_weight`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10218,12 +10218,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testAddWeightDefaultDtype()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_add_weight3.py",
-        "consume",
-        1,
-        1,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4))));
+    test("tf2_test_add_weight3.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_4_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10175,6 +10175,29 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins <a href="https://github.com/wala/ML/issues/672">wala/ML#672</a>: {@code add_weight}
+   * without a {@code dtype} argument follows Keras's documented default and types float32 (the
+   * layer variable dtype under the default global policy), via the allocator's float32 default.
+   * Completes the dtype-form trio with {@link #testCollectionProbeAddWeight()} (string) and {@link
+   * #testAddWeightArguments()} (module constant).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testAddWeightDefaultDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_add_weight3.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4))));
+  }
+
+  /**
    * Pins the vendored gpt-2 {@code EmbeddingLayer} forward result (wala/ML#618): the {@code
    * add_weight}-created weight dispatches and both {@code mode} branches contribute to the result
    * union. With {@code add_weight} consuming its {@code shape}/{@code dtype} arguments

--- a/com.ibm.wala.cast.python.test/data/tf2_test_add_weight3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_add_weight3.py
@@ -1,0 +1,25 @@
+# Pins wala/ML#672: `add_weight` without a `dtype` argument follows Keras's documented default
+# and types float32 (the layer variable dtype under the default global policy). Completes the
+# dtype-form trio: string ("float32", tf2_test_add_weight.py), module constant (tf.float32,
+# tf2_test_add_weight2.py), and absent (this fixture).
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+class Linear(tf.keras.layers.Layer):
+    def build(self, input_shape):
+        self.w = self.add_weight("w", shape=[2, 4])
+
+    def call(self, x):
+        consume(self.w)
+        return tf.matmul(x, self.w)
+
+
+layer = Linear()
+out = layer(tf.ones((3, 2)))
+
+assert tuple(layer.w.shape) == (2, 4)
+assert layer.w.dtype == tf.float32


### PR DESCRIPTION
Triage of wala/ML#672 refutes its premise empirically: the issue's own minimal repro (a `build()`-created weight with no `dtype` argument) already types `(2, 4)` float32 on master. The `AddWeight` generator extends `TensorTypeAllocator`, whose absent-argument default is float32 — matching the Keras variable-dtype contract the issue asks for — and that default has been in place since the generator landed (ponder-lab/ML#506, in 0.52.13). The wala/ML#667 text's "fall back to `DType.UNKNOWN`" suggestion was never what shipped.

The rank-3 `unknown` members in `testGpt2GetLossVendored`'s `pred` union therefore come from other producers on the logits path (reshape/elementwise results), not from the `dtype`-less `add_weight`; the issue's self-flagged inferred attribution does not hold.

This PR adds the missing regression guard: `testAddWeightDefaultDtype` pins the absent-`dtype` form at `(2, 4)` float32, completing the dtype-form trio (string, module constant, absent).

Closes wala/ML#672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
