### PR TITLE
Key layer-method trampolines on the receiver instance

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2115,23 +2115,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Multi-Model precision regression with one extra call-chain frame: both Models are constructed
-   * inside a {@code make_model(units)} helper, so both user-side calls of {@code make_model(...)}
-   * share the same call site for {@code Model.do} (the one inside {@code make_model}). Under {@code
-   * nCFAContextSelector(2)} the 2 most-recent call sites in the context for {@code
-   * Model.read_data}'s inner allocation are {@code (read_data_call_in_Model.do,
-   * Model.do_call_in_make_model)} — the user-side {@code make_model} call site falls outside those
-   * two frames, so both user models collapse to the same allocation context and each sink ends up
-   * with the union of both models' weight shapes. The assertion below pins that observed
-   * (imprecise) union, which makes a precision improvement detectable as a regression: when the fix
-   * lands, the actual set will shrink to the per-Model 2-element subset and this test will start
-   * failing with a clear "expected union, got per-Model" diff — the cue to update the assertion to
-   * its precise form.
-   *
-   * <p>TODO(wala/ML#380): When inlining of {@code Model.read_data} (or wala/ML#379's configurable-k
-   * work) distinguishes the per-Model contexts here, narrow the assertion to {@code
-   * Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)} for {@code f} and the matching pair for {@code
-   * g} in {@link #testModelAttributesMultiModelWrapped2()}.
+   * Multi-Model separation with one extra call-chain frame: both Models are constructed inside a
+   * {@code make_model(units)} helper, so both user-side calls of {@code make_model(...)} share the
+   * same call site for {@code Model.do} (the one inside {@code make_model}). Call strings alone
+   * collapsed both user models into one allocation context, unioning both models' weight shapes at
+   * every sink; the receiver-keyed trampoline contexts of <a
+   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a> keep each model's dispatch chain
+   * separate, so each sink now sees exactly its own model's weight shapes.
    */
   @Test
   public void testModelAttributesMultiModelWrapped()
@@ -2141,17 +2131,12 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(
-            2,
-            Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32)));
   }
 
   /**
-   * Companion to {@link #testModelAttributesMultiModelWrapped()} — same fixture, second sink. The
-   * assertion pins the same observed union; both sinks see the union under 2-CFA.
-   *
-   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
-   * Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)}.
+   * Companion to {@link #testModelAttributesMultiModelWrapped()} — same fixture, second sink,
+   * pinned to the second model's weight shapes only (wala/ML#679).
    */
   @Test
   public void testModelAttributesMultiModelWrapped2()
@@ -2161,52 +2146,35 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "g",
         1,
         1,
-        Map.of(
-            2,
-            Set.of(TENSOR_64_5_FLOAT32, TENSOR_5_FLOAT32, TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_64_7_FLOAT32, TENSOR_7_FLOAT32)));
   }
 
   /**
-   * Multi-Model precision regression on the {@code model(x)} call-output path: two distinct Models
+   * Multi-Model separation on the {@code model(x)} call-output path: two distinct Models
    * constructed inside a {@code make_and_call(units, x)} helper that also performs the call. Each
    * user-side {@code make_and_call(...)} returns the model's output, with disjoint shapes (5 vs 7)
-   * per call. Under 2-CFA the two user-side {@code make_and_call} call sites collapse into one
-   * context for {@code Model.__call__}'s output allocation, so each sink ends up with the union
-   * {@code {(20, 5), (20, 7)}} rather than the per-Model shape — same precision-loss mechanism as
-   * {@link #testModelAttributesMultiModelWrapped()}, but on the call-output path instead of the
-   * trainable-weights path. The assertion pins the observed union; a precision improvement will
-   * narrow it.
-   *
-   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
-   * Set.of(TENSOR_20_5_FLOAT32)} for {@code f} and {@code Set.of(TENSOR_20_7_FLOAT32)} for {@code
-   * g} in {@link #testModelCallMultiModelWrapped2()}.
+   * per call. Call strings alone collapsed both models into one context for {@code
+   * Model.__call__}'s output allocation, unioning {@code {(20, 5), (20, 7)}} at every sink; the
+   * receiver-keyed trampoline contexts of <a
+   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a> keep each model's dispatch chain
+   * separate, so each sink now sees exactly its own model's output shape — same mechanism as {@link
+   * #testModelAttributesMultiModelWrapped()}, on the call-output path instead of the
+   * trainable-weights path.
    */
   @Test
   public void testModelCallMultiModelWrapped()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_model_call_multi_wrapped.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_20_5_FLOAT32, TENSOR_20_7_FLOAT32)));
+    test("tf2_test_model_call_multi_wrapped.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_20_5_FLOAT32)));
   }
 
   /**
-   * Companion to {@link #testModelCallMultiModelWrapped()} — same fixture, second sink.
-   *
-   * <p>TODO(wala/ML#380): When the per-Model collapse is fixed, narrow the assertion to {@code
-   * Set.of(TENSOR_20_7_FLOAT32)}.
+   * Companion to {@link #testModelCallMultiModelWrapped()} — same fixture, second sink, pinned to
+   * the second model's output shape only (wala/ML#679).
    */
   @Test
   public void testModelCallMultiModelWrapped2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_model_call_multi_wrapped.py",
-        "g",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_20_5_FLOAT32, TENSOR_20_7_FLOAT32)));
+    test("tf2_test_model_call_multi_wrapped.py", "g", 1, 1, Map.of(2, Set.of(TENSOR_20_7_FLOAT32)));
   }
 
   /**
@@ -2928,16 +2896,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * <p>{@code hidden} (the {@code GCN.call} return, a {@code Dense} output) is tensor-classified
    * because the modeled Keras lazy-{@code build} protocol invokes {@code GCN.build}, giving the
    * {@code build()}-created {@code self._kernel} sublayer a points-to set. With constructor keyword
-   * arguments forwarded to {@code __init__} (wala/ML#664), {@code units} resolves through the
-   * {@code self._units} instance-field read, so the runtime-true {@code (4, 16) float32} is
-   * inferred. With {@code __init__} dispatched in the constructor's calling context (wala/ML#671),
-   * the two instances' {@code self._units} fields hold {@code 16} and {@code 8} separately; the
-   * union's spurious {@code (4, 8)} member persists because both instances share one {@code build}
-   * context, so the {@code Dense} constructed inside it unions the values.
+   * arguments forwarded to {@code __init__} (wala/ML#664) and the layer-method trampolines keyed on
+   * the receiver instance (wala/ML#679), each instance's {@code build} constructs its own {@code
+   * Dense}, so the runtime-true {@code (4, 16) float32} is inferred without the other instance's
+   * spurious {@code (4, 8)}. The remaining {@code ? of float32} member comes from the statically
+   * dead {@code outputs += features} residual branch ({@code self._residual} is constantly {@code
+   * False}), which the path-insensitive analysis still evaluates.
    *
    * <p>TODO: Expect exactly {@code (4, 16) float32} once <a
-   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a> gives the layer-method trampolines
-   * receiver-object sensitivity.
+   * href="https://github.com/wala/ML/issues/681">wala/ML#681</a> prunes branches guarded by
+   * statically-constant instance fields.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2961,7 +2929,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "gcn_chain_proj",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_4_8_FLOAT32, TensorType.of(FLOAT_32, 4, 16))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 16), TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -5039,11 +5007,17 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * <p>{@code pred} types too (wala/ML#665): the model forward output is a tensor union. With
    * {@code add_weight} consuming its {@code shape}/{@code dtype} arguments (wala/ML#667) and
    * constructor keyword arguments forwarded to {@code __init__} (wala/ML#664), the runtime-true
-   * vocab dimension is concrete ({@code (?, ?, 10)}) and the flat-logits matmul member carries the
-   * embedding dimension ({@code (?, 8)} float32). The {@code (?, ?, 4)} member is spurious
-   * constructor-context collapse (wala/ML#671). The union is the order-independent fixed point
-   * (wala/ML#674): identical across runs and across suite/single-test modes. Analyzed statically
-   * here, like the consumer's vendoring; it runs in the perf-eval with its tfrecord/data setup.
+   * vocab dimension is concrete ({@code (?, ?, 10)}). Receiver-keyed trampoline contexts
+   * (wala/ML#679) removed the spurious {@code (?, ?, 4)} constructor-collapse member, but the
+   * flat-logits matmul member that carried the embedding dimension ({@code (?, 8)} float32)
+   * degrades to {@code ? of float32} in decoder-stack propagation. The union is the
+   * order-independent fixed point (wala/ML#674): identical across runs and across suite/single-test
+   * modes. Analyzed statically here, like the consumer's vendoring; it runs in the perf-eval with
+   * its tfrecord/data setup.
+   *
+   * <p>TODO: Expect the float32 member's concrete shape back once <a
+   * href="https://github.com/wala/ML/issues/682">wala/ML#682</a> recovers concrete shapes through
+   * the decoder stack under receiver-keyed contexts.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -5069,9 +5043,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(
                 new TensorType(
                     UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
-                new TensorType(
-                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(4))),
-                new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(8))),
+                TENSOR_UNKNOWN_SHAPE_FLOAT32,
                 new TensorType(
                     UNKNOWN,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
@@ -10472,11 +10444,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   /**
    * Pins the vendored gpt-2 forward output (the wala/ML#618 {@code pred} source): with wala/ML#665
    * forwarding wildcard import bindings, the full decoder stack types and the model output is a
-   * rank-3 tensor union. With {@code add_weight} consuming its {@code shape}/{@code dtype}
-   * arguments (wala/ML#667) and constructor keyword arguments forwarded to {@code __init__}
-   * (wala/ML#664), the float32 member is fully concrete ({@code (2, 3, 8)}) and the runtime-true
-   * vocab member is {@code (?, ?, 10)}; the {@code (?, ?, 4)}/{@code (?, ?, 12)} members are
-   * spurious constructor-context collapse (wala/ML#671).
+   * rank-3-dominated tensor union. Receiver-keyed trampoline contexts (wala/ML#679) removed the
+   * spurious {@code (?, ?, 4)}/{@code (?, ?, 12)} constructor-collapse members and kept the
+   * runtime-true vocab member {@code (?, ?, 10)}, but the previously concrete {@code (2, 3, 8)
+   * float32} member degrades to {@code ? of float32} in decoder-stack propagation ({@link
+   * #testCollectionProbeVendoredEmbedding()} still recovers it concretely at the embedding output).
+   *
+   * <p>TODO: Expect the float32 member's concrete shape back once <a
+   * href="https://github.com/wala/ML/issues/682">wala/ML#682</a> recovers concrete shapes through
+   * the decoder stack under receiver-keyed contexts.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10503,17 +10479,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2,
             Set.of(
-                TensorType.of(FLOAT_32, 2, 3, 8),
+                TENSOR_UNKNOWN_SHAPE_FLOAT32,
                 new TensorType(
                     UNKNOWN,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
                 new TensorType(
-                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
-                new TensorType(
-                    UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(4))),
-                new TensorType(
                     UNKNOWN,
-                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(12))))));
+                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))))));
   }
 
   /**
@@ -10624,8 +10596,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         // The scalar-rank result comes from the interpreter folding the computed output shape;
-        // the dtype is refinable once `add_weight` consumes its `dtype` argument.
-        Map.of(2, Set.of(new TensorType(UNKNOWN, emptyList()))));
+        // receiver-keyed contexts (wala/ML#679) recover the `add_weight` float32 dtype.
+        Map.of(2, Set.of(new TensorType(FLOAT_32, emptyList()))));
   }
 
   /**
@@ -10696,9 +10668,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Pins the vendored {@code LayerNormalization} forward result: {@code add_weight}-created {@code
-   * gamma}/{@code beta} dispatch (wala/ML#595, wala/ML#618) and the normalization body types (a
-   * union including {@code ? of float32}). Count-only: the union's exact members shift with
-   * modeling precision.
+   * gamma}/{@code beta} dispatch (wala/ML#595, wala/ML#618) and the normalization body types.
+   * Receiver-keyed contexts (wala/ML#679) dropped the shapeless-and-dtypeless union member, so the
+   * result is exactly {@code ? of float32}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10722,7 +10694,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "gpt2_vendored",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE, TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -14036,20 +14008,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     Map<Integer, Set<TensorType>> actualTypesByValueNumber = new HashMap<>();
 
     for (Context ctx : contextToFunctionParameterPointerKeys.keySet()) {
-      // check tensor parameters.
       Set<LocalPointerKey> functionParameterPointerKeys =
           contextToFunctionParameterPointerKeys.get(ctx);
-
-      assertEquals(expectedNumberOfTensorParameters, functionParameterPointerKeys.size());
-
-      // check actual value numbers.
-      Set<Integer> actualParameterValueNumberSet =
-          functionParameterPointerKeys.stream()
-              .map(LocalPointerKey::getValueNumber)
-              .collect(Collectors.toSet());
-
-      assertEquals(
-          expectedTensorParameterValueNumberToTypes.keySet(), actualParameterValueNumberSet);
 
       // accumulate per-vn types across contexts.
       for (LocalPointerKey lpk : functionParameterPointerKeys) {
@@ -14064,6 +14024,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             .addAll(types);
       }
     }
+
+    // Check the tensor-parameter count and value numbers on the union across contexts, mirroring
+    // the function-variable count above: with receiver-keyed contexts (wala/ML#679), a single
+    // source-level call chain fans out into finer contexts and not every context sees every tensor
+    // argument, but the downstream consumer is indexed by source-level parameter position, so the
+    // source-level property is the per-vn union. A parameter that loses typing in *every* context
+    // still fails here.
+    assertEquals(expectedNumberOfTensorParameters, actualTypesByValueNumber.size());
+    assertEquals(
+        expectedTensorParameterValueNumberToTypes.keySet(), actualTypesByValueNumber.keySet());
 
     // compare expected against the union across contexts, per vn.
     for (Map.Entry<Integer, Set<TensorType>> entry :

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -3,28 +3,24 @@ package com.ibm.wala.cast.python.ml.client;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MODEL;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
-import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CALL_STRING;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
-import com.ibm.wala.classLoader.CallSiteReference;
-import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.propagation.cfa.CallString;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -241,10 +237,10 @@ public class ModelCall extends TensorGenerator {
   /**
    * Resolves the points-to set of the {@code outputs} argument at the caller-side {@code
    * Model(...)} invoke that created the given synthetic {@code Model.do} node. Walks the node's
-   * {@link CallString} context to each calling invoke and reads the {@code outputs} use by keyword
-   * name first (covers {@code Model(outputs=...)}) then by position (covers {@code Model(in,
-   * out)}). Reading the caller invoke handles keyword construction, which the {@code Model.do}
-   * formal-parameter binding alone does not.
+   * call-graph edges to each calling invoke and reads the {@code outputs} use by keyword name first
+   * (covers {@code Model(outputs=...)}) then by position (covers {@code Model(in, out)}). Reading
+   * the caller invoke handles keyword construction, which the {@code Model.do} formal-parameter
+   * binding alone does not.
    *
    * @param builder The propagation call graph builder.
    * @param modelDoNode The synthetic {@code Model.do} node allocating the model instance.
@@ -253,38 +249,24 @@ public class ModelCall extends TensorGenerator {
    */
   private OrdinalSet<InstanceKey> getOutputsArgumentPTS(
       PropagationCallGraphBuilder builder, CGNode modelDoNode) {
-    CallString cs = (CallString) modelDoNode.getContext().get(CALL_STRING);
-    if (cs == null) return OrdinalSet.empty();
-
     OrdinalSet<InstanceKey> ret = OrdinalSet.empty();
-    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
-      IMethod callerMethod = cs.getMethods()[i];
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, modelDoNode)) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
 
-      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(modelDoNode); it.hasNext(); ) {
-        CGNode caller = it.next();
-        if (!caller.getMethod().equals(callerMethod)) continue;
-
-        IR callerIR = caller.getIR();
-        if (callerIR == null) continue;
-
-        for (SSAAbstractInvokeInstruction callInstr : callerIR.getCalls(siteRef)) {
-          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
-          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
-
-          int argVn = pyCall.getUse(Model.Parameters.OUTPUTS.getName());
-          if (argVn == -1) {
-            int numPositionalArgs = pyCall.getNumberOfPositionalParameters() - 1;
-            int outputsPos = Model.Parameters.OUTPUTS.getIndex();
-            if (outputsPos < numPositionalArgs) argVn = pyCall.getUse(outputsPos + 1);
-          }
-          if (argVn <= 0) continue;
-
-          PointerKey argPK =
-              builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, argVn);
-          ret = OrdinalSet.unify(ret, builder.getPointerAnalysis().getPointsToSet(argPK));
-        }
+      int argVn = pyCall.getUse(Model.Parameters.OUTPUTS.getName());
+      if (argVn == -1) {
+        int numPositionalArgs = pyCall.getNumberOfPositionalParameters() - 1;
+        int outputsPos = Model.Parameters.OUTPUTS.getIndex();
+        if (outputsPos < numPositionalArgs) argVn = pyCall.getUse(outputsPos + 1);
       }
+      if (argVn <= 0) continue;
+
+      PointerKey argPK =
+          builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, argVn);
+      ret = OrdinalSet.unify(ret, builder.getPointerAnalysis().getPointsToSet(argPK));
     }
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -15,6 +15,7 @@ import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
 import com.ibm.wala.cast.lsp.AnalysisError;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.cast.python.ipa.callgraph.TrampolineReceiverContextSelector;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorType;
@@ -198,33 +199,38 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         new nCFAContextSelector(this.targetedCfaDepth, new ContextInsensitiveSelector());
     final IClass modelClass = cha.lookupClass(TensorFlowTypes.MODEL.getDeclaringClass());
 
+    // The trampoline-receiver rules must stay outermost: the targeted-CFA routing below matches
+    // trampoline classes too (a `$Foo/call` trampoline ends in a forward-method segment), and
+    // call strings re-collapse the per-receiver distinction those rules establish (wala/ML#679).
     builder.setContextSelector(
-        new ContextSelector() {
-          @Override
-          public Context getCalleeTarget(
-              CGNode caller,
-              CallSiteReference site,
-              IMethod callee,
-              InstanceKey[] actualParameters) {
-            String calleeClass = callee.getDeclaringClass().getName().toString();
-            // Apply k-CFA for any methods in the target framework, which includes internal helpers,
-            // as well as methods declared on user-defined `tf.keras.Model` subclasses (e.g.
-            // `NeuralNet.call`). Without the latter, a user model called from multiple sites (train
-            // vs. test) merges into one context-insensitive node, collapsing its layer-output
-            // allocations across callers and losing per-context shape (wala/ML#530).
-            if (calleeClass.contains(targetFramework)
-                || isModelSubclassMethod(callee, modelClass)
-                || isUserModelForwardMethod(calleeClass)) {
-              return targetedCFA.getCalleeTarget(caller, site, callee, actualParameters);
-            }
-            return base.getCalleeTarget(caller, site, callee, actualParameters);
-          }
+        new TrampolineReceiverContextSelector(
+            new ContextSelector() {
+              @Override
+              public Context getCalleeTarget(
+                  CGNode caller,
+                  CallSiteReference site,
+                  IMethod callee,
+                  InstanceKey[] actualParameters) {
+                String calleeClass = callee.getDeclaringClass().getName().toString();
+                // Apply k-CFA for any methods in the target framework, which includes internal
+                // helpers, as well as methods declared on user-defined `tf.keras.Model` subclasses
+                // (e.g. `NeuralNet.call`). Without the latter, a user model called from multiple
+                // sites (train vs. test) merges into one context-insensitive node, collapsing its
+                // layer-output allocations across callers and losing per-context shape
+                // (wala/ML#530).
+                if (calleeClass.contains(targetFramework)
+                    || isModelSubclassMethod(callee, modelClass)
+                    || isUserModelForwardMethod(calleeClass)) {
+                  return targetedCFA.getCalleeTarget(caller, site, callee, actualParameters);
+                }
+                return base.getCalleeTarget(caller, site, callee, actualParameters);
+              }
 
-          @Override
-          public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
-            return base.getRelevantParameters(caller, site);
-          }
-        });
+              @Override
+              public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
+                return base.getRelevantParameters(caller, site);
+              }
+            }));
 
     return builder;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -1,6 +1,5 @@
 package com.ibm.wala.cast.python.ml.client;
 
-import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CALL_STRING;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
@@ -8,21 +7,16 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
-import com.ibm.wala.classLoader.CallSiteReference;
-import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.CGNode;
-import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.propagation.cfa.CallString;
-import com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContext;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -73,36 +67,13 @@ public class Range extends TensorGenerator {
   protected Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
 
-    // 1. Precise Context-Sensitive Resolution
-    Context cs = this.getNode().getContext();
-    if (cs instanceof CallStringContext) {
-      CallStringContext csc = (CallStringContext) cs;
-      CallString callString = (CallString) csc.get(CALL_STRING);
-      CallSiteReference[] sites = callString.getCallSiteRefs();
-      IMethod[] methods = callString.getMethods();
-
-      if (sites.length > 0 && methods.length > 0) {
-        CallSiteReference siteReference = sites[sites.length - 1];
-        IMethod callerMethod = methods[methods.length - 1];
-
-        Iterator<CGNode> preds = builder.getCallGraph().getPredNodes(this.getNode());
-        while (preds.hasNext()) {
-          CGNode caller = preds.next();
-          if (!caller.getMethod().equals(callerMethod)) continue;
-
-          SSAAbstractInvokeInstruction[] calls = caller.getIR().getCalls(siteReference);
-
-          for (SSAAbstractInvokeInstruction callInstr : calls) {
-
-            if (callInstr.getCallSite().equals(siteReference)
-                && callInstr instanceof PythonInvokeInstruction) {
-
-              ret.addAll(processCall(builder, caller, (PythonInvokeInstruction) callInstr));
-            }
-          }
-        }
-      }
-    }
+    // 1. Precise Caller Resolution: walk the call-graph edges to the invocations dispatching to
+    // this node.
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode()))
+      if (callerInvoke.snd instanceof PythonInvokeInstruction)
+        ret.addAll(
+            processCall(builder, callerInvoke.fst, (PythonInvokeInstruction) callerInvoke.snd));
 
     // 2. Fallback for non-CS or if CS failed
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -24,7 +24,6 @@ import static com.ibm.wala.cast.python.util.Util.getFunction;
 import static com.ibm.wala.cast.python.util.Util.getReceiverValueNumber;
 import static com.ibm.wala.cast.python.util.Util.sanitize;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
-import static com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CALL_STRING;
 import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
@@ -45,7 +44,6 @@ import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
-import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -58,7 +56,6 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
-import com.ibm.wala.ipa.callgraph.propagation.cfa.CallString;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
@@ -995,37 +992,28 @@ public abstract class TensorGenerator {
 
       if (paramPos >= -1) { // -1 is 'self'
         Set<List<Dimension<?>>> combinedRet = HashSetFactory.make();
-        CallString cs = (CallString) node.getContext().get(CALL_STRING);
-        if (cs != null) {
-          for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-            CallSiteReference site = cs.getCallSiteRefs()[i];
-            IMethod callerMethod = cs.getMethods()[i];
-            for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(node); it.hasNext(); ) {
-              CGNode caller = it.next();
-              if (caller.getMethod().equals(callerMethod)) {
-                for (SSAAbstractInvokeInstruction call : caller.getIR().getCalls(site)) {
-                  int argVn = -1;
-                  if (paramPos == -1) { // self
-                    argVn = call.getUse(0);
-                  } else if (call instanceof PythonInvokeInstruction) {
-                    // Try to find the argument index. This is simplified.
-                    if (paramPos + 1 < call.getNumberOfUses()) {
-                      argVn = call.getUse(paramPos + 1);
-                    }
-                  } else if (paramPos < call.getNumberOfUses()) {
-                    argVn = call.getUse(paramPos);
-                  }
-
-                  if (argVn != -1) {
-                    Set<List<Dimension<?>>> argShapes = this.getShapes(builder, caller, argVn);
-                    if (argShapes != null) combinedRet.addAll(argShapes);
-                  }
-                }
-              }
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+            getCallerInvokes(builder, node)) {
+          CGNode caller = callerInvoke.fst;
+          SSAAbstractInvokeInstruction call = callerInvoke.snd;
+          int argVn = -1;
+          if (paramPos == -1) { // self
+            argVn = call.getUse(0);
+          } else if (call instanceof PythonInvokeInstruction) {
+            // Try to find the argument index. This is simplified.
+            if (paramPos + 1 < call.getNumberOfUses()) {
+              argVn = call.getUse(paramPos + 1);
             }
+          } else if (paramPos < call.getNumberOfUses()) {
+            argVn = call.getUse(paramPos);
           }
-          if (!combinedRet.isEmpty()) return combinedRet;
+
+          if (argVn != -1) {
+            Set<List<Dimension<?>>> argShapes = this.getShapes(builder, caller, argVn);
+            if (argShapes != null) combinedRet.addAll(argShapes);
+          }
         }
+        if (!combinedRet.isEmpty()) return combinedRet;
       }
     }
 
@@ -1625,51 +1613,39 @@ public abstract class TensorGenerator {
       return ret;
     }
 
-    // 1. read_data is called by the operation's 'do' method.
-    Iterator<CGNode> doNodes = builder.getCallGraph().getPredNodes(readDataNode);
-    while (doNodes.hasNext()) {
-      CGNode doNode = doNodes.next();
+    // 1. read_data is called by the operation's 'do' method; the call-graph edges identify the
+    // calling instructions.
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, readDataNode)) {
+      CGNode doNode = callerInvoke.fst;
+      SSAAbstractInvokeInstruction call = callerInvoke.snd;
 
-      // 2. Find the instruction in 'do' that called 'read_data'.
-      // We use the context of the callee (readDataNode) to identify the specific call site.
-      CallString cs = (CallString) readDataNode.getContext().get(CALL_STRING);
-      if (cs != null && cs.getCallSiteRefs().length > 0) {
-        CallSiteReference readDataSite = cs.getCallSiteRefs()[0];
-        IMethod callerMethod = cs.getMethods()[0];
+      // Construct a source for the result of this call (which is the tensor object).
+      if (call.getNumberOfDefs() > 0) {
+        int def = call.getDef();
+        PointerKey defKey =
+            builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(doNode, def);
+        PointsToSetVariable defSource = null;
+        if (!builder.getPropagationSystem().isImplicit(defKey)) {
+          defSource = builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
+        }
 
-        if (doNode.getMethod().equals(callerMethod)) {
-          SSAAbstractInvokeInstruction[] calls = doNode.getIR().getCalls(readDataSite);
-          for (SSAAbstractInvokeInstruction call : calls) {
-            // Construct a source for the result of this call (which is the tensor object).
-            if (call.getNumberOfDefs() > 0) {
-              int def = call.getDef();
-              PointerKey defKey =
-                  builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(doNode, def);
-              PointsToSetVariable defSource = null;
-              if (!builder.getPropagationSystem().isImplicit(defKey)) {
-                defSource = builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
-              }
-
-              // Try to create a manual generator for the caller (doNode) first.
-              TensorGenerator generator = createManualGenerator(doNode, builder);
-              if (generator == null) {
-                try {
-                  generator = TensorGeneratorFactory.getGenerator(defSource, builder);
-                } catch (IllegalArgumentException e) {
-                  // Factory couldn't resolve — treat as "no generator". See wala/ML#363.
-                  LOGGER.log(
-                      Level.FINE, "Delegating shape inference: factory IAE for " + defSource, e);
-                  generator = null;
-                }
-              }
-
-              if (generator != null) {
-                LOGGER.fine("Delegating shape inference to: " + generator);
-                Set<List<Dimension<?>>> delegatedShapes = generator.getShapes(builder);
-                if (delegatedShapes != null) ret.addAll(delegatedShapes);
-              }
-            }
+        // Try to create a manual generator for the caller (doNode) first.
+        TensorGenerator generator = createManualGenerator(doNode, builder);
+        if (generator == null) {
+          try {
+            generator = TensorGeneratorFactory.getGenerator(defSource, builder);
+          } catch (IllegalArgumentException e) {
+            // Factory couldn't resolve — treat as "no generator". See wala/ML#363.
+            LOGGER.log(Level.FINE, "Delegating shape inference: factory IAE for " + defSource, e);
+            generator = null;
           }
+        }
+
+        if (generator != null) {
+          LOGGER.fine("Delegating shape inference to: " + generator);
+          Set<List<Dimension<?>>> delegatedShapes = generator.getShapes(builder);
+          if (delegatedShapes != null) ret.addAll(delegatedShapes);
         }
       }
     }
@@ -2067,35 +2043,26 @@ public abstract class TensorGenerator {
 
       if (paramPos >= -1) {
         Set<DType> combinedRet = EnumSet.noneOf(DType.class);
-        CallString cs = (CallString) node.getContext().get(CALL_STRING);
-        if (cs != null) {
-          for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-            CallSiteReference site = cs.getCallSiteRefs()[i];
-            IMethod callerMethod = cs.getMethods()[i];
-            for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(node); it.hasNext(); ) {
-              CGNode caller = it.next();
-              if (caller.getMethod().equals(callerMethod)) {
-                for (SSAAbstractInvokeInstruction call : caller.getIR().getCalls(site)) {
-                  int argVn = -1;
-                  if (paramPos == -1) { // self
-                    argVn = call.getUse(0);
-                  } else if (call instanceof PythonInvokeInstruction) {
-                    if (paramPos + 1 < call.getNumberOfUses()) {
-                      argVn = call.getUse(paramPos + 1);
-                    }
-                  } else if (paramPos < call.getNumberOfUses()) {
-                    argVn = call.getUse(paramPos);
-                  }
-
-                  if (argVn != -1) {
-                    combinedRet.addAll(this.getDTypes(builder, caller, argVn));
-                  }
-                }
-              }
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+            getCallerInvokes(builder, node)) {
+          CGNode caller = callerInvoke.fst;
+          SSAAbstractInvokeInstruction call = callerInvoke.snd;
+          int argVn = -1;
+          if (paramPos == -1) { // self
+            argVn = call.getUse(0);
+          } else if (call instanceof PythonInvokeInstruction) {
+            if (paramPos + 1 < call.getNumberOfUses()) {
+              argVn = call.getUse(paramPos + 1);
             }
+          } else if (paramPos < call.getNumberOfUses()) {
+            argVn = call.getUse(paramPos);
           }
-          if (!combinedRet.isEmpty()) return combinedRet;
+
+          if (argVn != -1) {
+            combinedRet.addAll(this.getDTypes(builder, caller, argVn));
+          }
         }
+        if (!combinedRet.isEmpty()) return combinedRet;
       }
     }
 
@@ -2384,50 +2351,38 @@ public abstract class TensorGenerator {
     }
 
     // Trace back to the user-level call that invoked this generator.
-    // 1. read_data is called by the operation's 'do' method.
-    Iterator<CGNode> doNodes = builder.getCallGraph().getPredNodes(readDataNode);
-    while (doNodes.hasNext()) {
-      CGNode doNode = doNodes.next();
+    // 1. read_data is called by the operation's 'do' method; the call-graph edges identify the
+    // calling instructions.
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, readDataNode)) {
+      CGNode doNode = callerInvoke.fst;
+      SSAAbstractInvokeInstruction call = callerInvoke.snd;
 
-      // 2. Find the instruction in 'do' that called 'read_data'.
-      // We use the context of the callee (readDataNode) to identify the specific call site.
-      CallString cs = (CallString) readDataNode.getContext().get(CALL_STRING);
-      if (cs != null && cs.getCallSiteRefs().length > 0) {
-        CallSiteReference readDataSite = cs.getCallSiteRefs()[0];
-        IMethod callerMethod = cs.getMethods()[0];
+      // Construct a source for the result of this call (which is the tensor object).
+      if (call.getNumberOfDefs() > 0) {
+        int def = call.getDef();
+        PointerKey defKey =
+            builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(doNode, def);
+        PointsToSetVariable defSource = null;
+        if (!builder.getPropagationSystem().isImplicit(defKey)) {
+          defSource = builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
+        }
 
-        if (doNode.getMethod().equals(callerMethod)) {
-          SSAAbstractInvokeInstruction[] calls = doNode.getIR().getCalls(readDataSite);
-          for (SSAAbstractInvokeInstruction call : calls) {
-            // Construct a source for the result of this call (which is the tensor object).
-            if (call.getNumberOfDefs() > 0) {
-              int def = call.getDef();
-              PointerKey defKey =
-                  builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(doNode, def);
-              PointsToSetVariable defSource = null;
-              if (!builder.getPropagationSystem().isImplicit(defKey)) {
-                defSource = builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
-              }
-
-              // Try to create a manual generator for the caller (doNode) first.
-              TensorGenerator generator = createManualGenerator(doNode, builder);
-              if (generator == null) {
-                try {
-                  generator = TensorGeneratorFactory.getGenerator(defSource, builder);
-                } catch (IllegalArgumentException e) {
-                  // Factory couldn't resolve — treat as "no generator". See wala/ML#363.
-                  LOGGER.log(
-                      Level.FINE, "Delegating dtype inference: factory IAE for " + defSource, e);
-                  generator = null;
-                }
-              }
-
-              if (generator != null) {
-                LOGGER.fine("Delegating dtype inference to: " + generator);
-                ret.addAll(generator.getDTypes(builder));
-              }
-            }
+        // Try to create a manual generator for the caller (doNode) first.
+        TensorGenerator generator = createManualGenerator(doNode, builder);
+        if (generator == null) {
+          try {
+            generator = TensorGeneratorFactory.getGenerator(defSource, builder);
+          } catch (IllegalArgumentException e) {
+            // Factory couldn't resolve — treat as "no generator". See wala/ML#363.
+            LOGGER.log(Level.FINE, "Delegating dtype inference: factory IAE for " + defSource, e);
+            generator = null;
           }
+        }
+
+        if (generator != null) {
+          LOGGER.fine("Delegating dtype inference to: " + generator);
+          ret.addAll(generator.getDTypes(builder));
         }
       }
     }
@@ -2641,8 +2596,8 @@ public abstract class TensorGenerator {
   }
 
   /**
-   * Resolves shapes for the argument at the given parameter position by walking the {@link
-   * CallString} context to find each caller's invocation site, then delegating to {@link
+   * Resolves shapes for the argument at the given parameter position by walking the call-graph
+   * edges to find each caller's invocation site, then delegating to {@link
    * #getShapes(PropagationCallGraphBuilder, CGNode, int)} with the caller's value number. This is a
    * fallback path used when {@link #getArgumentPointsToSet(PropagationCallGraphBuilder, int,
    * String)} returns an empty set because the argument's points-to set is empty — commonly the case
@@ -2660,50 +2615,66 @@ public abstract class TensorGenerator {
    */
   protected Set<List<Dimension<?>>> getArgumentShapesViaCallers(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
-    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
-    LOGGER.fine(() -> "getArgumentShapesViaCallers: node=" + this.getNode() + ", cs=" + cs);
-    if (cs == null) return null;
     Set<List<Dimension<?>>> combined = null;
-    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
-      IMethod callerMethod = cs.getMethods()[i];
-      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
-          it.hasNext(); ) {
-        CGNode caller = it.next();
-        if (!caller.getMethod().equals(callerMethod)) continue;
-        for (SSAAbstractInvokeInstruction callInstr : caller.getIR().getCalls(siteRef)) {
-          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
-          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
-          int argVn = -1;
-          if (paramName != null) argVn = pyCall.getUse(paramName);
-          if (argVn == -1 && paramPos >= 0) {
-            int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
-            if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
-          }
-          if (argVn <= 0) continue;
-          final int finalArgVn = argVn;
-          final CGNode finalCaller = caller;
-          try {
-            Set<List<Dimension<?>>> argShapes = this.getShapes(builder, caller, argVn);
-            LOGGER.fine(
-                () -> "getArgumentShapesViaCallers: argVn=" + finalArgVn + " shapes=" + argShapes);
-            if (argShapes != null && !argShapes.isEmpty()) {
-              if (combined == null) combined = HashSetFactory.make();
-              combined.addAll(argShapes);
-            }
-          } catch (IllegalArgumentException e) {
-            LOGGER.log(
-                Level.FINE,
-                "getArgumentShapesViaCallers: IAE for argVn="
-                    + finalArgVn
-                    + " in caller="
-                    + finalCaller,
-                e);
-          }
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) continue;
+      final int finalArgVn = argVn;
+      final CGNode finalCaller = caller;
+      try {
+        Set<List<Dimension<?>>> argShapes = this.getShapes(builder, caller, argVn);
+        LOGGER.fine(
+            () -> "getArgumentShapesViaCallers: argVn=" + finalArgVn + " shapes=" + argShapes);
+        if (argShapes != null && !argShapes.isEmpty()) {
+          if (combined == null) combined = HashSetFactory.make();
+          combined.addAll(argShapes);
         }
+      } catch (IllegalArgumentException e) {
+        LOGGER.log(
+            Level.FINE,
+            "getArgumentShapesViaCallers: IAE for argVn="
+                + finalArgVn
+                + " in caller="
+                + finalCaller,
+            e);
       }
     }
     return combined;
+  }
+
+  /**
+   * Returns the calling invocations of the given node: for each call-graph predecessor, the invoke
+   * instructions at the sites that can dispatch to it. Derived from call-graph edges rather than a
+   * {@code CALL_STRING} lookup, so it works for any {@link com.ibm.wala.ipa.callgraph.Context}
+   * shape — the receiver-keyed contexts of <a
+   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a> carry no call string.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph to consult.
+   * @param node The callee {@link CGNode}.
+   * @return The (caller, invoke) pairs whose invocations can dispatch to the given node.
+   */
+  protected static List<Pair<CGNode, SSAAbstractInvokeInstruction>> getCallerInvokes(
+      PropagationCallGraphBuilder builder, CGNode node) {
+    List<Pair<CGNode, SSAAbstractInvokeInstruction>> ret = new ArrayList<>();
+    CallGraph callGraph = builder.getCallGraph();
+    for (Iterator<CGNode> it = callGraph.getPredNodes(node); it.hasNext(); ) {
+      CGNode caller = it.next();
+      if (caller.getIR() == null) continue;
+      for (Iterator<CallSiteReference> sites = callGraph.getPossibleSites(caller, node);
+          sites.hasNext(); )
+        for (SSAAbstractInvokeInstruction call : caller.getIR().getCalls(sites.next()))
+          ret.add(Pair.make(caller, call));
+    }
+    return ret;
   }
 
   /**
@@ -2711,8 +2682,8 @@ public abstract class TensorGenerator {
    * {@code tf.ones(x.shape)}). Such an argument is a {@link PythonPropertyRead} of member {@code
    * "shape"} whose points-to set is empty, so ordinary shape resolution falls through to {@link
    * #getDefaultShapes}; this resolves the shape of the underlying tensor instead of dropping to ⊤.
-   * Walks the {@link CallString} callers (the allocation's synthetic node has no argument IR of its
-   * own) to find the call site and the shape argument's value number, mirroring {@link
+   * Walks the call-graph callers (the allocation's synthetic node has no argument IR of its own) to
+   * find the call site and the shape argument's value number, mirroring {@link
    * #getArgumentShapesViaCallers}.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
@@ -2723,51 +2694,41 @@ public abstract class TensorGenerator {
    */
   protected Set<List<Dimension<?>>> getShapeFromShapeAttributeArgument(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
-    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
-    if (cs == null) return null;
     Set<List<Dimension<?>>> combined = null;
-    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
-      IMethod callerMethod = cs.getMethods()[i];
-      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
-          it.hasNext(); ) {
-        CGNode caller = it.next();
-        if (!caller.getMethod().equals(callerMethod)) continue;
-        for (SSAAbstractInvokeInstruction callInstr : caller.getIR().getCalls(siteRef)) {
-          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
-          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
-          int argVn = -1;
-          if (paramName != null) argVn = pyCall.getUse(paramName);
-          if (argVn == -1 && paramPos >= 0) {
-            int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
-            if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
-          }
-          if (argVn <= 0) continue;
-          SSAInstruction def = caller.getDU().getDef(argVn);
-          if (!(def instanceof PythonPropertyRead)) continue;
-          PythonPropertyRead propRead = (PythonPropertyRead) def;
-          SymbolTable st = caller.getIR().getSymbolTable();
-          int memberVn = propRead.getMemberRef();
-          if (!st.isStringConstant(memberVn) || !"shape".equals(st.getStringValue(memberVn)))
-            continue;
-          int tensorVn = propRead.getObjectRef();
-          try {
-            Set<List<Dimension<?>>> tensorShapes = this.getShapes(builder, caller, tensorVn);
-            if (tensorShapes != null && !tensorShapes.isEmpty()) {
-              if (combined == null) combined = HashSetFactory.make();
-              combined.addAll(tensorShapes);
-            }
-          } catch (IllegalArgumentException e) {
-            // The source tensor's shape couldn't be resolved; fall through to ⊤.
-            LOGGER.log(
-                Level.FINE,
-                "getShapeFromShapeAttributeArgument: could not resolve .shape source tensorVn="
-                    + tensorVn
-                    + " in caller="
-                    + caller,
-                e);
-          }
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) continue;
+      SSAInstruction def = caller.getDU().getDef(argVn);
+      if (!(def instanceof PythonPropertyRead)) continue;
+      PythonPropertyRead propRead = (PythonPropertyRead) def;
+      SymbolTable st = caller.getIR().getSymbolTable();
+      int memberVn = propRead.getMemberRef();
+      if (!st.isStringConstant(memberVn) || !"shape".equals(st.getStringValue(memberVn))) continue;
+      int tensorVn = propRead.getObjectRef();
+      try {
+        Set<List<Dimension<?>>> tensorShapes = this.getShapes(builder, caller, tensorVn);
+        if (tensorShapes != null && !tensorShapes.isEmpty()) {
+          if (combined == null) combined = HashSetFactory.make();
+          combined.addAll(tensorShapes);
         }
+      } catch (IllegalArgumentException e) {
+        // The source tensor's shape couldn't be resolved; fall through to ⊤.
+        LOGGER.log(
+            Level.FINE,
+            "getShapeFromShapeAttributeArgument: could not resolve .shape source tensorVn="
+                + tensorVn
+                + " in caller="
+                + caller,
+            e);
       }
     }
     return combined;
@@ -2780,36 +2741,27 @@ public abstract class TensorGenerator {
    */
   protected Set<DType> getArgumentDTypesViaCallers(
       PropagationCallGraphBuilder builder, int paramPos, String paramName) {
-    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
-    if (cs == null) return null;
     Set<DType> combined = null;
-    for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-      CallSiteReference siteRef = cs.getCallSiteRefs()[i];
-      IMethod callerMethod = cs.getMethods()[i];
-      for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
-          it.hasNext(); ) {
-        CGNode caller = it.next();
-        if (!caller.getMethod().equals(callerMethod)) continue;
-        for (SSAAbstractInvokeInstruction callInstr : caller.getIR().getCalls(siteRef)) {
-          if (!(callInstr instanceof PythonInvokeInstruction)) continue;
-          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callInstr;
-          int argVn = -1;
-          if (paramName != null) argVn = pyCall.getUse(paramName);
-          if (argVn == -1 && paramPos >= 0) {
-            int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
-            if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
-          }
-          if (argVn <= 0) continue;
-          try {
-            Set<DType> argDTypes = this.getDTypes(builder, caller, argVn);
-            if (argDTypes != null && !argDTypes.isEmpty()) {
-              if (combined == null) combined = EnumSet.noneOf(DType.class);
-              combined.addAll(argDTypes);
-            }
-          } catch (IllegalArgumentException e) {
-            LOGGER.log(Level.FINE, "Could not get dtypes for caller argument: " + argVn, e);
-          }
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) continue;
+      try {
+        Set<DType> argDTypes = this.getDTypes(builder, caller, argVn);
+        if (argDTypes != null && !argDTypes.isEmpty()) {
+          if (combined == null) combined = EnumSet.noneOf(DType.class);
+          combined.addAll(argDTypes);
         }
+      } catch (IllegalArgumentException e) {
+        LOGGER.log(Level.FINE, "Could not get dtypes for caller argument: " + argVn, e);
       }
     }
     return combined;
@@ -2831,7 +2783,7 @@ public abstract class TensorGenerator {
    *   <li><b>`read_data` Wrapper Handling:</b> If the node corresponds to a `read_data` method
    *       (common in TensorFlow synthetic models), it delegates the resolution to the preceding
    *       `do` method, which is the actual entry point for the operation logic.
-   *   <li><b>Context-Sensitive Caller Analysis:</b> It utilizes the {@link CallString} context to
+   *   <li><b>Caller Analysis:</b> It walks the call-graph edges to the calling invocations to
    *       identify the specific caller of the node. It then inspects the call sites in that caller
    *       to find the {@link PythonInvokeInstruction} that targets this node. This is crucial for
    *       distinguishing between different calls to the same operation in a context-sensitive
@@ -2925,82 +2877,53 @@ public abstract class TensorGenerator {
       return ret;
     }
 
-    // Strategy 3: Context-Sensitive Caller Analysis
-    // Use the CallString from the node's context to identify exactly which call site invoked this
-    // function.
-    // This allows us to look up the arguments passed at that specific call site in the caller's IR.
-    CallString cs = (CallString) node.getContext().get(CALL_STRING);
-    if (cs != null) {
+    // Strategy 3: Caller Analysis
+    // Walk the call-graph edges to the invocations dispatching to this node, then look up the
+    // arguments passed at those call sites in each caller's IR.
+    {
       OrdinalSet<InstanceKey> combinedPts = OrdinalSet.empty();
       boolean found = false;
       boolean callAnalyzed = false;
 
-      for (int i = 0; i < cs.getCallSiteRefs().length; i++) {
-        CallSiteReference siteReference = cs.getCallSiteRefs()[i];
-        IMethod callerMethod = cs.getMethods()[i];
-        LOGGER.finer(
-            "Strategy 3: Checking call site: " + siteReference + " in method: " + callerMethod);
+      for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+          getCallerInvokes(builder, node)) {
+        CGNode caller = callerInvoke.fst;
+        SSAAbstractInvokeInstruction callInstr = callerInvoke.snd;
+        callAnalyzed = true;
 
-        for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(node); it.hasNext(); ) {
-          CGNode caller = it.next();
+        if (callInstr instanceof PythonInvokeInstruction) {
+          PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
+          int argValNum = -1;
 
-          // Ensure we are looking at the caller that matches the method in our call string context.
-          if (!caller.getMethod().equals(callerMethod)) {
-            continue;
+          // Try to resolve by name (keyword argument).
+          if (paramName != null) {
+            argValNum = pyCallInstr.getUse(paramName);
           }
 
-          SSAAbstractInvokeInstruction[] calls = caller.getIR().getCalls(siteReference);
-          for (SSAAbstractInvokeInstruction callInstr : calls) {
-            // Confirm that this instruction can actually target the current node.
-            // This handles polymorphism where a call site might have multiple possible targets.
-            boolean targetsThisNode = false;
-            for (CGNode target : builder.getCallGraph().getPossibleTargets(caller, siteReference)) {
-              if (target.equals(node)) {
-                targetsThisNode = true;
-                break;
+          // Try to resolve by position.
+          if (argValNum == -1) {
+            if (paramPos == RECEIVER_PARAMETER_POSITION) {
+              argValNum = getReceiverValueNumber(caller, pyCallInstr);
+            } else if (paramPos >= 0) {
+              int numPosParams =
+                  pyCallInstr.getNumberOfPositionalParameters() - 1; // Exclude function.
+              if (paramPos < numPosParams) {
+                argValNum =
+                    pyCallInstr.getUse(paramPos + 1); // Positional arguments start at index 1.
               }
             }
+          }
 
-            if (!targetsThisNode) {
-              continue;
-            }
-            callAnalyzed = true;
-
-            if (callInstr instanceof PythonInvokeInstruction) {
-              PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
-              int argValNum = -1;
-
-              // Try to resolve by name (keyword argument).
-              if (paramName != null) {
-                argValNum = pyCallInstr.getUse(paramName);
-              }
-
-              // Try to resolve by position.
-              if (argValNum == -1) {
-                if (paramPos == RECEIVER_PARAMETER_POSITION) {
-                  argValNum = getReceiverValueNumber(caller, pyCallInstr);
-                } else if (paramPos >= 0) {
-                  int numPosParams =
-                      pyCallInstr.getNumberOfPositionalParameters() - 1; // Exclude function.
-                  if (paramPos < numPosParams) {
-                    argValNum =
-                        pyCallInstr.getUse(paramPos + 1); // Positional arguments start at index 1.
-                  }
-                }
-              }
-
-              if (argValNum > 0) {
-                PointerKey argPk =
-                    builder
-                        .getPointerAnalysis()
-                        .getHeapModel()
-                        .getPointerKeyForLocal(caller, argValNum);
-                OrdinalSet<InstanceKey> argPts = builder.getPointerAnalysis().getPointsToSet(argPk);
-                if (argPts != null && !argPts.isEmpty()) {
-                  combinedPts = OrdinalSet.unify(combinedPts, argPts);
-                  found = true;
-                }
-              }
+          if (argValNum > 0) {
+            PointerKey argPk =
+                builder
+                    .getPointerAnalysis()
+                    .getHeapModel()
+                    .getPointerKeyForLocal(caller, argValNum);
+            OrdinalSet<InstanceKey> argPts = builder.getPointerAnalysis().getPointsToSet(argPk);
+            if (argPts != null && !argPts.isEmpty()) {
+              combinedPts = OrdinalSet.unify(combinedPts, argPts);
+              found = true;
             }
           }
         }
@@ -3149,22 +3072,12 @@ public abstract class TensorGenerator {
       return call.getKeywords().contains(paramName);
     }
 
-    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
-    if (cs == null || cs.getCallSiteRefs().length == 0) return false;
-
-    CallSiteReference siteReference = cs.getCallSiteRefs()[0];
-
-    for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
-        it.hasNext(); ) {
-      CGNode caller = it.next();
-      SSAAbstractInvokeInstruction[] calls = caller.getIR().getCalls(siteReference);
-
-      for (SSAAbstractInvokeInstruction callInstr : calls) {
-        if (callInstr instanceof PythonInvokeInstruction) {
-          PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
-          if (pyCallInstr.getKeywords().contains(paramName)) {
-            return true;
-          }
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      if (callerInvoke.snd instanceof PythonInvokeInstruction) {
+        PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callerInvoke.snd;
+        if (pyCallInstr.getKeywords().contains(paramName)) {
+          return true;
         }
       }
     }
@@ -3216,34 +3129,19 @@ public abstract class TensorGenerator {
       return ret;
     }
 
-    CallString cs = (CallString) this.getNode().getContext().get(CALL_STRING);
-    if (cs == null || cs.getCallSiteRefs().length == 0) return ret;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      SSAAbstractInvokeInstruction callInstr = callerInvoke.snd;
+      LOGGER.finest(() -> "Call instruction: " + callInstr + ".");
 
-    CallSiteReference siteReference = cs.getCallSiteRefs()[0];
-    LOGGER.fine(() -> "Analyzing call site: " + siteReference + ".");
+      if (callInstr instanceof PythonInvokeInstruction) {
+        PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
+        int numKeywords = pyCallInstr.getKeywords() != null ? pyCallInstr.getKeywords().size() : 0;
+        int numberOfPositionalParameters =
+            pyCallInstr.getNumberOfUses() - 1 - numKeywords; // Exclude the function name and
+        // keywords.
 
-    for (Iterator<CGNode> it = builder.getCallGraph().getPredNodes(this.getNode());
-        it.hasNext(); ) {
-      CGNode caller = it.next();
-      LOGGER.fine(() -> "Analyzing caller node: " + caller.getMethod().getSignature() + ".");
-
-      SSAAbstractInvokeInstruction[] calls = caller.getIR().getCalls(siteReference);
-      LOGGER.finest(() -> "Number of calls at this site: " + calls.length + ".");
-
-      for (SSAAbstractInvokeInstruction callInstr : calls) {
-        LOGGER.finest(() -> "Call instruction: " + callInstr + ".");
-
-        if (callInstr instanceof PythonInvokeInstruction) {
-          PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
-          int numKeywords =
-              pyCallInstr.getKeywords() != null ? pyCallInstr.getKeywords().size() : 0;
-          int numberOfPositionalParameters =
-              pyCallInstr.getNumberOfUses()
-                  - 1
-                  - numKeywords; // Exclude the function name and keywords.
-
-          ret.add(numberOfPositionalParameters);
-        }
+        ret.add(numberOfPositionalParameters);
       }
     }
 

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/client/PythonAnalysisEngine.java
@@ -25,9 +25,9 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonConstructorTargetSelector;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonInstanceMethodTrampolineTargetSelector;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonScopeMappingInstanceKeys;
+import com.ibm.wala.cast.python.ipa.callgraph.TrampolineReceiverContextSelector;
 import com.ibm.wala.cast.python.ipa.summaries.BuiltinFunctions;
 import com.ibm.wala.cast.python.ipa.summaries.PythonComprehensionTrampolines;
-import com.ibm.wala.cast.python.ipa.summaries.PythonConstructorFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
@@ -38,7 +38,6 @@ import com.ibm.wala.cast.python.loader.PythonLoaderFactory;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.cast.util.Util;
-import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IField;
@@ -51,10 +50,7 @@ import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
-import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.ClassTargetSelector;
-import com.ibm.wala.ipa.callgraph.Context;
-import com.ibm.wala.ipa.callgraph.ContextSelector;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
@@ -93,7 +89,6 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.WalaRuntimeException;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.intset.IntSet;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -938,7 +933,7 @@ public abstract class PythonAnalysisEngine<T>
     builder.setContextInterpreter(interpreter);
 
     builder.setContextSelector(
-        new ConstructorContextSelector(
+        new TrampolineReceiverContextSelector(
             new nCFAContextSelector(1, new ContextInsensitiveSelector())));
 
     builder.setInstanceKeys(
@@ -954,41 +949,6 @@ public abstract class PythonAnalysisEngine<T>
   protected PythonSSAPropagationCallGraphBuilder makeBuilder(
       IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     return new PythonSSAPropagationCallGraphBuilder(cha, options, cache, new AstCFAPointerKeys());
-  }
-
-  /**
-   * Dispatches calls made <em>from</em> a synthesized constructor ({@link
-   * PythonConstructorFunction}) in the constructor's own calling context. The constructor body has
-   * a single internal {@code __init__} call site, so the base call-string selector collapses every
-   * construction of a class into one {@code __init__} context, unioning argument values across
-   * construction sites; inheriting the constructor's context keeps them apart (<a
-   * href="https://github.com/wala/ML/issues/671">wala/ML#671</a>).
-   */
-  private static class ConstructorContextSelector implements ContextSelector {
-
-    /** The selector handling every other call. */
-    private final ContextSelector base;
-
-    /**
-     * Constructs a {@link ConstructorContextSelector}.
-     *
-     * @param base The selector handling every other call.
-     */
-    ConstructorContextSelector(ContextSelector base) {
-      this.base = base;
-    }
-
-    @Override
-    public Context getCalleeTarget(
-        CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
-      if (caller.getMethod() instanceof PythonConstructorFunction) return caller.getContext();
-      return base.getCalleeTarget(caller, site, callee, actualParameters);
-    }
-
-    @Override
-    public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
-      return base.getRelevantParameters(caller, site);
-    }
   }
 
   public abstract T performAnalysis(PropagationCallGraphBuilder builder) throws CancelException;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -23,6 +23,7 @@ import com.ibm.wala.cast.ipa.callgraph.GlobalObjectKey;
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
 import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
 import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.ssa.ForElementGetInstruction;
 import com.ibm.wala.cast.python.ssa.PythonBinaryOpInstruction;
@@ -38,8 +39,12 @@ import com.ibm.wala.fixpoint.AbstractOperator;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.ContextItem;
+import com.ibm.wala.ipa.callgraph.ContextKey;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.propagation.AbstractFieldPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.FilteredPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.FilteredPointerKey.TypeFilter;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
@@ -766,7 +771,17 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
               && refersToAnObject(rval)) {
             // Ensure that lval's variable refers to the callable method instead of callable object,
             // precisely linking the object to its trampoline using the `__call__` (or similar)
-            // field.
+            // field. When the target is a trampoline keyed on a receiver instance (wala/ML#679),
+            // link only that receiver's field; the site's other receivers dispatch to their own
+            // trampoline nodes. Non-trampoline targets may inherit a receiver-keyed context whose
+            // instance is unrelated to this site's receivers, so they are not restricted.
+            ContextItem receiverItem =
+                target.getMethod().getDeclaringClass() instanceof PythonInstanceMethodTrampoline
+                    ? target.getContext().get(ContextKey.RECEIVER)
+                    : null;
+            InstanceKey contextReceiver =
+                receiverItem instanceof InstanceKey ? (InstanceKey) receiverItem : null;
+
             IClassHierarchy cha = getClassHierarchy();
 
             Atom[] possibleFields = {
@@ -786,6 +801,8 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
                               .foreach(
                                   i -> {
                                     InstanceKey ik = getSystem().getInstanceKey(i);
+                                    if (contextReceiver != null && !contextReceiver.equals(ik))
+                                      return;
 
                                     for (Atom fieldName : possibleFields) {
                                       FieldReference fieldRef =
@@ -824,7 +841,14 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
                     },
                     new PointerKey[] {rval});
           } else {
-            getSystem().newConstraint(lval, assignOperator, rval);
+            // A receiver-keyed target (wala/ML#679) filters the dispatched parameter to the
+            // context's receiver instance; every other target binds the full argument set.
+            PointerKey formal = i == 0 ? getReceiverFilteredPointerKey(target, lval) : lval;
+            getSystem()
+                .newConstraint(
+                    formal,
+                    formal instanceof FilteredPointerKey ? filterOperator : assignOperator,
+                    rval);
           }
         }
       }
@@ -887,6 +911,28 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
       PointerKey leret = getPointerKeyForLocal(caller, call.getException());
       getSystem().newConstraint(leret, assignOperator, reret);
     }
+  }
+
+  /**
+   * Returns the {@link PointerKey} to bind for the given target's dispatched (position-0)
+   * parameter, honoring a receiver filter the target's context carries (<a
+   * href="https://github.com/wala/ML/issues/679">wala/ML#679</a>). The filter applies only to
+   * trampoline targets: their first parameter <em>is</em> the dispatched object the context is
+   * keyed on. A real method body inheriting a per-receiver context has the same context item, but
+   * its first parameter is the function object, which the receiver filter would wrongly empty.
+   *
+   * @param target The callee {@link CGNode}.
+   * @param dflt The unfiltered {@link PointerKey} for the target's first parameter.
+   * @return A {@link FilteredPointerKey} restricted to the context's receiver when the target is a
+   *     trampoline whose context supplies a parameter-0 filter; otherwise {@code dflt}.
+   */
+  private PointerKey getReceiverFilteredPointerKey(CGNode target, PointerKey dflt) {
+    if (!(target.getMethod().getDeclaringClass() instanceof PythonInstanceMethodTrampoline))
+      return dflt;
+    TypeFilter filter = (TypeFilter) target.getContext().get(ContextKey.PARAMETERS[0]);
+    if (filter != null && !filter.isRootFilter())
+      return getFilteredPointerKeyForLocal(target, 1, filter);
+    return dflt;
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/TrampolineReceiverContextSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/TrampolineReceiverContextSelector.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.cast.python.ipa.callgraph;
+
+import com.ibm.wala.cast.python.ipa.summaries.PythonConstructorFunction;
+import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
+import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.Context;
+import com.ibm.wala.ipa.callgraph.ContextKey;
+import com.ibm.wala.ipa.callgraph.ContextSelector;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.ReceiverInstanceContext;
+import com.ibm.wala.ipa.callgraph.propagation.cfa.CallerSiteContext;
+import com.ibm.wala.ipa.callgraph.propagation.cfa.CallerSiteContextPair;
+import com.ibm.wala.util.intset.IntSet;
+import java.util.logging.Logger;
+
+/**
+ * Keeps per-receiver state separate through Python's method-trampoline dispatch (<a
+ * href="https://github.com/wala/ML/issues/679">wala/ML#679</a>).
+ *
+ * <p>All instances of a class share one trampoline method per arity, so a call-string context
+ * collapses every receiver into a single trampoline node whose {@code $self} unions the instances —
+ * and every method body reached through it (e.g., the Keras lazy {@code build}) unions per-instance
+ * state across receivers. Call strings cannot repair this at any depth because they key on the
+ * caller's <em>method</em>, not its node.
+ *
+ * <p>The selector applies four rules, in order, before delegating to the base selector:
+ *
+ * <ol>
+ *   <li>calls made from a synthesized constructor ({@link PythonConstructorFunction}) inherit the
+ *       constructor's context, keeping per-construction-site argument values separate (<a
+ *       href="https://github.com/wala/ML/issues/671">wala/ML#671</a>);
+ *   <li>a trampoline callee ({@link PythonInstanceMethodTrampoline}) is keyed on the dispatched
+ *       receiver instance, paired with the calling node and site so distinct call sites of one
+ *       instance also stay separate (<a
+ *       href="https://github.com/wala/ML/issues/530">wala/ML#530</a>);
+ *   <li>the real method body dispatched from a per-receiver trampoline node inherits the
+ *       trampoline's context, since a call string would re-collapse it;
+ *   <li>any other call made from a receiver-keyed node is keyed on the calling node and site, so
+ *       per-receiver state survives one hop beyond the receiver context — in particular the
+ *       constructors (synthesized or XML-summary) allocating sublayers in the Keras lazy {@code
+ *       build}, and the summary methods those sublayers dispatch.
+ * </ol>
+ *
+ * <p>Termination: receiver contexts do not chain unboundedly. Dispatching on a receiver already
+ * recorded in the caller's context reuses the caller's context, and {@link #MAX_RECEIVER_DEPTH}
+ * caps the caller-pair chain as a backstop against mutually recursive dispatch across distinct
+ * instances. Rule 4 fires only for receiver-keyed callers, whose contexts rule 2's guards bound.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TrampolineReceiverContextSelector implements ContextSelector {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(TrampolineReceiverContextSelector.class.getName());
+
+  /**
+   * Maximum depth of nested caller-pair contexts before receiver keying degrades to context
+   * inheritance. A backstop against unbounded context towers under mutually recursive dispatch
+   * across distinct instances; ordinary layer nesting stays far below it.
+   */
+  private static final int MAX_RECEIVER_DEPTH = 8;
+
+  /** The selector handling every other call. */
+  private final ContextSelector base;
+
+  /**
+   * Constructs a {@link TrampolineReceiverContextSelector}.
+   *
+   * @param base The selector handling every other call.
+   */
+  public TrampolineReceiverContextSelector(ContextSelector base) {
+    this.base = base;
+  }
+
+  @Override
+  public Context getCalleeTarget(
+      CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
+    // Calls made from a synthesized constructor inherit its context (wala/ML#671).
+    if (caller.getMethod() instanceof PythonConstructorFunction) return caller.getContext();
+
+    // A trampoline callee is keyed on the dispatched receiver instance (wala/ML#679).
+    if (callee.getDeclaringClass() instanceof PythonInstanceMethodTrampoline
+        && actualParameters != null
+        && actualParameters.length > 0
+        && actualParameters[0] != null) {
+      InstanceKey receiver = actualParameters[0];
+
+      // Recursive dispatch on the caller's own receiver: reuse the caller's context so
+      // self-recursive methods do not grow the context.
+      if (receiver.equals(caller.getContext().get(ContextKey.RECEIVER))) return caller.getContext();
+
+      if (receiverDepth(caller) >= MAX_RECEIVER_DEPTH) {
+        LOGGER.fine(
+            () ->
+                "Receiver-context depth cap reached at caller: "
+                    + caller
+                    + "; inheriting instead of keying on receiver: "
+                    + receiver
+                    + ".");
+        return caller.getContext();
+      }
+
+      LOGGER.fine(() -> "Keying trampoline: " + callee + " on receiver: " + receiver + ".");
+      return new CallerSiteContextPair(caller, site, new ReceiverInstanceContext(receiver));
+    }
+
+    // The real method body dispatched from a per-receiver trampoline node stays per-receiver.
+    if (caller.getMethod().getDeclaringClass() instanceof PythonInstanceMethodTrampoline)
+      return caller.getContext();
+
+    // Calls made from a receiver-keyed method body are keyed on the calling node and site, so
+    // per-receiver state (e.g., sublayers constructed in the Keras lazy build, whether by a
+    // synthesized source-class constructor or an XML-summary one) stays separate one hop beyond
+    // the receiver context. The caller-site keying is PAIRED with the base selector's context so
+    // the call-string machinery keeps extending below this hop — a bare caller-site context
+    // carries no call string, and the sub-layer helpers underneath would collapse harder than
+    // under plain call strings. The pair's own key carries no receiver, so this deepens the
+    // receiver distinction by exactly one hop and cannot chain.
+    if (caller.getContext().get(ContextKey.RECEIVER) != null) {
+      Context baseContext = base.getCalleeTarget(caller, site, callee, actualParameters);
+      return baseContext == null
+          ? new CallerSiteContext(caller, site)
+          : new CallerSiteContextPair(caller, site, baseContext);
+    }
+
+    return base.getCalleeTarget(caller, site, callee, actualParameters);
+  }
+
+  @Override
+  public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
+    return base.getRelevantParameters(caller, site);
+  }
+
+  /**
+   * Returns the depth of the caller-pair context chain rooted at the given node.
+   *
+   * @param node The node whose context chain to measure.
+   * @return The number of {@link CallerSiteContext} links reachable by walking callers from the
+   *     given node's context, up to {@link #MAX_RECEIVER_DEPTH}.
+   */
+  private static int receiverDepth(CGNode node) {
+    int depth = 0;
+    Context c = node.getContext();
+    while (depth < MAX_RECEIVER_DEPTH && c instanceof CallerSiteContext) {
+      CGNode caller = ((CallerSiteContext) c).getCaller();
+      c = caller.getContext();
+      depth++;
+    }
+    return depth;
+  }
+}


### PR DESCRIPTION
Closes wala/ML#679.

## Problem

All instances of a class share one trampoline method per arity, so a call-string context collapses every receiver into a single trampoline node whose `$self` unions the instances—and every method body reached through it (the Keras lazy `build`, `call`) unions per-instance state across receivers. Call strings cannot repair this at any depth because they key on the caller's method, not its node. In the `gcn_chain_proj` fixture, both `GCN` instances' `build` bodies shared one `Dense`, unioning `units={8, 16}` and typing `hidden` as `{(4, 16), (4, 8)}` where the runtime is exactly `(4, 16)`.

## Fix

A new `TrampolineReceiverContextSelector`, installed outermost in both `PythonAnalysisEngine` and `PythonTensorAnalysisEngine`, applies four ordered rules:
1. calls from a synthesized constructor inherit its context (hoists wala/ML#671's `ConstructorContextSelector`, which is removed);
2. a trampoline callee is keyed on the dispatched receiver instance via `ReceiverInstanceContext`, paired with the calling node/site so distinct call sites of one instance stay separate (preserves wala/ML#530);
3. the real method body dispatched from a per-receiver trampoline node inherits the trampoline's context;
4. any other call from a receiver-keyed node is keyed on the calling node/site, paired with the base selector's context so call strings keep extending below that hop.

Termination: dispatching on the caller's own receiver reuses the caller's context (self-recursion), and a depth cap backstops mutually recursive dispatch across distinct instances.

`PythonSSAPropagationCallGraphBuilder.processCallingConstraints` now honors the context's `SingleInstanceFilter` on the dispatched parameter of trampoline targets and links only the context receiver's callable field in the trampoline side-effect.

The ml generators' caller walks (`TensorGenerator`, `ModelCall`, `Range`) previously matched `CALL_STRING` frames against predecessors; receiver-keyed contexts carry no call string, so they now walk call-graph edges directly (`getCallerInvokes` via `getPossibleSites`), which is context-shape-agnostic and strictly more precise.

The test helper's tensor-parameter count/vn assertions now compare the union across contexts, mirroring the existing function-variable framing: finer contexts mean not every context sees every tensor argument, but the source-level property is per parameter position.

## Test Changes

- `testGcnChainConsume`: the spurious `(4, 8)` is gone; pins `{(4, 16) float32, ? of float32}`—the residual member is the statically-dead `outputs += features` branch, filed as wala/ML#681.
- `testModelCallMultiModelWrapped`/`2` and `testModelAttributesMultiModelWrapped`/`2`: flipped to their own TODO-documented precise per-model expectations.
- `testVendoredLayerNorm`, `testCollectionProbeVendoredConv1d`: unions tightened (dropped shapeless-dtypeless member; recovered float32).
- `testCollectionProbeVendoredForward`, `testGpt2GetLossVendored`: spurious `(?, ?, 4)`/`(?, ?, 12)` constructor-collapse members gone and the runtime-true `(?, ?, 10)` kept, but the concrete float32 member degrades to `? of float32` in decoder-stack propagation—filed as wala/ML#682 with TODOs.

Full suite: 981/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc