### PR TITLE
Log the plain-import binding decision for the wala/ML#687 per-machine discriminator

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -1112,12 +1112,33 @@ public class PythonCAstToIRTranslator extends AstTranslator {
       // already translated, so an importer translated before its importee silently fell through
       // to the (nonexistent) library-import path and the module never bound (wala/ML#691). The
       // scope-name check decides by what the analysis scope CONTAINS, not by translation order.
-      if (loader.lookupClass(TypeName.findOrCreate("Lscript " + name + ".py")) != null
-          || (loader instanceof PythonLoader pythonLoader
-              && pythonLoader.definesScriptInScope(name + ".py"))) {
+      boolean alreadyTranslated =
+          loader.lookupClass(TypeName.findOrCreate("Lscript " + name + ".py")) != null;
+      boolean inScope =
+          loader instanceof PythonLoader pythonLoader
+              && pythonLoader.definesScriptInScope(name + ".py");
+
+      if (alreadyTranslated || inScope) {
+        LOGGER.fine(
+            () ->
+                "Binding import of: "
+                    + name
+                    + " to script: "
+                    + name
+                    + ".py (already translated: "
+                    + alreadyTranslated
+                    + ", in scope: "
+                    + inScope
+                    + ") (wala/ML#687).");
         FieldReference global = makeGlobalRef("script " + name + ".py");
         context.cfg().addInstruction(new AstGlobalRead(idx, resultVal, global));
       } else {
+        LOGGER.fine(
+            () ->
+                "Import of: "
+                    + name
+                    + " matches no script in scope; treating it as a library import"
+                    + " (wala/ML#687).");
         TypeReference imprt = TypeReference.findOrCreate(PythonTypes.pythonLoader, "L" + name);
         MethodReference call =
             MethodReference.findOrCreate(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -151,7 +151,7 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
                   + scriptNamesInScope.stream()
                       .filter(n -> n.endsWith("/" + fileName) || fileName.endsWith("/" + n))
                       .sorted()
-                      .collect(Collectors.toList())
+                      .collect(toList())
                   + " (wala/ML#687).");
 
     return defines;

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -137,7 +137,24 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
    * @return {@code true} iff a source module with that file name is in scope.
    */
   public boolean definesScriptInScope(String fileName) {
-    return scriptNamesInScope.contains(fileName);
+    boolean defines = scriptNamesInScope.contains(fileName);
+
+    // On a miss, name the collected entries that differ only in path prefix, so a per-machine
+    // divergence in scope construction (e.g. project-relative vs root-prefixed entry names) is
+    // visible from the log alone (wala/ML#687).
+    if (!defines)
+      LOGGER.fine(
+          () ->
+              "Script: "
+                  + fileName
+                  + " is not in scope; near misses: "
+                  + scriptNamesInScope.stream()
+                      .filter(n -> n.endsWith("/" + fileName) || fileName.endsWith("/" + n))
+                      .sorted()
+                      .collect(Collectors.toList())
+                  + " (wala/ML#687).");
+
+    return defines;
   }
 
   /**


### PR DESCRIPTION
Contributes to https://github.com/wala/ML/issues/687.

The order-independent in-scope binding (https://github.com/ponder-lab/ML/pull/531) closed the fixture-scale axis of the issue, but one desktop still fails all six consumer gate tests while CI passes, and the binding path emitted nothing at resolution time to discriminate the divergence. This adds FINE logging at both ends of the decision:

- `PythonCAstToIRTranslator.doPrimitive` logs which branch a plain import takes: `Binding import of: <name> to script: <name>.py (already translated: <b>, in scope: <b>)` on the script path, and `Import of: <name> matches no script in scope; treating it as a library import` on the library fallthrough.
- `PythonLoader.definesScriptInScope` logs scope-membership misses together with the collected entries that differ only in path prefix, so a per-machine divergence in scope construction (project-relative vs root-prefixed entry names) is visible from the log alone.

On the failing configuration, one grep for the importee's name across these lines and the existing `Collected script name in scope:` line distinguishes the three candidate failure modes: the file never collected, collected under a different spelling, or looked up under a different name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc