### PR TITLE
Pin both wala/ML#687 import-form probes as positive guards

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10644,6 +10644,71 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Control half of the <a href="https://github.com/wala/ML/issues/687">wala/ML#687</a> MRE: the
+   * sibling script's Keras layer reached through {@code from B import Padding2D} analyzes fully —
+   * the layer call's result types concretely.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testImportFrom()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"importmod_proj/B.py", "importmod_proj/tf2_test_import_from.py"},
+        "B.py",
+        "Padding2D.call",
+        "importmod_proj",
+        1,
+        1,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        DynamicDim.INSTANCE,
+                        new NumericDim(32),
+                        new NumericDim(32),
+                        new NumericDim(3))))));
+  }
+
+  /**
+   * Reported-failing half of the <a href="https://github.com/wala/ML/issues/687">wala/ML#687</a>
+   * MRE: the byte-identical layer reached through a plain {@code import B} module object. On
+   * current master both import forms behave identically — {@code Padding2D.call} gets its node and
+   * {@code x} types concretely — so this pins the plain-import form as a positive guard.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testImportModule()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"importmod_proj/B.py", "importmod_proj/tf2_test_import_module.py"},
+        "B.py",
+        "Padding2D.call",
+        "importmod_proj",
+        1,
+        1,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        DynamicDim.INSTANCE,
+                        new NumericDim(32),
+                        new NumericDim(32),
+                        new NumericDim(3))))));
+  }
+
+  /**
    * Pins wala/ML#665: {@code tf} reached through {@code from helpers import *} binds, matching
    * Python's wildcard semantics (every public module-level name is exported, including modules the
    * source module imported).

--- a/com.ibm.wala.cast.python.test/data/importmod_proj/B.py
+++ b/com.ibm.wala.cast.python.test/data/importmod_proj/B.py
@@ -1,0 +1,8 @@
+# wala/ML#687 MRE: a sibling script module imported by A-variants.
+import tensorflow as tf
+import tensorflow.keras as keras
+
+
+class Padding2D(keras.layers.Layer):
+    def call(self, x):
+        return tf.pad(x, [[0, 0], [1, 1], [1, 1], [0, 0]], mode="symmetric")

--- a/com.ibm.wala.cast.python.test/data/importmod_proj/tf2_test_import_from.py
+++ b/com.ibm.wala.cast.python.test/data/importmod_proj/tf2_test_import_from.py
@@ -1,0 +1,15 @@
+# wala/ML#687 control: the same class reached through `from B import Padding2D`.
+import tensorflow.keras as keras
+
+from B import Padding2D
+
+
+def consume(t):
+    pass
+
+
+input_node = keras.layers.Input(shape=(32, 32, 3))
+pad = Padding2D()(input_node)
+consume(pad)
+
+assert pad.shape.as_list() == [None, 34, 34, 3]

--- a/com.ibm.wala.cast.python.test/data/importmod_proj/tf2_test_import_module.py
+++ b/com.ibm.wala.cast.python.test/data/importmod_proj/tf2_test_import_module.py
@@ -1,0 +1,15 @@
+# wala/ML#687 MRE: the class is reached through a plain `import B` module object.
+import tensorflow.keras as keras
+
+import B
+
+
+def consume(t):
+    pass
+
+
+input_node = keras.layers.Input(shape=(32, 32, 3))
+pad = B.Padding2D()(input_node)
+consume(pad)
+
+assert pad.shape.as_list() == [None, 34, 34, 3]


### PR DESCRIPTION
Does not close wala/ML#687 (triage on the issue).

Vendors the wala/ML#687 MRE (`importmod_proj`: `B.py` defining a Keras layer, plus the plain-`import B` and `from B import Padding2D` A-variants) and pins both import forms as positive guards: in each, `Padding2D.call` gets its call-graph node and its `x` parameter types concretely as `(?, 32, 32, 3) float32`. Since the plain-import binding is sound at MRE scale on master, the reported whole-project divide points at the configuration/module-resolution axis—consistent with the issue's 2024 machine-dependence observation and the wala/ML#684 pattern.

Full suite: 983/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc