### PR TITLE
Flow tensor types through user-defined generator functions

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -188,6 +188,25 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     default void addGlobal(String n) {
       getParent().addGlobal(n);
     }
+
+    /**
+     * Marks the nearest enclosing function context as a generator. Called when a {@code yield} (or
+     * {@code yield from}) is translated; delegates up the context chain, since the yield may be
+     * nested in loop or try contexts whose visitors are distinct from the function body's.
+     */
+    default void markGenerator() {
+      getParent().markGenerator();
+    }
+
+    /**
+     * Returns whether the nearest enclosing function context has been marked as a generator.
+     *
+     * @return True iff a {@code yield} (or {@code yield from}) has been translated in the nearest
+     *     enclosing function context.
+     */
+    default boolean isGenerator() {
+      return getParent().isGenerator();
+    }
   }
 
   private static class RootContext extends TranslatorToCAst.RootContext<WalkContext, PythonTree>
@@ -236,6 +255,15 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     public CAstNode getCatchTarget(String s) {
       return null;
     }
+
+    /** A module-level {@code yield} is a syntax error in Python; ignore it rather than crash. */
+    @Override
+    public void markGenerator() {}
+
+    @Override
+    public boolean isGenerator() {
+      return false;
+    }
   }
 
   private static class FunctionContext
@@ -243,6 +271,13 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     private final AbstractCodeEntity fun;
     private final java.util.Set<String> downwardGlobals;
     private final java.util.Set<String> definedNames = HashSetFactory.make();
+
+    /**
+     * Whether this function is a generator, i.e., a {@code yield} (or {@code yield from}) has been
+     * translated in its body (possibly by a nested loop or try visitor delegating up the context
+     * chain).
+     */
+    private boolean generator;
 
     public WalkContext getParent() {
       return parent;
@@ -294,6 +329,16 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
     @Override
     public Map<CAstNode, Collection<CAstEntity>> getScopedEntities() {
       return fun.getAllScopedEntities();
+    }
+
+    @Override
+    public void markGenerator() {
+      this.generator = true;
+    }
+
+    @Override
+    public boolean isGenerator() {
+      return this.generator;
     }
   }
 
@@ -1410,6 +1455,12 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
 
         private final Collection<CAstAnnotation> annotations;
 
+        /**
+         * Whether this function is a generator, i.e., its body contains a {@code yield} (or {@code
+         * yield from}). Known only after the body has been visited, hence mutable.
+         */
+        private boolean generator;
+
         @Override
         public Iterable<CAstNode> dynamicAnnotations() {
           return dynamicAnnotations;
@@ -1432,6 +1483,47 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
         @Override
         public int getKind() {
           return CAstEntity.FUNCTION_ENTITY;
+        }
+
+        /**
+         * Marks this function as a generator, adding a {@code return} of the function object to its
+         * AST so that calling it evaluates to the object accumulating its yields.
+         *
+         * @param generator Whether the function's body contains a {@code yield} (or {@code yield
+         *     from}).
+         */
+        protected void setGenerator(boolean generator) {
+          this.generator = generator;
+        }
+
+        /**
+         * Prepends a conditional {@code return} of the enclosing function object to the given body
+         * when this function is a generator, so that calling it evaluates to the object carrying
+         * the yields written to {@value PythonTypes#GENERATOR_CONTENT_FIELD_NAME} (wala/ML#696).
+         *
+         * <p>The {@code return} is guarded by a test on the (non-constant) function object rather
+         * than appended after the body: a generator body commonly ends in {@code while True:},
+         * which the translator emits as an unconditional back edge, leaving any trailing statement
+         * unreachable and dropped from the IR. Both branches of a non-constant test survive
+         * translation, so the {@code return} stays reachable while the body is still analyzed on
+         * the fall-through path.
+         *
+         * @param body The function body {@link CAstNode} to extend.
+         * @return The given body, with the guarded {@code return} prepended when this function is a
+         *     generator.
+         */
+        private CAstNode prependGeneratorReturn(CAstNode body) {
+          if (!generator) return body;
+          CAst Ast = PythonParser.Ast;
+          return Ast.makeNode(
+              CAstNode.BLOCK_STMT,
+              Ast.makeNode(
+                  CAstNode.IF_STMT,
+                  Ast.makeNode(CAstNode.VAR, Ast.makeConstant("the function")),
+                  Ast.makeNode(
+                      CAstNode.RETURN,
+                      Ast.makeNode(CAstNode.VAR, Ast.makeConstant("the function")))),
+              body);
         }
 
         @Override
@@ -1474,9 +1566,10 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
                               Ast.makeConstant("$self")),
                           Ast.makeNode(CAstNode.VAR, Ast.makeConstant(getArgumentNames()[1]))));
 
