### PR TITLE
Bind plain imports of in-scope scripts order-independently

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10866,7 +10866,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testImportFrom()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        new String[] {"importmod_proj/B.py", "importmod_proj/tf2_test_import_from.py"},
+        new String[] {"importmod_proj/tf2_test_import_from.py", "importmod_proj/B.py"},
         "B.py",
         "Padding2D.call",
         "importmod_proj",
@@ -10886,9 +10886,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Reported-failing half of the <a href="https://github.com/wala/ML/issues/687">wala/ML#687</a>
-   * MRE: the byte-identical layer reached through a plain {@code import B} module object. On
-   * current master both import forms behave identically — {@code Padding2D.call} gets its node and
-   * {@code x} types concretely — so this pins the plain-import form as a positive guard.
+   * MRE: the byte-identical layer reached through a plain {@code import B} module object, with the
+   * importer passed <em>first</em> — the translation order that reproduced the loss before the
+   * scope-membership binding fix (<a href="https://github.com/wala/ML/issues/691">wala/ML#691</a>):
+   * the plain-import binding used to require the importee to be already translated.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10897,6 +10898,37 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    */
   @Test
   public void testImportModule()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"importmod_proj/tf2_test_import_module.py", "importmod_proj/B.py"},
+        "B.py",
+        "Padding2D.call",
+        "importmod_proj",
+        1,
+        1,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        DynamicDim.INSTANCE,
+                        new NumericDim(32),
+                        new NumericDim(32),
+                        new NumericDim(3))))));
+  }
+
+  /**
+   * Importee-first twin of {@link #testImportModule()} (wala/ML#691): the previously-working
+   * translation order, guarded so both orders stay equivalent.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testImportModuleImporteeFirst()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
         new String[] {"importmod_proj/B.py", "importmod_proj/tf2_test_import_module.py"},

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -1108,7 +1108,13 @@ public class PythonCAstToIRTranslator extends AstTranslator {
       currentPosition = context.getSourceMap().getPosition(primitiveCall);
       // System.err.println("&&&&& switched to " + currentPosition);
 
-      if (loader.lookupClass(TypeName.findOrCreate("Lscript " + name + ".py")) != null) {
+      // The binding decision must be order-independent: `lookupClass` succeeds only for scripts
+      // already translated, so an importer translated before its importee silently fell through
+      // to the (nonexistent) library-import path and the module never bound (wala/ML#691). The
+      // scope-name check decides by what the analysis scope CONTAINS, not by translation order.
+      if (loader.lookupClass(TypeName.findOrCreate("Lscript " + name + ".py")) != null
+          || (loader instanceof PythonLoader pythonLoader
+              && pythonLoader.definesScriptInScope(name + ".py"))) {
         FieldReference global = makeGlobalRef("script " + name + ".py");
         context.cfg().addInstruction(new AstGlobalRead(idx, resultVal, global));
       } else {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -54,10 +54,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("this-escape")
 public abstract class PythonLoader extends CAstAbstractModuleLoader {
+
+  private static final Logger LOGGER = Logger.getLogger(PythonLoader.class.getName());
 
   /**
    * Summary readers whose {@code <class name="..." super="...">} declarations should be
@@ -77,6 +80,13 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
   }
 
   /**
+   * The file names of the source modules in the analysis scope, collected before translation so
+   * cross-module references can be decided order-independently (<a
+   * href="https://github.com/wala/ML/issues/691">wala/ML#691</a>).
+   */
+  private final Set<String> scriptNamesInScope = HashSetFactory.make();
+
+  /**
    * {@inheritDoc}
    *
    * <p>Registers the summary-modeled class shells before translating source, so a source class
@@ -86,10 +96,48 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
    */
   @Override
   public void init(List<Module> modules) {
+    // Collect every source module's file name BEFORE any body is translated: the translator's
+    // plain-`import` binding decision must not depend on whether the imported script happens to
+    // have been translated already (wala/ML#691).
+    for (Module module : modules) module.getEntries().forEachRemaining(this::collectScriptNames);
+
     for (XMLMethodSummaryReader summaries : summaryClassShellReaders) {
       Util.addSummaryClassShells(this, summaries);
     }
     super.init(modules);
+  }
+
+  /**
+   * Collects the file names under the given module entry into {@link #scriptNamesInScope},
+   * recursing into nested modules (wala/ML#691).
+   *
+   * @param entry The module entry to collect from.
+   */
+  private void collectScriptNames(ModuleEntry entry) {
+    if (entry.isModuleFile())
+      entry.asModule().getEntries().forEachRemaining(this::collectScriptNames);
+    else {
+      String name = entry.getName();
+      LOGGER.fine("Collected script name in scope: " + name + " (wala/ML#691).");
+      scriptNamesInScope.add(name);
+      // Script class names are project-relative while module entry names may carry the project
+      // root as their first component; record the stripped form too so the translator's
+      // scope-membership check matches the naming the script classes will use.
+      int slash = name.indexOf('/');
+      if (slash >= 0) scriptNamesInScope.add(name.substring(slash + 1));
+    }
+  }
+
+  /**
+   * Returns whether a source module with the given file name is in the analysis scope, regardless
+   * of whether it has been translated yet (<a
+   * href="https://github.com/wala/ML/issues/691">wala/ML#691</a>).
+   *
+   * @param fileName The script file name as it appears in the scope (e.g. {@code B.py}).
+   * @return {@code true} iff a source module with that file name is in scope.
+   */
+  public boolean definesScriptInScope(String fileName) {
+    return scriptNamesInScope.contains(fileName);
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -118,7 +118,7 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
       entry.asModule().getEntries().forEachRemaining(this::collectScriptNames);
     else {
       String name = entry.getName();
-      LOGGER.fine("Collected script name in scope: " + name + " (wala/ML#691).");
+      LOGGER.fine(() -> "Collected script name in scope: " + name + " (wala/ML#691).");
       scriptNamesInScope.add(name);
       // Script class names are project-relative while module entry names may carry the project
       // root as their first component; record the stripped form too so the translator's


### PR DESCRIPTION
## Problem

`PythonCAstToIRTranslator.doPrimitive`'s plain-import branch (`import B`) decides between a script global read and a synthetic library import by whether `loader.lookupClass("Lscript <name>.py")` already resolves. That gate is translation-order-dependent: when the importer is translated before the importee, the importee's script class doesn't exist yet, so the import silently falls to the library-import path and the importee's toplevel definitions (e.g. a Keras `Layer` subclass) never bind — the importer's tensor flow through the imported module is lost. The from-import (3-child) branch has no such gate and works in either order.

## Fix

`PythonLoader` now collects the names of all scripts in the analysis scope up front (`collectScriptNames` over the module tree in `init`, before `super.init`), exposing `definesScriptInScope(String)`. The plain-import gate consults scope membership in addition to `lookupClass`, so an in-scope importee binds as a script global regardless of translation order.

## Tests

`testImportModule` now lists the importer first (the previously-failing order) and a `testImportModuleImporteeFirst` twin pins the previously-passing order, guarding the lookup both ways per the regression contract.

Closes wala/ML#691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc