### PR TITLE
Add the subject wildcard package inits to the wala/ML#690 slice fixture

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1977,6 +1977,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test(
         new String[] {
           "nlpgnn_slice_proj/nlpgnn/__init__.py",
+          "nlpgnn_slice_proj/nlpgnn/callbacks.py",
           "nlpgnn_slice_proj/nlpgnn/models/__init__.py",
           "nlpgnn_slice_proj/nlpgnn/models/gpt2.py",
           "nlpgnn_slice_proj/nlpgnn/sample/__init__.py",
@@ -2010,6 +2011,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     test(
         new String[] {
           "nlpgnn_slice_proj/nlpgnn/__init__.py",
+          "nlpgnn_slice_proj/nlpgnn/callbacks.py",
           "nlpgnn_slice_proj/nlpgnn/models/__init__.py",
           "nlpgnn_slice_proj/nlpgnn/models/gpt2.py",
           "nlpgnn_slice_proj/nlpgnn/sample/__init__.py",

--- a/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/__init__.py
+++ b/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/__init__.py
@@ -1,1 +1,1 @@
-
+from .callbacks import *

--- a/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/callbacks.py
+++ b/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/callbacks.py
@@ -1,0 +1,6 @@
+# Miniature of NLPGNN's `nlpgnn/callbacks.py` (wala/ML#690): the wildcard-exported module the
+# package init pulls in.
+class EarlyStopping:
+    def __init__(self, monitor="loss", min_delta=0):
+        self.monitor = monitor
+        self.min_delta = min_delta

--- a/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/models/__init__.py
+++ b/com.ibm.wala.cast.python.test/data/nlpgnn_slice_proj/nlpgnn/models/__init__.py
@@ -1,1 +1,3 @@
-
+# Miniature of NLPGNN's `nlpgnn/models/__init__.py` (wala/ML#690): the package init
+# wildcard-imports every model module.
+from .gpt2 import *


### PR DESCRIPTION
Does not close wala/ML#690 (reproduction updates on the issue).

Raises the `nlpgnn_slice_proj` fixture's fidelity to the subject's package structure: `nlpgnn/__init__.py` performs `from .callbacks import *` and `nlpgnn/models/__init__.py` performs `from .gpt2 import *`, mirroring the real NLPGNN inits and putting the wala/ML#665 cross-module named-binding machinery in scope for the same-name-capture probes. Both slice guards still pass with both classes intact—another excluded axis, recorded on the issue along with the file-order-flip exclusion and the one-grep discriminator for the failing run's log.

Full suite: 991/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc