### PR TITLE
Resolve computed tuple members of mapped dataset elements at the SSA level

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1873,6 +1873,48 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Probe for <a href="https://github.com/wala/ML/issues/688">wala/ML#688</a>: a {@code map} stage
+   * returning a tuple, batched with a tuple {@code padded_shapes}, iterated with destructuring —
+   * the vendored gpt-2 {@code input_fn} element shape in miniature. Both halves type the
+   * runtime-true {@code (4, 3) int64} (batch 4, padded to the longest sequence): the computed
+   * second member resolves through the wala/ML#688 SSA fallback and the batch stage applies.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPaddedBatchPair()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_padded_batch_pair.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(DType.INT64, 4, 3))));
+  }
+
+  /**
+   * Sibling half of {@link #testPaddedBatchPair()} (wala/ML#688): the second tuple member.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPaddedBatchPair2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_padded_batch_pair.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(DType.INT64, 4, 3))));
+  }
+
+  /**
    * Pins the <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a> {@code
    * TuckERLoader.target_convert} row on the vendored subject: the loader is vendored verbatim from
    * {@code kyzhouhzau/NLPGNN} ({@code nlpgnn/datas/graphloader.py}); the driver, the tiny {@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 
+import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.classLoader.IField;
@@ -15,10 +16,18 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.ssa.SSAPutInstruction;
+import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -192,6 +201,19 @@ public class DatasetMapGenerator extends DatasetGenerator {
       Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, componentPTS);
       if (shapes != null && !shapes.isEmpty()) return shapes;
     }
+
+    // A computed tuple member (e.g. a binary-op result in `map_func`) has no allocation, so the
+    // tuple field's points-to set is empty; walk the callback's store into the field at the SSA
+    // level instead (wala/ML#688).
+    Set<List<Dimension<?>>> ssaShapes = HashSetFactory.make();
+    for (Pair<CGNode, Integer> componentValue :
+        getMappedElementComponentValueNumbers(builder, index)) {
+      Set<List<Dimension<?>>> shapes =
+          this.getShapes(builder, componentValue.fst, componentValue.snd);
+      if (shapes != null) ssaShapes.addAll(shapes);
+    }
+    if (!ssaShapes.isEmpty()) return ssaShapes;
+
     return super.getShapesForIndex(builder, index);
   }
 
@@ -202,6 +224,71 @@ public class DatasetMapGenerator extends DatasetGenerator {
       Set<DType> dtypes = this.getDTypesOfValue(builder, componentPTS);
       if (dtypes != null && !dtypes.isEmpty()) return dtypes;
     }
+
+    // The SSA fallback for computed tuple members; see getShapesForIndex (wala/ML#688).
+    Set<DType> ssaDTypes = EnumSet.noneOf(DType.class);
+    for (Pair<CGNode, Integer> componentValue :
+        getMappedElementComponentValueNumbers(builder, index)) {
+      Set<DType> dtypes = this.getDTypes(builder, componentValue.fst, componentValue.snd);
+      if (dtypes != null) ssaDTypes.addAll(dtypes);
+    }
+    if (!ssaDTypes.isEmpty()) return ssaDTypes;
+
     return super.getDTypesForIndex(builder, index);
+  }
+
+  /**
+   * Finds the SSA values stored into the given numeric field of the mapped element tuple, per
+   * containing node: for each tuple allocation flowing out of {@code map_func}, locates its
+   * allocation's definition and the instruction storing {@code <field index>} on it, and returns
+   * the stored value number. This recovers computed tuple members (binary-op results and other
+   * allocation-less values) whose points-to sets are empty (<a
+   * href="https://github.com/wala/ML/issues/688">wala/ML#688</a>).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for the analysis.
+   * @param index The tuple index whose stores to find.
+   * @return The (node, value number) pairs stored into the field; empty if none resolve.
+   */
+  private Set<Pair<CGNode, Integer>> getMappedElementComponentValueNumbers(
+      PropagationCallGraphBuilder builder, int index) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    OrdinalSet<InstanceKey> elementPTS = getMappedElementPointsToSet(builder);
+    if (elementPTS == null || elementPTS.isEmpty()) return ret;
+
+    String fieldName = String.valueOf(index);
+    for (InstanceKey ik : elementPTS) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin == null) continue;
+      CGNode node = asin.getNode();
+      IR ir = node.getIR();
+      if (ir == null) continue;
+
+      // Find the allocation's definition.
+      int allocVn = -1;
+      for (SSAInstruction inst : ir.getInstructions())
+        if (inst instanceof SSANewInstruction newInst
+            && newInst.getNewSite().equals(asin.getSite())) {
+          allocVn = newInst.getDef();
+          break;
+        }
+      if (allocVn < 0) continue;
+
+      // Find the stores into `<field index>` on that allocation.
+      for (SSAInstruction inst : ir.getInstructions()) {
+        if (inst instanceof SSAPutInstruction put
+            && !put.isStatic()
+            && put.getRef() == allocVn
+            && put.getDeclaredField().getName().toString().equals(fieldName))
+          ret.add(Pair.make(node, put.getVal()));
+        else if (inst instanceof AstPropertyWrite write && write.getObjectRef() == allocVn) {
+          SymbolTable symbolTable = ir.getSymbolTable();
+          int memberVn = write.getMemberRef();
+          if (symbolTable.isConstant(memberVn)
+              && fieldName.equals(String.valueOf(symbolTable.getConstantValue(memberVn))))
+            ret.add(Pair.make(node, write.getValue()));
+        }
+      }
+    }
+    return ret;
   }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_padded_batch_pair.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_padded_batch_pair.py
