### PR TITLE
Match in-scope script names by path suffix

### DIFF
--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestScriptNameMatching.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestScriptNameMatching.java
@@ -1,0 +1,65 @@
+package com.ibm.wala.cast.python.test;
+
+import static com.ibm.wala.cast.python.loader.PythonLoader.scriptNameMatches;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link com.ibm.wala.cast.python.loader.PythonLoader#scriptNameMatches(String, String)}, the
+ * scope-membership predicate behind the plain-import binding decision (<a
+ * href="https://github.com/wala/ML/issues/687">wala/ML#687</a>). Depending on how the embedding
+ * client constructs its modules, collected entry names may be bare, project-relative, or the
+ * absolute filesystem path of the checkout, while the importer always looks up the script-relative
+ * name.
+ */
+public class TestScriptNameMatching {
+
+  /** A bare collected name matches itself. */
+  @Test
+  public void testExactMatch() {
+    assertTrue(scriptNameMatches("B.py", "B.py"));
+  }
+
+  /** A project-relative collected name matches the bare lookup. */
+  @Test
+  public void testProjectRelativeMatch() {
+    assertTrue(scriptNameMatches("proj/B.py", "B.py"));
+  }
+
+  /**
+   * An absolute collected name matches the bare lookup — the wala/ML#687 failing-desktop shape,
+   * where every entry is collected under the checkout's absolute path.
+   */
+  @Test
+  public void testAbsolutePathMatch() {
+    assertTrue(
+        scriptNameMatches(
+            "/home/user/git/Client/tests/resources/Function/testModule6/in/B.py", "B.py"));
+  }
+
+  /** A dotted (package-qualified) lookup matches at the same suffix boundary. */
+  @Test
+  public void testPackageQualifiedLookupMatch() {
+    assertTrue(scriptNameMatches("/home/user/proj/custom/layers.py", "custom/layers.py"));
+  }
+
+  /** The suffix must start at a path-component boundary. */
+  @Test
+  public void testNoPartialComponentMatch() {
+    assertFalse(scriptNameMatches("/home/user/proj/AB.py", "B.py"));
+  }
+
+  /** A different file name does not match. */
+  @Test
+  public void testDifferentNameNoMatch() {
+    assertFalse(scriptNameMatches("/home/user/proj/C.py", "B.py"));
+  }
+
+  /** The lookup being longer than the collected name does not match. */
+  @Test
+  public void testLongerLookupNoMatch() {
+    assertFalse(scriptNameMatches("B.py", "in/B.py"));
+  }
+}

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestScriptNameMatching.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestScriptNameMatching.java
@@ -39,7 +39,10 @@ public class TestScriptNameMatching {
             "/home/user/git/Client/tests/resources/Function/testModule6/in/B.py", "B.py"));
   }
 
