### PR TITLE
Guard against the diagnostic-logging OOM class returning

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
@@ -1,0 +1,75 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static org.junit.Assert.assertTrue;
+
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Test;
+
+/**
+ * Diagnostic-logging volume guard (<a
+ * href="https://github.com/wala/ML/issues/702">wala/ML#702</a>): an infrastructure test, separate
+ * from the tensor-model assertions in {@link TestTensorflow2Model}, that bounds the formatted
+ * {@code FINEST} volume of a whole-project analysis.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class DiagnosticLoggingVolumeTest {
+
+  /**
+   * Reruns the nlpgnn generation analysis — the cyclic-closure call graph that triggered <a
+   * href="https://github.com/wala/ML/issues/697">wala/ML#697</a> — with every {@code
+   * com.ibm.wala.cast.python} logger at {@code FINEST}, routing records through {@link
+   * DiscardingFormattingHandler}, which formats and discards them while summing their volume.
+   *
+   * <p>Correct code renders diagnostics through the bounded {@code Loggables.describe(...)} (~0.6
+   * GB of formatted {@code FINEST} output for this analysis); a bare render of a {@code
+   * Context}-bearing value inflates that by more than an order of magnitude (~14 GB measured),
+   * which this bound catches. The failure is invisible at CI's {@code WARNING} level (the message
+   * strings are never built), so this test is the pipeline's guard against its return. See {@code
+   * CONTRIBUTING.md}'s Diagnostic Logging section and <a
+   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992</a> for the upstream root cause.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDiagnosticLoggingVolumeBounded()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // Fixed code emits ~0.6 GB of formatted FINEST volume for this analysis; a bare `Context`
+    // render measured ~14 GB. 2 GB sits well above the former and far below the latter.
+    final long maxFormattedChars = 2_000_000_000L;
+
+    Logger pkg = Logger.getLogger("com.ibm.wala.cast.python");
+    DiscardingFormattingHandler handler = new DiscardingFormattingHandler();
+    handler.setLevel(Level.ALL);
+    Level oldLevel = pkg.getLevel();
+    boolean oldUseParentHandlers = pkg.getUseParentHandlers();
+    pkg.addHandler(handler);
+    pkg.setLevel(Level.FINEST);
+    // Count the FINEST volume here; don't also propagate it to the console handlers.
+    pkg.setUseParentHandlers(false);
+    try {
+      DiscardingFormattingHandler.reset();
+      new TestTensorflow2Model().runNlpgnnFullGeneration();
+      long volume = DiscardingFormattingHandler.totalChars();
+      assertTrue(
+          "Diagnostic FINEST volume "
+              + volume
+              + " chars exceeds the "
+              + maxFormattedChars
+              + "-char bound; a pointer-analysis or call-graph value is likely logged without"
+              + " Loggables.describe(...). See CONTRIBUTING.md's Diagnostic Logging section.",
+          volume < maxFormattedChars);
+    } finally {
+      pkg.removeHandler(handler);
+      pkg.setLevel(oldLevel);
+      pkg.setUseParentHandlers(oldUseParentHandlers);
+    }
+  }
+}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiscardingFormattingHandler.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiscardingFormattingHandler.java
@@ -1,0 +1,49 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import com.ibm.wala.cast.python.ml.util.ShortClassNameFormatter;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * Formats every published record (exercising the full diagnostic-logging render path) but discards
+ * the output, tracking only the cumulative formatted volume.
+ *
+ * <p>Used by the wala/ML#702 diagnostic-logging volume guard. Correct code keeps every render
+ * bounded via {@code Loggables.describe(...)}, so FINEST volume stays small; a bare render of a
+ * {@code Context}-bearing value inflates a message by orders of magnitude, which the guard detects
+ * as excess volume — reproducing the wala/ML#697 failure that is invisible at CI's {@code WARNING}
+ * level, without depending on an actual {@code OutOfMemoryError} (whose timing varies with heap and
+ * output backpressure).
+ */
+public final class DiscardingFormattingHandler extends Handler {
+
+  private static final AtomicLong TOTAL_CHARS = new AtomicLong();
+
+  private final Formatter formatter = new ShortClassNameFormatter();
+
+  /** Returns the cumulative formatted-character count across all instances. */
+  public static long totalChars() {
+    return TOTAL_CHARS.get();
+  }
+
+  /** Resets the cumulative count; call before a measured run. */
+  public static void reset() {
+    TOTAL_CHARS.set(0L);
+  }
+
+  @Override
+  public void publish(LogRecord record) {
+    if (!isLoggable(record)) return;
+    // Format (not merely build the message) so the guard covers the full publish-path render, then
+    // discard the result — only its length feeds the running total.
+    TOTAL_CHARS.addAndGet(formatter.format(record).length());
+  }
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public void close() {}
+}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2215,7 +2215,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Diagnostic-logging volume guard (<a
-   * href="https://github.com/wala/ML/issues/702">wala/ML#702</a> ). Reruns the nlpgnn generation
+   * href="https://github.com/wala/ML/issues/702">wala/ML#702</a>). Reruns the nlpgnn generation
    * analysis — the cyclic-closure call graph that triggered <a
    * href="https://github.com/wala/ML/issues/697">wala/ML#697</a> — with every {@code
    * com.ibm.wala.cast.python} logger at {@code FINEST}, routing records through {@link
@@ -2227,8 +2227,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * which this bound catches. The failure is invisible at CI's {@code WARNING} level (the message
    * strings are never built), so this test is the pipeline's guard against its return. See {@code
    * CONTRIBUTING.md}'s Diagnostic Logging section and <a
-   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992 </a> for the upstream root
-   * cause.
+   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992</a> for the upstream root cause.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2214,6 +2214,63 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Diagnostic-logging volume guard (<a
+   * href="https://github.com/wala/ML/issues/702">wala/ML#702</a> ). Reruns the nlpgnn generation
+   * analysis — the cyclic-closure call graph that triggered <a
+   * href="https://github.com/wala/ML/issues/697">wala/ML#697</a> — with every {@code
+   * com.ibm.wala.cast.python} logger at {@code FINEST}, routing records through {@link
+   * DiscardingFormattingHandler}, which formats and discards them while summing their volume.
+   *
+   * <p>Correct code renders diagnostics through the bounded {@code Loggables.describe(...)} (~0.6
+   * GB of formatted {@code FINEST} output for this analysis); a bare render of a {@code
+   * Context}-bearing value inflates that by more than an order of magnitude (~14 GB measured),
+   * which this bound catches. The failure is invisible at CI's {@code WARNING} level (the message
+   * strings are never built), so this test is the pipeline's guard against its return. See {@code
+   * CONTRIBUTING.md}'s Diagnostic Logging section and <a
+   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992 </a> for the upstream root
+   * cause.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDiagnosticLoggingVolumeBounded()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // Fixed code emits ~0.6 GB of formatted FINEST volume for this analysis; a bare `Context`
+    // render measured ~14 GB. 2 GB sits well above the former and far below the latter.
+    final long maxFormattedChars = 2_000_000_000L;
+
+    Logger pkg = Logger.getLogger("com.ibm.wala.cast.python");
+    DiscardingFormattingHandler handler = new DiscardingFormattingHandler();
+    handler.setLevel(Level.ALL);
+    Level oldLevel = pkg.getLevel();
+    boolean oldUseParentHandlers = pkg.getUseParentHandlers();
+    pkg.addHandler(handler);
+    pkg.setLevel(Level.FINEST);
+    // Count the FINEST volume here; don't also propagate it to the console handlers.
+    pkg.setUseParentHandlers(false);
+    try {
+      DiscardingFormattingHandler.reset();
+      testNlpgnnFullGeneration();
+      long volume = DiscardingFormattingHandler.totalChars();
+      assertTrue(
+          "Diagnostic FINEST volume "
+              + volume
+              + " chars exceeds the "
+              + maxFormattedChars
+              + "-char bound; a pointer-analysis or call-graph value is likely logged without"
+              + " Loggables.describe(...). See CONTRIBUTING.md's Diagnostic Logging section.",
+          volume < maxFormattedChars);
+    } finally {
+      pkg.removeHandler(handler);
+      pkg.setLevel(oldLevel);
+      pkg.setUseParentHandlers(oldUseParentHandlers);
+    }
+  }
+
+  /**
    * Same-name-class guard for <a href="https://github.com/wala/ML/issues/678">wala/ML#678</a>: two
    * sibling scripts each define a Keras subclass named {@code GenGPT2} (with a {@code
    * super(GenGPT2, self)} by-name reference in {@code __init__}, mirroring the NLPGNN subject);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2183,6 +2183,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testNlpgnnFullGeneration()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    runNlpgnnFullGeneration();
+  }
+
+  /**
+   * Runs the NLPGNN whole-project generation analysis with its call-graph and type assertions.
+   * Package-visible so {@link DiagnosticLoggingVolumeTest} can rerun the analysis under {@code
+   * FINEST} without invoking another class's {@code @Test} method.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  void runNlpgnnFullGeneration()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
         NLPGNN_FULL_PROJECT_FILES,
         "tests/TG/EN/generation.py",
@@ -2215,62 +2230,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(3, Set.of(new TensorType(UNKNOWN, asList(DynamicDim.INSTANCE, new NumericDim(1))))));
-  }
-
-  /**
-   * Diagnostic-logging volume guard (<a
-   * href="https://github.com/wala/ML/issues/702">wala/ML#702</a>). Reruns the nlpgnn generation
-   * analysis — the cyclic-closure call graph that triggered <a
-   * href="https://github.com/wala/ML/issues/697">wala/ML#697</a> — with every {@code
-   * com.ibm.wala.cast.python} logger at {@code FINEST}, routing records through {@link
-   * DiscardingFormattingHandler}, which formats and discards them while summing their volume.
-   *
-   * <p>Correct code renders diagnostics through the bounded {@code Loggables.describe(...)} (~0.6
-   * GB of formatted {@code FINEST} output for this analysis); a bare render of a {@code
-   * Context}-bearing value inflates that by more than an order of magnitude (~14 GB measured),
-   * which this bound catches. The failure is invisible at CI's {@code WARNING} level (the message
-   * strings are never built), so this test is the pipeline's guard against its return. See {@code
-   * CONTRIBUTING.md}'s Diagnostic Logging section and <a
-   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992</a> for the upstream root cause.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
-   */
-  @Test
-  public void testDiagnosticLoggingVolumeBounded()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // Fixed code emits ~0.6 GB of formatted FINEST volume for this analysis; a bare `Context`
-    // render measured ~14 GB. 2 GB sits well above the former and far below the latter.
-    final long maxFormattedChars = 2_000_000_000L;
-
-    Logger pkg = Logger.getLogger("com.ibm.wala.cast.python");
-    DiscardingFormattingHandler handler = new DiscardingFormattingHandler();
-    handler.setLevel(Level.ALL);
-    Level oldLevel = pkg.getLevel();
-    boolean oldUseParentHandlers = pkg.getUseParentHandlers();
-    pkg.addHandler(handler);
-    pkg.setLevel(Level.FINEST);
-    // Count the FINEST volume here; don't also propagate it to the console handlers.
-    pkg.setUseParentHandlers(false);
-    try {
-      DiscardingFormattingHandler.reset();
-      testNlpgnnFullGeneration();
-      long volume = DiscardingFormattingHandler.totalChars();
-      assertTrue(
-          "Diagnostic FINEST volume "
-              + volume
-              + " chars exceeds the "
-              + maxFormattedChars
-              + "-char bound; a pointer-analysis or call-graph value is likely logged without"
-              + " Loggables.describe(...). See CONTRIBUTING.md's Diagnostic Logging section.",
-          volume < maxFormattedChars);
-    } finally {
-      pkg.removeHandler(handler);
-      pkg.setLevel(oldLevel);
-      pkg.setUseParentHandlers(oldUseParentHandlers);
-    }
   }
 
   /**


### PR DESCRIPTION
Implements wala/ML#702. Adds `testDiagnosticLoggingVolumeBounded`, a self-contained guard against the class of bug fixed by the `Loggables` sweep (#544): a bare render of a `Context`-bearing value in a log or exception message, whose cyclic `Context.toString()` exhausts the heap on large graphs (wala/ML#697; upstream root cause wala/WALA#1992). That class is invisible in CI, which logs at `WARNING` so the `FINE`/`FINEST` message strings are never built; that gap let ~56 sites accumulate unnoticed.

## How It Works

The test reruns the nlpgnn generation analysis (the cyclic-closure call graph behind #697) with every `com.ibm.wala.cast.python` logger at `FINEST`, routing records through a new `DiscardingFormattingHandler` that formats and discards them while summing the formatted volume, then asserts the total stays under a bound.

## Why a Volume Assertion, Not a Heap Cap

The issue proposed a capped-`-Xmx` `FINEST` run that OOMs on regression. Investigation showed that is fragile: the heap exhaustion happens in the publish path and is cumulative, so it only reproduces with real output writing (hundreds of MB to over a GB) and its timing depends on heap size and output backpressure. A volume assertion is deterministic instead: correct code renders through the bounded `Loggables.describe(...)` (~0.6 GB of formatted `FINEST` output here), while a bare render inflates that by more than an order of magnitude (~14 GB measured). The handler discards output, so the guard needs no capped heap, no gigabytes of log files, and no CI-workflow changes; it runs in the normal suite.

On a violation the failure names the likely cause (a value logged without `Loggables.describe(...)`) and points at `CONTRIBUTING.md`'s Diagnostic Logging section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)