@@ -1,0 +1,30 @@
+# Probe for wala/ML#688: a map stage returning a tuple, batched with a tuple `padded_shapes`,
+# iterated with destructuring — the vendored gpt-2 `input_fn` element shape in miniature.
+import tensorflow as tf
+
+
+def add_labels(x):
+    return x, x + 1
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+dataset = tf.data.Dataset.from_tensor_slices(tf.ones((8, 3), dtype=tf.int64))
+dataset = dataset.map(add_labels)
+dataset = dataset.padded_batch(4, padded_shapes=([-1], [-1]))
+
+for x, y in dataset:
+    consume(x)
+    consume2(y)
+
+    assert x.shape == (4, 3)
+    assert y.shape == (4, 3)
+    assert x.dtype == tf.int64
+    assert y.dtype == tf.int64
+    break


### PR DESCRIPTION
Closes wala/ML#688.

A `map_func` returning a tuple with a computed member (e.g. `return x, x + 1`) lost that member entirely: binary-op results have no allocation, so the tuple field's points-to set is empty and `DatasetMapGenerator`'s per-index resolution found nothing—the destructured half typed `? of unknown` while its sibling (an allocation-backed upstream element) typed fully.

`DatasetMapGenerator` now adds an SSA-level fallback behind the points-to path: it locates each mapped tuple allocation in the callback's IR, finds the store into `<field index>` (both `SSAPutInstruction` and `AstPropertyWrite` forms), and types the stored value number via the standard `(node, vn)` resolution—which handles allocation-less values like elementwise results. The existing `DatasetBatchGenerator` per-index batching applies on top, so both halves of a `map → padded_batch → destructured iteration` pipeline now type the runtime-exact element.

`testPaddedBatchPair`/`testPaddedBatchPair2` pin the fixture (the vendored gpt-2 `input_fn` shape in miniature): both halves `(4, 3) int64`, where the computed half was full ⊤ before.

The vendored gpt-2 `real` itself is unchanged: its chain additionally routes through the `fit`-loop/`enumerate`/nested-unpacking forwarding, which is wala/ML#570's list-mediated residual (noted on the issue).

Full suite: 989/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc