### PR TITLE
Consume allocator dtype arguments that read another tensor's dtype attribute

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10829,12 +10829,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * inside a name-mangled {@code @staticmethod} of a {@code tf.keras.Model} subclass invoked
    * self-qualified — the subject's {@code MusicTransformer.__prepare_train_data} shape, several
    * levels deeper than {@link #testCollectionProbeWildcardTf()}'s script-level read. The wildcard
-   * binding resolves and the shape is concrete; the dtype is float32 rather than the runtime int32
-   * because the {@code dtype=y.dtype} attribute argument is not consumed.
-   *
-   * <p>TODO: Expect {@code (2, 1) int32} once <a
-   * href="https://github.com/wala/ML/issues/686">wala/ML#686</a> consumes dtype arguments that read
-   * another tensor's {@code dtype} attribute.
+   * binding resolves, the shape is concrete, and the {@code dtype=y.dtype} attribute argument is
+   * consumed (wala/ML#686), so the result is the runtime-true {@code (2, 1) int32}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10851,7 +10847,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "wildcard_proj",
         1,
         1,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 1))));
+        Map.of(2, Set.of(TensorType.of(INT_32, 2, 1))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2735,6 +2735,63 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Dtype twin of {@link #getShapeFromShapeAttributeArgument(PropagationCallGraphBuilder, int,
+   * String)}: recovers an allocator's dtype when its dtype argument is another tensor's {@code
+   * .dtype} (e.g. {@code tf.ones((2, 1), dtype=y.dtype)}). Such an argument is a {@link
+   * PythonPropertyRead} of member {@code "dtype"} whose points-to set is empty, so ordinary dtype
+   * resolution falls through to {@link #getDefaultDTypes}; this resolves the dtype of the
+   * underlying tensor instead of taking the allocator's default (<a
+   * href="https://github.com/wala/ML/issues/686">wala/ML#686</a>).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param paramPos The 0-based positional index of the dtype parameter (excluding {@code self}).
+   * @param paramName The dtype parameter's keyword name, or {@code null}.
+   * @return The union of the source tensors' dtypes, or {@code null} if no {@code .dtype} argument
+   *     is found or none resolves.
+   */
+  protected Set<DType> getDTypeFromDTypeAttributeArgument(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    Set<DType> combined = null;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) continue;
+      SSAInstruction def = caller.getDU().getDef(argVn);
+      if (!(def instanceof PythonPropertyRead)) continue;
+      PythonPropertyRead propRead = (PythonPropertyRead) def;
+      SymbolTable st = caller.getIR().getSymbolTable();
+      int memberVn = propRead.getMemberRef();
+      if (!st.isStringConstant(memberVn) || !"dtype".equals(st.getStringValue(memberVn))) continue;
+      int tensorVn = propRead.getObjectRef();
+      try {
+        Set<DType> tensorDTypes = this.getDTypes(builder, caller, tensorVn);
+        if (tensorDTypes != null && !tensorDTypes.isEmpty()) {
+          if (combined == null) combined = EnumSet.noneOf(DType.class);
+          combined.addAll(tensorDTypes);
+        }
+      } catch (IllegalArgumentException e) {
+        // The source tensor's dtype couldn't be resolved; fall through to the default.
+        LOGGER.log(
+            Level.FINE,
+            "getDTypeFromDTypeAttributeArgument: could not resolve .dtype source tensorVn="
+                + tensorVn
+                + " in caller="
+                + caller,
+            e);
+      }
+    }
+    return combined;
+  }
+
+  /**
    * Dtype counterpart of {@link #getArgumentShapesViaCallers(PropagationCallGraphBuilder, int,
    * String)}. See that method for the rationale; the behaviour is the same but returns a set of
    * {@link DType}s resolved via {@link #getDTypes(PropagationCallGraphBuilder, CGNode, int)}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -55,6 +55,22 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    // Recovery: an allocator whose dtype argument is another tensor's `.dtype` (e.g.
+    // `tf.ones((2, 1), dtype=y.dtype)`) takes its dtype from that tensor. Resolve it rather than
+    // taking the float32 default. wala/ML#686.
+    Set<DType> fromDTypeAttribute =
+        this.getDTypeFromDTypeAttributeArgument(
+            builder, this.getDTypeParameterPosition(), this.getDTypeParameterName());
+    if (fromDTypeAttribute != null && !fromDTypeAttribute.isEmpty()) {
+      LOGGER.fine(
+          "Recovered allocator dtype from a `.dtype` argument for source: "
+              + source
+              + " -> "
+              + fromDTypeAttribute
+              + ".");
+      return fromDTypeAttribute;
+    }
+
     LOGGER.fine(
         "No dtype specified for source: " + source + ". Using default dtype of: " + FLOAT32 + " .");
 


### PR DESCRIPTION
Closes wala/ML#686.

`tf.ones((2, 1), dtype=y.dtype)` typed `(2, 1) float32` where the runtime is `int32`: a `dtype=` argument that is a property read of another tensor's `dtype` attribute has an empty points-to set, so dtype resolution fell through to the allocator's float32 default. The shape axis already had exactly this recovery (`getShapeFromShapeAttributeArgument`, for `tf.ones(x.shape)`); this adds the dtype twin.

- `TensorGenerator.getDTypeFromDTypeAttributeArgument`: walks the calling invocations, recognizes a `PythonPropertyRead` of constant member `dtype` in the dtype-argument position (keyword or positional), and delegates to the source tensor's dtypes.
- `TensorTypeAllocator.getDefaultDTypes` consults it before taking the float32 default, mirroring the shape-side hook.
- `testWildcardMethodTf` flips from the pinned float32 to the runtime-true `(2, 1) int32`, and its TODO is removed—resolving the runtime-assert-vs-pin divergence flagged on ponder-lab/ML#522.

Full suite: 987/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc