### PR TITLE
Dispatch `__init__` in the synthesized constructor's context

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2847,12 +2847,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code build()}-created {@code self._kernel} sublayer a points-to set. With constructor keyword
    * arguments forwarded to {@code __init__} (wala/ML#664), {@code units} resolves through the
    * {@code self._units} instance-field read, so the runtime-true {@code (4, 16) float32} is
-   * inferred. The union carries a spurious {@code (4, 8)} member because both {@code GCN(...)}
-   * constructions collapse into one {@code __init__} context, unioning the {@code units} values.
+   * inferred. With {@code __init__} dispatched in the constructor's calling context (wala/ML#671),
+   * the two instances' {@code self._units} fields hold {@code 16} and {@code 8} separately; the
+   * union's spurious {@code (4, 8)} member persists because both instances share one {@code build}
+   * context, so the {@code Dense} constructed inside it unions the values.
    *
    * <p>TODO: Expect exactly {@code (4, 16) float32} once <a
-   * href="https://github.com/wala/ML/issues/671">wala/ML#671</a> separates {@code __init__}
-   * argument values per construction site.
+   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a> gives the layer-method trampolines
+   * receiver-object sensitivity.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -27,6 +27,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ipa.callgraph.PythonScopeMappingInstanceKeys;
 import com.ibm.wala.cast.python.ipa.summaries.BuiltinFunctions;
 import com.ibm.wala.cast.python.ipa.summaries.PythonComprehensionTrampolines;
+import com.ibm.wala.cast.python.ipa.summaries.PythonConstructorFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
@@ -37,6 +38,7 @@ import com.ibm.wala.cast.python.loader.PythonLoaderFactory;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.cast.util.Util;
+import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IField;
@@ -49,7 +51,10 @@ import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.ClassTargetSelector;
+import com.ibm.wala.ipa.callgraph.Context;
+import com.ibm.wala.ipa.callgraph.ContextSelector;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
@@ -88,6 +93,7 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.WalaRuntimeException;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.IntSet;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -931,7 +937,9 @@ public abstract class PythonAnalysisEngine<T>
         new AstContextInsensitiveSSAContextInterpreter(options, cache);
     builder.setContextInterpreter(interpreter);
 
-    builder.setContextSelector(new nCFAContextSelector(1, new ContextInsensitiveSelector()));
+    builder.setContextSelector(
+        new ConstructorContextSelector(
+            new nCFAContextSelector(1, new ContextInsensitiveSelector())));
 
     builder.setInstanceKeys(
         new PythonScopeMappingInstanceKeys(
@@ -946,6 +954,41 @@ public abstract class PythonAnalysisEngine<T>
   protected PythonSSAPropagationCallGraphBuilder makeBuilder(
       IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     return new PythonSSAPropagationCallGraphBuilder(cha, options, cache, new AstCFAPointerKeys());
+  }
+
+  /**
+   * Dispatches calls made <em>from</em> a synthesized constructor ({@link
+   * PythonConstructorFunction}) in the constructor's own calling context. The constructor body has
+   * a single internal {@code __init__} call site, so the base call-string selector collapses every
+   * construction of a class into one {@code __init__} context, unioning argument values across
+   * construction sites; inheriting the constructor's context keeps them apart (<a
+   * href="https://github.com/wala/ML/issues/671">wala/ML#671</a>).
+   */
+  private static class ConstructorContextSelector implements ContextSelector {
+
+    /** The selector handling every other call. */
+    private final ContextSelector base;
+
+    /**
+     * Constructs a {@link ConstructorContextSelector}.
+     *
+     * @param base The selector handling every other call.
+     */
+    ConstructorContextSelector(ContextSelector base) {
+      this.base = base;
+    }
+
+    @Override
+    public Context getCalleeTarget(
+        CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
+      if (caller.getMethod() instanceof PythonConstructorFunction) return caller.getContext();
+      return base.getCalleeTarget(caller, site, callee, actualParameters);
+    }
+
+    @Override
+    public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
+      return base.getRelevantParameters(caller, site);
+    }
   }
 
   public abstract T performAnalysis(PropagationCallGraphBuilder builder) throws CancelException;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -17,6 +17,7 @@ import static com.ibm.wala.cast.python.types.Util.makeGlobalRef;
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.loader.DynamicCallSiteReference;
+import com.ibm.wala.cast.python.ipa.summaries.PythonConstructorFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
@@ -376,7 +377,7 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             ctor.setValueNames(Collections.singletonMap(1, Atom.findOrCreateUnicodeAtom("self")));
           }
 
-          ctors.put(receiver, new PythonSummarizedFunction(ref, ctor, receiver));
+          ctors.put(receiver, new PythonConstructorFunction(ref, ctor, receiver));
         }
 
         return ctors.get(receiver);

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2018 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.cast.python.ipa.summaries;
 
 import com.ibm.wala.classLoader.IClass;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
@@ -1,0 +1,32 @@
+package com.ibm.wala.cast.python.ipa.summaries;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.ipa.summaries.MethodSummary;
+import com.ibm.wala.types.MethodReference;
+
+/**
+ * The synthesized constructor of a source-defined Python class (see {@code
+ * PythonConstructorTargetSelector}): allocates the instance, wires the method trampolines, and
+ * forwards to {@code __init__}. Distinguished from other {@link PythonSummarizedFunction}s so the
+ * engine's context selector can dispatch the internal {@code __init__} call in the constructor's
+ * own calling context — the constructor body has a single {@code __init__} call site, so a plain
+ * call-string context there collapses every construction of the class into one {@code __init__}
+ * context, unioning the argument values across construction sites (<a
+ * href="https://github.com/wala/ML/issues/671">wala/ML#671</a>).
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class PythonConstructorFunction extends PythonSummarizedFunction {
+
+  /**
+   * Constructs a {@link PythonConstructorFunction}.
+   *
+   * @param ref The constructor's method reference.
+   * @param summary The synthesized constructor body.
+   * @param declaringClass The class being constructed.
+   */
+  public PythonConstructorFunction(
+      MethodReference ref, MethodSummary summary, IClass declaringClass) {
+    super(ref, summary, declaringClass);
+  }
+}


### PR DESCRIPTION
Fixes wala/ML#671: the synthesized constructor has a single internal `__init__` call site, so the depth-limited call-string selector collapsed every construction of a class into one `__init__` context, unioning argument values across construction sites (e.g. `GCN(units=16)` and `GCN(units=8)` both yielding `self._units = {8, 16}`).

A `PythonConstructorFunction` marker distinguishes the synthesized constructor, and a `ConstructorContextSelector` (following the `PythonSuper.SuperContextSelector` pattern) makes calls dispatched from it inherit the constructor's own calling context — so `__init__` runs once per construction site.

Verified on `gcn_chain_proj`: `__init__` now has one context per construction site and the two instances' `self._units` fields hold `{16}` and `{8}` separately. The fixture's spurious union member persists one stage later — both instances share one `build` context, so the `Dense` constructed inside unions the values; that needs receiver-object sensitivity on the layer trampolines and is filed as wala/ML#679, with `testGcnChainConsume`'s TODO retargeted there. Full suite green with no expectation shifts (the wala/ML#674 fixed point absorbed the context change).

Closes wala/ML#671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc
