### PR TITLE
Gate the import-binding trace onto stderr for JUL-blind harnesses

### DIFF
--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -15,6 +15,7 @@ import static com.ibm.wala.cast.python.ir.PythonLanguage.Python;
 import static com.ibm.wala.cast.python.types.PythonTypes.pythonLoader;
 import static com.ibm.wala.cast.python.util.Util.IMPORT_WILDCARD_CHARACTER;
 import static com.ibm.wala.cast.python.util.Util.MODULE_INITIALIZATION_FILENAME;
+import static com.ibm.wala.cast.python.util.Util.traceImportBinding;
 
 import com.ibm.wala.cast.ir.ssa.AssignInstruction;
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
@@ -1119,7 +1120,8 @@ public class PythonCAstToIRTranslator extends AstTranslator {
               && pythonLoader.definesScriptInScope(name + ".py");
 
       if (alreadyTranslated || inScope) {
-        LOGGER.fine(
+        traceImportBinding(
+            LOGGER,
             () ->
                 "Binding import of: "
                     + name
@@ -1133,7 +1135,8 @@ public class PythonCAstToIRTranslator extends AstTranslator {
         FieldReference global = makeGlobalRef("script " + name + ".py");
         context.cfg().addInstruction(new AstGlobalRead(idx, resultVal, global));
       } else {
-        LOGGER.fine(
+        traceImportBinding(
+            LOGGER,
             () ->
                 "Import of: "
                     + name

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.loader;
 
 import static com.ibm.wala.cast.python.types.PythonTypes.pythonLoader;
 import static com.ibm.wala.cast.python.util.Util.getNames;
+import static com.ibm.wala.cast.python.util.Util.traceImportBinding;
 import static java.util.stream.Collectors.toList;
 
 import com.ibm.wala.cast.ir.translator.AstTranslator.AstLexicalInformation;
@@ -118,7 +119,8 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
       entry.asModule().getEntries().forEachRemaining(this::collectScriptNames);
     else {
       String name = entry.getName();
-      LOGGER.fine(() -> "Collected script name in scope: " + name + " (wala/ML#691).");
+      traceImportBinding(
+          LOGGER, () -> "Collected script name in scope: " + name + " (wala/ML#691).");
       scriptNamesInScope.add(name);
       // Script class names are project-relative while module entry names may carry the project
       // root as their first component; record the stripped form too so the translator's
@@ -143,7 +145,8 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
     // divergence in scope construction (e.g. project-relative vs root-prefixed entry names) is
     // visible from the log alone (wala/ML#687).
     if (!defines)
-      LOGGER.fine(
+      traceImportBinding(
+          LOGGER,
           () ->
               "Script: "
                   + fileName

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/util/Util.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/util/Util.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -115,6 +116,32 @@ public class Util {
       getNameWithoutExtension(MODULE_INITIALIZATION_FILENAME);
 
   public static final String IMPORT_WILDCARD_CHARACTER = "*";
+
+  /**
+   * System property that, when {@code true}, echoes the plain-import binding-decision trace (<a
+   * href="https://github.com/wala/ML/issues/687">wala/ML#687</a>) to {@link System#err} in addition
+   * to the FINE log. Embedding runtimes such as a Tycho-surefire OSGi harness preempt {@code
+   * java.util.logging} configuration, making the FINE channel unobservable exactly where the
+   * binding divergence manifests; stderr survives those harnesses.
+   */
+  public static final String IMPORT_BINDING_TRACE_PROPERTY = "wala.ml.import.binding.trace";
+
+  /**
+   * Emits the given import-binding trace message to {@link System#err} when {@link
+   * #IMPORT_BINDING_TRACE_PROPERTY} is set to {@code true}, and to the FINE log unconditionally.
+   * The message text is shared between the two channels so the wala/ML#687 grep recipe applies to
+   * either.
+   *
+   * @param logger The logger of the emitting class, so the FINE line carries its source.
+   * @param message Supplier of the trace message; evaluated only if a channel consumes it.
+   */
+  public static void traceImportBinding(Logger logger, Supplier<String> message) {
+    if (Boolean.getBoolean(IMPORT_BINDING_TRACE_PROPERTY)) {
+      String text = message.get();
+      System.err.println(text);
+      logger.fine(text);
+    } else logger.fine(message);
+  }
 
   /**
    * Add Pytest entrypoints to the given {@link PropagationCallGraphBuilder}.


### PR DESCRIPTION
Contributes to https://github.com/wala/ML/issues/687.

Per https://github.com/wala/ML/issues/687#issuecomment-4880366309, the affected desktop's tycho-surefire OSGi runtime preempts `java.util.logging` configuration, so the FINE discriminator lines shipped in https://github.com/ponder-lab/ML/pull/537 are unobservable in exactly the configuration that exhibits the defect (three capture attempts, zero signatures, control content flowing).

This routes the four discriminator signatures (`Binding import of:`, `matches no script in scope`, `is not in scope; near misses:`, `Collected script name in scope:`) through `Util.traceImportBinding`, which echoes them to `System.err` when `-Dwala.ml.import.binding.trace=true` is set (e.g. via `JAVA_TOOL_OPTIONS`, the channel the consumer has already proven reaches the forked test JVM) and logs FINE otherwise. The message text is identical on both channels, so the posted grep recipe applies unchanged. With the property unset, behavior is exactly as before.

Verified end-to-end with FINE suppressed (`logging.ci.properties`) and the property delivered via `JAVA_TOOL_OPTIONS`: the signatures appear raw on stderr; without the property, nothing is emitted outside the FINE log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc