### PR TITLE
Wire the generator fixtures `gen1`-`gen3` into call-graph assertions (wala/ML#700)

### DIFF
--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -93,10 +93,17 @@ public class TestGenerators extends TestJythonCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     CallGraph cg = process("gen1.py");
     verifyGraphAssertions(cg, assertionsGen1);
-    // The generator expression's yielded functions are not reachable; assert their absence so the
-    // gap cannot silently regress. When wala/ML#701 is fixed these will start failing, cueing an
-    // update to positive reachability.
-    assertNodesAbsent(cg, "Lscript gen1.py/f1", "Lscript gen1.py/f2", "Lscript gen1.py/f3");
+    // The generator expression's yielded functions and their returned lambdas are not reachable;
+    // assert their absence so the gap cannot silently regress. When wala/ML#701 is fixed these will
+    // start failing, cueing an update to positive reachability.
+    assertNodesAbsent(
+        cg,
+        "Lscript gen1.py/f1",
+        "Lscript gen1.py/f2",
+        "Lscript gen1.py/f3",
+        "Lscript gen1.py/f1/lambda1",
+        "Lscript gen1.py/f2/lambda1",
+        "Lscript gen1.py/f3/lambda1");
   }
 
   /**
@@ -112,9 +119,16 @@ public class TestGenerators extends TestJythonCallGraphShape {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     CallGraph cg = process("gen3.py");
     verifyGraphAssertions(cg, assertionsGen3);
-    // As with gen1.py, the generator expression's yielded functions are not reachable; assert their
-    // absence so the gap cannot silently regress (wala/ML#701).
-    assertNodesAbsent(cg, "Lscript gen3.py/f1", "Lscript gen3.py/f2", "Lscript gen3.py/f3");
+    // As with gen1.py, the generator expression's yielded functions and their returned lambdas are
+    // not reachable; assert their absence so the gap cannot silently regress (wala/ML#701).
+    assertNodesAbsent(
+        cg,
+        "Lscript gen3.py/f1",
+        "Lscript gen3.py/f2",
+        "Lscript gen3.py/f3",
+        "Lscript gen3.py/f1/lambda1",
+        "Lscript gen3.py/f2/lambda1",
+        "Lscript gen3.py/f3/lambda1");
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -1,6 +1,6 @@
 package com.ibm.wala.cast.python.test;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
 
 import com.ibm.wala.cast.util.test.TestCallGraphShape.GraphAssertion;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -8,7 +8,9 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 
 /**
@@ -138,11 +140,11 @@ public class TestGenerators extends TestJythonCallGraphShape {
    * @param absentClassNames The qualified declaring-class names expected to have no node.
    */
   private static void assertNodesAbsent(CallGraph cg, String... absentClassNames) {
-    for (CGNode node : cg) {
-      String declaringClass = node.getMethod().getDeclaringClass().getName().toString();
-      for (String absent : absentClassNames)
-        assertNotEquals(
-            "Expected no call-graph node declared by " + absent, absent, declaringClass);
-    }
+    Set<String> declaringClasses = new HashSet<>();
+    for (CGNode node : cg)
+      declaringClasses.add(node.getMethod().getDeclaringClass().getName().toString());
+    for (String absent : absentClassNames)
+      assertFalse(
+          "Expected no call-graph node declared by " + absent, declaringClasses.contains(absent));
   }
 }

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -1,6 +1,10 @@
 package com.ibm.wala.cast.python.test;
 
+import static org.junit.Assert.assertNotEquals;
+
 import com.ibm.wala.cast.util.test.TestCallGraphShape.GraphAssertion;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
@@ -87,7 +91,12 @@ public class TestGenerators extends TestJythonCallGraphShape {
   @Test
   public void testGen1()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    verifyGraphAssertions(process("gen1.py"), assertionsGen1);
+    CallGraph cg = process("gen1.py");
+    verifyGraphAssertions(cg, assertionsGen1);
+    // The generator expression's yielded functions are not reachable; assert their absence so the
+    // gap cannot silently regress. When wala/ML#701 is fixed these will start failing, cueing an
+    // update to positive reachability.
+    assertNodesAbsent(cg, "Lscript gen1.py/f1", "Lscript gen1.py/f2", "Lscript gen1.py/f3");
   }
 
   /**
@@ -101,6 +110,25 @@ public class TestGenerators extends TestJythonCallGraphShape {
   @Test
   public void testGen3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    verifyGraphAssertions(process("gen3.py"), assertionsGen3);
+    CallGraph cg = process("gen3.py");
+    verifyGraphAssertions(cg, assertionsGen3);
+    // As with gen1.py, the generator expression's yielded functions are not reachable; assert their
+    // absence so the gap cannot silently regress (wala/ML#701).
+    assertNodesAbsent(cg, "Lscript gen3.py/f1", "Lscript gen3.py/f2", "Lscript gen3.py/f3");
+  }
+
+  /**
+   * Asserts that no call-graph node is declared by any of the given classes.
+   *
+   * @param cg The call graph to check.
+   * @param absentClassNames The qualified declaring-class names expected to have no node.
+   */
+  private static void assertNodesAbsent(CallGraph cg, String... absentClassNames) {
+    for (CGNode node : cg) {
+      String declaringClass = node.getMethod().getDeclaringClass().getName().toString();
+      for (String absent : absentClassNames)
+        assertNotEquals(
+            "Expected no call-graph node declared by " + absent, absent, declaringClass);
+    }
   }
 }

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -45,7 +45,8 @@ public class TestGenerators extends TestJythonCallGraphShape {
    * called. Unlike the generator function of {@code gen2.py}, the expression's yielded functions
    * {@code f1}/{@code f2}/{@code f3} are <em>not</em> reachable; only the script itself is. This
    * pins the current behavior. TODO: extend to reach {@code f1}/{@code f2}/{@code f3} once
-   * generator expressions are modeled at the call-graph level.
+   * generator expressions are modeled at the call-graph level (<a
+   * href="https://github.com/wala/ML/issues/701">wala/ML#701</a>).
    */
   protected static final List<GraphAssertion> assertionsGen1 =
       List.of(new GraphAssertion(ROOT, new String[] {"script gen1.py"}));
@@ -55,7 +56,7 @@ public class TestGenerators extends TestJythonCallGraphShape {
    * makeGenerator} is reachable, but the expression's yielded functions {@code f1}/{@code
    * f2}/{@code f3} are not — the same generator-expression gap as {@code gen1.py}. TODO: extend to
    * reach {@code f1}/{@code f2}/{@code f3} once generator expressions are modeled at the call-graph
-   * level.
+   * level (<a href="https://github.com/wala/ML/issues/701">wala/ML#701</a>).
    */
   protected static final List<GraphAssertion> assertionsGen3 =
       List.of(

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -1,0 +1,106 @@
+package com.ibm.wala.cast.python.test;
+
+import com.ibm.wala.cast.util.test.TestCallGraphShape.GraphAssertion;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Call-graph reachability guards for the three generator fixtures inherited from upstream. {@code
+ * gen2.py} (a generator <em>function</em> yielding functions) is the call-graph shape that <a
+ * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>'s modeling supports: iterating
+ * {@code gen()} reaches the yielded {@code f1}/{@code f2}/{@code f3} and their returned lambdas.
+ * {@code gen1.py} and {@code gen3.py} exercise generator <em>expressions</em>, whose yielded
+ * functions are not reachable on this front-end — a distinct modeling gap pinned by the tests
+ * below.
+ */
+public class TestGenerators extends TestJythonCallGraphShape {
+
+  /**
+   * {@code gen2.py}: {@code for f in gen(): g = f(i); g(i)} over a generator function that yields
+   * {@code f1}/{@code f2}/{@code f3}. The yielded functions and their returned lambdas are all
+   * reachable — a call-graph-level regression guard for <a
+   * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> (the existing guards assert tensor
+   * typing, not call-graph reachability).
+   */
+  protected static final List<GraphAssertion> assertionsGen2 =
+      List.of(
+          new GraphAssertion(ROOT, new String[] {"script gen2.py"}),
+          new GraphAssertion(
+              "script gen2.py",
+              new String[] {
+                "script gen2.py/gen",
+                "script gen2.py/f1",
+                "script gen2.py/f2",
+                "script gen2.py/f3",
+                "script gen2.py/f1/lambda1",
+                "script gen2.py/f2/lambda1",
+                "script gen2.py/f3/lambda1"
+              }));
+
+  /**
+   * {@code gen1.py}: a generator <em>expression</em> {@code (f(3) for f in fs)} iterated and
+   * called. Unlike the generator function of {@code gen2.py}, the expression's yielded functions
+   * {@code f1}/{@code f2}/{@code f3} are <em>not</em> reachable; only the script itself is. This
+   * pins the current behavior. TODO: extend to reach {@code f1}/{@code f2}/{@code f3} once
+   * generator expressions are modeled at the call-graph level.
+   */
+  protected static final List<GraphAssertion> assertionsGen1 =
+      List.of(new GraphAssertion(ROOT, new String[] {"script gen1.py"}));
+
+  /**
+   * {@code gen3.py}: a generator <em>expression</em> returned from {@code makeGenerator()}. {@code
+   * makeGenerator} is reachable, but the expression's yielded functions {@code f1}/{@code
+   * f2}/{@code f3} are not — the same generator-expression gap as {@code gen1.py}. TODO: extend to
+   * reach {@code f1}/{@code f2}/{@code f3} once generator expressions are modeled at the call-graph
+   * level.
+   */
+  protected static final List<GraphAssertion> assertionsGen3 =
+      List.of(
+          new GraphAssertion(ROOT, new String[] {"script gen3.py"}),
+          new GraphAssertion("script gen3.py", new String[] {"script gen3.py/makeGenerator"}));
+
+  /**
+   * Guards {@code gen2.py}'s call-graph shape; see {@link #assertionsGen2}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGen2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    verifyGraphAssertions(process("gen2.py"), assertionsGen2);
+  }
+
+  /**
+   * Pins {@code gen1.py}'s call-graph shape; see {@link #assertionsGen1}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGen1()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    verifyGraphAssertions(process("gen1.py"), assertionsGen1);
+  }
+
+  /**
+   * Pins {@code gen3.py}'s call-graph shape; see {@link #assertionsGen3}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGen3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    verifyGraphAssertions(process("gen3.py"), assertionsGen3);
+  }
+}

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -141,10 +141,12 @@ public class TestGenerators extends TestJythonCallGraphShape {
    */
   private static void assertNodesAbsent(CallGraph cg, String... absentClassNames) {
     Set<String> declaringClasses = new HashSet<>();
-    for (CGNode node : cg)
+    for (CGNode node : cg) {
       declaringClasses.add(node.getMethod().getDeclaringClass().getName().toString());
-    for (String absent : absentClassNames)
+    }
+    for (String absent : absentClassNames) {
       assertFalse(
           "Expected no call-graph node declared by " + absent, declaringClasses.contains(absent));
+    }
   }
 }

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestGenerators.java
@@ -13,15 +13,14 @@ import org.junit.Test;
  * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>'s modeling supports: iterating
  * {@code gen()} reaches the yielded {@code f1}/{@code f2}/{@code f3} and their returned lambdas.
  * {@code gen1.py} and {@code gen3.py} exercise generator <em>expressions</em>, whose yielded
- * functions are not reachable on this front-end — a distinct modeling gap pinned by the tests
- * below.
+ * functions are not reachable on this front-end, a distinct modeling gap pinned by the tests below.
  */
 public class TestGenerators extends TestJythonCallGraphShape {
 
   /**
    * {@code gen2.py}: {@code for f in gen(): g = f(i); g(i)} over a generator function that yields
    * {@code f1}/{@code f2}/{@code f3}. The yielded functions and their returned lambdas are all
-   * reachable — a call-graph-level regression guard for <a
+   * reachable, giving a call-graph-level regression guard for <a
    * href="https://github.com/wala/ML/issues/696">wala/ML#696</a> (the existing guards assert tensor
    * typing, not call-graph reachability).
    */
@@ -44,19 +43,19 @@ public class TestGenerators extends TestJythonCallGraphShape {
    * {@code gen1.py}: a generator <em>expression</em> {@code (f(3) for f in fs)} iterated and
    * called. Unlike the generator function of {@code gen2.py}, the expression's yielded functions
    * {@code f1}/{@code f2}/{@code f3} are <em>not</em> reachable; only the script itself is. This
-   * pins the current behavior. TODO: extend to reach {@code f1}/{@code f2}/{@code f3} once
-   * generator expressions are modeled at the call-graph level (<a
-   * href="https://github.com/wala/ML/issues/701">wala/ML#701</a>).
+   * pins the current behavior. TODO(<a
+   * href="https://github.com/wala/ML/issues/701">wala/ML#701</a>): extend to reach {@code
+   * f1}/{@code f2}/{@code f3} once generator expressions are modeled at the call-graph level.
    */
   protected static final List<GraphAssertion> assertionsGen1 =
       List.of(new GraphAssertion(ROOT, new String[] {"script gen1.py"}));
 
   /**
-   * {@code gen3.py}: a generator <em>expression</em> returned from {@code makeGenerator()}. {@code
-   * makeGenerator} is reachable, but the expression's yielded functions {@code f1}/{@code
-   * f2}/{@code f3} are not — the same generator-expression gap as {@code gen1.py}. TODO: extend to
-   * reach {@code f1}/{@code f2}/{@code f3} once generator expressions are modeled at the call-graph
-   * level (<a href="https://github.com/wala/ML/issues/701">wala/ML#701</a>).
+   * {@code gen3.py}: a generator <em>expression</em> returned from {@code makeGenerator(fs)}.
+   * {@code makeGenerator} is reachable, but the expression's yielded functions {@code f1}/{@code
+   * f2}/{@code f3} are not reachable, the same generator-expression gap as {@code gen1.py}. TODO(<a
+   * href="https://github.com/wala/ML/issues/701">wala/ML#701</a>): extend to reach {@code
+   * f1}/{@code f2}/{@code f3} once generator expressions are modeled at the call-graph level.
    */
   protected static final List<GraphAssertion> assertionsGen3 =
       List.of(


### PR DESCRIPTION
## What

`com.ibm.wala.cast.python.test/data` carries three generator fixtures inherited from upstream (`gen1.py`, `gen2.py`, `gen3.py`) that no test referenced, leaving the fork with zero call-graph-level generator coverage. `TestGenerators` wires all three into call-graph assertions.

## Findings

- **`gen2.py`** (a generator *function* yielding functions): the modeling works. Iterating `gen()` reaches the yielded `f1`/`f2`/`f3`, and their returned lambdas are reachable through the `g(i)` call sites. This is asserted in full, giving a call-graph-level regression guard for wala/ML#696 that the existing tensor-typing guards do not cover.
- **`gen1.py`** and **`gen3.py`** (generator *expressions*): the expression's yielded functions `f1`/`f2`/`f3` are **not** reachable. For `gen1.py` only the script node is reachable; for `gen3.py`, `makeGenerator` is reached but its expression body is not connected to `f1`/`f2`/`f3`. The tests pin this current behavior and carry a `TODO`, establishing the generator-expression modeling gap now tracked as wala/ML#701.

The pinned `gen1`/`gen3` assertions can be extended to positive reachability once wala/ML#701 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
