### PR TITLE
Union the default of `next(it, default)` into the result (wala/ML#699)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10758,6 +10758,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Probe for the two-argument {@code next(it, default)} form: the iterator is an empty generator,
+   * so at runtime {@code next} returns the default and its type must reach the result. The
+   * default's flow was dropped because the summary read only the iterator's generator content
+   * field. A regression guard for <a href="https://github.com/wala/ML/issues/699">wala/ML#699</a>,
+   * where the default (arg 3) is unioned into the result through a reachable join.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGenNextDefault()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_gen_next_default.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+  }
+
+  /**
    * Companion probe for the generator transit: the same yielded pair consumed by for-loop
    * destructuring over the generator instead of {@code next()}. Also dropped (<a
    * href="https://github.com/wala/ML/issues/696">wala/ML#696</a>); distinct from the {@code

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gen_next_default.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gen_next_default.py
@@ -1,0 +1,19 @@
+# Reproducer for wala/ML#699: the two-argument `next(it, default)` form dropped the default's flow.
+# The generator is empty, so at runtime `next` returns the default; statically the default's type
+# must reach the result. With the bug, the default contributed nothing and the type was dropped.
+import tensorflow as tf
+
+
+def consume(imgs):
+    assert imgs.shape == (4, 4)
+    assert imgs.dtype == tf.float32
+
+
+def empty_batches():
+    return
+    yield  # unreachable; the `yield` keyword makes this a generator that yields nothing
+
+
+batches = empty_batches()
+imgs = next(batches, tf.ones((4, 4)))
+consume(imgs)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -155,6 +155,11 @@ public class BuiltinFunctions {
    * dataset iterators), the read has an empty points-to set and contributes nothing, matching the
    * previous behavior for the dataflow analysis.
    *
+   * <p>The two-argument form {@code next(it, default)} returns {@code default} when the iterator is
+   * exhausted, so the yields are unioned with the default (arg 3) through a common box field. The
+   * union is a reachable join rather than a second, unreachable return, which would be dropped
+   * (wala/ML#699).
+   *
    * @param cls The builtin function class whose summary this is.
    * @param name The builtin's name ({@code next}).
    * @return The populated summary.
@@ -165,12 +170,30 @@ public class BuiltinFunctions {
     PythonSummary x = new PythonSummary(ref, 10);
 
     AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
-    int result = 11;
+    int content = 11;
     int fieldKey = 12;
+    int box = 13;
+    int joinKey = 14;
+    int result = 15;
+    int idx = 0;
 
+    // content = arg2[GENERATOR_CONTENT_FIELD_NAME] -- the generator's accumulated yields.
     x.addConstant(fieldKey, new ConstantValue(PythonTypes.GENERATOR_CONTENT_FIELD_NAME));
-    x.addStatement(factory.PropertyRead(0, result, 2, fieldKey));
-    x.addStatement(factory.ReturnInstruction(1, result, false));
+    x.addStatement(factory.PropertyRead(idx++, content, 2, fieldKey));
+
+    // Union the yields with the two-argument default (`next(it, default)`, arg 3) through a common
+    // box field, so the default reaches the result via a reachable join rather than a second,
+    // unreachable return (which would be dropped -- the trap that forced the guarded prepended
+    // return of wala/ML#696). When `next` is called with one argument, arg 3 is unbound: its read
+    // has an empty points-to set and contributes nothing, so the same summary serves both call
+    // forms. See wala/ML#699.
+    x.addStatement(
+        factory.NewInstruction(idx++, box, NewSiteReference.make(0, PythonTypes.object)));
+    x.addConstant(joinKey, new ConstantValue(0));
+    x.addStatement(factory.PropertyWrite(idx++, box, joinKey, content));
+    x.addStatement(factory.PropertyWrite(idx++, box, joinKey, 3));
+    x.addStatement(factory.PropertyRead(idx++, result, box, joinKey));
+    x.addStatement(factory.ReturnInstruction(idx++, result, false));
 
     return new PythonSummarizedFunction(ref, x, cls);
   }


### PR DESCRIPTION
## Problem

The `next` builtin summary (added for wala/ML#696) reads the generator content field off its first argument only. The two-argument form `next(it, default)`, which returns `default` when the iterator is exhausted, contributed nothing from the default to the result, so `imgs = next(batches, fallback_tensor)` dropped `fallback_tensor`'s type.

## Fix

`next`'s summary now unions the yields (the generator content field of arg 2) with the default (arg 3) through a common box field: both are written under one key on a fresh object, and the result is read back from it. This is a reachable join. A naive second `ReturnInstruction` would land in an unreachable block and be dropped, the same trap that forced the guarded prepended return of wala/ML#696.

The one-argument form `next(it)` leaves arg 3 unbound; its read has an empty points-to set and contributes nothing, so a single summary serves both call forms. Dataset iterators, whose content field is empty, are likewise unaffected: the box receives nothing and their element types continue to flow through the existing seeding.

Adds a reproducer fixture (an empty generator whose `next(it, default)` returns the default at runtime) and a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
