### PR TITLE
Surface append-accumulated list contents at subscript reads

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10460,6 +10460,58 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Probe for the indexed sub-layer dispatch shape of <a
+   * href="https://github.com/wala/ML/issues/661">wala/ML#661</a>: a plain list of sublayers
+   * populated by {@code append} in {@code build}, dispatched through a dynamic subscript ({@code
+   * self.sub_layers[i](out, training)}) in {@code call} — the miniature of NLPGNN's {@code
+   * GAAELayer.encoder}. The inner layer's {@code call} must exist in the call graph with its {@code
+   * inputs} parameter tensor-typed.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testIndexedLayerListCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_layer_list.py", "Inner.call", 1, 1, Map.of(3, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * Constant-index variant of {@link #testIndexedLayerListCall()} (wala/ML#661): {@code
+   * self.sub_layers[0](out, training)} over an append-built list. Pins that the fix does not depend
+   * on the subscript being dynamic.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testIndexedLayerListCallConst()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_layer_list_const.py", "Inner.call", 1, 1, Map.of(3, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * List-literal variant of {@link #testIndexedLayerListCall()} (wala/ML#661): the sublayer list is
+   * built as a literal instead of by {@code append}, so the subscript read resolves through the
+   * ordinary numeric field. This passed before the fix and pins the discriminator that localized
+   * the gap to the append-contents property.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testIndexedLayerListCallLiteral()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_layer_list_lit.py", "Inner.call", 1, 1, Map.of(3, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
    * Pins the forward result of a nested layer call whose argument is a {@code NamedTuple} and whose
    * inner {@code call} computes through a field read, a matmul, and an {@code unsorted_segment_sum}
    * (<a href="https://github.com/wala/ML/issues/570">wala/ML#570</a>).

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list.py
@@ -1,0 +1,39 @@
+# Miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch (wala/ML#661 shape 3):
+# a plain list of sublayers populated by `append` in `build`, dispatched through a
+# dynamic subscript in `call`.
+import tensorflow as tf
+
+
+class Inner(tf.keras.layers.Layer):
+    def call(self, inputs, training=True):
+        return inputs
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self, num_layers=2, **kwargs):
+        super(Outer, self).__init__(**kwargs)
+        self.num_layers = num_layers
+
+    def build(self, input_shape):
+        self.sub_layers = []
+        for _ in range(self.num_layers):
+            self.sub_layers.append(Inner())
+
+    def call(self, inputs, training=True):
+        out = inputs
+        for i in range(self.num_layers):
+            out = self.sub_layers[i](out, training)
+        return out
+
+
+def consume(t):
+    pass
+
+
+layer = Outer()
+x = tf.ones((2, 3))
+out = layer(x)
+consume(out)
+
+assert out.shape == (2, 3)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_const.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_const.py
@@ -1,6 +1,6 @@
 # Miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch (wala/ML#661 shape 3):
 # a plain list of sublayers populated by `append` in `build`, dispatched through a
-# dynamic subscript in `call`.
+# constant subscript in `call`, the index-form variant of `tf2_test_layer_list.py`.
 import tensorflow as tf
 
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_const.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_const.py
@@ -1,0 +1,39 @@
+# Miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch (wala/ML#661 shape 3):
+# a plain list of sublayers populated by `append` in `build`, dispatched through a
+# dynamic subscript in `call`.
+import tensorflow as tf
+
+
+class Inner(tf.keras.layers.Layer):
+    def call(self, inputs, training=True):
+        return inputs
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self, num_layers=2, **kwargs):
+        super(Outer, self).__init__(**kwargs)
+        self.num_layers = num_layers
+
+    def build(self, input_shape):
+        self.sub_layers = []
+        for _ in range(self.num_layers):
+            self.sub_layers.append(Inner())
+
+    def call(self, inputs, training=True):
+        out = inputs
+        for i in range(self.num_layers):
+            out = self.sub_layers[0](out, training)
+        return out
+
+
+def consume(t):
+    pass
+
+
+layer = Outer()
+x = tf.ones((2, 3))
+out = layer(x)
+consume(out)
+
+assert out.shape == (2, 3)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_lit.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_lit.py
@@ -1,0 +1,37 @@
+# Miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch (wala/ML#661 shape 3):
+# a plain list of sublayers populated by `append` in `build`, dispatched through a
+# constant subscript over a list literal in `call`.
+import tensorflow as tf
+
+
+class Inner(tf.keras.layers.Layer):
+    def call(self, inputs, training=True):
+        return inputs
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self, num_layers=2, **kwargs):
+        super(Outer, self).__init__(**kwargs)
+        self.num_layers = num_layers
+
+    def build(self, input_shape):
+        self.sub_layers = [Inner(), Inner()]
+
+    def call(self, inputs, training=True):
+        out = inputs
+        for i in range(self.num_layers):
+            out = self.sub_layers[0](out, training)
+        return out
+
+
+def consume(t):
+    pass
+
+
+layer = Outer()
+x = tf.ones((2, 3))
+out = layer(x)
+consume(out)
+
+assert out.shape == (2, 3)
+assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -384,6 +384,36 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
     }
 
     /**
+     * Surfaces append-accumulated list contents at subscript reads (<a
+     * href="https://github.com/wala/ML/issues/661">wala/ML#661</a>): a property read whose member
+     * is not a constant string also reads the synthetic {@value #LIST_APPEND_CONTENTS_FIELD}
+     * property, the read-side dual of {@link #processListAppend}'s write. Without this, values
+     * accumulated through {@code append} surface only under value iteration, and an indexed
+     * dispatch such as {@code self.sub_layers[i](x)} over an append-built list has an empty callee
+     * set. Named-attribute reads (constant string members) are excluded so method and attribute
+     * lookups do not observe element values; the synthetic property is only ever written on append
+     * receivers, so on all other objects the extra read contributes nothing.
+     *
+     * @param instruction The property read to examine.
+     */
+    private void processListContentsRead(AstPropertyRead instruction) {
+      SymbolTable symtab = ir.getSymbolTable();
+      int memberRef = instruction.getMemberRef();
+      if (symtab.isConstant(memberRef) && symtab.getConstantValue(memberRef) instanceof String)
+        return;
+
+      InstanceKey contentsKey =
+          getBuilder().getInstanceKeyForConstant(PythonTypes.string, LIST_APPEND_CONTENTS_FIELD);
+
+      newFieldOperationFieldConstant(
+          node,
+          true,
+          fieldReadAction(getPointerKeyForLocal(instruction.getDef())),
+          instruction.getObjectRef(),
+          new InstanceKey[] {contentsKey});
+    }
+
+    /**
      * Models {@code xs.append(v)} as a property write of {@code v} onto {@code xs} under the
      * synthetic {@value #LIST_APPEND_CONTENTS_FIELD} key, so values accumulated through {@code
      * append} surface when the collection is iterated ({@code visitForElementGet} reads the
@@ -460,6 +490,7 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
     @Override
     public void visitPropertyRead(AstPropertyRead instruction) {
       super.visitPropertyRead(instruction);
+      processListContentsRead(instruction);
 
       if (this.ir.getSymbolTable().isConstant(instruction.getMemberRef())) {
         Object constantValue =


### PR DESCRIPTION
## Problem

The indexed sub-layer dispatch shape of wala/ML#661 (`self.container[i](x)`, NLPGNN's `GAAELayer.encoder`): the sub-layer's `call` never enters the call graph, leaving the enclosing method's successor set incomplete.

## Root Cause

`xs.append(v)` is modeled as a property write of `v` under the synthetic `__list_append_contents__` key (`processListAppend`). Value iteration surfaces that property, but subscript reads never consulted it, so any indexed access over an append-built list had an empty points-to set; the dispatch on it had no callees. The discriminators pin this exactly: a list-literal fixture passes while append-built fixtures fail with both dynamic and constant indices.

## Fix

`PythonConstraintVisitor.visitPropertyRead` now adds the read-side dual of `processListAppend`'s write: a property read whose member is not a constant string also reads the synthetic contents property. Named-attribute reads are excluded, so method and attribute lookups cannot observe element values; the property is only ever written on append receivers, so on all other objects the extra read contributes nothing. Index precision within the list is not modeled (all appended elements flow to any subscript read), matching the write side's index-insensitivity.

## Guards

`testIndexedLayerListCall` (dynamic index), `testIndexedLayerListCallConst` (constant index), and `testIndexedLayerListCallLiteral` (list literal, the pre-fix-passing discriminator), each pinning `Inner.call` typed `[2, 3]` float32 through the dispatch.

Addresses the indexed-dispatch shape of wala/ML#661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc