### PR TITLE
Skip the lexical-refresh side effect when the function value is invariant

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -191,6 +191,14 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
      * @param revisit Re-invokes the superclass visit for {@code instruction}.
      */
     private void refreshLexicalOnClosureGrowth(SSAInstruction instruction, Runnable revisit) {
+      // When the function value's contents are invariant, the visit's snapshot is already
+      // complete (the single closure object is known statically) and its points-to set is
+      // implicitly represented, so registering a side effect is both unnecessary and disallowed:
+      // `newSideEffect` would crash `findOrCreatePointsToSet` (the wala/ML#668 trap; observed as
+      // `UnimplementedError` on script-toplevel nodes in WALA's JS test suite for the upstream
+      // form of this fix, wala/WALA#1991).
+      if (contentsAreInvariant(ir.getSymbolTable(), du, 1)) return;
+
       PointerKey function = getPointerKeyForLocal(1);
       system.newSideEffect(
           new LexicalRefreshOperator(node, instruction.iIndex(), revisit), function);


### PR DESCRIPTION
## Problem

`refreshLexicalOnClosureGrowth` (the wala/ML#690 fix, ponder-lab/ML#532) registers its side effect unconditionally. When the node's function value (v1) has invariant contents, that value's points-to set is implicitly represented, and `PropagationSystem.newSideEffect` crashes `findOrCreatePointsToSet` with `UnimplementedError`—the same trap wala/ML#668 documented for `processListAppend`. Latent in this repository (no Python test reaches an invariant v1 with lexical accesses today), but the upstream form of the fix tripped it across WALA's JS test suite on script-toplevel nodes (wala/WALA#1991).

## Fix

Return early when `contentsAreInvariant(..., 1)` holds: an invariant function value means exactly one statically-known closure object, so the visit's one-time resolution was already complete and no re-registration is needed—the guard is the correct semantics, not just crash avoidance.

Hardening follow-up to ponder-lab/ML#532; mirrors the guard in the upstream draft wala/WALA#1991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc