### PR TITLE
Parse the einsum equation to infer `tf.einsum`'s output shape (wala/ML#507)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12641,14 +12641,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Generator-dispatch test for {@code tf.einsum(equation, *inputs)}. Output dtype inherits from
-   * the first tensor input ({@code float32} in the fixture). See {@link
-   * com.ibm.wala.cast.python.ml.client.Einsum} (wala/ML#449 Tier 5).
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/507">wala/ML#507</a>): output shape is
-   * currently ⊤. Precise shape inference requires parsing the einsum equation string (e.g. {@code
-   * "ij,jk->ik"}) and composing it against each input's shape. Tighten to the precise post-parse
-   * shape ({@code (2, 2)} for this fixture) once #507 lands.
+   * Generator test for {@code tf.einsum(equation, *inputs)}. The {@link
+   * com.ibm.wala.cast.python.ml.client.Einsum} generator parses the equation string ({@code
+   * "ij,jk->ik"}) and composes the output shape from each input's shape: {@code (2, 2)} einsum
+   * {@code (2, 2)} over {@code "ij,jk->ik"} is {@code (2, 2)}. Output dtype inherits from the first
+   * tensor input ({@code float32}). See wala/ML#507.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -12658,7 +12655,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testEinsum()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_einsum.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+    test("tf2_test_einsum.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12694,6 +12694,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Diagonal einsum (a repeated label within one term, {@code "ii->i"}): the parser doesn't model
+   * diagonal extraction, so it soundly falls back to an unknown ({@code ⊤}) shape while keeping the
+   * dtype precise. The Python runtime shape is {@code (2,)}; the analysis reports {@code ⊤} until
+   * the diagonal form is modeled.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/705">wala/ML#705</a>): tighten to the
+   * precise shape once ellipsis and diagonal einsum forms are handled.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumDiagonalFallback()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_einsum_diag.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12642,9 +12642,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * Generator test for {@code tf.einsum(equation, *inputs)}. The {@link
-   * com.ibm.wala.cast.python.ml.client.Einsum} generator parses the equation string ({@code
-   * "ij,jk->ik"}) and composes the output shape from each input's shape: {@code (2, 2)} einsum
-   * {@code (2, 2)} over {@code "ij,jk->ik"} is {@code (2, 2)}. Output dtype inherits from the first
+   * com.ibm.wala.cast.python.ml.client.Einsum} generator parses the equation string and composes
+   * the output shape from each input's shape. Here {@code einsum("ij,jk->ik", a, b)} with {@code a}
+   * and {@code b} both {@code (2, 2)} yields {@code (2, 2)}. Output dtype inherits from the first
    * tensor input ({@code float32}). See wala/ML#507.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
@@ -12656,6 +12656,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testEinsum()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_einsum.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
+   * Implicit-output einsum: with no {@code ->}, the output labels are those occurring exactly once,
+   * in alphabetical order, so {@code "ij,jk"} composes the same {@code (2, 2)} shape as {@code
+   * "ij,jk->ik"}. See wala/ML#507.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumImplicit()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_einsum_implicit.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT32)));
+  }
+
+  /**
+   * Broadcasting-ellipsis einsum: the parser doesn't model {@code ...}, so it soundly falls back to
+   * an unknown ({@code ⊤}) shape while keeping the dtype precise. The Python runtime shape is
+   * {@code (2, 2)}; the analysis reports {@code ⊤} until the ellipsis form is modeled.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/705">wala/ML#705</a>): tighten to the
+   * precise shape once ellipsis and diagonal einsum forms are handled.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumEllipsisFallback()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_einsum_ellipsis.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -214,11 +214,20 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
    * Composes the output shape by mapping each label to the input dimension it names, then indexing
    * the output labels into that map.
    *
+   * <p>An input shape may encode a statically-unknown dimension size as a raw {@code null} entry
+   * (see {@code TensorType.RaggedDim}'s Javadoc and wala/ML#414). Presence in the label map is
+   * therefore tracked with {@code containsKey}, never by a null-check on the value: a label whose
+   * occurrences are all {@code null} stays {@code null} (unknown size) in the output, preserving
+   * the output's rank instead of degrading the whole shape to ⊤, and a label seen with both a
+   * {@code null} and a concrete dimension merges to {@code null} (statically unagreed) rather than
+   * letting either occurrence win.
+   *
    * @param parsed The parsed equation.
    * @param inputShapes The resolved shape of each input, in input order.
-   * @return The composed output shape, or {@code null} when a term's label count doesn't match its
-   *     input's rank, a term repeats a label (diagonal, unmodeled), or an output label names no
-   *     input.
+   * @return The composed output shape (possibly containing {@code null} unknown-size entries), or
+   *     {@code null} (⊤) when a term's label count doesn't match its input's rank, a term repeats a
+   *     label (diagonal, unmodeled), a shared label maps to conflicting known dimensions, or an
+   *     output label names no input.
    */
   private static List<Dimension<?>> composeOutputShape(
       ParsedEquation parsed, List<List<Dimension<?>>> inputShapes) {
@@ -234,18 +243,21 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
         String label = labels.get(d);
         if (!seenInTerm.add(label)) return null; // Repeated label within a term (diagonal): ⊤.
         Dimension<?> dim = shape.get(d);
-        Dimension<?> previous = labelToDim.putIfAbsent(label, dim);
-        // A label shared across inputs must name the same dimension; if the statically-known dims
-        // disagree, the equation's constraint isn't satisfied statically, so fall back to ⊤.
-        if (previous != null && !previous.equals(dim)) return null;
+        if (!labelToDim.containsKey(label)) labelToDim.put(label, dim);
+        else {
+          Dimension<?> previous = labelToDim.get(label);
+          // An unknown (null) occurrence keeps the label unknown; conflicting known dims mean the
+          // equation's same-dimension constraint isn't satisfied statically, so fall back to ⊤.
+          if (previous == null || dim == null) labelToDim.put(label, null);
+          else if (!previous.equals(dim)) return null;
+        }
       }
     }
 
     List<Dimension<?>> output = new ArrayList<>(parsed.output().size());
     for (String label : parsed.output()) {
-      Dimension<?> dim = labelToDim.get(label);
-      if (dim == null) return null; // Output label names no input.
-      output.add(dim);
+      if (!labelToDim.containsKey(label)) return null; // Output label names no input.
+      output.add(labelToDim.get(label)); // May be null: known rank, unknown size.
     }
     return output;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -203,7 +203,11 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
       for (int i = 0; i < outputPart.length(); i++) {
         char c = outputPart.charAt(i);
         if (!isAsciiLetter(c)) return null;
-        output.add(String.valueOf(c));
+        String label = String.valueOf(c);
+        // TensorFlow/NumPy require output subscripts to be unique; a repeated output label (e.g.
+        // "ij,jk->ii") is rejected at runtime, so don't infer a shape for it.
+        if (output.contains(label)) return null;
+        output.add(label);
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -142,9 +142,11 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
 
     String found = null;
     for (InstanceKey ik : pts) {
-      if (!(ik instanceof ConstantKey)) continue;
+      // Any non-string-constant possible value makes the equation unknown: fall back to ⊤ rather
+      // than treating a mixed argument as a single constant.
+      if (!(ik instanceof ConstantKey)) return null;
       Object value = ((ConstantKey<?>) ik).getValue();
-      if (!(value instanceof String)) continue;
+      if (!(value instanceof String)) return null;
       if (found == null) found = (String) value;
       else if (!found.equals(value)) return null; // Ambiguous equation across contexts.
     }
@@ -231,7 +233,11 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
       for (int d = 0; d < labels.size(); d++) {
         String label = labels.get(d);
         if (!seenInTerm.add(label)) return null; // Repeated label within a term (diagonal): ⊤.
-        labelToDim.putIfAbsent(label, shape.get(d));
+        Dimension<?> dim = shape.get(d);
+        Dimension<?> previous = labelToDim.putIfAbsent(label, dim);
+        // A label shared across inputs must name the same dimension; if the statically-known dims
+        // disagree, the equation's constraint isn't satisfied statically, so fall back to ⊤.
+        if (previous != null && !previous.equals(dim)) return null;
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -2,29 +2,43 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
- * Generator for {@code tf.einsum(equation, *inputs, **kwargs)}. Output shape is left at ⊤ pending
- * equation-string parsing — the precise shape is derivable from the equation's output label
- * sequence and each input's shape, but that requires an einsum-equation parser that this generator
- * doesn't yet implement. Output dtype inherits from the first tensor input (TF promotes per-input
- * dtypes upstream of einsum, so the first input's dtype is the canonical source).
+ * Generator for {@code tf.einsum(equation, *inputs, **kwargs)}. Parses the equation string (e.g.
+ * {@code "ij,jk->ik"}) and composes the precise output shape from each input's shape: every output
+ * label is resolved to the input dimension it names. Output dtype inherits from the first tensor
+ * input (TF promotes per-input dtypes upstream of einsum, so the first input's dtype is the
+ * canonical source).
  *
- * <p>Argument layout per {@code tensorflow.xml}:
+ * <p>Falls back to ⊤ (unknown shape) when the equation can't be resolved to a single constant
+ * string, uses broadcasting ellipsis ({@code ...}) or a repeated (diagonal) label within one term,
+ * or when any input's shape is itself ⊤ — the sound answer in those cases.
+ *
+ * <p>Argument layout at the call site: the {@code *inputs} varargs are spread positionally after
+ * the equation (the packing into a single {@code inputs} tuple is callee-side only), so:
  *
  * <ul>
  *   <li>position 0: {@code equation} (string).
- *   <li>position 1: first tensor input (varargs); dtype source.
- *   <li>position 2+: additional tensor inputs.
+ *   <li>position 1: the first tensor input; the dtype source.
+ *   <li>position 2, 3, ...: the remaining tensor inputs, one per equation term.
  * </ul>
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linalg/einsum">tf.linalg.einsum</a>
- * @see <a href="https://github.com/wala/ML/issues/449">wala/ML#449</a> (Tier 5).
+ * @see <a href="https://github.com/wala/ML/issues/507">wala/ML#507</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class Einsum extends PassThroughUnaryTensorGenerator {
@@ -36,10 +50,10 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
    * source is {@code INPUTS} at position 1.
    */
   protected enum Parameters {
-    /** The einsum equation string (e.g. {@code "ij,jk->ik"}); not consumed by this generator. */
+    /** The einsum equation string (e.g. {@code "ij,jk->ik"}). */
     EQUATION,
 
-    /** The first tensor input (the {@code *inputs} varargs); the dtype source. */
+    /** The first tensor input (positional index 1); the dtype source and the first shape input. */
     INPUTS;
 
     /**
@@ -81,16 +95,160 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
   }
 
   /**
-   * Override the inherited shape passthrough to ⊤. The first tensor input's shape isn't a sound
-   * approximation for einsum's output shape — the equation can permute, contract, or expand dims
-   * arbitrarily. Without an einsum-equation parser, ⊤ is the only sound answer. (The dtype
-   * passthrough from the parent class IS sound, since einsum preserves the (promoted) dtype.)
+   * Composes the precise output shape by parsing the equation and indexing each output label into
+   * the corresponding input dimension. Returns ⊤ (unknown shape, {@code null}) when the equation or
+   * any input shape can't be resolved statically, or when the equation uses a form this parser
+   * doesn't model (ellipsis, diagonal labels).
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return {@code null} — ⊤, unknown shape.
+   * @return The single composed output shape, or {@code null} (⊤) when it can't be resolved.
    */
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    return null;
+    String equation = this.getEquation(builder);
+    if (equation == null) return null;
+
+    ParsedEquation parsed = parseEquation(equation);
+    if (parsed == null) return null;
+
+    // The inputs are spread positionally after the equation (they only pack into the callee's
+    // *inputs tuple), so input i is at positional index i + 1.
+    int inputCount = parsed.inputs().size();
+    List<List<Dimension<?>>> inputShapes = new ArrayList<>(inputCount);
+    for (int i = 0; i < inputCount; i++) {
+      int position = Parameters.INPUTS.getIndex() + i;
+      Set<List<Dimension<?>>> shapes = this.shapesOfArg(builder, position, null);
+      // Require a single known shape per input. A ⊤ or multi-shape input yields a ⊤ output; the
+      // multi-shape cross-product is deferred as a precision follow-up.
+      if (shapes == null || shapes.size() != 1) return null;
+      inputShapes.add(shapes.iterator().next());
+    }
+
+    List<Dimension<?>> outputShape = composeOutputShape(parsed, inputShapes);
+    return outputShape == null ? null : Collections.singleton(outputShape);
   }
+
+  /**
+   * Resolves the {@code equation} argument to a single constant string.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The equation string, or {@code null} if the argument isn't a single constant string.
+   */
+  private String getEquation(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> pts =
+        this.getArgumentPointsToSet(
+            builder, Parameters.EQUATION.getIndex(), Parameters.EQUATION.getName());
+    if (pts == null || pts.isEmpty()) return null;
+
+    String found = null;
+    for (InstanceKey ik : pts) {
+      if (!(ik instanceof ConstantKey)) continue;
+      Object value = ((ConstantKey<?>) ik).getValue();
+      if (!(value instanceof String)) continue;
+      if (found == null) found = (String) value;
+      else if (!found.equals(value)) return null; // Ambiguous equation across contexts.
+    }
+    return found;
+  }
+
+  /**
+   * Parses an einsum equation into its per-input label lists and its output label list.
+   *
+   * <p>Supports explicit ({@code "ij,jk->ik"}) and implicit ({@code "ij,jk"}) output modes. In
+   * implicit mode the output is the labels occurring exactly once, in alphabetical order (the
+   * NumPy/TensorFlow convention). Returns {@code null} for forms this parser doesn't model:
+   * broadcasting ellipsis ({@code ...}), a malformed equation, or a non-letter label.
+   *
+   * @param equation The raw equation string.
+   * @return The parsed equation, or {@code null} if it uses an unsupported or malformed form.
+   */
+  private static ParsedEquation parseEquation(String equation) {
+    String eq = equation.replace(" ", "");
+    if (eq.isEmpty() || eq.contains("...")) return null; // Broadcasting ellipsis: ⊤.
+
+    String inputsPart;
+    String outputPart;
+    int arrow = eq.indexOf("->");
+    if (arrow >= 0) {
+      if (eq.indexOf("->", arrow + 2) >= 0) return null; // A second arrow is malformed.
+      inputsPart = eq.substring(0, arrow);
+      outputPart = eq.substring(arrow + 2);
+    } else {
+      inputsPart = eq;
+      outputPart = null; // Implicit output mode.
+    }
+
+    List<List<String>> inputs = new ArrayList<>();
+    for (String term : inputsPart.split(",", -1)) {
+      List<String> labels = new ArrayList<>();
+      for (int i = 0; i < term.length(); i++) {
+        char c = term.charAt(i);
+        if (!Character.isLetter(c)) return null;
+        labels.add(String.valueOf(c));
+      }
+      inputs.add(labels);
+    }
+
+    List<String> output = new ArrayList<>();
+    if (outputPart == null) {
+      // Implicit mode: labels occurring exactly once, alphabetical (TreeMap key order).
+      Map<String, Integer> counts = new TreeMap<>();
+      for (List<String> term : inputs)
+        for (String label : term) counts.merge(label, 1, Integer::sum);
+      for (Map.Entry<String, Integer> entry : counts.entrySet())
+        if (entry.getValue() == 1) output.add(entry.getKey());
+    } else {
+      for (int i = 0; i < outputPart.length(); i++) {
+        char c = outputPart.charAt(i);
+        if (!Character.isLetter(c)) return null;
+        output.add(String.valueOf(c));
+      }
+    }
+
+    return new ParsedEquation(inputs, output);
+  }
+
+  /**
+   * Composes the output shape by mapping each label to the input dimension it names, then indexing
+   * the output labels into that map.
+   *
+   * @param parsed The parsed equation.
+   * @param inputShapes The resolved shape of each input, in input order.
+   * @return The composed output shape, or {@code null} when a term's label count doesn't match its
+   *     input's rank, a term repeats a label (diagonal, unmodeled), or an output label names no
+   *     input.
+   */
+  private static List<Dimension<?>> composeOutputShape(
+      ParsedEquation parsed, List<List<Dimension<?>>> inputShapes) {
+    Map<String, Dimension<?>> labelToDim = new HashMap<>();
+
+    for (int i = 0; i < parsed.inputs().size(); i++) {
+      List<String> labels = parsed.inputs().get(i);
+      List<Dimension<?>> shape = inputShapes.get(i);
+      if (labels.size() != shape.size()) return null; // Rank mismatch: labels vs. shape.
+
+      Set<String> seenInTerm = new HashSet<>();
+      for (int d = 0; d < labels.size(); d++) {
+        String label = labels.get(d);
+        if (!seenInTerm.add(label)) return null; // Repeated label within a term (diagonal): ⊤.
+        labelToDim.putIfAbsent(label, shape.get(d));
+      }
+    }
+
+    List<Dimension<?>> output = new ArrayList<>(parsed.output().size());
+    for (String label : parsed.output()) {
+      Dimension<?> dim = labelToDim.get(label);
+      if (dim == null) return null; // Output label names no input.
+      output.add(dim);
+    }
+    return output;
+  }
+
+  /**
+   * A parsed einsum equation: the label list of each input term and the output label list.
+   *
+   * @param inputs The per-input-term label lists, in input order.
+   * @param output The output label list.
+   */
+  private record ParsedEquation(List<List<String>> inputs, List<String> output) {}
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -185,7 +185,7 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
       List<String> labels = new ArrayList<>();
       for (int i = 0; i < term.length(); i++) {
         char c = term.charAt(i);
-        if (!Character.isLetter(c)) return null;
+        if (!isAsciiLetter(c)) return null;
         labels.add(String.valueOf(c));
       }
       inputs.add(labels);
@@ -202,7 +202,7 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
     } else {
       for (int i = 0; i < outputPart.length(); i++) {
         char c = outputPart.charAt(i);
-        if (!Character.isLetter(c)) return null;
+        if (!isAsciiLetter(c)) return null;
         output.add(String.valueOf(c));
       }
     }
@@ -260,6 +260,18 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
       output.add(labelToDim.get(label)); // May be null: known rank, unknown size.
     }
     return output;
+  }
+
+  /**
+   * Returns whether the character is an ASCII letter. Einsum subscript labels are restricted to
+   * {@code [A-Za-z]} by TensorFlow/NumPy (aside from the ellipsis), so a Unicode letter accepted by
+   * {@link Character#isLetter(char)} would type an equation the runtime rejects.
+   *
+   * @param c The candidate label character.
+   * @return {@code true} iff {@code c} is in {@code [A-Za-z]}.
+   */
+  private static boolean isAsciiLetter(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -34,7 +34,8 @@ import java.util.TreeMap;
  * <ul>
  *   <li>position 0: {@code equation} (string).
  *   <li>position 1: the first tensor input; the dtype source.
- *   <li>position 2, 3, ...: the remaining tensor inputs, one per equation term.
+ *   <li>position 2, 3, ...: the remaining tensor inputs; input {@code i} of the equation's terms
+ *       sits at position {@code i + 1}.
  * </ul>
  *
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/linalg/einsum">tf.linalg.einsum</a>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum.py
@@ -5,9 +5,9 @@ def f(a):
     pass
 
 
-# `tf.einsum` is the dispatch test. Generator emits ⊤ shape (since the
-# precise shape requires equation parsing) but inherits the dtype from
-# the first tensor input (`a` here, which is float32).
+# `tf.einsum` is the dispatch test. The generator parses the equation and
+# composes the precise (2, 2) output shape from the input shapes, and
+# inherits the dtype from the first tensor input (`a` here, float32).
 a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
 b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
 result = tf.einsum("ij,jk->ik", a, b)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_diag.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_diag.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Diagonal einsum (a repeated label within one term): the generator doesn't
+# model diagonal extraction, so the analysis soundly reports an unknown (⊤)
+# shape while keeping the dtype precise. The shape assert below documents the
+# Python runtime truth, not the analysis result; `testEinsumDiagonalFallback`
+# pins the analysis-side ⊤ until wala/ML#705 models the diagonal form.
+a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+result = tf.einsum("ii->i", a)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2,)
+assert result.dtype == tf.float32
+f(result)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_ellipsis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_ellipsis.py
@@ -5,8 +5,11 @@ def f(a):
     pass
 
 
-# Broadcasting-ellipsis einsum: the generator doesn't model `...`, so it soundly
-# falls back to an unknown (⊤) shape while keeping the dtype precise.
+# Broadcasting-ellipsis einsum: the generator doesn't model `...`, so the
+# analysis soundly reports an unknown (⊤) shape while keeping the dtype
+# precise. The shape assert below documents the Python runtime truth, not the
+# analysis result; `testEinsumEllipsisFallback` pins the analysis-side ⊤ until
+# wala/ML#705 models the ellipsis form.
 a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
 b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
 result = tf.einsum("...ij,...jk->...ik", a, b)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_ellipsis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_ellipsis.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Broadcasting-ellipsis einsum: the generator doesn't model `...`, so it soundly
+# falls back to an unknown (⊤) shape while keeping the dtype precise.
+a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
+result = tf.einsum("...ij,...jk->...ik", a, b)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 2)
+assert result.dtype == tf.float32
+f(result)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_implicit.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_implicit.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Implicit-output einsum (no `->`): the output is the labels occurring exactly
+# once, in alphabetical order, so `"ij,jk"` is equivalent to `"ij,jk->ik"`.
+a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
+result = tf.einsum("ij,jk", a, b)
+assert isinstance(result, tf.Tensor)
+assert result.shape == (2, 2)
+assert result.dtype == tf.float32
+f(result)


### PR DESCRIPTION
Closes wala/ML#507.

`com.ibm.wala.cast.python.ml.client.Einsum` previously emitted ⊤ for `tf.einsum`'s output shape. It now parses the equation string and composes the precise output shape from each input's shape.

## What Changed

`Einsum.getDefaultShapes`:

- Resolves the `equation` argument to a constant string.
- Parses it into per-input label lists and an output label list, supporting explicit (`"ij,jk->ik"`) and implicit (`"ij,jk"`) output modes. Implicit output is the labels occurring exactly once, in alphabetical order (the NumPy/TensorFlow convention).
- Reads each input's shape from its positional argument (the `*inputs` varargs are spread positionally at the call site).
- Maps each output label to the input dimension it names to build the output shape.

## Soundness

The generator falls back to ⊤ (unknown shape) whenever precise composition isn't statically justified: a non-constant or ambiguous equation, a non-string equation value, broadcasting ellipsis (`...`), a repeated (diagonal) label within a term, a label that maps to non-equal dimensions across inputs, a label count that doesn't match an input's rank, or any input shape that is itself ⊤. Dtype handling is unchanged (still inherited from the first tensor input).

## Coverage

`testEinsum` tightens from `TENSOR_UNKNOWN_SHAPE_FLOAT32` to the precise `(2, 2)` for `einsum("ij,jk->ik", a, b)`. `testEinsumImplicit` covers the no-arrow form, and `testEinsumEllipsisFallback` pins the sound ⊤ fallback (tracked for precision by wala/ML#705).

## Context

This lets attention and dense layers whose output dims come from a weight (for example NLPGNN's `DenseLayer3d`) carry a static trailing dimension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)