### PR TITLE
Wire the dataset-distribution objects on the functional-API default strategy

### DIFF
--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2401,6 +2401,11 @@
           <new def="runObj" class="Ltensorflow/distribute/run/run"/>
           <putfield class="LRoot" field="run" fieldType="LRoot" ref="ds" value="runObj"/>
           <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="ds" value="runObj"/>
+          <new def="ddffObj" class="Ltensorflow/distribute/run/distribute_datasets_from_function"/>
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="ds" value="ddffObj"/>
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="ds" value="ddffObj"/>
+          <new def="eddObj" class="Ltensorflow/distribute/run/experimental_distribute_dataset"/>
+          <putfield class="LRoot" field="experimental_distribute_dataset" fieldType="LRoot" ref="ds" value="eddObj"/>
           <putfield class="LRoot" field="_distribution_strategy" fieldType="LRoot" ref="res" value="ds"/>
           <putfield class="LRoot" field="distribute_strategy" fieldType="LRoot" ref="res" value="ds"/>
           <return value="res"/>


### PR DESCRIPTION
Follow-up to ponder-lab/ML#523 (wala/ML#683): the merge queue landed the PR before this review-requested commit was pushed. The functional-API `Model(inputs, outputs)` constructor's synthesized default strategy now wires `distribute_datasets_from_function`/`experimental_distribute_datasets_from_function` and `experimental_distribute_dataset` in addition to `run`/`experimental_run_v2`, matching the shell `Model.__init__` and the strategy constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc