### PR TITLE
Pin that module argument order no longer affects the call graph

### DIFF
--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestMulti.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestMulti.java
@@ -47,13 +47,13 @@ public class TestMulti extends TestJythonCallGraphShape {
 
   protected static final List<GraphAssertion> assertionsMulti2 =
       List.of(
-          new GraphAssertion(ROOT, new String[] {"script multi1.py", "script multi2.py"})
-          // TODO: Add the following code once https://github.com/wala/ML/issues/168 is fixed:
-          // new GraphAssertion("script multi1.py", new String[] {"script multi2.py/silly"})
-          // TODO: Add the following code once https://github.com/wala/ML/issues/168 is fixed:
-          // new GraphAssertion("script multi2.py/silly", new String[] {"script
-          // multi2.py/silly/inner"})
-          );
+          new GraphAssertion(ROOT, new String[] {"script multi1.py", "script multi2.py"}),
+          // Importer-first order resolves the cross-module edges (wala/ML#168): these two
+          // assertions match `assertionsMulti1`'s importee-first order, pinning that argument
+          // order no longer affects the call graph.
+          new GraphAssertion("script multi1.py", new String[] {"script multi2.py/silly"}),
+          new GraphAssertion(
+              "script multi2.py/silly", new String[] {"script multi2.py/silly/inner"}));
 
   @Test
   public void testMulti2()


### PR DESCRIPTION
Triage of wala/ML#168 finds it no longer reproduces: `testMulti2` (the importer-before-importee order the issue reports) passes with the full edge assertions its TODO deferred — `multi1 → multi2/silly` and `silly → inner` resolve regardless of argument order, matching `testMulti1`'s importee-first result. The fix arrived silently in the recent front-end work (the WALA 1.8.0 bump and the wala/ML#665 binding forwarding are the likely candidates in the window).

This enables the deferred assertions, converting the test into a positive regression guard per the repo convention.

Closes wala/ML#168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