-              return PythonParser.Ast.makeNode(CAstNode.BLOCK_STMT, newNodes);
+              return prependGeneratorReturn(
+                  PythonParser.Ast.makeNode(CAstNode.BLOCK_STMT, newNodes));
             } else {
-              return PythonParser.Ast.makeNode(CAstNode.BLOCK_STMT, nodes);
+              return prependGeneratorReturn(PythonParser.Ast.makeNode(CAstNode.BLOCK_STMT, nodes));
             }
           } else {
             return PythonParser.Ast.makeNode(
@@ -1541,6 +1634,8 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
       for (S s : body) {
         nodes[i++] = s.accept(cv);
       }
+
+      fun.setGenerator(child.isGenerator());
 
       if (isMethod) {
         context.addScopedEntity(null, fun);
@@ -2497,10 +2592,29 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
       return handleWith(arg0.getInternalBody(), arg0.getInternalItems());
     }
 
+    /**
+     * Makes an access to the synthetic field of the enclosing function object that accumulates the
+     * values the enclosing generator yields.
+     *
+     * @return A {@link CAstNode} referencing {@value PythonTypes#GENERATOR_CONTENT_FIELD_NAME} on
+     *     the enclosing function object.
+     */
+    private CAstNode makeGeneratorContentRef() {
+      return Ast.makeNode(
+          CAstNode.OBJECT_REF,
+          Ast.makeNode(CAstNode.VAR, Ast.makeConstant("the function")),
+          Ast.makeConstant(PythonTypes.GENERATOR_CONTENT_FIELD_NAME));
+    }
+
     @Override
     public CAstNode visitYield(Yield arg0) throws Exception {
+      context.markGenerator();
+
       if (arg0.getInternalValue() != null) {
-        return arg0.getInternalValue().accept(this);
+        // Accumulate the yielded value in the enclosing function object's synthetic content
+        // field, where `next()` and `for`-loop value iteration read it back out (wala/ML#696).
+        return Ast.makeNode(
+            CAstNode.ASSIGN, makeGeneratorContentRef(), arg0.getInternalValue().accept(this));
       } else {
         return Ast.makeNode(CAstNode.RETURN_WITHOUT_BRANCH);
       }
@@ -2586,7 +2700,17 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
 
     @Override
     public CAstNode visitYieldFrom(YieldFrom arg0) throws Exception {
-      return arg0.getInternalValue().accept(this);
+      context.markGenerator();
+
+      // Forward the delegate generator's accumulated yields into the enclosing function object's
+      // synthetic content field (wala/ML#696).
+      return Ast.makeNode(
+          CAstNode.ASSIGN,
+          makeGeneratorContentRef(),
+          Ast.makeNode(
+              CAstNode.OBJECT_REF,
+              arg0.getInternalValue().accept(this),
+              Ast.makeConstant(PythonTypes.GENERATOR_CONTENT_FIELD_NAME)));
     }
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10701,10 +10701,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * #testModelForwardTupleReshapeReturn()} but the model input arrives via {@code next()} on a
    * generator function, tuple-unpacked at the call site. The generator transit drops the tensor
    * typing (<a href="https://github.com/wala/ML/issues/696">wala/ML#696</a>), so {@code consume}
-   * currently sees zero tensor parameters, which this test captures.
-   *
-   * <p>TODO: Expect two tensor parameters, both typed {@code [4, 4] float32}, once <a
-   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> is fixed.
+   * previously saw zero tensor parameters; a regression guard for <a
+   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10714,18 +10712,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testModelForwardTupleReshapeGenInput()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_model_tuple_reshape_gen_input.py", "consume", 0, 0, Map.of());
+    test(
+        "tf2_test_model_tuple_reshape_gen_input.py",
+        "consume",
+        2,
+        2,
+        Map.of(2, Set.of(TENSOR_4_4_FLOAT32), 3, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
   /**
    * Probe for the bare generator/next transit: a tensor yielded by a generator function, obtained
    * via {@code next()} with tuple unpacking, flows directly to {@code consume} with no model in
-   * between. The typing is dropped (<a
-   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>), so {@code consume} currently
-   * sees zero tensor parameters, which this test captures.
-   *
-   * <p>TODO: Expect one tensor parameter typed {@code [4, 4] float32}, once <a
-   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> is fixed.
+   * between; a regression guard for <a
+   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>, where the generator transit
+   * dropped the typing.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10735,18 +10735,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testGenNextUnpack()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gen_next_unpack.py", "consume", 0, 0, Map.of());
+    test("tf2_test_gen_next_unpack.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
   /**
    * Narrowing probe for the generator transit: the generator yields a single tensor (no tuple),
    * retrieved via {@code next()} with no unpacking. The minimal failing shape of <a
    * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>: neither tuple unpacking nor a
-   * model forward is involved, yet the typing is dropped and {@code consume} currently sees zero
-   * tensor parameters, which this test captures.
-   *
-   * <p>TODO: Expect one tensor parameter typed {@code [4, 4] float32}, once <a
-   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> is fixed.
+   * model forward is involved. The minimal shape of <a
+   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>, where the generator transit
+   * dropped the typing; now a regression guard for it.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10756,7 +10754,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testGenNextSingle()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gen_next_single.py", "consume", 0, 0, Map.of());
+    test("tf2_test_gen_next_single.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
   /**
@@ -10765,11 +10763,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>); distinct from the {@code
    * tf.data} destructuring shape of <a
    * href="https://github.com/wala/ML/issues/396">wala/ML#396</a>, where the producer is modeled and
-   * the symptom is swapped element types. {@code consume} currently sees zero tensor parameters,
-   * which this test captures.
-   *
-   * <p>TODO: Expect one tensor parameter typed {@code [4, 4] float32}, once <a
-   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> is fixed.
+   * the symptom is swapped element types. A regression guard for <a
+   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>, where the generator transit
+   * dropped the typing.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -10779,7 +10775,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testGenForUnpack()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_gen_for_unpack.py", "consume", 0, 0, Map.of());
+    test("tf2_test_gen_for_unpack.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -164,9 +164,10 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
      *     <p>For some collection types in Python, mainly sets and lists, iteration over a
      *     collection returns the values contained in that collection. For other types, such as
      *     dictionaries, iteration is over the keys that that collection contains.
-     *     <p>We also use this mechanism for generators, which put everything in a fake field named
-     *     "__contents__" which is read by this mechanism. Generator expressions use the iterator
-     *     type and generator functions use CodeBody.
+     *     <p>We also use this mechanism for generators, which put every yielded value in the
+     *     synthetic field named {@value PythonTypes#GENERATOR_CONTENT_FIELD_NAME}, which is read by
+     *     this mechanism. Generator expressions use the iterator type and generator functions use
+     *     CodeBody (wala/ML#696).
      */
     private boolean isValueForKeyType(IClass objType) {
       IClassHierarchy cha = getClassHierarchy();

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -145,6 +145,36 @@ public class BuiltinFunctions {
     return new PythonSummarizedFunction(ref, x, cls);
   }
 
+  /**
+   * Builds the summary for {@code next}: a read of the {@value
+   * PythonTypes#GENERATOR_CONTENT_FIELD_NAME} field off the argument. A generator function's object
+   * accumulates every yielded value in that field (the front-end translates {@code yield x} as a
+   * write to it and calling a generator evaluates to that object), so {@code next(gen)} recovers
+   * the yields. Without this, {@code next} returned a freshly-allocated opaque {@code object} and
+   * every value flowing through it unraveled (wala/ML#696). On arguments lacking the field (e.g.,
+   * dataset iterators), the read has an empty points-to set and contributes nothing, matching the
+   * previous behavior for the dataflow analysis.
+   *
+   * @param cls The builtin function class whose summary this is.
+   * @param name The builtin's name ({@code next}).
+   * @return The populated summary.
+   */
+  private static IMethod nextSummary(IClass cls, String name) {
+    TypeReference type = builtinFunction(name);
+    MethodReference ref = MethodReference.findOrCreate(type, AstMethodReference.fnSelector);
+    PythonSummary x = new PythonSummary(ref, 10);
+
+    AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
+    int result = 11;
+    int fieldKey = 12;
+
+    x.addConstant(fieldKey, new ConstantValue(PythonTypes.GENERATOR_CONTENT_FIELD_NAME));
+    x.addStatement(factory.PropertyRead(0, result, 2, fieldKey));
+    x.addStatement(factory.ReturnInstruction(1, result, false));
+
+    return new PythonSummarizedFunction(ref, x, cls);
+  }
+
   private static IMethod argSummary(IClass cls, String name, int arg) {
     PythonSummary S = argSummary(cls, builtinFunction(name), arg);
     return new PythonSummarizedFunction(S.getMethod(), S, cls);
@@ -194,7 +224,11 @@ public class BuiltinFunctions {
                   // see `zipSummary` (wala/ML#618).
                   : name.equals("zip")
                       ? zipSummary(this, name)
-                      : typeSummary(this, name, returnedType);
+                      // `next` must read the yields accumulated on a generator object; see
+                      // `nextSummary` (wala/ML#696).
+                      : name.equals("next")
+                          ? nextSummary(this, name)
+                          : typeSummary(this, name, returnedType);
     }
 
     private BuiltinFunction(IClassHierarchy cha, String name, int arg) {

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/types/PythonTypes.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/types/PythonTypes.java
@@ -76,6 +76,16 @@ public class PythonTypes extends AstTypeReference {
    */
   public static final String ARTIFICIAL_SUFFIX_FOR_TRAMPOLINED_SYNTHETIC_CLASSES = "class";
 
+  /**
+   * The name of the synthetic field on a generator function's object that holds every value the
+   * generator yields. The front-end translates {@code yield x} as a write of {@code x} into this
+   * field of the enclosing function object and adds a {@code return} of that object to the
+   * generator's body, so calling a generator function evaluates to an object carrying its yields;
+   * the {@code next} builtin and {@code for}-loop value iteration read the yields back out. Mirrors
+   * the JEP front-end's modeling (<a href="https://github.com/wala/ML/issues/696">wala/ML#696</a>).
+   */
+  public static final String GENERATOR_CONTENT_FIELD_NAME = "__content__";
+
   public static final Atom pythonName = Atom.findOrCreateUnicodeAtom(pythonNameStr);
 
   public static final Atom pythonLoaderName = Atom.findOrCreateUnicodeAtom(pythonLoaderNameStr);


### PR DESCRIPTION
Ports the JEP front-end's generator modeling to the Jython3 parser. `PythonParser.visitYield()` previously translated `yield x` as the bare expression `x`, evaluated and discarded, so a yielded tensor never reached its consumption site through `next()` or `for`-loop iteration—the whole-project consequence being that the common training-loop idiom `x, y = next(gen)` left every downstream function untyped.

Three pieces:
- `visitYield()`/`visitYieldFrom()` write the yielded value into the synthetic `__content__` field of the enclosing function object (`PythonTypes.GENERATOR_CONTENT_FIELD_NAME`), marking the enclosing function context as a generator via a new `WalkContext.markGenerator()` delegation chain—the yield is commonly nested in loop visitors distinct from the function body's, so a per-visitor flag never reaches the function.
- A generator function's body gets a prepended conditional `return` of the function object, so calling a generator evaluates to the object carrying its yields. The `return` is guarded by a non-constant test rather than appended after the body: a trailing `return` after `while True:` is an unconditional back edge away from ever executing, and the translator drops it from the IR.
- The `next` builtin summary reads `__content__` off its argument instead of allocating a fresh opaque `object`. `for`-loop value iteration already reads generator fields via the `CodeBody` branch of `PythonSSAPropagationCallGraphBuilder.isValueForKeyType()`, whose Javadoc described exactly this design (implemented until now only in the JEP front-end); the Javadoc is updated to name the actual field.

The four wala/ML#696 probes from #542 flip from observed-zero assertions to positive regression guards: `[4, 4] float32` now reaches `consume` through `next()` (single and tuple-unpacked), `for`-loop destructuring, and the generator-fed model forward. The two direct-input controls are unaffected.

Closes wala/ML#696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4KFEBmmLarb8DfWjdeSnj