### PR TITLE
Bound diagnostic logging that materializes divergent call-graph contexts (wala/ML#697)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/LoggablesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/LoggablesTest.java
@@ -44,6 +44,6 @@ public class LoggablesTest {
 
   @Test
   public void describeEmptyOrdinalSet() {
-    assertEquals("[]", Loggables.describe(OrdinalSet.<InstanceKey>empty()));
+    assertEquals("[]", Loggables.describe(OrdinalSet.empty()));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/LoggablesTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/LoggablesTest.java
@@ -1,0 +1,49 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static org.junit.Assert.assertEquals;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.util.intset.OrdinalSet;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Loggables}, guarding the null-safety of its context-free renderers. {@code
+ * findCreator} calls these with a {@code null} source, so a regression to the pre-guard form would
+ * throw a {@link NullPointerException} at FINE-level logging; see <a
+ * href="https://github.com/wala/ML/issues/697">wala/ML#697</a>.
+ */
+public class LoggablesTest {
+
+  @Test
+  public void describeNullPointsToSetVariable() {
+    assertEquals("null", Loggables.describe((PointsToSetVariable) null));
+  }
+
+  @Test
+  public void describeNullPointerKey() {
+    assertEquals("null", Loggables.describe((PointerKey) null));
+  }
+
+  @Test
+  public void describeNullCGNode() {
+    assertEquals("null", Loggables.describe((CGNode) null));
+  }
+
+  @Test
+  public void describeNullInstanceKey() {
+    assertEquals("null", Loggables.describe((InstanceKey) null));
+  }
+
+  @Test
+  public void describeNullOrdinalSet() {
+    assertEquals("null", Loggables.describe((OrdinalSet<InstanceKey>) null));
+  }
+
+  @Test
+  public void describeEmptyOrdinalSet() {
+    assertEquals("[]", Loggables.describe(OrdinalSet.<InstanceKey>empty()));
+  }
+}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -14716,23 +14716,25 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     assertNotNull(CG);
 
     if (LOGGER.isLoggable(Level.FINE)) {
-      CAstCallGraphUtil.AVOID_DUMP.set(false);
-      CAstCallGraphUtil.dumpCG(
-          ((SSAPropagationCallGraphBuilder) builder).getCFAContextInterpreter(),
-          builder.getPointerAnalysis(),
-          CG);
-      // Log the call graph one node at a time rather than via CallGraph.toString(), whose
-      // monolithic string materialization exhausts the heap on large graphs (e.g., nlpgnn); see
+      // Both the IR dump (`dumpCG`) and the per-node call-graph dump render each node's context,
+      // whose scope-mapping/receiver contexts recurse and materialize gigantic strings on large
+      // graphs (e.g., nlpgnn). Gate the whole dump behind a node-count limit rather than via
+      // CallGraph.toString(), whose monolithic materialization exhausts the heap; see
       // https://github.com/wala/ML/issues/697.
       int nodeCount = CG.getNumberOfNodes();
       if (nodeCount <= CALL_GRAPH_DUMP_NODE_LIMIT) {
+        CAstCallGraphUtil.AVOID_DUMP.set(false);
+        CAstCallGraphUtil.dumpCG(
+            ((SSAPropagationCallGraphBuilder) builder).getCFAContextInterpreter(),
+            builder.getPointerAnalysis(),
+            CG);
         LOGGER.fine("Call graph has " + nodeCount + " node(s):");
         for (CGNode node : CG) LOGGER.fine(node::toString);
       } else
         LOGGER.fine(
             "Call graph has "
                 + nodeCount
-                + " node(s); per-node dump skipped (limit "
+                + " node(s); dump skipped (limit "
                 + CALL_GRAPH_DUMP_NODE_LIMIT
                 + ").");
     }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -14747,7 +14747,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             builder.getPointerAnalysis(),
             CG);
         LOGGER.fine("Call graph has " + nodeCount + " node(s):");
-        for (CGNode node : CG) LOGGER.fine(node::toString);
+        // Render each node by number and method signature rather than CGNode.toString(), which
+        // renders the node's context and can trigger the same runaway recursion; see
+        // https://github.com/wala/ML/issues/697.
+        for (CGNode node : CG)
+          LOGGER.fine(() -> CG.getNumber(node) + ": " + node.getMethod().getSignature());
       } else
         LOGGER.fine(
             "Call graph has "

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -81,6 +81,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final Logger LOGGER = Logger.getLogger(TestTensorflow2Model.class.getName());
 
+  /**
+   * The largest call graph, in nodes, whose per-node FINE dump is emitted. Above this, only the
+   * node count is logged. Large graphs (e.g., nlpgnn) would otherwise emit gigabytes of log output;
+   * see <a href="https://github.com/wala/ML/issues/697">wala/ML#697</a>.
+   */
+  private static final int CALL_GRAPH_DUMP_NODE_LIMIT = 10_000;
+
   private static final String FLOAT_32 = FLOAT32.name().toLowerCase();
 
   private static final String COMPLEX_64 = COMPLEX64.name().toLowerCase();
@@ -14714,7 +14721,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
           ((SSAPropagationCallGraphBuilder) builder).getCFAContextInterpreter(),
           builder.getPointerAnalysis(),
           CG);
-      LOGGER.fine("Call graph:\n" + CG);
+      // Log the call graph one node at a time rather than via CallGraph.toString(), whose
+      // monolithic string materialization exhausts the heap on large graphs (e.g., nlpgnn); see
+      // https://github.com/wala/ML/issues/697.
+      int nodeCount = CG.getNumberOfNodes();
+      if (nodeCount <= CALL_GRAPH_DUMP_NODE_LIMIT) {
+        LOGGER.fine("Call graph has " + nodeCount + " node(s):");
+        for (CGNode node : CG) LOGGER.fine(node::toString);
+      } else
+        LOGGER.fine(
+            "Call graph has "
+                + nodeCount
+                + " node(s); per-node dump skipped (limit "
+                + CALL_GRAPH_DUMP_NODE_LIMIT
+                + ").");
     }
 
     TensorTypeAnalysis analysis = engine.performAnalysis(builder);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/AstypeOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/AstypeOperation.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -26,7 +28,11 @@ public class AstypeOperation extends TensorGenerator {
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     int receiverVn = getReceiverVn();
     LOGGER.fine(
-        () -> "AstypeOperation.getDefaultShapes: source=" + source + ", receiverVn=" + receiverVn);
+        () ->
+            "AstypeOperation.getDefaultShapes: source="
+                + describe(source)
+                + ", receiverVn="
+                + receiverVn);
     if (receiverVn > 0) {
       try {
         Set<List<Dimension<?>>> shapes = getShapes(builder, getNode(), receiverVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
@@ -355,7 +355,10 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
     if (tensorsPTS != null && !tensorsPTS.isEmpty()) {
       Set<DType> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
-        LOGGER.fine(DatasetFromTensorsGenerator.class.getName() + ": processing ik=" + ik);
+        LOGGER.fine(
+            DatasetFromTensorsGenerator.class.getName()
+                + ": processing ik="
+                + Loggables.describe(ik));
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           // It's a structured element. We return the union of all possible dtypes of its members.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorsGenerator.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
@@ -356,9 +357,7 @@ public class DatasetFromTensorsGenerator extends DatasetGenerator implements Tup
       Set<DType> ret = HashSetFactory.make();
       for (InstanceKey ik : tensorsPTS) {
         LOGGER.fine(
-            DatasetFromTensorsGenerator.class.getName()
-                + ": processing ik="
-                + Loggables.describe(ik));
+            DatasetFromTensorsGenerator.class.getName() + ": processing ik=" + describe(ik));
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
         if (asin != null && asin.concreteType().getReference().equals(tuple)) {
           // It's a structured element. We return the union of all possible dtypes of its members.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
@@ -101,9 +102,9 @@ public class DenseCall extends TensorGenerator {
     LOGGER.fine(
         () ->
             "Found `self` points-to set: "
-                + Loggables.describe(selfPTS)
+                + describe(selfPTS)
                 + " for node: "
-                + Loggables.describe(this.getNode())
+                + describe(this.getNode())
                 + ".");
 
     if (selfPTS != null)
@@ -111,9 +112,9 @@ public class DenseCall extends TensorGenerator {
         LOGGER.finer(
             () ->
                 "Found `self` instance key: "
-                    + Loggables.describe(selfIK)
+                    + describe(selfIK)
                     + " for node: "
-                    + Loggables.describe(this.getNode())
+                    + describe(this.getNode())
                     + ".");
 
         // Extract the 'units' value from the Dense layer instance (Parameters.SELF).
@@ -131,14 +132,18 @@ public class DenseCall extends TensorGenerator {
         if (f != null) {
           PointerKey fieldPK = builder.getPointerKeyForInstanceField(selfASIN, f);
           LOGGER.finer(
-              "Field pointer key: " + fieldPK + " for field reference: " + unitsFieldRef + ".");
+              "Field pointer key: "
+                  + describe(fieldPK)
+                  + " for field reference: "
+                  + unitsFieldRef
+                  + ".");
 
           OrdinalSet<InstanceKey> unitsPTS = builder.getPointerAnalysis().getPointsToSet(fieldPK);
           LOGGER.finer(
               "Points-to set: "
-                  + Loggables.describe(unitsPTS)
+                  + describe(unitsPTS)
                   + " for field pointer key: "
-                  + Loggables.describe(fieldPK)
+                  + describe(fieldPK)
                   + ".");
 
           Set<Long> unitValues = getPossibleLongValues(unitsPTS);
@@ -156,7 +161,7 @@ public class DenseCall extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.fine(() -> "Deriving shape for Dense call at: " + Loggables.describe(this.getNode()));
+    LOGGER.fine(() -> "Deriving shape for Dense call at: " + describe(this.getNode()));
 
     Set<List<Dimension<?>>> inputShapes = this.getInputShapes(builder);
     if (inputShapes == null || inputShapes.isEmpty()) return null;
@@ -206,9 +211,7 @@ public class DenseCall extends TensorGenerator {
       // the other phi operand supplies the base shape. See wala/ML#599.
       LOGGER.fine(
           () ->
-              "getInputShapes: cycle detected at node "
-                  + Loggables.describe(self)
-                  + "; breaking recursion.");
+              "getInputShapes: cycle detected at node " + describe(self) + "; breaking recursion.");
       return null;
     }
     try {
@@ -250,7 +253,7 @@ public class DenseCall extends TensorGenerator {
     Set<List<Dimension<?>>> ret = new HashSet<>();
 
     for (InstanceKey inputIK : inputPts) {
-      LOGGER.fine(() -> "Found input tensor instance key: " + Loggables.describe(inputIK));
+      LOGGER.fine(() -> "Found input tensor instance key: " + describe(inputIK));
       AllocationSiteInNode inputASIN = getAllocationSiteInNode(inputIK);
       if (inputASIN == null) continue;
 
@@ -261,9 +264,9 @@ public class DenseCall extends TensorGenerator {
               "Found input tensor generator: "
                   + generator
                   + " for instance key: "
-                  + inputIK
+                  + describe(inputIK)
                   + " at node: "
-                  + node
+                  + describe(node)
                   + ".");
 
       if (generator != null) {
@@ -272,7 +275,12 @@ public class DenseCall extends TensorGenerator {
         if (generatorShapes != null) ret.addAll(generatorShapes);
       } else {
         LOGGER.fine(
-            () -> "No generator found for instance key: " + inputIK + " at node: " + node + ".");
+            () ->
+                "No generator found for instance key: "
+                    + describe(inputIK)
+                    + " at node: "
+                    + describe(node)
+                    + ".");
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -250,7 +250,7 @@ public class DenseCall extends TensorGenerator {
     Set<List<Dimension<?>>> ret = new HashSet<>();
 
     for (InstanceKey inputIK : inputPts) {
-      LOGGER.fine(() -> "Found input tensor instance key: " + inputIK);
+      LOGGER.fine(() -> "Found input tensor instance key: " + Loggables.describe(inputIK));
       AllocationSiteInNode inputASIN = getAllocationSiteInNode(inputIK);
       if (inputASIN == null) continue;
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -99,12 +99,22 @@ public class DenseCall extends TensorGenerator {
     OrdinalSet<InstanceKey> selfPTS =
         this.getArgumentPointsToSet(builder, Parameters.SELF.getIndex(), Parameters.SELF.getName());
     LOGGER.fine(
-        () -> "Found `self` points-to set: " + selfPTS + " for node: " + this.getNode() + ".");
+        () ->
+            "Found `self` points-to set: "
+                + Loggables.describe(selfPTS)
+                + " for node: "
+                + Loggables.describe(this.getNode())
+                + ".");
 
     if (selfPTS != null)
       for (InstanceKey selfIK : selfPTS) {
         LOGGER.finer(
-            () -> "Found `self` instance key: " + selfIK + " for node: " + this.getNode() + ".");
+            () ->
+                "Found `self` instance key: "
+                    + Loggables.describe(selfIK)
+                    + " for node: "
+                    + Loggables.describe(this.getNode())
+                    + ".");
 
         // Extract the 'units' value from the Dense layer instance (Parameters.SELF).
         AllocationSiteInNode selfASIN = getAllocationSiteInNode(selfIK);
@@ -124,7 +134,12 @@ public class DenseCall extends TensorGenerator {
               "Field pointer key: " + fieldPK + " for field reference: " + unitsFieldRef + ".");
 
           OrdinalSet<InstanceKey> unitsPTS = builder.getPointerAnalysis().getPointsToSet(fieldPK);
-          LOGGER.finer("Points-to set: " + unitsPTS + " for field pointer key: " + fieldPK + ".");
+          LOGGER.finer(
+              "Points-to set: "
+                  + Loggables.describe(unitsPTS)
+                  + " for field pointer key: "
+                  + Loggables.describe(fieldPK)
+                  + ".");
 
           Set<Long> unitValues = getPossibleLongValues(unitsPTS);
           LOGGER.finer(
@@ -141,7 +156,7 @@ public class DenseCall extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.fine(() -> "Deriving shape for Dense call at: " + this.getNode());
+    LOGGER.fine(() -> "Deriving shape for Dense call at: " + Loggables.describe(this.getNode()));
 
     Set<List<Dimension<?>>> inputShapes = this.getInputShapes(builder);
     if (inputShapes == null || inputShapes.isEmpty()) return null;
@@ -189,7 +204,11 @@ public class DenseCall extends TensorGenerator {
       // Cyclic chain: this `Dense.__call__` node's input flows back to itself (e.g., a layer-list
       // loop whose output feeds in as its own input under 1-CFA node collapse). Break the cycle;
       // the other phi operand supplies the base shape. See wala/ML#599.
-      LOGGER.fine(() -> "getInputShapes: cycle detected at node " + self + "; breaking recursion.");
+      LOGGER.fine(
+          () ->
+              "getInputShapes: cycle detected at node "
+                  + Loggables.describe(self)
+                  + "; breaking recursion.");
       return null;
     }
     try {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.util.TensorShapeUtil.areBroadcastable;
 import static com.ibm.wala.cast.python.ml.util.TensorShapeUtil.getBroadcastedShapes;
 import static java.util.Collections.emptyList;
@@ -98,9 +99,9 @@ public class ElementWiseOperation extends TensorGenerator {
     LOGGER.fine(
         () ->
             "EWO.getDefaultShapes entered with source="
-                + Loggables.describe(this.source)
+                + describe(this.source)
                 + ", node="
-                + Loggables.describe(this.getNode()));
+                + describe(this.getNode()));
 
     int xVn = this.getXArgumentValueNumber(builder);
     LOGGER.fine(() -> "EWO.getDefaultShapes xVn: " + xVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -97,7 +97,10 @@ public class ElementWiseOperation extends TensorGenerator {
 
     LOGGER.fine(
         () ->
-            "EWO.getDefaultShapes entered with source=" + this.source + ", node=" + this.getNode());
+            "EWO.getDefaultShapes entered with source="
+                + Loggables.describe(this.source)
+                + ", node="
+                + Loggables.describe(this.getNode()));
 
     int xVn = this.getXArgumentValueNumber(builder);
     LOGGER.fine(() -> "EWO.getDefaultShapes xVn: " + xVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingCall.java
@@ -131,7 +131,13 @@ public class EmbeddingCall extends TensorGenerator {
       PointerKey fieldPK = builder.getPointerKeyForInstanceField(selfAsin, f);
       OrdinalSet<InstanceKey> dimPts = builder.getPointerAnalysis().getPointsToSet(fieldPK);
       Set<Long> values = getPossibleLongValues(dimPts);
-      LOGGER.fine(() -> "Possible `output_dim` values: " + values + " for source: " + selfIK + ".");
+      LOGGER.fine(
+          () ->
+              "Possible `output_dim` values: "
+                  + values
+                  + " for source: "
+                  + Loggables.describe(selfIK)
+                  + ".");
       if (values != null) ret.addAll(values);
     }
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingCall.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
@@ -133,11 +134,7 @@ public class EmbeddingCall extends TensorGenerator {
       Set<Long> values = getPossibleLongValues(dimPts);
       LOGGER.fine(
           () ->
-              "Possible `output_dim` values: "
-                  + values
-                  + " for source: "
-                  + Loggables.describe(selfIK)
-                  + ".");
+              "Possible `output_dim` values: " + values + " for source: " + describe(selfIK) + ".");
       if (values != null) ret.addAll(values);
     }
     return ret;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FILL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TYPE_REFERENCE_TO_SIGNATURE;
 import static java.util.logging.Logger.getLogger;
@@ -129,7 +130,7 @@ public class Fill extends Constant {
           "Recovered "
               + SIGNATURE
               + " shape from a .shape argument for source: "
-              + source
+              + describe(source)
               + " -> "
               + fromShapeAttribute
               + ".");
@@ -144,11 +145,11 @@ public class Fill extends Constant {
             ? "Could not resolve the dims argument of "
                 + SIGNATURE
                 + " for source: "
-                + source
+                + describe(source)
                 + "; returning ⊤. Candidate for a wala/ML#370 shape annotation."
             : SIGNATURE
                 + " reached without its mandatory dims argument for source: "
-                + source
+                + describe(source)
                 + " (malformed call?); returning ⊤.");
     return null;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
@@ -98,9 +99,9 @@ public class Input extends TensorTypeAllocator {
 
     LOGGER.fine(
         "Found possible dtypes: "
-            + Loggables.describe(pointsToSet)
+            + describe(pointsToSet)
             + " for source: "
-            + Loggables.describe(this.getSource())
+            + describe(this.getSource())
             + ".");
     return this.getDTypesFromDTypeArgument(builder, pointsToSet);
   }
@@ -120,9 +121,7 @@ public class Input extends TensorTypeAllocator {
               builder, this.getTensorParameterPosition(), this.getTensorParameterName());
       if (tensorPts != null && !tensorPts.isEmpty()) {
         LOGGER.fine(
-            "Reading shape from `tensor` argument for source: "
-                + Loggables.describe(this.getSource())
-                + ".");
+            "Reading shape from `tensor` argument for source: " + describe(this.getSource()) + ".");
         return this.getShapes(builder, tensorValNum);
       }
     }
@@ -153,7 +152,7 @@ public class Input extends TensorTypeAllocator {
       if (shapePts == null || shapePts.isEmpty()) {
         LOGGER.fine(
             "No shapes found for source: "
-                + Loggables.describe(this.getSource())
+                + describe(this.getSource())
                 + "; using default shapes.");
         shapes = this.getDefaultShapes(builder);
       } else {
@@ -167,9 +166,7 @@ public class Input extends TensorTypeAllocator {
       }
     } else {
       LOGGER.fine(
-          "No shapes found for source: "
-              + Loggables.describe(this.getSource())
-              + "; using default shapes.");
+          "No shapes found for source: " + describe(this.getSource()) + "; using default shapes.");
       shapes = this.getDefaultShapes(builder);
     }
 
@@ -232,8 +229,7 @@ public class Input extends TensorTypeAllocator {
       }
     }
 
-    LOGGER.fine(
-        "Generated shapes: " + newShapes + " for source: " + Loggables.describe(source) + ".");
+    LOGGER.fine("Generated shapes: " + newShapes + " for source: " + describe(source) + ".");
     return newShapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Input.java
@@ -96,7 +96,12 @@ public class Input extends TensorTypeAllocator {
       // Fallback to default.
       return this.getDefaultDTypes(builder);
 
-    LOGGER.fine("Found possible dtypes: " + pointsToSet + " for source: " + this.getSource() + ".");
+    LOGGER.fine(
+        "Found possible dtypes: "
+            + Loggables.describe(pointsToSet)
+            + " for source: "
+            + Loggables.describe(this.getSource())
+            + ".");
     return this.getDTypesFromDTypeArgument(builder, pointsToSet);
   }
 
@@ -114,7 +119,10 @@ public class Input extends TensorTypeAllocator {
           this.getArgumentPointsToSet(
               builder, this.getTensorParameterPosition(), this.getTensorParameterName());
       if (tensorPts != null && !tensorPts.isEmpty()) {
-        LOGGER.fine("Reading shape from `tensor` argument for source: " + this.getSource() + ".");
+        LOGGER.fine(
+            "Reading shape from `tensor` argument for source: "
+                + Loggables.describe(this.getSource())
+                + ".");
         return this.getShapes(builder, tensorValNum);
       }
     }
@@ -143,7 +151,10 @@ public class Input extends TensorTypeAllocator {
               builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
       if (shapePts == null || shapePts.isEmpty()) {
-        LOGGER.fine("No shapes found for source: " + this.getSource() + "; using default shapes.");
+        LOGGER.fine(
+            "No shapes found for source: "
+                + Loggables.describe(this.getSource())
+                + "; using default shapes.");
         shapes = this.getDefaultShapes(builder);
       } else {
         LOGGER.fine(
@@ -155,7 +166,10 @@ public class Input extends TensorTypeAllocator {
         shapes = this.getShapesFromShapeArgument(builder, shapePts);
       }
     } else {
-      LOGGER.fine("No shapes found for source: " + this.getSource() + "; using default shapes.");
+      LOGGER.fine(
+          "No shapes found for source: "
+              + Loggables.describe(this.getSource())
+              + "; using default shapes.");
       shapes = this.getDefaultShapes(builder);
     }
 
@@ -218,7 +232,8 @@ public class Input extends TensorTypeAllocator {
       }
     }
 
-    LOGGER.fine("Generated shapes: " + newShapes + " for source: " + source + ".");
+    LOGGER.fine(
+        "Generated shapes: " + newShapes + " for source: " + Loggables.describe(source) + ".");
     return newShapes;
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
@@ -1,0 +1,100 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceFieldKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.util.intset.OrdinalSet;
+
+/**
+ * Context-free renderers for logging pointer-analysis and call-graph values. Their own {@code
+ * toString()} methods render the enclosing {@link com.ibm.wala.ipa.callgraph.Context}, whose
+ * scope-mapping and receiver contexts can reference each other cyclically and recurse until the
+ * heap is exhausted on large graphs (e.g., nlpgnn). These helpers render only bounded, context-free
+ * fields (value numbers, method signatures, allocation sites), so a {@code LOGGER.fine("..." +
+ * describe(x))} is safe at any logging level. See <a
+ * href="https://github.com/wala/ML/issues/697">wala/ML#697</a>.
+ */
+final class Loggables {
+
+  private Loggables() {}
+
+  /**
+   * Describes a points-to variable by its pointer key.
+   *
+   * @param variable The variable to describe, or {@code null}.
+   * @return A bounded, context-free description.
+   */
+  static String describe(PointsToSetVariable variable) {
+    return variable == null ? "null" : describe(variable.getPointerKey());
+  }
+
+  /**
+   * Describes a pointer key using only context-free fields.
+   *
+   * @param pk The pointer key to describe, or {@code null}.
+   * @return A bounded, context-free description.
+   */
+  static String describe(PointerKey pk) {
+    if (pk == null) return "null";
+    if (pk instanceof LocalPointerKey) {
+      LocalPointerKey lpk = (LocalPointerKey) pk;
+      return "v" + lpk.getValueNumber() + " in " + signature(lpk.getNode());
+    }
+    if (pk instanceof InstanceFieldKey) {
+      InstanceFieldKey ifk = (InstanceFieldKey) pk;
+      return ifk.getField().getName() + " on " + describe(ifk.getInstanceKey());
+    }
+    return pk.getClass().getSimpleName();
+  }
+
+  /**
+   * Describes a call-graph node by its method signature, omitting its context.
+   *
+   * @param node The node to describe, or {@code null}.
+   * @return A bounded, context-free description.
+   */
+  static String describe(CGNode node) {
+    return node == null ? "null" : signature(node);
+  }
+
+  /**
+   * Describes an instance key by its allocation site, omitting the allocating node's context.
+   *
+   * @param ik The instance key to describe, or {@code null}.
+   * @return A bounded, context-free description.
+   */
+  static String describe(InstanceKey ik) {
+    if (ik == null) return "null";
+    if (ik instanceof AllocationSiteInNode) {
+      AllocationSiteInNode asin = (AllocationSiteInNode) ik;
+      return asin.getSite() + " in " + signature(asin.getNode());
+    }
+    return ik.getClass().getSimpleName();
+  }
+
+  /**
+   * Describes a set of instance keys element-wise.
+   *
+   * @param set The set to describe, or {@code null}.
+   * @return A bounded, context-free description.
+   */
+  static String describe(OrdinalSet<InstanceKey> set) {
+    if (set == null) return "null";
+    StringBuilder sb = new StringBuilder("[");
+    boolean first = true;
+    for (InstanceKey ik : set) {
+      if (!first) sb.append(", ");
+      sb.append(describe(ik));
+      first = false;
+    }
+    return sb.append("]").toString();
+  }
+
+  private static String signature(CGNode node) {
+    return node.getMethod().getSignature();
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
@@ -20,6 +20,9 @@ import com.ibm.wala.util.intset.OrdinalSet;
  */
 final class Loggables {
 
+  /** The most instance keys {@link #describe(OrdinalSet)} renders before truncating. */
+  private static final int MAX_SET_ELEMENTS = 10;
+
   private Loggables() {}
 
   /**
@@ -58,7 +61,7 @@ final class Loggables {
    * @return A bounded, context-free description.
    */
   static String describe(CGNode node) {
-    return node == null ? "null" : signature(node);
+    return signature(node);
   }
 
   /**
@@ -77,7 +80,8 @@ final class Loggables {
   }
 
   /**
-   * Describes a set of instance keys element-wise.
+   * Describes a set of instance keys element-wise, rendering at most {@link #MAX_SET_ELEMENTS} of
+   * them so a large points-to set cannot materialize a large string.
    *
    * @param set The set to describe, or {@code null}.
    * @return A bounded, context-free description.
@@ -85,16 +89,20 @@ final class Loggables {
   static String describe(OrdinalSet<InstanceKey> set) {
     if (set == null) return "null";
     StringBuilder sb = new StringBuilder("[");
-    boolean first = true;
+    int rendered = 0;
     for (InstanceKey ik : set) {
-      if (!first) sb.append(", ");
+      if (rendered == MAX_SET_ELEMENTS) {
+        sb.append(", ... (").append(set.size()).append(" total)");
+        break;
+      }
+      if (rendered > 0) sb.append(", ");
       sb.append(describe(ik));
-      first = false;
+      rendered++;
     }
     return sb.append("]").toString();
   }
 
   private static String signature(CGNode node) {
-    return node.getMethod().getSignature();
+    return node == null ? "null" : node.getMethod().getSignature();
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.MODEL;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
@@ -205,15 +206,15 @@ public class ModelCall extends TensorGenerator {
                   + ".");
 
       for (InstanceKey outputIK : outputsPTS) {
-        LOGGER.finest("Found output instance key: " + Loggables.describe(outputIK) + ".");
+        LOGGER.finest("Found output instance key: " + describe(outputIK) + ".");
 
         AllocationSiteInNode outputASIN = getAllocationSiteInNode(outputIK);
         if (outputASIN != null) {
           LOGGER.finest(
               "Found output allocation site: "
-                  + outputASIN
+                  + describe(outputASIN)
                   + " for instance key: "
-                  + outputIK
+                  + describe(outputIK)
                   + ".");
 
           TensorGenerator outputGenerator = createManualGenerator(outputASIN.getNode(), builder);
@@ -222,7 +223,7 @@ public class ModelCall extends TensorGenerator {
                 "Created tensor generator: "
                     + outputGenerator
                     + " for output allocation site: "
-                    + outputASIN
+                    + describe(outputASIN)
                     + ".");
 
             ret.add(outputGenerator);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -205,7 +205,7 @@ public class ModelCall extends TensorGenerator {
                   + ".");
 
       for (InstanceKey outputIK : outputsPTS) {
-        LOGGER.finest("Found output instance key: " + outputIK + ".");
+        LOGGER.finest("Found output instance key: " + Loggables.describe(outputIK) + ".");
 
         AllocationSiteInNode outputASIN = getAllocationSiteInNode(outputIK);
         if (outputASIN != null) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.ELLIPSIS;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
@@ -89,7 +90,7 @@ public class NdarraySubscriptOperation extends TensorGenerator {
     LOGGER.fine(
         () ->
             "isApplicable: source="
-                + source
+                + describe(source)
                 + " propRead="
                 + propRead
                 + " fields="
@@ -107,9 +108,7 @@ public class NdarraySubscriptOperation extends TensorGenerator {
     List<SubscriptField> fields = extractSubscriptFields(propRead, getNode(), builder);
     if (fields == null) {
       LOGGER.fine(
-          () ->
-              "NdarraySubscriptOperation: unsupported subscript pattern for "
-                  + Loggables.describe(source));
+          () -> "NdarraySubscriptOperation: unsupported subscript pattern for " + describe(source));
       return null;
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
@@ -106,7 +106,10 @@ public class NdarraySubscriptOperation extends TensorGenerator {
 
     List<SubscriptField> fields = extractSubscriptFields(propRead, getNode(), builder);
     if (fields == null) {
-      LOGGER.fine(() -> "NdarraySubscriptOperation: unsupported subscript pattern for " + source);
+      LOGGER.fine(
+          () ->
+              "NdarraySubscriptOperation: unsupported subscript pattern for "
+                  + Loggables.describe(source));
       return null;
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -44,7 +44,12 @@ public class NpArray extends TensorGenerator {
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     int sourceVn = getArgumentValueNumber(0);
-    LOGGER.fine(() -> "NpArray.getDefaultShapes: source=" + source + ", sourceVn=" + sourceVn);
+    LOGGER.fine(
+        () ->
+            "NpArray.getDefaultShapes: source="
+                + Loggables.describe(source)
+                + ", sourceVn="
+                + sourceVn);
     if (sourceVn > 0) {
       try {
         Set<List<Dimension<?>>> shapes = getShapes(builder, getNode(), sourceVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.list;
 import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
@@ -45,11 +46,7 @@ public class NpArray extends TensorGenerator {
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     int sourceVn = getArgumentValueNumber(0);
     LOGGER.fine(
-        () ->
-            "NpArray.getDefaultShapes: source="
-                + Loggables.describe(source)
-                + ", sourceVn="
-                + sourceVn);
+        () -> "NpArray.getDefaultShapes: source=" + describe(source) + ", sourceVn=" + sourceVn);
     if (sourceVn > 0) {
       try {
         Set<List<Dimension<?>>> shapes = getShapes(builder, getNode(), sourceVn);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static java.util.logging.Logger.getLogger;
 
@@ -48,7 +49,7 @@ public class NpOnes extends Ones {
     LOGGER.fine(
         () ->
             "No dtype specified for source: "
-                + source
+                + describe(source)
                 + ". Using NumPy default dtype of: "
                 + FLOAT64
                 + ".");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -367,7 +367,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         } else if (inst instanceof SSABinaryOpInstruction) {
           // Binary operations (e.g. +, *) on tensors are also sources.
           sources.add(src);
-          LOGGER.fine("Added dataflow source from binary op: " + src + ".");
+          LOGGER.fine("Added dataflow source from binary op: " + Loggables.describe(src) + ".");
         } else if (inst instanceof EachElementGetInstruction) {
           // We are potentially pulling a tensor out of a tensor iterable.
           EachElementGetInstruction eachElementGetInstruction = (EachElementGetInstruction) inst;
@@ -482,9 +482,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           || methodName.equals(DO_METHOD_NAME)) {
         try {
           TensorGenerator generator = getGenerator(src, builder);
-          LOGGER.fine(() -> "Found tensor generator: " + generator + " for source: " + src + ".");
+          LOGGER.fine(
+              () ->
+                  "Found tensor generator: "
+                      + generator
+                      + " for source: "
+                      + Loggables.describe(src)
+                      + ".");
           sources.add(src);
-          LOGGER.fine("Added dataflow source from tensor generator: " + src + ".");
+          LOGGER.fine(
+              "Added dataflow source from tensor generator: " + Loggables.describe(src) + ".");
           ret = true;
         } catch (IllegalArgumentException e) {
           // not a tensor source.
@@ -635,7 +642,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // First try intraprocedural analysis.
         if (definesTensorIterable(def, node, callGraph, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.fine("Added dataflow source from tensor iterable: " + src + ".");
+          LOGGER.fine(
+              "Added dataflow source from tensor iterable: " + Loggables.describe(src) + ".");
           return true;
         } else {
           // Use interprocedural analysis using the PA.
@@ -698,7 +706,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                 || reference.getName().toString().startsWith(DATA_PACKAGE_PREFIX))
             && isDatasetTensorElement(src, use, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.fine("Added dataflow source from tensor dataset: " + src + ".");
+          LOGGER.fine(
+              "Added dataflow source from tensor dataset: " + Loggables.describe(src) + ".");
           return true;
         }
       }
@@ -1214,7 +1223,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         if (isEnumerateFirstFieldRead(v, builder)) drops.add(v);
       }
       LOGGER.fine(() -> "wala/ML#409 drops (enumerate-first-field): " + drops.size());
-      for (PointsToSetVariable d : drops) LOGGER.fine(() -> "  drop: " + d.getPointerKey());
+      for (PointsToSetVariable d : drops)
+        LOGGER.fine(() -> "  drop: " + Loggables.describe(d.getPointerKey()));
 
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
@@ -1266,7 +1276,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    */
   private Set<TensorType> getTensorTypes(
       PointsToSetVariable source, PropagationCallGraphBuilder builder) {
-    LOGGER.fine("Getting tensor types for source: " + source + ".");
+    LOGGER.fine("Getting tensor types for source: " + Loggables.describe(source) + ".");
 
     try {
       TensorGenerator generator = getGenerator(source, builder);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.client.TensorGeneratorFactory.getGenerator;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATA_PACKAGE_PREFIX;
@@ -367,7 +368,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         } else if (inst instanceof SSABinaryOpInstruction) {
           // Binary operations (e.g. +, *) on tensors are also sources.
           sources.add(src);
-          LOGGER.fine("Added dataflow source from binary op: " + Loggables.describe(src) + ".");
+          LOGGER.fine("Added dataflow source from binary op: " + describe(src) + ".");
         } else if (inst instanceof EachElementGetInstruction) {
           // We are potentially pulling a tensor out of a tensor iterable.
           EachElementGetInstruction eachElementGetInstruction = (EachElementGetInstruction) inst;
@@ -483,15 +484,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         try {
           TensorGenerator generator = getGenerator(src, builder);
           LOGGER.fine(
-              () ->
-                  "Found tensor generator: "
-                      + generator
-                      + " for source: "
-                      + Loggables.describe(src)
-                      + ".");
+              () -> "Found tensor generator: " + generator + " for source: " + describe(src) + ".");
           sources.add(src);
-          LOGGER.fine(
-              "Added dataflow source from tensor generator: " + Loggables.describe(src) + ".");
+          LOGGER.fine("Added dataflow source from tensor generator: " + describe(src) + ".");
           ret = true;
         } catch (IllegalArgumentException e) {
           // not a tensor source.
@@ -642,8 +637,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // First try intraprocedural analysis.
         if (definesTensorIterable(def, node, callGraph, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.fine(
-              "Added dataflow source from tensor iterable: " + Loggables.describe(src) + ".");
+          LOGGER.fine("Added dataflow source from tensor iterable: " + describe(src) + ".");
           return true;
         } else {
           // Use interprocedural analysis using the PA.
@@ -706,8 +700,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                 || reference.getName().toString().startsWith(DATA_PACKAGE_PREFIX))
             && isDatasetTensorElement(src, use, pointerAnalysis)) {
           sources.add(src);
-          LOGGER.fine(
-              "Added dataflow source from tensor dataset: " + Loggables.describe(src) + ".");
+          LOGGER.fine("Added dataflow source from tensor dataset: " + describe(src) + ".");
           return true;
         }
       }
@@ -1224,7 +1217,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       }
       LOGGER.fine(() -> "wala/ML#409 drops (enumerate-first-field): " + drops.size());
       for (PointsToSetVariable d : drops)
-        LOGGER.fine(() -> "  drop: " + Loggables.describe(d.getPointerKey()));
+        LOGGER.fine(() -> "  drop: " + describe(d.getPointerKey()));
 
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
@@ -1276,7 +1269,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    */
   private Set<TensorType> getTensorTypes(
       PointsToSetVariable source, PropagationCallGraphBuilder builder) {
-    LOGGER.fine("Getting tensor types for source: " + Loggables.describe(source) + ".");
+    LOGGER.fine("Getting tensor types for source: " + describe(source) + ".");
 
     try {
       TensorGenerator generator = getGenerator(source, builder);
@@ -1295,7 +1288,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       return tensorTypes;
     } catch (IllegalArgumentException e) {
-      LOGGER.log(Level.FINER, "Source " + source + " is not a recognized tensor generator.", e);
+      LOGGER.log(
+          Level.FINER,
+          e,
+          () -> "Source " + describe(source) + " is not a recognized tensor generator.");
       return HashSetFactory.make();
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -88,7 +88,13 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(
+        () ->
+            "Inferred nrows for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalPossibleRowDims
+                + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -90,11 +91,7 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
     LOGGER.fine(
         () ->
-            "Inferred nrows for "
-                + Loggables.describe(this.getSource())
-                + ": "
-                + finalPossibleRowDims
-                + ".");
+            "Inferred nrows for " + describe(this.getSource()) + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -90,11 +91,7 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
     LOGGER.fine(
         () ->
-            "Inferred nrows for "
-                + Loggables.describe(this.getSource())
-                + ": "
-                + finalPossibleRowDims
-                + ".");
+            "Inferred nrows for " + describe(this.getSource()) + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -88,7 +88,13 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(
+        () ->
+            "Inferred nrows for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalPossibleRowDims
+                + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.client.RaggedFromRowSplits.Parameters.ROW_SPLITS;
 import static com.ibm.wala.cast.python.ml.client.RaggedFromRowSplits.Parameters.VALUES;
 import static java.util.Collections.emptySet;
@@ -95,11 +96,7 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
     LOGGER.fine(
         () ->
-            "Inferred nrows for "
-                + Loggables.describe(this.getSource())
-                + ": "
-                + finalPossibleRowDims
-                + ".");
+            "Inferred nrows for " + describe(this.getSource()) + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =
@@ -114,7 +111,7 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     LOGGER.fine(
         () ->
             "Possible values shapes for "
-                + Loggables.describe(this.getSource())
+                + describe(this.getSource())
                 + ": "
                 + finalValuesShapes
                 + ".");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -93,7 +93,13 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(
+        () ->
+            "Inferred nrows for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalPossibleRowDims
+                + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts =
@@ -106,7 +112,12 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
     LOGGER.fine(
-        () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
+        () ->
+            "Possible values shapes for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalValuesShapes
+                + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -97,11 +98,7 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
     LOGGER.fine(
         () ->
-            "Inferred nrows for "
-                + Loggables.describe(this.getSource())
-                + ": "
-                + finalPossibleRowDims
-                + ".");
+            "Inferred nrows for " + describe(this.getSource()) + ": " + finalPossibleRowDims + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts = this.getValuesPointsToSet(builder);
@@ -114,7 +111,7 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     LOGGER.fine(
         () ->
             "Possible values shapes for "
-                + Loggables.describe(this.getSource())
+                + describe(this.getSource())
                 + ": "
                 + finalValuesShapes
                 + ".");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -95,7 +95,13 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
     }
 
     final Set<Dimension<?>> finalPossibleRowDims = possibleRowDims;
-    LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalPossibleRowDims + ".");
+    LOGGER.fine(
+        () ->
+            "Inferred nrows for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalPossibleRowDims
+                + ".");
 
     // 2. Determine shape of `values`.
     OrdinalSet<InstanceKey> valuesPts = this.getValuesPointsToSet(builder);
@@ -106,7 +112,12 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
     LOGGER.fine(
-        () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
+        () ->
+            "Possible values shapes for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalValuesShapes
+                + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.list;
 import static com.ibm.wala.cast.python.types.PythonTypes.tuple;
@@ -86,7 +87,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
 
     if (pointsToSet == null || pointsToSet.isEmpty())
       throw new IllegalArgumentException(
-          "Empty points-to set in source: " + Loggables.describe(this.getSource()) + ".");
+          "Empty points-to set in source: " + describe(this.getSource()) + ".");
 
     Set<Long> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -147,9 +148,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
       }
     }
 
-    LOGGER.fine(
-        () ->
-            "Possible value rowids for " + Loggables.describe(this.getSource()) + ": " + ret + ".");
+    LOGGER.fine(() -> "Possible value rowids for " + describe(this.getSource()) + ": " + ret + ".");
     return ret;
   }
 
@@ -192,18 +191,13 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
       }
       final Set<Long> finalNrowsArgs = nrowsArgs;
       LOGGER.fine(
-          () ->
-              "Inferred nrows for "
-                  + Loggables.describe(this.getSource())
-                  + ": "
-                  + finalNrowsArgs
-                  + ".");
+          () -> "Inferred nrows for " + describe(this.getSource()) + ": " + finalNrowsArgs + ".");
     } else {
       final Set<Long> finalNrowsArgs = nrowsArgs;
       LOGGER.fine(
           () ->
               "Found nrows arguments for "
-                  + Loggables.describe(this.getSource())
+                  + describe(this.getSource())
                   + ": "
                   + finalNrowsArgs
                   + ".");
@@ -238,7 +232,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
     LOGGER.fine(
         () ->
             "Possible values shapes for "
-                + Loggables.describe(this.getSource())
+                + describe(this.getSource())
                 + ": "
                 + finalValuesShapes
                 + ".");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -86,7 +86,7 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
 
     if (pointsToSet == null || pointsToSet.isEmpty())
       throw new IllegalArgumentException(
-          "Empty points-to set in source: " + this.getSource() + ".");
+          "Empty points-to set in source: " + Loggables.describe(this.getSource()) + ".");
 
     Set<Long> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -147,7 +147,9 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
       }
     }
 
-    LOGGER.fine(() -> "Possible value rowids for " + this.getSource() + ": " + ret + ".");
+    LOGGER.fine(
+        () ->
+            "Possible value rowids for " + Loggables.describe(this.getSource()) + ": " + ret + ".");
     return ret;
   }
 
@@ -189,11 +191,22 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
         nrowsArgs = singleton(max + 1);
       }
       final Set<Long> finalNrowsArgs = nrowsArgs;
-      LOGGER.fine(() -> "Inferred nrows for " + this.getSource() + ": " + finalNrowsArgs + ".");
+      LOGGER.fine(
+          () ->
+              "Inferred nrows for "
+                  + Loggables.describe(this.getSource())
+                  + ": "
+                  + finalNrowsArgs
+                  + ".");
     } else {
       final Set<Long> finalNrowsArgs = nrowsArgs;
       LOGGER.fine(
-          () -> "Found nrows arguments for " + this.getSource() + ": " + finalNrowsArgs + ".");
+          () ->
+              "Found nrows arguments for "
+                  + Loggables.describe(this.getSource())
+                  + ": "
+                  + finalNrowsArgs
+                  + ".");
     }
 
     // For now, if nrows is missing, we might assume unknown or handle it if we can deduce from
@@ -223,7 +236,12 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
 
     final Set<List<Dimension<?>>> finalValuesShapes = valuesShapes;
     LOGGER.fine(
-        () -> "Possible values shapes for " + this.getSource() + ": " + finalValuesShapes + ".");
+        () ->
+            "Possible values shapes for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + finalValuesShapes
+                + ".");
 
     return constructRaggedShape(possibleRowDims, valuesShapes);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
@@ -43,12 +45,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
     if (valuesPts != null && !valuesPts.isEmpty()) {
       Set<DType> ret = this.getDTypesOfValue(builder, valuesPts);
       LOGGER.fine(
-          () ->
-              "Inferred dtypes from values for "
-                  + Loggables.describe(this.getSource())
-                  + ": "
-                  + ret
-                  + ".");
+          () -> "Inferred dtypes from values for " + describe(this.getSource()) + ": " + ret + ".");
       return ret;
     }
     return EnumSet.of(DType.UNKNOWN);
@@ -68,7 +65,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       LOGGER.fine(
           () ->
               "Determined default ragged shapes for "
-                  + Loggables.describe(this.getSource())
+                  + describe(this.getSource())
                   + ": "
                   + ret
                   + ".");
@@ -91,11 +88,7 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
 
     LOGGER.fine(
         () ->
-            "Determined final ragged shapes for "
-                + Loggables.describe(this.getSource())
-                + ": "
-                + ret
-                + ".");
+            "Determined final ragged shapes for " + describe(this.getSource()) + ": " + ret + ".");
     return ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -42,7 +42,13 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
     OrdinalSet<InstanceKey> valuesPts = getValuesPointsToSet(builder);
     if (valuesPts != null && !valuesPts.isEmpty()) {
       Set<DType> ret = this.getDTypesOfValue(builder, valuesPts);
-      LOGGER.fine(() -> "Inferred dtypes from values for " + this.getSource() + ": " + ret + ".");
+      LOGGER.fine(
+          () ->
+              "Inferred dtypes from values for "
+                  + Loggables.describe(this.getSource())
+                  + ": "
+                  + ret
+                  + ".");
       return ret;
     }
     return EnumSet.of(DType.UNKNOWN);
@@ -60,7 +66,12 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
         ret.add(shape);
       }
       LOGGER.fine(
-          () -> "Determined default ragged shapes for " + this.getSource() + ": " + ret + ".");
+          () ->
+              "Determined default ragged shapes for "
+                  + Loggables.describe(this.getSource())
+                  + ": "
+                  + ret
+                  + ".");
       return ret;
     }
 
@@ -78,7 +89,13 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
       }
     }
 
-    LOGGER.fine(() -> "Determined final ragged shapes for " + this.getSource() + ": " + ret + ".");
+    LOGGER.fine(
+        () ->
+            "Determined final ragged shapes for "
+                + Loggables.describe(this.getSource())
+                + ": "
+                + ret
+                + ".");
     return ret;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
@@ -111,14 +113,7 @@ public class Slice extends PassThroughUnaryTensorGenerator {
       // `getShapesFromShapeArgument` throws `IllegalStateException` for an unrecognized shape form;
       // degrade that to ⊤. Other runtime exceptions propagate as intended diagnostics.
       LOGGER.fine(
-          () ->
-              "Could not resolve "
-                  + name
-                  + " of "
-                  + Loggables.describe(this.getSource())
-                  + ": "
-                  + e
-                  + ".");
+          () -> "Could not resolve " + name + " of " + describe(this.getSource()) + ": " + e + ".");
       return null;
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
@@ -110,7 +110,15 @@ public class Slice extends PassThroughUnaryTensorGenerator {
     } catch (IllegalStateException e) {
       // `getShapesFromShapeArgument` throws `IllegalStateException` for an unrecognized shape form;
       // degrade that to ⊤. Other runtime exceptions propagate as intended diagnostics.
-      LOGGER.fine(() -> "Could not resolve " + name + " of " + this.getSource() + ": " + e + ".");
+      LOGGER.fine(
+          () ->
+              "Could not resolve "
+                  + name
+                  + " of "
+                  + Loggables.describe(this.getSource())
+                  + ": "
+                  + e
+                  + ".");
       return null;
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -62,10 +62,10 @@ public class SliceBuiltinOperation extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.fine(() -> "Entered getDefaultShapes for source=" + source);
+    LOGGER.fine(() -> "Entered getDefaultShapes for source=" + Loggables.describe(source));
     CallSiteView view = findCallSite(builder);
     if (view == null) {
-      LOGGER.fine(() -> "No call site resolved for " + source);
+      LOGGER.fine(() -> "No call site resolved for " + Loggables.describe(source));
       return null;
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.types.PythonTypes.ELLIPSIS;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
@@ -62,10 +63,10 @@ public class SliceBuiltinOperation extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    LOGGER.fine(() -> "Entered getDefaultShapes for source=" + Loggables.describe(source));
+    LOGGER.fine(() -> "Entered getDefaultShapes for source=" + describe(source));
     CallSiteView view = findCallSite(builder);
     if (view == null) {
-      LOGGER.fine(() -> "No call site resolved for " + Loggables.describe(source));
+      LOGGER.fine(() -> "No call site resolved for " + describe(source));
       return null;
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
@@ -72,7 +72,9 @@ public class Squeeze extends PassThroughUnaryTensorGenerator {
     } else {
       axes = resolveAxisInts(builder, axisPts);
       if (axes == null) {
-        LOGGER.fine(() -> "Non-constant axis for " + this.getSource() + "; returning ⊤.");
+        LOGGER.fine(
+            () ->
+                "Non-constant axis for " + Loggables.describe(this.getSource()) + "; returning ⊤.");
         return null;
       }
     }
@@ -133,7 +135,13 @@ public class Squeeze extends PassThroughUnaryTensorGenerator {
         } catch (IllegalStateException e) {
           // `getShapesFromShapeArgument` throws `IllegalStateException` for an unrecognized shape
           // form; degrade that to ⊤. Other runtime exceptions propagate as intended diagnostics.
-          LOGGER.fine(() -> "Could not resolve axis of " + this.getSource() + ": " + e + ".");
+          LOGGER.fine(
+              () ->
+                  "Could not resolve axis of "
+                      + Loggables.describe(this.getSource())
+                      + ": "
+                      + e
+                      + ".");
           return null;
         }
         if (lists == null) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -72,9 +74,7 @@ public class Squeeze extends PassThroughUnaryTensorGenerator {
     } else {
       axes = resolveAxisInts(builder, axisPts);
       if (axes == null) {
-        LOGGER.fine(
-            () ->
-                "Non-constant axis for " + Loggables.describe(this.getSource()) + "; returning ⊤.");
+        LOGGER.fine(() -> "Non-constant axis for " + describe(this.getSource()) + "; returning ⊤.");
         return null;
       }
     }
@@ -136,12 +136,7 @@ public class Squeeze extends PassThroughUnaryTensorGenerator {
           // `getShapesFromShapeArgument` throws `IllegalStateException` for an unrecognized shape
           // form; degrade that to ⊤. Other runtime exceptions propagate as intended diagnostics.
           LOGGER.fine(
-              () ->
-                  "Could not resolve axis of "
-                      + Loggables.describe(this.getSource())
-                      + ": "
-                      + e
-                      + ".");
+              () -> "Could not resolve axis of " + describe(this.getSource()) + ": " + e + ".");
           return null;
         }
         if (lists == null) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -483,7 +483,7 @@ public abstract class TensorGenerator {
                 // resolvable, so return ⊤ rather than aborting (wala/ML#471).
                 LOGGER.fine(
                     "Unrecognized nested shape element for instance field: "
-                        + pointerKeyForInstanceField
+                        + Loggables.describe(pointerKeyForInstanceField)
                         + ", got: "
                         + instanceFieldIK
                         + "; treating the shape as unknown (⊤).");
@@ -492,7 +492,7 @@ public abstract class TensorGenerator {
             } else {
               LOGGER.fine(
                   "Unrecognized shape element for instance field: "
-                      + pointerKeyForInstanceField
+                      + Loggables.describe(pointerKeyForInstanceField)
                       + ", got: "
                       + instanceFieldIK
                       + "; treating the shape as unknown (⊤).");
@@ -504,7 +504,7 @@ public abstract class TensorGenerator {
               "Found possible shape dimensions: "
                   + tensorDimensions
                   + " for field: "
-                  + pointerKeyForInstanceField
+                  + Loggables.describe(pointerKeyForInstanceField)
                   + " for source: "
                   + this.getSource()
                   + ".");
@@ -1482,7 +1482,9 @@ public abstract class TensorGenerator {
 
             PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
             LOGGER.fine(
-                "Found pointer key for instance field: " + pointerKeyForInstanceField + ".");
+                "Found pointer key for instance field: "
+                    + Loggables.describe(pointerKeyForInstanceField)
+                    + ".");
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
@@ -2254,7 +2256,9 @@ public abstract class TensorGenerator {
 
             PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
             LOGGER.fine(
-                "Found pointer key for instance field: " + pointerKeyForInstanceField + ".");
+                "Found pointer key for instance field: "
+                    + Loggables.describe(pointerKeyForInstanceField)
+                    + ".");
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine.TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_CHOOSE_FROM_DATASETS_TYPE;
@@ -344,9 +345,7 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
     if (pointsToSet == null || !pointsToSet.iterator().hasNext())
       throw new IllegalArgumentException(
-          "Empty points-to set for shape argument in source: "
-              + Loggables.describe(this.getSource())
-              + ".");
+          "Empty points-to set for shape argument in source: " + describe(this.getSource()) + ".");
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -422,16 +421,14 @@ public abstract class TensorGenerator {
           PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
           LOGGER.fine(
               "Found pointer key for instance field: "
-                  + Loggables.describe(pointerKeyForInstanceField)
+                  + describe(pointerKeyForInstanceField)
                   + ".");
 
           // Get the points-to set for the instance field.
           OrdinalSet<InstanceKey> instanceFieldPointsToSet =
               pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
           LOGGER.fine(
-              "Points-to set for instance field: "
-                  + Loggables.describe(instanceFieldPointsToSet)
-                  + ".");
+              "Points-to set for instance field: " + describe(instanceFieldPointsToSet) + ".");
 
           // If the instance field points to a constant, we can use it as the shape.
           // TODO: Is it possible to also do it for (simple) expressions?
@@ -483,18 +480,18 @@ public abstract class TensorGenerator {
                 // resolvable, so return ⊤ rather than aborting (wala/ML#471).
                 LOGGER.fine(
                     "Unrecognized nested shape element for instance field: "
-                        + Loggables.describe(pointerKeyForInstanceField)
+                        + describe(pointerKeyForInstanceField)
                         + ", got: "
-                        + instanceFieldIK
+                        + describe(instanceFieldIK)
                         + "; treating the shape as unknown (⊤).");
                 return null;
               }
             } else {
               LOGGER.fine(
                   "Unrecognized shape element for instance field: "
-                      + Loggables.describe(pointerKeyForInstanceField)
+                      + describe(pointerKeyForInstanceField)
                       + ", got: "
-                      + instanceFieldIK
+                      + describe(instanceFieldIK)
                       + "; treating the shape as unknown (⊤).");
               return null;
             }
@@ -504,9 +501,9 @@ public abstract class TensorGenerator {
               "Found possible shape dimensions: "
                   + tensorDimensions
                   + " for field: "
-                  + Loggables.describe(pointerKeyForInstanceField)
+                  + describe(pointerKeyForInstanceField)
                   + " for source: "
-                  + this.getSource()
+                  + describe(this.getSource())
                   + ".");
 
           // Add the shape dimensions.
@@ -942,7 +939,7 @@ public abstract class TensorGenerator {
     LOGGER.fine(
         () ->
             "getShapes(node, vn): node="
-                + node
+                + describe(node)
                 + ", vn="
                 + valueNumber
                 + ", ptsEmpty="
@@ -1035,7 +1032,7 @@ public abstract class TensorGenerator {
             "Could not trace shape for value number "
                 + valueNumber
                 + " in "
-                + node
+                + describe(node)
                 + "; flooring to ⊥ (not a tensor). wala/ML#620.");
     return Collections.emptySet();
   }
@@ -1483,15 +1480,13 @@ public abstract class TensorGenerator {
             PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
             LOGGER.fine(
                 "Found pointer key for instance field: "
-                    + Loggables.describe(pointerKeyForInstanceField)
+                    + describe(pointerKeyForInstanceField)
                     + ".");
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
             LOGGER.fine(
-                "Points-to set for instance field: "
-                    + Loggables.describe(instanceFieldPointsToSet)
-                    + ".");
+                "Points-to set for instance field: " + describe(instanceFieldPointsToSet) + ".");
 
             Set<List<Dimension<?>>> shapesOfField =
                 this.getShapesOfValue(builder, instanceFieldPointsToSet);
@@ -1510,9 +1505,9 @@ public abstract class TensorGenerator {
             }
           }
         } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
-          LOGGER.fine("Ignoring DType: " + Loggables.describe(asin));
+          LOGGER.fine("Ignoring DType: " + describe(asin));
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
-          LOGGER.fine("Ignoring feature: " + Loggables.describe(asin));
+          LOGGER.fine("Ignoring feature: " + describe(asin));
         } else {
           // Assume the value is a tensor and attempt to find the generator that created it
           // to ask for its shape.
@@ -1677,9 +1672,7 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
     if (pointsToSet == null || !pointsToSet.iterator().hasNext())
       throw new IllegalArgumentException(
-          "Empty points-to set for dtype argument in source: "
-              + Loggables.describe(this.getSource())
-              + ".");
+          "Empty points-to set for dtype argument in source: " + describe(this.getSource()) + ".");
 
     Set<DType> ret = EnumSet.noneOf(DType.class);
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -1711,7 +1704,7 @@ public abstract class TensorGenerator {
         CGNode importNode = ((AllocationSiteInNode) instanceKey).getNode();
 
         if (importNode != null) {
-          LOGGER.fine("Found import node of interest: " + Loggables.describe(importNode) + ".");
+          LOGGER.fine("Found import node of interest: " + describe(importNode) + ".");
           for (TypeReference ownerType :
               new TypeReference[] {TENSORFLOW_TYPE, TensorFlowTypes.NUMPY_TYPE}) {
             InstanceKey ownerIK =
@@ -1738,9 +1731,9 @@ public abstract class TensorGenerator {
                           "Found dtype: "
                               + dtype
                               + " for source: "
-                              + this.getSource()
+                              + describe(this.getSource())
                               + " from dType: "
-                              + instanceKey
+                              + describe(instanceKey)
                               + ".");
                       found = true;
                       break;
@@ -1767,7 +1760,12 @@ public abstract class TensorGenerator {
         // whole call graph (wala/ML#637). Lose dtype precision for this one value rather than
         // killing the analysis, but log it so the modeling gap is still visible.
         LOGGER.warning(
-            () -> "Unmodeled dtype: " + instanceKey + "; degrading to " + DType.UNKNOWN + ".");
+            () ->
+                "Unmodeled dtype: "
+                    + describe(instanceKey)
+                    + "; degrading to "
+                    + DType.UNKNOWN
+                    + ".");
         ret.add(DType.UNKNOWN);
       } else if (asin != null
           && asin.getNode()
@@ -2090,7 +2088,7 @@ public abstract class TensorGenerator {
             "Could not trace dtype for value number "
                 + valueNumber
                 + " in "
-                + node
+                + describe(node)
                 + "; flooring to ⊥ (not a tensor). wala/ML#620.");
     return Collections.emptySet();
   }
@@ -2257,25 +2255,23 @@ public abstract class TensorGenerator {
             PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
             LOGGER.fine(
                 "Found pointer key for instance field: "
-                    + Loggables.describe(pointerKeyForInstanceField)
+                    + describe(pointerKeyForInstanceField)
                     + ".");
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
             LOGGER.fine(
-                "Points-to set for instance field: "
-                    + Loggables.describe(instanceFieldPointsToSet)
-                    + ".");
+                "Points-to set for instance field: " + describe(instanceFieldPointsToSet) + ".");
 
             Set<DType> fieldDTypes = this.getDTypesOfValue(builder, instanceFieldPointsToSet);
             if (fieldDTypes != null) ret.addAll(fieldDTypes);
           }
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
           // Ignore features.
-          LOGGER.fine("Ignoring feature: " + Loggables.describe(asin));
+          LOGGER.fine("Ignoring feature: " + describe(asin));
         } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
           // Ignore DTypes.
-          LOGGER.fine("Ignoring DType: " + Loggables.describe(asin));
+          LOGGER.fine("Ignoring DType: " + describe(asin));
         } else {
           // Assume the value is a tensor and attempt to find the generator that created it
           // to ask for its dtype.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -344,7 +344,9 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
     if (pointsToSet == null || !pointsToSet.iterator().hasNext())
       throw new IllegalArgumentException(
-          "Empty points-to set for shape argument in source: " + this.getSource() + ".");
+          "Empty points-to set for shape argument in source: "
+              + Loggables.describe(this.getSource())
+              + ".");
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -418,12 +420,18 @@ public abstract class TensorGenerator {
 
           // We can now get the pointer key for the instance field.
           PointerKey pointerKeyForInstanceField = builder.getPointerKeyForInstanceField(asin, f);
-          LOGGER.fine("Found pointer key for instance field: " + pointerKeyForInstanceField + ".");
+          LOGGER.fine(
+              "Found pointer key for instance field: "
+                  + Loggables.describe(pointerKeyForInstanceField)
+                  + ".");
 
           // Get the points-to set for the instance field.
           OrdinalSet<InstanceKey> instanceFieldPointsToSet =
               pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
-          LOGGER.fine("Points-to set for instance field: " + instanceFieldPointsToSet + ".");
+          LOGGER.fine(
+              "Points-to set for instance field: "
+                  + Loggables.describe(instanceFieldPointsToSet)
+                  + ".");
 
           // If the instance field points to a constant, we can use it as the shape.
           // TODO: Is it possible to also do it for (simple) expressions?
@@ -1478,7 +1486,10 @@ public abstract class TensorGenerator {
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
-            LOGGER.fine("Points-to set for instance field: " + instanceFieldPointsToSet + ".");
+            LOGGER.fine(
+                "Points-to set for instance field: "
+                    + Loggables.describe(instanceFieldPointsToSet)
+                    + ".");
 
             Set<List<Dimension<?>>> shapesOfField =
                 this.getShapesOfValue(builder, instanceFieldPointsToSet);
@@ -1497,9 +1508,9 @@ public abstract class TensorGenerator {
             }
           }
         } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
-          LOGGER.fine("Ignoring DType: " + asin);
+          LOGGER.fine("Ignoring DType: " + Loggables.describe(asin));
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
-          LOGGER.fine("Ignoring feature: " + asin);
+          LOGGER.fine("Ignoring feature: " + Loggables.describe(asin));
         } else {
           // Assume the value is a tensor and attempt to find the generator that created it
           // to ask for its shape.
@@ -1664,7 +1675,9 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, Iterable<InstanceKey> pointsToSet) {
     if (pointsToSet == null || !pointsToSet.iterator().hasNext())
       throw new IllegalArgumentException(
-          "Empty points-to set for dtype argument in source: " + this.getSource() + ".");
+          "Empty points-to set for dtype argument in source: "
+              + Loggables.describe(this.getSource())
+              + ".");
 
     Set<DType> ret = EnumSet.noneOf(DType.class);
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
@@ -1696,7 +1709,7 @@ public abstract class TensorGenerator {
         CGNode importNode = ((AllocationSiteInNode) instanceKey).getNode();
 
         if (importNode != null) {
-          LOGGER.fine("Found import node of interest: " + importNode + ".");
+          LOGGER.fine("Found import node of interest: " + Loggables.describe(importNode) + ".");
           for (TypeReference ownerType :
               new TypeReference[] {TENSORFLOW_TYPE, TensorFlowTypes.NUMPY_TYPE}) {
             InstanceKey ownerIK =
@@ -2245,17 +2258,20 @@ public abstract class TensorGenerator {
 
             OrdinalSet<InstanceKey> instanceFieldPointsToSet =
                 pointerAnalysis.getPointsToSet(pointerKeyForInstanceField);
-            LOGGER.fine("Points-to set for instance field: " + instanceFieldPointsToSet + ".");
+            LOGGER.fine(
+                "Points-to set for instance field: "
+                    + Loggables.describe(instanceFieldPointsToSet)
+                    + ".");
 
             Set<DType> fieldDTypes = this.getDTypesOfValue(builder, instanceFieldPointsToSet);
             if (fieldDTypes != null) ret.addAll(fieldDTypes);
           }
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
           // Ignore features.
-          LOGGER.fine("Ignoring feature: " + asin);
+          LOGGER.fine("Ignoring feature: " + Loggables.describe(asin));
         } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
           // Ignore DTypes.
-          LOGGER.fine("Ignoring DType: " + asin);
+          LOGGER.fine("Ignoring DType: " + Loggables.describe(asin));
         } else {
           // Assume the value is a tensor and attempt to find the generator that created it
           // to ask for its dtype.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.RESHAPE_METHOD;
@@ -413,7 +414,7 @@ public class TensorGeneratorFactory {
     // toString() renders the node's context, whose scope-mapping/receiver contexts reference each
     // other cyclically and recurse until the heap is exhausted on large graphs (e.g., nlpgnn); see
     // https://github.com/wala/ML/issues/697.
-    LOGGER.fine(() -> "findCreator started for source: " + Loggables.describe(source));
+    LOGGER.fine(() -> "findCreator started for source: " + describe(source));
 
     while (!queue.isEmpty()) {
       PointsToSetVariable current = queue.poll();
@@ -421,10 +422,10 @@ public class TensorGeneratorFactory {
       // is enqueued below; skip it rather than dereferencing null. wala/ML#613.
       if (current == null) continue;
       PointerKey pk = current.getPointerKey();
-      LOGGER.fine(() -> "findCreator visiting: " + Loggables.describe(pk));
+      LOGGER.fine(() -> "findCreator visiting: " + describe(pk));
 
       if (pk instanceof ReturnValueKey) {
-        LOGGER.fine(() -> "findCreator found ReturnValueKey: " + Loggables.describe(pk));
+        LOGGER.fine(() -> "findCreator found ReturnValueKey: " + describe(pk));
         return current;
       }
 
@@ -443,14 +444,13 @@ public class TensorGeneratorFactory {
           it.hasNext(); ) {
         PointsToSetVariable pred = it.next();
         if (pred != null && visited.add(pred)) {
-          LOGGER.fine(() -> "findCreator adding pred: " + Loggables.describe(pred));
+          LOGGER.fine(() -> "findCreator adding pred: " + describe(pred));
           queue.add(pred);
         }
       }
     }
 
-    LOGGER.fine(
-        () -> "findCreator fallback returning original source: " + Loggables.describe(source));
+    LOGGER.fine(() -> "findCreator fallback returning original source: " + describe(source));
     return source;
   }
 
@@ -658,7 +658,7 @@ public class TensorGeneratorFactory {
                 "TensorGeneratorFactory: dispatching `."
                     + value
                     + "(...)` call at "
-                    + node
+                    + describe(node)
                     + " v"
                     + vn
                     + " via property-name registry.");
@@ -682,7 +682,8 @@ public class TensorGeneratorFactory {
     try {
       return getGenerator(source, builder, visited);
     } catch (IllegalArgumentException e) {
-      LOGGER.log(Level.FINE, "tryGetGenerator: swallowed IAE for source=" + source, e);
+      LOGGER.log(
+          Level.FINE, e, () -> "tryGetGenerator: swallowed IAE for source=" + describe(source));
       return null;
     }
   }
@@ -933,7 +934,7 @@ public class TensorGeneratorFactory {
             LOGGER.fine(
                 () ->
                     "TensorGeneratorFactory: dispatching astype call at "
-                        + node
+                        + describe(node)
                         + " v"
                         + vn
                         + " to AstypeOperation.");
@@ -952,7 +953,7 @@ public class TensorGeneratorFactory {
             LOGGER.fine(
                 () ->
                     "TensorGeneratorFactory: dispatching ndarray.reshape call at "
-                        + node
+                        + describe(node)
                         + " v"
                         + vn
                         + " to NdarrayReshape.");
@@ -1312,8 +1313,9 @@ public class TensorGeneratorFactory {
             () ->
                 "Rejecting ElementWiseOperation dispatch — no operand has tensor"
                     + " evidence. source="
-                    + source);
-        throw new IllegalArgumentException("Binary op with no tensor operand: " + source + ".");
+                    + describe(source));
+        throw new IllegalArgumentException(
+            "Binary op with no tensor operand: " + describe(source) + ".");
       }
       return new ElementWiseOperation(source);
     } else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
@@ -1607,7 +1609,7 @@ public class TensorGeneratorFactory {
         return new ReadDataFallback(source);
       }
       throw new IllegalArgumentException(
-          "Unknown call: " + calledFunction + " for source: " + source + ".");
+          "Unknown call: " + calledFunction + " for source: " + describe(source) + ".");
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -409,7 +409,11 @@ public class TensorGeneratorFactory {
     Queue<PointsToSetVariable> queue = new LinkedList<>();
     queue.add(source);
     visited.add(source);
-    LOGGER.fine("findCreator started for source: " + source);
+    // Log a context-free description rather than the variable or its pointer key: the key's
+    // toString() renders the node's context, whose scope-mapping/receiver contexts reference each
+    // other cyclically and recurse until the heap is exhausted on large graphs (e.g., nlpgnn); see
+    // https://github.com/wala/ML/issues/697.
+    LOGGER.fine(() -> "findCreator started for source: " + describe(source));
 
     while (!queue.isEmpty()) {
       PointsToSetVariable current = queue.poll();
@@ -417,10 +421,10 @@ public class TensorGeneratorFactory {
       // is enqueued below; skip it rather than dereferencing null. wala/ML#613.
       if (current == null) continue;
       PointerKey pk = current.getPointerKey();
-      LOGGER.fine("findCreator visiting: " + current);
+      LOGGER.fine(() -> "findCreator visiting: " + describe(pk));
 
       if (pk instanceof ReturnValueKey) {
-        LOGGER.fine("findCreator found ReturnValueKey: " + current);
+        LOGGER.fine(() -> "findCreator found ReturnValueKey: " + describe(pk));
         return current;
       }
 
@@ -430,7 +434,7 @@ public class TensorGeneratorFactory {
         if (def instanceof SSAAbstractInvokeInstruction
             || def instanceof EachElementGetInstruction
             || def instanceof PythonPropertyRead) {
-          LOGGER.fine("findCreator found creator instruction: " + def);
+          LOGGER.fine(() -> "findCreator found creator instruction: " + def);
           return current;
         }
       }
@@ -439,14 +443,43 @@ public class TensorGeneratorFactory {
           it.hasNext(); ) {
         PointsToSetVariable pred = it.next();
         if (pred != null && visited.add(pred)) {
-          LOGGER.fine("findCreator adding pred: " + pred);
+          LOGGER.fine(() -> "findCreator adding pred: " + describe(pred));
           queue.add(pred);
         }
       }
     }
 
-    LOGGER.fine("findCreator fallback returning original source: " + source);
+    LOGGER.fine(() -> "findCreator fallback returning original source: " + describe(source));
     return source;
+  }
+
+  /**
+   * Describes a points-to variable for logging without rendering its context.
+   *
+   * @param variable The {@link PointsToSetVariable} to describe.
+   * @return A bounded, context-free description of {@code variable}.
+   */
+  private static String describe(PointsToSetVariable variable) {
+    return variable == null ? "null" : describe(variable.getPointerKey());
+  }
+
+  /**
+   * Describes a pointer key for logging using only context-free fields (the value number and method
+   * signature). The key's own {@code toString()} renders the node's context, whose scope-mapping
+   * and receiver contexts reference each other cyclically and recurse until the heap is exhausted
+   * on large graphs (e.g., nlpgnn); see <a
+   * href="https://github.com/wala/ML/issues/697">wala/ML#697</a>.
+   *
+   * @param pk The {@link PointerKey} to describe.
+   * @return A bounded, context-free description of {@code pk}.
+   */
+  private static String describe(PointerKey pk) {
+    if (pk == null) return "null";
+    if (pk instanceof LocalPointerKey) {
+      LocalPointerKey lpk = (LocalPointerKey) pk;
+      return "v" + lpk.getValueNumber() + " in " + lpk.getNode().getMethod().getSignature();
+    }
+    return pk.getClass().getSimpleName();
   }
 
   private static PointsToSetVariable getPointsToSetVariable(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -422,7 +422,7 @@ public class TensorGeneratorFactory {
       // is enqueued below; skip it rather than dereferencing null. wala/ML#613.
       if (current == null) continue;
       PointerKey pk = current.getPointerKey();
-      LOGGER.fine(() -> "findCreator visiting: " + describe(pk));
+      LOGGER.fine(() -> "findCreator visiting: " + describe(current));
 
       if (pk instanceof ReturnValueKey) {
         LOGGER.fine(() -> "findCreator found ReturnValueKey: " + describe(pk));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -413,7 +413,7 @@ public class TensorGeneratorFactory {
     // toString() renders the node's context, whose scope-mapping/receiver contexts reference each
     // other cyclically and recurse until the heap is exhausted on large graphs (e.g., nlpgnn); see
     // https://github.com/wala/ML/issues/697.
-    LOGGER.fine(() -> "findCreator started for source: " + describe(source));
+    LOGGER.fine(() -> "findCreator started for source: " + Loggables.describe(source));
 
     while (!queue.isEmpty()) {
       PointsToSetVariable current = queue.poll();
@@ -421,10 +421,10 @@ public class TensorGeneratorFactory {
       // is enqueued below; skip it rather than dereferencing null. wala/ML#613.
       if (current == null) continue;
       PointerKey pk = current.getPointerKey();
-      LOGGER.fine(() -> "findCreator visiting: " + describe(pk));
+      LOGGER.fine(() -> "findCreator visiting: " + Loggables.describe(pk));
 
       if (pk instanceof ReturnValueKey) {
-        LOGGER.fine(() -> "findCreator found ReturnValueKey: " + describe(pk));
+        LOGGER.fine(() -> "findCreator found ReturnValueKey: " + Loggables.describe(pk));
         return current;
       }
 
@@ -443,43 +443,15 @@ public class TensorGeneratorFactory {
           it.hasNext(); ) {
         PointsToSetVariable pred = it.next();
         if (pred != null && visited.add(pred)) {
-          LOGGER.fine(() -> "findCreator adding pred: " + describe(pred));
+          LOGGER.fine(() -> "findCreator adding pred: " + Loggables.describe(pred));
           queue.add(pred);
         }
       }
     }
 
-    LOGGER.fine(() -> "findCreator fallback returning original source: " + describe(source));
+    LOGGER.fine(
+        () -> "findCreator fallback returning original source: " + Loggables.describe(source));
     return source;
-  }
-
-  /**
-   * Describes a points-to variable for logging without rendering its context.
-   *
-   * @param variable The {@link PointsToSetVariable} to describe.
-   * @return A bounded, context-free description of {@code variable}.
-   */
-  private static String describe(PointsToSetVariable variable) {
-    return variable == null ? "null" : describe(variable.getPointerKey());
-  }
-
-  /**
-   * Describes a pointer key for logging using only context-free fields (the value number and method
-   * signature). The key's own {@code toString()} renders the node's context, whose scope-mapping
-   * and receiver contexts reference each other cyclically and recurse until the heap is exhausted
-   * on large graphs (e.g., nlpgnn); see <a
-   * href="https://github.com/wala/ML/issues/697">wala/ML#697</a>.
-   *
-   * @param pk The {@link PointerKey} to describe.
-   * @return A bounded, context-free description of {@code pk}.
-   */
-  private static String describe(PointerKey pk) {
-    if (pk == null) return "null";
-    if (pk instanceof LocalPointerKey) {
-      LocalPointerKey lpk = (LocalPointerKey) pk;
-      return "v" + lpk.getValueNumber() + " in " + lpk.getNode().getMethod().getSignature();
-    }
-    return pk.getClass().getSimpleName();
   }
 
   private static PointsToSetVariable getPointsToSetVariable(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static java.util.logging.Logger.getLogger;
 
@@ -64,7 +65,7 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     if (fromDTypeAttribute != null && !fromDTypeAttribute.isEmpty()) {
       LOGGER.fine(
           "Recovered allocator dtype from a `.dtype` argument for source: "
-              + source
+              + describe(source)
               + " -> "
               + fromDTypeAttribute
               + ".");
@@ -72,7 +73,11 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     }
 
     LOGGER.fine(
-        "No dtype specified for source: " + source + ". Using default dtype of: " + FLOAT32 + " .");
+        "No dtype specified for source: "
+            + describe(source)
+            + ". Using default dtype of: "
+            + FLOAT32
+            + " .");
 
     // Use the default dtype of float32.
     return EnumSet.of(FLOAT32);
@@ -107,7 +112,7 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     if (fromShapeAttribute != null && !fromShapeAttribute.isEmpty()) {
       LOGGER.fine(
           "Recovered allocator shape from a `.shape` argument for source: "
-              + source
+              + describe(source)
               + " -> "
               + fromShapeAttribute
               + ".");
@@ -120,7 +125,7 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     // (which is what throwing here did, wala/ML#604).
     LOGGER.fine(
         "Unresolved allocator shape for source: "
-            + source
+            + describe(source)
             + "; returning ⊤ (unknown shape). Candidate for a wala/ML#370 shape annotation.");
     return null;
   }
@@ -160,6 +165,6 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
     }
 
     throw new IllegalArgumentException(
-        "Cannot get integer value from non-constant InstanceKey: " + instanceKey + ".");
+        "Cannot get integer value from non-constant InstanceKey: " + describe(instanceKey) + ".");
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -77,10 +79,7 @@ public class Tile extends PassThroughUnaryTensorGenerator {
         resolveMultiplesList(builder, this.getArgumentPointsToSet(builder, 1, "multiples"));
     if (multiples == null) {
       LOGGER.fine(
-          () ->
-              "Non-constant multiples for "
-                  + Loggables.describe(this.getSource())
-                  + "; returning ⊤.");
+          () -> "Non-constant multiples for " + describe(this.getSource()) + "; returning ⊤.");
       return null;
     }
 
@@ -136,12 +135,7 @@ public class Tile extends PassThroughUnaryTensorGenerator {
       } catch (IllegalStateException e) {
         // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
         LOGGER.fine(
-            () ->
-                "Could not resolve multiples of "
-                    + Loggables.describe(this.getSource())
-                    + ": "
-                    + e
-                    + ".");
+            () -> "Could not resolve multiples of " + describe(this.getSource()) + ": " + e + ".");
         return null;
       }
       if (lists == null) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
@@ -76,7 +76,11 @@ public class Tile extends PassThroughUnaryTensorGenerator {
     List<Integer> multiples =
         resolveMultiplesList(builder, this.getArgumentPointsToSet(builder, 1, "multiples"));
     if (multiples == null) {
-      LOGGER.fine(() -> "Non-constant multiples for " + this.getSource() + "; returning ⊤.");
+      LOGGER.fine(
+          () ->
+              "Non-constant multiples for "
+                  + Loggables.describe(this.getSource())
+                  + "; returning ⊤.");
       return null;
     }
 
@@ -131,7 +135,13 @@ public class Tile extends PassThroughUnaryTensorGenerator {
         lists = this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
       } catch (IllegalStateException e) {
         // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
-        LOGGER.fine(() -> "Could not resolve multiples of " + this.getSource() + ": " + e + ".");
+        LOGGER.fine(
+            () ->
+                "Could not resolve multiples of "
+                    + Loggables.describe(this.getSource())
+                    + ": "
+                    + e
+                    + ".");
         return null;
       }
       if (lists == null) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
@@ -83,7 +83,9 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
     } else {
       perm = resolvePermList(builder, permPts);
       if (perm == null) {
-        LOGGER.fine(() -> "Non-constant perm for " + this.getSource() + "; returning ⊤.");
+        LOGGER.fine(
+            () ->
+                "Non-constant perm for " + Loggables.describe(this.getSource()) + "; returning ⊤.");
         return null;
       }
     }
@@ -160,7 +162,13 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
         lists = this.getShapesFromShapeArgument(builder, Collections.singleton(ik));
       } catch (IllegalStateException e) {
         // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
-        LOGGER.fine(() -> "Could not resolve perm of " + this.getSource() + ": " + e + ".");
+        LOGGER.fine(
+            () ->
+                "Could not resolve perm of "
+                    + Loggables.describe(this.getSource())
+                    + ": "
+                    + e
+                    + ".");
         return null;
       }
       if (lists == null) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -83,9 +85,7 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
     } else {
       perm = resolvePermList(builder, permPts);
       if (perm == null) {
-        LOGGER.fine(
-            () ->
-                "Non-constant perm for " + Loggables.describe(this.getSource()) + "; returning ⊤.");
+        LOGGER.fine(() -> "Non-constant perm for " + describe(this.getSource()) + "; returning ⊤.");
         return null;
       }
     }
@@ -163,12 +163,7 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
       } catch (IllegalStateException e) {
         // `getShapesFromShapeArgument` throws for an unrecognized shape form; degrade that to ⊤.
         LOGGER.fine(
-            () ->
-                "Could not resolve perm of "
-                    + Loggables.describe(this.getSource())
-                    + ": "
-                    + e
-                    + ".");
+            () -> "Could not resolve perm of " + describe(this.getSource()) + ": " + e + ".");
         return null;
       }
       if (lists == null) return null;


### PR DESCRIPTION
## Problem

`testNlpgnnFullGeneration` and `testNlpgnnFullInteractive` fail locally with `OutOfMemoryError` under the repo's FINEST `logging.properties`. The analysis completes; the OOM is in diagnostic logging that materializes gigantic strings from the nlpgnn call graph. CI stays green only because `logging.ci.properties` runs at `WARNING`, so the offending `fine(...)` records are never published.

## Root Cause

The reported stack pointed at one line, the test helper's `"Call graph:\n" + CG`. Fixing only that reveals the actual, systemic cause: many diagnostic-logging sites render a `PointsToSetVariable`, `PointerKey`, `CGNode`, `InstanceKey`, `AllocationSiteInNode`, or `OrdinalSet<InstanceKey>`, whose `toString()` walks the node's `Context`. nlpgnn's nested closures produce `ScopeMappingInstanceKey`, `ReceiverInstanceContext`, and `CallerSiteContextPair` contexts that reference each other cyclically, so the render recurses and materializes a multi-megabyte string. Raising the forked-JVM heap does not help (the default is already ~16 GB here and still OOMs), and the string is built during argument concatenation, so it cannot be intercepted at the handler.

## What This Does

- A shared `Loggables` renderer renders each context-bearing type using only bounded, context-free fields (value numbers, method signatures, allocation sites). The roughly 50 offending log sites across the tensor generators route through it.
- `TensorGeneratorFactory.findCreator` and the test helper's call-graph dump were the first two sites; the dump is now gated behind a node-count limit (`CALL_GRAPH_DUMP_NODE_LIMIT`), covering both the per-node dump and the `dumpCG` IR dump, which renders each node's context as well.

Both `nlpgnn` full tests now complete at FINEST with no OOM (0 errors, ~40 s).

## Upstream Follow-Up

The divergent `Context.toString()` is the true upstream defect; these sites are only the triggers. Filed upstream as wala/WALA#1992.
