### PR TITLE
Probe the wala/ML#684 subject shape

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10667,6 +10667,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Probe for <a href="https://github.com/wala/ML/issues/684">wala/ML#684</a>: {@code tf} arrives
+   * through {@code from helpers import *} in a script with no direct tensorflow import, and is read
+   * inside a name-mangled {@code @staticmethod} of a {@code tf.keras.Model} subclass invoked
+   * self-qualified — the subject's {@code MusicTransformer.__prepare_train_data} shape, several
+   * levels deeper than {@link #testCollectionProbeWildcardTf()}'s script-level read. The wildcard
+   * binding resolves and the shape is concrete; the dtype is float32 rather than the runtime int32
+   * because the {@code dtype=y.dtype} attribute argument is not consumed.
+   *
+   * <p>TODO: Expect {@code (2, 1) int32} once <a
+   * href="https://github.com/wala/ML/issues/686">wala/ML#686</a> consumes dtype arguments that read
+   * another tensor's {@code dtype} attribute.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testWildcardMethodTf()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"wildcard_proj/helpers.py", "wildcard_proj/tf2_test_wildcard_method_tf.py"},
+        "tf2_test_wildcard_method_tf.py",
+        "consume",
+        "wildcard_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 1))));
+  }
+
+  /**
    * Pins the vendored {@code LayerNormalization} forward result: {@code add_weight}-created {@code
    * gamma}/{@code beta} dispatch (wala/ML#595, wala/ML#618) and the normalization body types.
    * Receiver-keyed contexts (wala/ML#679) dropped the shapeless-and-dtypeless union member, so the

--- a/com.ibm.wala.cast.python.test/data/wildcard_proj/tf2_test_wildcard_method_tf.py
+++ b/com.ibm.wala.cast.python.test/data/wildcard_proj/tf2_test_wildcard_method_tf.py
@@ -1,0 +1,34 @@
+# Probe for wala/ML#684: this script never imports tensorflow directly; `tf` arrives through
+# `from helpers import *` (a wildcard re-export of an import binding) and is read inside a
+# name-mangled @staticmethod of a keras.Model subclass, called self-qualified — the subject's
+# `MusicTransformer.__prepare_train_data` shape.
+from helpers import *
+
+
+class M(tf.keras.Model):
+    def __init__(self, **kwargs):
+        super(M, self).__init__(**kwargs)
+
+    def call(self, inputs, is_training=True):
+        return inputs
+
+    @staticmethod
+    def __prepare_train_data(y):
+        start_token = tf.ones((2, 1), dtype=y.dtype) * 3
+        return start_token
+
+    def prep(self, y):
+        return self.__prepare_train_data(y)
+
+
+def consume(t):
+    pass
+
+
+m = M()
+y = tf.ones((2, 4), dtype=tf.int32)
+out = m.prep(y)
+consume(out)
+
+assert out.shape == (2, 1)
+assert out.dtype == tf.int32


### PR DESCRIPTION
Does not close wala/ML#684; files and pins wala/ML#686.

Fixture-scale probe of wala/ML#684's wildcard-mediated `tf` binding at the subject's exact shape: a name-mangled `@staticmethod` of a `tf.keras.Model` subclass whose script has no direct tensorflow import (`MusicTransformer.__prepare_train_data`'s form). The binding resolves and the shape is concrete—no reproduction of the whole-project empty points-to set (triage on the issue)—so `testWildcardMethodTf` pins the shape as a positive guard.

The probe exposed wala/ML#686: the `dtype=y.dtype` attribute argument is not consumed, so the result types `(2, 1) float32` where the runtime is `int32`; the guard pins the observed dtype with a TODO referencing it.

Full suite: 982/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc