### PR TITLE
Model `padded_batch` shapes and make type resolution order-independent

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1877,11 +1877,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * TuckERLoader.target_convert} row on the vendored subject: the loader is vendored verbatim from
    * {@code kyzhouhzau/NLPGNN} ({@code nlpgnn/datas/graphloader.py}); the driver, the tiny {@code
    * data/} triple files, and the {@code nlpgnn/gnn/utils.py} reachable slice are bespoke. The
-   * {@code targets} parameter (a {@code padded_batch} dict-element field) is tensor-classified with
-   * the correct int32 dtype — the issue's core claim — but its shape under-resolves to rank-0.
-   * TODO: expect {@code (2, ?)} int32 once <a
-   * href="https://github.com/wala/ML/issues/673">wala/ML#673</a> accounts for the {@code
-   * padded_batch} dimensions on the dict-element path.
+   * {@code targets} parameter (a {@code padded_batch} dict-element field) types {@code (2, ?)}
+   * int32 — the declared {@code padded_shapes} dims under the batch dimension (<a
+   * href="https://github.com/wala/ML/issues/673">wala/ML#673</a>) — unioned with the standard
+   * partial-batch sibling {@code (?, ?)}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1905,7 +1904,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tucker_proj",
         1,
         7,
-        Map.of(3, Set.of(TensorType.of(INT_32))));
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(INT_32, asList(new NumericDim(2), DynamicDim.INSTANCE)),
+                new TensorType(INT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE)))));
   }
 
   @Test
@@ -4942,16 +4945,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code map_func}'s return (wala/ML#506, {@link #testDatasetMapTuple()}); a pass-through
    * transform after {@code map} keeps the mapped type (wala/ML#649, {@link
    * #testDatasetMapRepeat()}); {@code TFRecordDataset} is chainable ({@link #testTfrecordMap()});
-   * the dataset survives the list (wala/ML#648, {@link #testFitLoop()}). So {@code real} resolves
-   * to {@code (?,)} int32.
+   * the dataset survives the list (wala/ML#648, {@link #testFitLoop()}); and the {@code
+   * padded_batch} dims apply (wala/ML#673). So {@code real} resolves to the batched element {@code
+   * (32, ?)} int32 (the pipeline's {@code batch_size=32} with the pad-to-longest sequence dim),
+   * unioned with the standard partial-batch sibling {@code (?, ?)}.
    *
    * <p>{@code pred} types too (wala/ML#665): the model forward output is a tensor union. With
    * {@code add_weight} consuming its {@code shape}/{@code dtype} arguments (wala/ML#667) and
    * constructor keyword arguments forwarded to {@code __init__} (wala/ML#664), the runtime-true
    * vocab dimension is concrete ({@code (?, ?, 10)}) and the flat-logits matmul member carries the
    * embedding dimension ({@code (?, 8)} float32). The {@code (?, ?, 4)} member is spurious
-   * constructor-context collapse (wala/ML#671). Analyzed statically here, like the consumer's
-   * vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * constructor-context collapse (wala/ML#671). The pinned union is the suite-mode result; a fresh
+   * JVM yields a coarser (also stable) union, an iteration-order dependence tracked by <a
+   * href="https://github.com/wala/ML/issues/674">wala/ML#674</a>. Analyzed statically here, like
+   * the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4972,7 +4979,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         8,
         Map.of(
             3,
-            Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE))),
+            Set.of(
+                new TensorType(INT_32, asList(new NumericDim(32), DynamicDim.INSTANCE)),
+                new TensorType(INT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE))),
             4,
             Set.of(
                 new TensorType(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4955,10 +4955,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * constructor keyword arguments forwarded to {@code __init__} (wala/ML#664), the runtime-true
    * vocab dimension is concrete ({@code (?, ?, 10)}) and the flat-logits matmul member carries the
    * embedding dimension ({@code (?, 8)} float32). The {@code (?, ?, 4)} member is spurious
-   * constructor-context collapse (wala/ML#671). The pinned union is the suite-mode result; a fresh
-   * JVM yields a coarser (also stable) union, an iteration-order dependence tracked by <a
-   * href="https://github.com/wala/ML/issues/674">wala/ML#674</a>. Analyzed statically here, like
-   * the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * constructor-context collapse (wala/ML#671). The union is the order-independent fixed point
+   * (wala/ML#674): identical across runs and across suite/single-test modes. Analyzed statically
+   * here, like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -4979,9 +4978,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         8,
         Map.of(
             3,
-            Set.of(
-                new TensorType(INT_32, asList(new NumericDim(32), DynamicDim.INSTANCE)),
-                new TensorType(INT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE))),
+            Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE))),
             4,
             Set.of(
                 new TensorType(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
@@ -116,7 +116,7 @@ public class DatasetBatchGenerator extends DatasetGenerator {
     return this.getShapes(builder);
   }
 
-  private Set<List<Dimension<?>>> applyBatching(
+  protected Set<List<Dimension<?>>> applyBatching(
       Set<List<Dimension<?>>> inputShapes, PropagationCallGraphBuilder builder) {
     Set<Long> batchSizes =
         getPossibleLongValues(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetPaddedBatchGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetPaddedBatchGenerator.java
@@ -1,0 +1,107 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * A generator for tensors created by {@code tf.data.Dataset.padded_batch}. Like {@link
+ * DatasetBatchGenerator}, the batch dimension is prepended; unlike plain {@code batch}, the
+ * per-element shape is declared by the {@code padded_shapes} argument (a shape, or a dict/nested
+ * structure of shapes, with {@code None} marking dims padded to the longest element), so when that
+ * argument resolves it overrides the upstream element shape. See <a
+ * href="https://github.com/wala/ML/issues/673">wala/ML#673</a>.
+ *
+ * @see <a
+ *     href="https://www.tensorflow.org/api_docs/python/tf/data/Dataset#padded_batch">tf.data.Dataset.padded_batch</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class DatasetPaddedBatchGenerator extends DatasetBatchGenerator {
+
+  /** Parameter positions and keyword names for {@code padded_batch}. */
+  protected enum PaddedParameters {
+    /** The batch size; same position as {@code batch}'s. */
+    BATCH_SIZE,
+
+    /** The per-element padded shape structure. */
+    PADDED_SHAPES,
+
+    /** The padding values; not consumed by this generator. */
+    PADDING_VALUES,
+
+    /** Whether to drop the final partial batch; not consumed by this generator. */
+    DROP_REMAINDER;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "padded_shapes"}).
+     */
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  /**
+   * Constructs a {@code DatasetPaddedBatchGenerator} from a caller-side {@link
+   * PointsToSetVariable}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the {@code
+   *     padded_batch} invoke.
+   */
+  public DatasetPaddedBatchGenerator(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs a {@code DatasetPaddedBatchGenerator} anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the {@code padded_batch} synthetic method.
+   */
+  public DatasetPaddedBatchGenerator(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * Resolves the element shapes from the {@code padded_shapes} argument when it resolves (dims from
+   * the declared structure, {@code None} as a dynamic dim), then applies the batch dimension; falls
+   * back to the upstream element shape otherwise.
+   *
+   * @param builder The propagation call graph builder.
+   * @return The batched shapes, or {@code null} if neither the argument nor the upstream shape
+   *     resolves.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> paddedShapesPts =
+        this.getArgumentPointsToSet(
+            builder,
+            PaddedParameters.PADDED_SHAPES.getIndex(),
+            PaddedParameters.PADDED_SHAPES.getName());
+
+    if (paddedShapesPts != null && !paddedShapesPts.isEmpty()) {
+      Set<List<Dimension<?>>> elementShapes =
+          this.getShapesFromShapeArgument(builder, paddedShapesPts);
+      if (elementShapes != null && !elementShapes.isEmpty()) {
+        return this.applyBatching(elementShapes, builder);
+      }
+    }
+
+    return super.getDefaultShapes(builder);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -84,6 +84,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   public static final int DEFAULT_TARGETED_CFA_DEPTH = 2;
 
   /**
+   * Upper bound on source-type resolution rounds (wala/ML#674). Convergence normally takes two to
+   * three rounds (one to seed, one for cycle members to see each other's approximations, one to
+   * confirm stability); the bound only guards against oscillation.
+   */
+  private static final int MAX_TYPE_RESOLUTION_ROUNDS = 5;
+
+  /**
    * The recommended targeted k-CFA depth for consumers analyzing the <em>model-forward
    * archetype</em>: {@code tf.keras.Model} subclasses whose {@code call}/{@code predict} chain
    * layer invocations ({@code x = self.layer1(x); x = self.layer2(x)}). Such a model invoked from
@@ -1117,9 +1124,29 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       Set<PointsToSetVariable> sources = getDataflowSources(builder, dataflow);
 
+      // Resolve the per-source types in rounds until they stabilize (wala/ML#674): a cycle in a
+      // value's producer graph (e.g. a loop-carried variable) makes single-pass resolution depend
+      // on which cycle member is computed first, since the re-entered member floors to ⊤. Each
+      // round recomputes against the previous round's approximations (read on cycle re-entry in
+      // `TensorGenerator.getShapes`/`getDTypes`), so the result converges to an entry-order-
+      // independent fixed point. The bound is a safety net against oscillation; convergence is
+      // logged at FINE.
       Map<PointsToSetVariable, Set<TensorType>> init = HashMapFactory.make();
+      Map<PointsToSetVariable, Set<TensorType>> previousRound = null;
 
-      for (PointsToSetVariable v : sources) init.put(v, getTensorTypes(v, builder));
+      for (int round = 0; round < MAX_TYPE_RESOLUTION_ROUNDS; round++) {
+        init = HashMapFactory.make();
+        for (PointsToSetVariable v : sources) init.put(v, getTensorTypes(v, builder));
+
+        if (init.equals(previousRound)) {
+          final int stableRound = round;
+          LOGGER.fine(() -> "Source-type resolution stabilized after round: " + stableRound + ".");
+          break;
+        }
+
+        previousRound = init;
+        TensorGenerator.advanceRound(builder);
+      }
 
       Map<PointsToSetVariable, TensorType> placeholders =
           handleShapeSourceOp(builder, dataflow, placeholder, 2);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -310,6 +310,38 @@ public abstract class TensorGenerator {
       if (asin == null) continue;
       TypeReference reference = asin.concreteType().getReference();
 
+      if (reference.equals(dict)) {
+        // A dict-structured shape specification, e.g. `padded_shapes={'h_r': [None], 't':
+        // [None]}`. The values (keyed by arbitrary string names) are the per-leaf shape specs;
+        // recurse into each value and union the results, mirroring the dict-structured dtype
+        // handling (wala/ML#615). See wala/ML#673.
+        OrdinalSet<InstanceKey> dictCatalogPts =
+            pointerAnalysis.getPointsToSet(
+                ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                    .getPointerKeyForObjectCatalog(asin));
+
+        for (InstanceKey catalogIK : dictCatalogPts) {
+          if (!(catalogIK instanceof ConstantKey)) continue;
+          Object keyValue = ((ConstantKey<?>) catalogIK).getValue();
+          // Dict keys are strings; the value is stored as an instance field named by the key.
+          if (!(keyValue instanceof String)) continue;
+
+          FieldReference subscript =
+              FieldReference.findOrCreate(Root, findOrCreateAsciiAtom((String) keyValue), Root);
+
+          IField f = builder.getClassHierarchy().resolveField(subscript);
+          if (f != null) {
+            PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
+            OrdinalSet<InstanceKey> fieldPts = pointerAnalysis.getPointsToSet(pk);
+            if (fieldPts == null || fieldPts.isEmpty()) continue;
+            Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPts);
+            if (sub == null) return null;
+            ret.addAll(sub);
+          }
+        }
+        continue;
+      }
+
       if (reference.equals(list) || reference.equals(tuple)) {
         // We have a list of integers that represent the shape.
         OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -822,7 +854,10 @@ public abstract class TensorGenerator {
     synchronized (cache) {
       if (cache.containsKey(key)) return cache.get(key);
       Set<List<Dimension<?>>> result = computeShapes(builder, node, valueNumber);
-      cache.put(key, result);
+      // Only cache resolved results: a null (⊤) may be a cycle-guard artifact of the visit
+      // order, and freezing it makes the analysis result depend on generator iteration order
+      // (which varies by JVM identity hash codes). Recompute ⊤ on re-entry instead.
+      if (result != null) cache.put(key, result);
       return result;
     }
   }
@@ -1881,7 +1916,9 @@ public abstract class TensorGenerator {
     synchronized (cache) {
       if (cache.containsKey(key)) return cache.get(key);
       Set<DType> result = computeDTypes(builder, node, valueNumber);
-      cache.put(key, result);
+      // See `getShapes` above: a null may be a cycle-guard artifact of the visit order; do not
+      // freeze it.
+      if (result != null) cache.put(key, result);
       return result;
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -357,6 +357,38 @@ public abstract class TensorGenerator {
       if (asin == null) continue;
       TypeReference reference = asin.concreteType().getReference();
 
+      if (reference.equals(dict)) {
+        // A dict-structured shape specification, e.g. `padded_shapes={'h_r': [None], 't':
+        // [None]}`. The values (keyed by arbitrary string names) are the per-leaf shape specs;
+        // recurse into each value and union the results, mirroring the dict-structured dtype
+        // handling (wala/ML#615). See wala/ML#673.
+        OrdinalSet<InstanceKey> dictCatalogPts =
+            pointerAnalysis.getPointsToSet(
+                ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                    .getPointerKeyForObjectCatalog(asin));
+
+        for (InstanceKey catalogIK : dictCatalogPts) {
+          if (!(catalogIK instanceof ConstantKey)) continue;
+          Object keyValue = ((ConstantKey<?>) catalogIK).getValue();
+          // Dict keys are strings; the value is stored as an instance field named by the key.
+          if (!(keyValue instanceof String)) continue;
+
+          FieldReference subscript =
+              FieldReference.findOrCreate(Root, findOrCreateAsciiAtom((String) keyValue), Root);
+
+          IField f = builder.getClassHierarchy().resolveField(subscript);
+          if (f != null) {
+            PointerKey pk = builder.getPointerKeyForInstanceField(asin, f);
+            OrdinalSet<InstanceKey> fieldPts = pointerAnalysis.getPointsToSet(pk);
+            if (fieldPts == null || fieldPts.isEmpty()) continue;
+            Set<List<Dimension<?>>> sub = this.getShapesFromShapeArgument(builder, fieldPts);
+            if (sub == null) return null;
+            ret.addAll(sub);
+          }
+        }
+        continue;
+      }
+
       if (reference.equals(list) || reference.equals(tuple)) {
         // We have a list of integers that represent the shape.
         OrdinalSet<InstanceKey> objectCatalogPointsToSet =
@@ -876,7 +908,15 @@ public abstract class TensorGenerator {
       if (!inProgress.add(key)) {
         Map<Pair<CGNode, Integer>, Set<List<Dimension<?>>>> previous =
             PREVIOUS_SHAPES_CACHE.get(builder);
-        return previous == null ? null : previous.get(key);
+        Set<List<Dimension<?>>> approximation = previous == null ? null : previous.get(key);
+        LOGGER.fine(
+            () ->
+                "Shape cycle re-entry on key: "
+                    + key
+                    + "; returning previous-round approximation: "
+                    + approximation
+                    + ".");
+        return approximation;
       }
       try {
         Set<List<Dimension<?>>> result = computeShapes(builder, node, valueNumber);
@@ -1946,7 +1986,15 @@ public abstract class TensorGenerator {
           DTYPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
       if (!inProgress.add(key)) {
         Map<Pair<CGNode, Integer>, Set<DType>> previous = PREVIOUS_DTYPES_CACHE.get(builder);
-        return previous == null ? null : previous.get(key);
+        Set<DType> approximation = previous == null ? null : previous.get(key);
+        LOGGER.fine(
+            () ->
+                "Dtype cycle re-entry on key: "
+                    + key
+                    + "; returning previous-round approximation: "
+                    + approximation
+                    + ".");
+        return approximation;
       }
       try {
         Set<DType> result = computeDTypes(builder, node, valueNumber);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -165,6 +165,49 @@ public abstract class TensorGenerator {
       DTYPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
+   * The previous resolution round's shape results (wala/ML#674). A recursive re-entry on the same
+   * {@code (node, vn)} key (a cycle in the value's producer graph, e.g. a loop-carried variable)
+   * reads the previous round's approximation instead of flooring to ⊤, so the resolved result no
+   * longer depends on which cycle member happens to be computed first. {@link
+   * PythonTensorAnalysisEngine#performAnalysis} drives rounds via {@link
+   * #advanceRound(PropagationCallGraphBuilder)} until the per-source types stabilize.
+   */
+  private static final Map<
+          PropagationCallGraphBuilder, Map<Pair<CGNode, Integer>, Set<List<Dimension<?>>>>>
+      PREVIOUS_SHAPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /** Dtype counterpart of {@link #PREVIOUS_SHAPES_CACHE}. */
+  private static final Map<PropagationCallGraphBuilder, Map<Pair<CGNode, Integer>, Set<DType>>>
+      PREVIOUS_DTYPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
+   * The {@code (node, vn)} shape computations currently on the recursion stack, per builder;
+   * membership marks a cycle re-entry (wala/ML#674).
+   */
+  private static final Map<PropagationCallGraphBuilder, Set<Pair<CGNode, Integer>>>
+      SHAPES_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /** Dtype counterpart of {@link #SHAPES_IN_PROGRESS}. */
+  private static final Map<PropagationCallGraphBuilder, Set<Pair<CGNode, Integer>>>
+      DTYPES_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
+   * Begins a new resolution round for the given builder (wala/ML#674): the current shape/dtype
+   * results become the previous round's approximations (read on cycle re-entry), and the current
+   * caches restart empty.
+   *
+   * @param builder The builder whose caches should advance.
+   */
+  public static void advanceRound(PropagationCallGraphBuilder builder) {
+    Map<Pair<CGNode, Integer>, Set<List<Dimension<?>>>> shapes = SHAPES_CACHE.remove(builder);
+    if (shapes != null) PREVIOUS_SHAPES_CACHE.put(builder, shapes);
+    Map<Pair<CGNode, Integer>, Set<DType>> dtypes = DTYPES_CACHE.remove(builder);
+    if (dtypes != null) PREVIOUS_DTYPES_CACHE.put(builder, dtypes);
+    SHAPES_IN_PROGRESS.remove(builder);
+    DTYPES_IN_PROGRESS.remove(builder);
+  }
+
+  /**
    * Drops the shape/dtype caches for the given builder. Intended to be called at the end of an
    * analysis to release cache memory deterministically, rather than waiting for the builder to be
    * garbage-collected. Safe to call more than once.
@@ -178,6 +221,10 @@ public abstract class TensorGenerator {
   public static void clearCaches(PropagationCallGraphBuilder builder) {
     SHAPES_CACHE.remove(builder);
     DTYPES_CACHE.remove(builder);
+    PREVIOUS_SHAPES_CACHE.remove(builder);
+    PREVIOUS_DTYPES_CACHE.remove(builder);
+    SHAPES_IN_PROGRESS.remove(builder);
+    DTYPES_IN_PROGRESS.remove(builder);
   }
 
   /** The source of the tensor, represented by a points-to set variable. */
@@ -821,9 +868,23 @@ public abstract class TensorGenerator {
     // inner `containsKey` / `get` / `put` calls are no-op re-entries.
     synchronized (cache) {
       if (cache.containsKey(key)) return cache.get(key);
-      Set<List<Dimension<?>>> result = computeShapes(builder, node, valueNumber);
-      cache.put(key, result);
-      return result;
+      // A same-key re-entry is a cycle in the value's producer graph (e.g. a loop-carried
+      // variable). Return the previous round's approximation instead of recursing — flooring
+      // here made the result depend on which cycle member was computed first (wala/ML#674).
+      Set<Pair<CGNode, Integer>> inProgress =
+          SHAPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
+      if (!inProgress.add(key)) {
+        Map<Pair<CGNode, Integer>, Set<List<Dimension<?>>>> previous =
+            PREVIOUS_SHAPES_CACHE.get(builder);
+        return previous == null ? null : previous.get(key);
+      }
+      try {
+        Set<List<Dimension<?>>> result = computeShapes(builder, node, valueNumber);
+        cache.put(key, result);
+        return result;
+      } finally {
+        inProgress.remove(key);
+      }
     }
   }
 
@@ -1877,12 +1938,23 @@ public abstract class TensorGenerator {
     Map<Pair<CGNode, Integer>, Set<DType>> cache =
         DTYPES_CACHE.computeIfAbsent(builder, b -> Collections.synchronizedMap(new HashMap<>()));
     Pair<CGNode, Integer> key = Pair.make(node, valueNumber);
-    // See `getShapes` above — same atomic check-compute-put pattern, same null-cache rationale.
+    // See `getShapes` above — same atomic check-compute-put pattern, same null-cache rationale,
+    // and the same previous-round approximation on a same-key cycle re-entry (wala/ML#674).
     synchronized (cache) {
       if (cache.containsKey(key)) return cache.get(key);
-      Set<DType> result = computeDTypes(builder, node, valueNumber);
-      cache.put(key, result);
-      return result;
+      Set<Pair<CGNode, Integer>> inProgress =
+          DTYPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
+      if (!inProgress.add(key)) {
+        Map<Pair<CGNode, Integer>, Set<DType>> previous = PREVIOUS_DTYPES_CACHE.get(builder);
+        return previous == null ? null : previous.get(key);
+      }
+      try {
+        Set<DType> result = computeDTypes(builder, node, valueNumber);
+        cache.put(key, result);
+        return result;
+      } finally {
+        inProgress.remove(key);
+      }
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1203,6 +1203,17 @@ public class TensorGeneratorFactory {
         // tensor (e.g. a subscript-slice `x[1::2]` of an opaque `argparse` attribute), so the
         // result is not a tensor either; dispatching `TensorElementGenerator` here would over-type
         // it. wala/ML#656.
+        // A string-keyed subscript on a dataset element (e.g. `batch["t"]` over a
+        // dict-structured dataset) navigates the element's record structure rather than
+        // extracting a positional slice of a tensor, so no dimension is peeled: the field
+        // carries the element's (per-field-unioned) type. wala/ML#673.
+        if (propertyName != null
+            && propertyIndex == null
+            && !isNonTensorAttribute(propertyName)
+            && containerGenerator instanceof DatasetElementGenerator) {
+          return containerGenerator;
+        }
+
         if (containerGenerator != null
             && (propertyName == null || !isNonTensorAttribute(propertyName))) {
           return (containerGenerator instanceof DatasetGenerator)
@@ -1325,9 +1336,10 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, DATASET_BATCH_TYPE)) return new DatasetBatchGenerator(source);
     else if (isType(calledFunction, DATASET_MAP_TYPE)) return new DatasetMapGenerator(source);
     else if (isType(calledFunction, DATASET_PADDED_BATCH_TYPE))
-      // `padded_batch` prepends a batch dimension like `batch`; reuse the batch generator. The
-      // padded inner dimensions are an upper-bound approximation. wala/ML#623.
-      return new DatasetBatchGenerator(source);
+      // `padded_batch` prepends a batch dimension like `batch`; the padded generator additionally
+      // reads the declared `padded_shapes` element structure (wala/ML#673). The padded inner
+      // dimensions remain an upper-bound approximation. wala/ML#623.
+      return new DatasetPaddedBatchGenerator(source);
     else if (isType(calledFunction, DATASET_RANGE_TYPE)) return new DatasetRangeGenerator(source);
     else if (isType(calledFunction, TEXT_LINE_DATASET_TYPE))
       return new TextLineDatasetGenerator(source);


### PR DESCRIPTION
Three interlocking fixes; the modeling exposed the substrate bugs, so they ship together.

**`padded_batch` element shapes (closes wala/ML#673)**: a `DatasetPaddedBatchGenerator` reads the declared `padded_shapes` structure (including dict structures, via a new dict branch in the shape-argument parser mirroring the wala/ML#615 dict-dtype handling) and applies the batch dimension; a string-keyed subscript on a dataset element navigates the record structure instead of peeling a leading dimension. `testTuckerTargetConvert` recovers the runtime-true `(2, ?)` int32 (up from rank-0).

**Order-independent type resolution (closes wala/ML#674)**: pinning the vendored gpt-2 fixture exposed that single-pass resolution floors whichever loop-carried cycle member is computed first — with JVM-identity-dependent entry order, identical runs produced different unions. Same-key re-entries in the shapes/dtypes memoization now return the previous resolution round's approximation, and `performAnalysis` recomputes source types in rounds until they stabilize (bounded as an oscillation safety net; convergence takes 1-2 rounds). Validated: three single-test runs and two full suites all produce the identical gpt-2 union; the fixture's Javadoc caveat is retired. `real` deterministically keeps its 0.52.13 typing (the cycle floors at the fixed point — recovering precision through loop cycles is future work); `pred` keeps the rich union; the padded gains hold on acyclic pipelines.

**Recursion bound (closes wala/ML#675)**: the same in-progress tracking cuts the unguarded caller-walk ring that overflowed the stack on whole-project NLPGNN (the repeating `getDTypes(node, vn)` unit in the reported trace); the append-`concat` fixtures exercise the ring at unit scale. Confirmation on the reporting subject comes with the evaluator's next run.

Closes wala/ML#673. Closes wala/ML#674. Closes wala/ML#675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