-  /** A dotted (package-qualified) lookup matches at the same suffix boundary. */
+  /**
+   * A path-qualified lookup (the slashed spelling a dotted import such as {@code from custom.layers
+   * import *} produces) matches at the same suffix boundary.
+   */
   @Test
   public void testPackageQualifiedLookupMatch() {
     assertTrue(scriptNameMatches("/home/user/proj/custom/layers.py", "custom/layers.py"));

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -138,11 +138,15 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
    * @return {@code true} iff a source module whose path ends with that file name is in scope.
    */
   public boolean definesScriptInScope(String fileName) {
-    boolean defines = scriptNamesInScope.stream().anyMatch(n -> scriptNameMatches(n, fileName));
+    String suffix = "/" + fileName;
+    boolean defines =
+        scriptNamesInScope.stream().anyMatch(n -> scriptNameMatches(n, fileName, suffix));
 
     // On a miss, name the collected entries sharing the file name's base name, so a spelling
     // divergence in scope construction is visible from the log alone (wala/ML#687).
-    if (!defines)
+    if (!defines) {
+      String base = baseName(fileName);
+
       traceImportBinding(
           LOGGER,
           () ->
@@ -150,10 +154,11 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
                   + fileName
                   + " is not in scope; near misses: "
                   + scriptNamesInScope.stream()
-                      .filter(n -> baseName(n).equals(baseName(fileName)))
+                      .filter(n -> baseName(n).equals(base))
                       .sorted()
                       .collect(toList())
                   + " (wala/ML#687).");
+    }
 
     return defines;
   }
@@ -169,7 +174,20 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
    * @return {@code true} iff {@code collectedName} denotes {@code fileName}.
    */
   public static boolean scriptNameMatches(String collectedName, String fileName) {
-    return collectedName.equals(fileName) || collectedName.endsWith("/" + fileName);
+    return scriptNameMatches(collectedName, fileName, "/" + fileName);
+  }
+
+  /**
+   * The scan form of {@link #scriptNameMatches(String, String)}, taking the slash-prefixed lookup
+   * name so a membership scan over all collected entries allocates it once rather than per entry.
+   *
+   * @param collectedName An entry name as collected from the analysis scope.
+   * @param fileName The script file name as the importer spells it.
+   * @param suffix {@code "/" + fileName}, precomputed by the caller.
+   * @return {@code true} iff {@code collectedName} denotes {@code fileName}.
+   */
+  private static boolean scriptNameMatches(String collectedName, String fileName, String suffix) {
+    return collectedName.equals(fileName) || collectedName.endsWith(suffix);
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/loader/PythonLoader.java
@@ -122,28 +122,26 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
       traceImportBinding(
           LOGGER, () -> "Collected script name in scope: " + name + " (wala/ML#691).");
       scriptNamesInScope.add(name);
-      // Script class names are project-relative while module entry names may carry the project
-      // root as their first component; record the stripped form too so the translator's
-      // scope-membership check matches the naming the script classes will use.
-      int slash = name.indexOf('/');
-      if (slash >= 0) scriptNamesInScope.add(name.substring(slash + 1));
     }
   }
 
   /**
    * Returns whether a source module with the given file name is in the analysis scope, regardless
    * of whether it has been translated yet (<a
-   * href="https://github.com/wala/ML/issues/691">wala/ML#691</a>).
+   * href="https://github.com/wala/ML/issues/691">wala/ML#691</a>). Collected entry names are
+   * matched by path suffix, not exact spelling: depending on how the embedding client constructs
+   * its modules, entries may carry a project-relative prefix or the absolute filesystem path of the
+   * checkout, while the importer always looks up the script-relative name (<a
+   * href="https://github.com/wala/ML/issues/687">wala/ML#687</a>).
    *
-   * @param fileName The script file name as it appears in the scope (e.g. {@code B.py}).
-   * @return {@code true} iff a source module with that file name is in scope.
+   * @param fileName The script file name as the importer spells it (e.g. {@code B.py}).
+   * @return {@code true} iff a source module whose path ends with that file name is in scope.
    */
   public boolean definesScriptInScope(String fileName) {
-    boolean defines = scriptNamesInScope.contains(fileName);
+    boolean defines = scriptNamesInScope.stream().anyMatch(n -> scriptNameMatches(n, fileName));
 
-    // On a miss, name the collected entries that differ only in path prefix, so a per-machine
-    // divergence in scope construction (e.g. project-relative vs root-prefixed entry names) is
-    // visible from the log alone (wala/ML#687).
+    // On a miss, name the collected entries sharing the file name's base name, so a spelling
+    // divergence in scope construction is visible from the log alone (wala/ML#687).
     if (!defines)
       traceImportBinding(
           LOGGER,
@@ -152,12 +150,36 @@ public abstract class PythonLoader extends CAstAbstractModuleLoader {
                   + fileName
                   + " is not in scope; near misses: "
                   + scriptNamesInScope.stream()
-                      .filter(n -> n.endsWith("/" + fileName) || fileName.endsWith("/" + n))
+                      .filter(n -> baseName(n).equals(baseName(fileName)))
                       .sorted()
                       .collect(toList())
                   + " (wala/ML#687).");
 
     return defines;
+  }
+
+  /**
+   * Returns whether the given collected in-scope entry name denotes the script the importer looks
+   * up: either the spellings are identical, or the entry name ends with the looked-up name at a
+   * path-component boundary (e.g. entry {@code /home/user/proj/in/B.py} matches lookup {@code B.py}
+   * but not {@code AB.py}).
+   *
+   * @param collectedName An entry name as collected from the analysis scope.
+   * @param fileName The script file name as the importer spells it.
+   * @return {@code true} iff {@code collectedName} denotes {@code fileName}.
+   */
+  public static boolean scriptNameMatches(String collectedName, String fileName) {
+    return collectedName.equals(fileName) || collectedName.endsWith("/" + fileName);
+  }
+
+  /**
+   * Returns the last path component of the given name.
+   *
+   * @param name A possibly slash-separated name.
+   * @return The substring after the last {@code /}, or {@code name} itself if it has none.
+   */
+  private static String baseName(String name) {
+    return name.substring(name.lastIndexOf('/') + 1);
   }
 
   /**


### PR DESCRIPTION
Contributes to https://github.com/wala/ML/issues/687.

The 0.52.19 discriminator run on the affected desktop (https://github.com/wala/ML/issues/687#issuecomment-4881742496) resolved the per-machine divide to "collected under a different spelling": every module entry there is collected under its absolute filesystem path (`/home/.../testModule6/in/B.py`, 659 records, no relative spellings), while the importer always looks up the bare script-relative name (`B.py`). The exact-match check with its single leading-component strip cannot bridge that; stripping an absolute path's first component even yields the junk slash-less spelling visible in the reported near-miss list.

## Changes

- `PythonLoader.definesScriptInScope` now matches by path suffix: a collected entry denotes the looked-up script iff the spellings are equal or the entry ends with the name at a path-component boundary (`.../in/B.py` matches `B.py`; `AB.py` does not). The single-strip at collection time is removed as subsumed.
- The predicate is extracted as `scriptNameMatches` and unit-tested (`TestScriptNameMatching`), including the failing desktop's absolute-path shape.
- The near-miss trace now reports same-base-name entries.

On the failing machine this flips the binding decision to the script branch. Whether the six gated tests then pass depends on whether the script classes and globals there carry relative names; either way the next consumer run is decisive, since the `Binding import of:` trace line will now show `in scope: true` and any residual divergence surfaces as a new, visible shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc