### PR TITLE
Guard the comprehension-built indexed sub-layer dispatch gap (wala/ML#694)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -10897,6 +10897,31 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Indexed dispatch over a comprehension-built sublayer list (wala/ML#661 shape 3, wala/ML#694):
+   * {@code self.sub_layers = [Inner() for _ in range(n)]} dispatched through {@code
+   * self.sub_layers[i](out)} in a loop. {@code Inner.call} returns a distinctly-shaped {@code (6,
+   * 1)} tensor, so a working dispatch would flow {@code (6, 1)} to {@code consume}. The analysis
+   * instead reports the pre-loop input's {@code (2, 3)} (carried by the loop phi): the
+   * comprehension-built indexed call materializes no callee, so the sub-layer forward result never
+   * reaches the sink.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/694">wala/ML#694</a>): once the
+   * comprehension-built indexed dispatch materializes its callee, tighten the assertion to the
+   * precise {@code (6, 1)} shape (the Python runtime shape).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testIndexedComprehensionLayerListCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // TODO(wala/ML#694): observed-but-imprecise (2, 3); the runtime shape is (6, 1).
+    test("tf2_test_layer_list_compr.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
    * Pins {@code self.add_weight(...)} (wala/ML#618): the Keras weight-creation API, called from the
    * lazily-invoked {@code build} (wala/ML#595), creates a tensor whose shape and dtype come from
    * the call's {@code shape} list and {@code dtype} string arguments (wala/ML#667), so the matmul

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_compr.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_compr.py
@@ -1,0 +1,39 @@
+# Miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch (wala/ML#661 shape 3):
+# a plain list of sublayers built by a list comprehension in `build`, dispatched through a
+# dynamic subscript in `call`. `Inner.call` returns a distinctly-shaped tensor so the sub-layer
+# forward result is observable at the sink: a masked dispatch failure would leave the input's
+# (2, 3) shape (carried by the loop phi) rather than the sub-layer's (6, 1).
+import tensorflow as tf
+
+
+class Inner(tf.keras.layers.Layer):
+    def call(self, inputs, training=True):
+        return tf.ones((6, 1))
+
+
+class Outer(tf.keras.layers.Layer):
+    def __init__(self, num_layers=2, **kwargs):
+        super(Outer, self).__init__(**kwargs)
+        self.num_layers = num_layers
+
+    def build(self, input_shape):
+        self.sub_layers = [Inner() for _ in range(self.num_layers)]
+
+    def call(self, inputs, training=True):
+        out = inputs
+        for i in range(self.num_layers):
+            out = self.sub_layers[i](out, training)
+        return out
+
+
+def consume(t):
+    pass
+
+
+layer = Outer()
+x = tf.ones((2, 3))
+out = layer(x)
+consume(out)
+
+assert out.shape == (6, 1)
+assert out.dtype == tf.float32


### PR DESCRIPTION
Adds a regression-documenting test for wala/ML#694 (also wala/ML#661 shape 3), which had no coverage.

## The Gap

A sublayer list built by a comprehension and dispatched through a dynamic subscript:

```python
def build(self, input_shape):
    self.sub_layers = [Inner() for _ in range(self.num_layers)]

def call(self, inputs, training=True):
    out = inputs
    for i in range(self.num_layers):
        out = self.sub_layers[i](out, training)
    return out
```

The indexed call `self.sub_layers[i](out)` materializes no callee, so the sub-layer's forward result never reaches the sink. `Inner.call` returns a distinctly-shaped `(6, 1)` tensor, which makes the miss observable: the analysis reports the pre-loop input's `(2, 3)` (carried by the loop phi) rather than the runtime `(6, 1)`.

## What This Adds

`testIndexedComprehensionLayerListCall` pins the observed `(2, 3)` with a `TODO(wala/ML#694)` to tighten to the precise `(6, 1)` once the dispatch materializes its callee. The fixture (`tf2_test_layer_list_compr.py`) is a miniature of NLPGNN's `GAAELayer` indexed sub-layer dispatch; its `Inner.call` is deliberately shape-changing so the test discriminates a working dispatch from a phi-masked one (an identity sub-layer would pass even on the failure).

No production code changes; test and fixture only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)