### PR TITLE
Match tuple-index member constants that flow as ConstantKeys

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetMapGenerator.java
@@ -283,8 +283,11 @@ public class DatasetMapGenerator extends DatasetGenerator {
         else if (inst instanceof AstPropertyWrite write && write.getObjectRef() == allocVn) {
           SymbolTable symbolTable = ir.getSymbolTable();
           int memberVn = write.getMemberRef();
-          if (symbolTable.isConstant(memberVn)
-              && fieldName.equals(String.valueOf(symbolTable.getConstantValue(memberVn))))
+          // The member constant may live in the symbol table or flow as a ConstantKey through the
+          // points-to set; check both, mirroring TensorGeneratorFactory.constantMemberEquals.
+          if ((symbolTable.isConstant(memberVn)
+                  && fieldName.equals(String.valueOf(symbolTable.getConstantValue(memberVn))))
+              || TensorGeneratorFactory.constantMemberEquals(node, memberVn, index, builder))
             ret.add(Pair.make(node, write.getValue()));
         }
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -576,7 +576,7 @@ public class TensorGeneratorFactory {
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @return {@code true} iff the member reference is exactly the constant {@code index}.
    */
-  private static boolean constantMemberEquals(
+  static boolean constantMemberEquals(
       CGNode node, int memberRef, int index, PropagationCallGraphBuilder builder) {
     PointerKey memberKey =
         builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, memberRef);


### PR DESCRIPTION
Follow-up to ponder-lab/ML#527 (wala/ML#688), addressing the review note that landed after the queue merged: the SSA fallback's `AstPropertyWrite` branch matched the tuple-index member only when it is a `SymbolTable` constant, but member constants can also flow as `ConstantKey`s through the points-to set. The branch now checks both, reusing `TensorGeneratorFactory.constantMemberEquals` (relaxed to package-private).

Full suite: 989/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc