### PR TITLE
Resolve shape vectors (`t.shape.as_list()[-2:]`) by def-use provenance (wala/ML#703)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -364,6 +364,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_3_2_2_FLOAT32 = TensorType.of(FLOAT_32, 3, 2, 2);
 
+  private static final TensorType TENSOR_5_6_FLOAT32 = TensorType.of(FLOAT_32, 5, 6);
+
+  private static final TensorType TENSOR_4_5_6_FLOAT32 = TensorType.of(FLOAT_32, 4, 5, 6);
+
   private static final TensorType TENSOR_7_5_2_FLOAT32 = TensorType.of(FLOAT_32, 7, 5, 2);
 
   private static final TensorType TENSOR_30_3_2_FLOAT32 = TensorType.of(FLOAT_32, 30, 3, 2);
@@ -11288,9 +11292,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "gpt2_vendored",
         1,
         1,
-        // The scalar-rank result comes from the interpreter folding the computed output shape;
-        // receiver-keyed contexts (wala/ML#679) recover the `add_weight` float32 dtype.
-        Map.of(2, Set.of(new TensorType(FLOAT_32, emptyList()))));
+        // The computed output shape is opaque (a runtime-built list), so the reshape result is
+        // pinned at unknown rank (wala/ML#703); receiver-keyed contexts (wala/ML#679) recover the
+        // `add_weight` float32 dtype.
+        Map.of(2, Set.of(new TensorType(FLOAT_32, null))));
   }
 
   /**
@@ -11332,8 +11337,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         // The interpreter evaluates the concatenated shape expression to the concrete
-        // (2, 3, 16); a scalar leak rides along in the union.
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 16), SCALAR_TENSOR_OF_FLOAT32)));
+        // (2, 3, 16); the opaque-shape-operand unknown-rank pin (wala/ML#703) rides along in the
+        // union. TODO(https://github.com/wala/ML/issues/703): drop the ⊤ member once the pin
+        // defers to interpreter-resolved shape operands.
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 16), new TensorType(FLOAT_32, null))));
   }
 
   /**
@@ -12432,8 +12439,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * com.ibm.wala.cast.python.ml.client.Reshape} (mirroring {@link
    * com.ibm.wala.cast.python.ml.client.BroadcastTo}'s localized try/catch), the analysis no longer
    * throws on the {@code tf.shape(...)} shape arg. The inferred parameter type for {@code x} (vn=2)
-   * is currently the imprecise union {@code [() of float32, (⊤) of float32]} rather than the
-   * precise {@code (2, 3) float32}.
+   * is currently the imprecise {@code (⊤) of float32} (the opaque-shape-operand unknown-rank pin,
+   * wala/ML#703) rather than the precise {@code (2, 3) float32}.
    *
    * <p>TODO(<a href="https://github.com/wala/ML/issues/473">wala/ML#473</a>): tighten the parameter
    * type to {@link #TENSOR_2_3_FLOAT32} when the helper learns to resolve {@code tf.shape(y)}'s
@@ -12447,7 +12454,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32, new TensorType(FLOAT_32, null))));
+        Map.of(2, Set.of(new TensorType(FLOAT_32, null))));
   }
 
   @Test
@@ -12659,6 +12666,39 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testEinsum()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_einsum.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Shape-vector provenance (wala/ML#703): {@code tf.reshape(x, t.shape.as_list()[-2:])} resolves
+   * to the source tensor's trailing sub-shape. The shape argument's points-to set is empty (the
+   * {@code shape} member, {@code as_list}, and the slice are unmodeled in the heap), so {@code
+   * Reshape} recovers it by def-use provenance: the slice of the {@code as_list()} of the {@code
+   * .shape} of {@code t} of shape {@code (4, 5, 6)}, sliced with {@code [-2:]}, is {@code (5, 6)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeAsListSlice()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_as_list_slice.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
+   * Unsliced companion of {@link #testShapeAsListSlice()} (wala/ML#703): {@code tf.reshape(x,
+   * t.shape.as_list())} resolves to the source tensor's full shape.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeAsList()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_as_list.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_4_5_6_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -11295,7 +11295,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         // The computed output shape is opaque (a runtime-built list), so the reshape result is
         // pinned at unknown rank (wala/ML#703); receiver-keyed contexts (wala/ML#679) recover the
         // `add_weight` float32 dtype.
-        Map.of(2, Set.of(new TensorType(FLOAT_32, null))));
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -11340,7 +11340,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         // (2, 3, 16); the opaque-shape-operand unknown-rank pin (wala/ML#703) rides along in the
         // union. TODO(https://github.com/wala/ML/issues/703): drop the ⊤ member once the pin
         // defers to interpreter-resolved shape operands.
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 16), new TensorType(FLOAT_32, null))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 16), TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -12454,7 +12454,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(FLOAT_32, null))));
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   @Test

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -52,6 +52,7 @@ import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
@@ -917,6 +918,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         builder,
         (CGNode src, SSAAbstractInvokeInstruction call) -> {
           if (call.getNumberOfUses() > param) {
+            // `TensorType.shapeArg` reads the shape operand's element writes, so it is only
+            // meaningful for a literal container construction (a `new` list/tuple). A shape
+            // vector (`t.shape.as_list()[-2:]` and friends) is resolved precisely by the
+            // generator-side provenance walk, so pinning would only pollute its result — skip it
+            // (wala/ML#703). Any other opaque operand — a `tf.shape(y)` tensor, a computed list,
+            // or a parameter — has no element writes, and `shapeArg` would fabricate a scalar
+            // type for it; pin a tensor of unknown rank instead, which keeps the result
+            // tensor-classified without asserting a wrong shape.
+            int shapeVn = call.getUse(param);
+            if (TensorGenerator.isShapeVectorChain(src, shapeVn)) return;
+            SSAInstruction shapeDef = src.getDU().getDef(shapeVn);
+            TensorType pinned =
+                shapeDef instanceof SSANewInstruction
+                    ? TensorType.shapeArg(src, shapeVn, builder)
+                    : new TensorType(
+                        TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),
+                        null);
             PointerKey defKey =
                 builder
                     .getPointerAnalysis()
@@ -926,9 +944,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // graph's IR (an unconditional debug print), so skip it; implicit keys carry no
             // explicit dataflow variable to pin (wala/ML#573).
             if (!builder.getPropagationSystem().isImplicit(defKey))
-              targets.put(
-                  builder.getPropagationSystem().findOrCreatePointsToSet(defKey),
-                  TensorType.shapeArg(src, call.getUse(param), builder));
+              targets.put(builder.getPropagationSystem().findOrCreatePointsToSet(defKey), pinned);
           }
         });
     return targets;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -929,8 +929,18 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             int shapeVn = call.getUse(param);
             if (TensorGenerator.isShapeVectorChain(src, shapeVn)) return;
             SSAInstruction shapeDef = src.getDU().getDef(shapeVn);
-            TensorType pinned =
+            boolean literalContainer =
                 shapeDef instanceof SSANewInstruction
+                    && (((SSANewInstruction) shapeDef)
+                            .getNewSite()
+                            .getDeclaredType()
+                            .equals(PythonTypes.list)
+                        || ((SSANewInstruction) shapeDef)
+                            .getNewSite()
+                            .getDeclaredType()
+                            .equals(PythonTypes.tuple));
+            TensorType pinned =
+                literalContainer
                     ? TensorType.shapeArg(src, shapeVn, builder)
                     : new TensorType(
                         TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -70,86 +70,99 @@ public class Reshape extends TensorGenerator {
         this.getArgumentPointsToSet(
             builder, this.getShapeParameterPosition(), this.getShapeParameterName());
 
+    Set<List<Dimension<?>>> rawShapes = null;
+
     if (shapePts != null && !shapePts.isEmpty()) {
       // `tf.reshape(arr, tf.shape(other))` is a common pattern where the shape argument is itself a
       // runtime Tensor (the result of `tf.shape(...)`); `getShapesFromShapeArgument` degrades such
       // unrecognized forms to ⊤ ("output shape unknown") rather than throwing (wala/ML#471). See
       // wala/ML#538 for the surfacing fixture (`tf2_test_take_along_axis.py`).
-      Set<List<Dimension<?>>> rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
+      rawShapes = this.getShapesFromShapeArgument(builder, shapePts);
       // Soundness: when the `shape` argument is present but unparseable, the output shape is ⊤
       // (the result is determined by `shape`, not the input tensor — falling back to input-shape
       // inference would be unsound).
       if (rawShapes == null) return null;
-      if (!rawShapes.isEmpty()) {
-        Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
+    }
 
-        for (List<Dimension<?>> shape : rawShapes) {
-          int unknownIndex = -1;
-          long productKnown = 1;
-          boolean canInfer = true;
+    if (rawShapes == null || rawShapes.isEmpty()) {
+      // The shape argument's points-to set is empty (or held no shape-bearing allocation). A shape
+      // vector derived from a tensor's shape (`t.shape.as_list()[-2:]` and friends) has no
+      // points-to state at all, so resolve it by def-use provenance instead (wala/ML#703).
+      Set<List<Dimension<?>>> vectorShapes =
+          this.getShapesFromShapeVectorArgument(
+              builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+      if (vectorShapes != null && !vectorShapes.isEmpty()) rawShapes = vectorShapes;
+    }
 
-          for (int i = 0; i < shape.size(); i++) {
-            Dimension<?> dim = shape.get(i);
-            if (dim instanceof NumericDim) {
-              int val = ((NumericDim) dim).value();
-              if (val == -1) {
-                if (unknownIndex != -1) {
-                  canInfer = false; // More than one -1
+    if (rawShapes != null && !rawShapes.isEmpty()) {
+      Set<List<Dimension<?>>> refinedShapes = HashSetFactory.make();
+
+      for (List<Dimension<?>> shape : rawShapes) {
+        int unknownIndex = -1;
+        long productKnown = 1;
+        boolean canInfer = true;
+
+        for (int i = 0; i < shape.size(); i++) {
+          Dimension<?> dim = shape.get(i);
+          if (dim instanceof NumericDim) {
+            int val = ((NumericDim) dim).value();
+            if (val == -1) {
+              if (unknownIndex != -1) {
+                canInfer = false; // More than one -1
+                break;
+              }
+              unknownIndex = i;
+            } else {
+              productKnown *= val;
+            }
+          } else {
+            canInfer = false; // Non-numeric dimension
+            break;
+          }
+        }
+
+        if (unknownIndex != -1) {
+          // We need input shapes to infer -1 dimension.
+          Set<List<Dimension<?>>> inputShapes = this.getDefaultShapes(builder);
+
+          if (canInfer && inputShapes != null && !inputShapes.isEmpty()) {
+            for (List<Dimension<?>> inputShape : inputShapes) {
+              long inputSize = 1;
+              boolean inputKnown = true;
+              for (Dimension<?> d : inputShape) {
+                if (d instanceof NumericDim) {
+                  inputSize *= ((NumericDim) d).value();
+                } else {
+                  inputKnown = false;
                   break;
                 }
-                unknownIndex = i;
+              }
+
+              List<Dimension<?>> refinedShape = new ArrayList<>(shape);
+              if (inputKnown) {
+                long inferredDim = inputSize / productKnown;
+                refinedShape.set(unknownIndex, new NumericDim((int) inferredDim));
               } else {
-                productKnown *= val;
-              }
-            } else {
-              canInfer = false; // Non-numeric dimension
-              break;
-            }
-          }
-
-          if (unknownIndex != -1) {
-            // We need input shapes to infer -1 dimension.
-            Set<List<Dimension<?>>> inputShapes = this.getDefaultShapes(builder);
-
-            if (canInfer && inputShapes != null && !inputShapes.isEmpty()) {
-              for (List<Dimension<?>> inputShape : inputShapes) {
-                long inputSize = 1;
-                boolean inputKnown = true;
-                for (Dimension<?> d : inputShape) {
-                  if (d instanceof NumericDim) {
-                    inputSize *= ((NumericDim) d).value();
-                  } else {
-                    inputKnown = false;
-                    break;
-                  }
-                }
-
-                List<Dimension<?>> refinedShape = new ArrayList<>(shape);
-                if (inputKnown) {
-                  long inferredDim = inputSize / productKnown;
-                  refinedShape.set(unknownIndex, new NumericDim((int) inferredDim));
-                } else {
-                  refinedShape.set(unknownIndex, new SymbolicDim("?"));
-                }
-                refinedShapes.add(refinedShape);
-              }
-            } else {
-              List<Dimension<?>> refinedShape = new ArrayList<>();
-              for (Dimension<?> dim : shape) {
-                if (dim instanceof NumericDim && ((NumericDim) dim).value() == -1) {
-                  refinedShape.add(new SymbolicDim("?"));
-                } else {
-                  refinedShape.add(dim);
-                }
+                refinedShape.set(unknownIndex, new SymbolicDim("?"));
               }
               refinedShapes.add(refinedShape);
             }
           } else {
-            refinedShapes.add(shape);
+            List<Dimension<?>> refinedShape = new ArrayList<>();
+            for (Dimension<?> dim : shape) {
+              if (dim instanceof NumericDim && ((NumericDim) dim).value() == -1) {
+                refinedShape.add(new SymbolicDim("?"));
+              } else {
+                refinedShape.add(dim);
+              }
+            }
+            refinedShapes.add(refinedShape);
           }
+        } else {
+          refinedShapes.add(shape);
         }
-        return refinedShapes;
       }
+      return refinedShapes;
     }
 
     // 2. Fallback: infer from input tensor.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2751,6 +2751,265 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Resolves a shape argument that is a <em>shape vector</em>: a Python value derived from a
+   * tensor's shape through the {@code t.shape} / {@code t.shape.as_list()} / {@code
+   * t.shape.as_list()[a:b]} idioms (<a
+   * href="https://github.com/wala/ML/issues/703">wala/ML#703</a>). Such values have an empty
+   * points-to set (the {@code shape} member and {@code as_list} are unmodeled), so ordinary shape
+   * resolution can't see them; this recovers the source tensor's shape by def-use walking and
+   * applies any slice with constant bounds.
+   *
+   * <p>Tries the generator's own invoke first (caller-side sources); for synthetic/manual nodes it
+   * walks the call-graph callers, mirroring {@link #getShapeFromShapeAttributeArgument}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param paramPos The 0-based positional index of the shape parameter (excluding {@code self}).
+   * @param paramName The shape parameter's keyword name, or {@code null}.
+   * @return The union of the recovered (sub-)shapes, or {@code null} if the argument isn't a
+   *     resolvable shape vector.
+   */
+  protected Set<List<Dimension<?>>> getShapesFromShapeVectorArgument(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    PythonInvokeInstruction call = getInvokeInstruction();
+    if (call != null) {
+      int argVn = -1;
+      if (paramName != null) argVn = call.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numKeywords = call.getKeywords() != null ? call.getKeywords().size() : 0;
+        int numPosParams = call.getNumberOfUses() - 1 - numKeywords;
+        if (paramPos < numPosParams) argVn = call.getUse(paramPos + 1);
+      }
+      if (argVn > 0) return this.getShapesOfShapeVector(builder, this.getNode(), argVn);
+      return null;
+    }
+
+    // Synthetic/manual node: walk the call-graph callers to find the argument's value number.
+    Set<List<Dimension<?>>> combined = null;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) continue;
+      Set<List<Dimension<?>>> shapes = this.getShapesOfShapeVector(builder, caller, argVn);
+      if (shapes != null && !shapes.isEmpty()) {
+        if (combined == null) combined = HashSetFactory.make();
+        combined.addAll(shapes);
+      }
+    }
+    return combined;
+  }
+
+  /**
+   * Def-use walker behind {@link #getShapesFromShapeVectorArgument}: resolves a value number to the
+   * tensor (sub-)shape it denotes. Recognizes, recursively:
+   *
+   * <ul>
+   *   <li>{@code t.shape} — a {@link PythonPropertyRead} of member {@code "shape"}; resolves the
+   *       source tensor's shapes via {@link #getShapes(PropagationCallGraphBuilder, CGNode, int)}.
+   *   <li>{@code v.as_list()} — an invoke whose function object is a property read of member {@code
+   *       "as_list"}; recurses on the receiver.
+   *   <li>{@code v[a:b]} — an invoke of the {@code slice} builtin with constant (or {@code None})
+   *       bounds and a unit step; recurses on the receiver and takes the corresponding sub-list of
+   *       each shape, with Python negative-index semantics.
+   * </ul>
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to resolve.
+   * @return The union of the denoted (sub-)shapes, or {@code null} (⊤) when the def-use chain
+   *     doesn't match a recognized shape-vector form, a slice bound isn't a compile-time constant
+   *     (the sub-list's rank is then unknown), or the source tensor's shape doesn't resolve.
+   */
+  protected Set<List<Dimension<?>>> getShapesOfShapeVector(
+      PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    if (vn <= 0 || node.getDU() == null) return null;
+    SSAInstruction def = node.getDU().getDef(vn);
+    SymbolTable st = node.getIR().getSymbolTable();
+
+    if (def instanceof PythonPropertyRead) {
+      PythonPropertyRead read = (PythonPropertyRead) def;
+      int memberVn = read.getMemberRef();
+      if (st.isStringConstant(memberVn) && "shape".equals(st.getStringValue(memberVn))) {
+        try {
+          return this.getShapes(builder, node, read.getObjectRef());
+        } catch (IllegalArgumentException e) {
+          LOGGER.log(
+              Level.FINE,
+              "getShapesOfShapeVector: could not resolve .shape source in node=" + node,
+              e);
+          return null;
+        }
+      }
+      return null;
+    }
+
+    if (def instanceof PythonInvokeInstruction) {
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
+      if (invoke.getNumberOfUses() < 1) return null;
+      SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
+
+      // v.as_list(): peel the call and recurse on the receiver of the property read.
+      if (funcDef instanceof PythonPropertyRead) {
+        PythonPropertyRead funcRead = (PythonPropertyRead) funcDef;
+        int memberVn = funcRead.getMemberRef();
+        if (st.isStringConstant(memberVn) && "as_list".equals(st.getStringValue(memberVn)))
+          return this.getShapesOfShapeVector(builder, node, funcRead.getObjectRef());
+        return null;
+      }
+
+      // v[a:b]: a slice-builtin invoke of the form slice(receiver, lower, upper, step).
+      if (funcDef instanceof SSANewInstruction
+          && ((SSANewInstruction) funcDef)
+              .getNewSite()
+              .getDeclaredType()
+              .equals(PythonTypes.SLICE_BUILTIN)
+          && invoke.getNumberOfUses() >= 2) {
+        Set<List<Dimension<?>>> base = this.getShapesOfShapeVector(builder, node, invoke.getUse(1));
+        if (base == null || base.isEmpty()) return null;
+
+        // A nested slice object as a bound means a multi-dim subscript; a shape vector is 1-D, so
+        // that form isn't a shape-list slice.
+        for (int u = 2; u < invoke.getNumberOfUses(); u++)
+          if (isSliceObjectDef(node, invoke.getUse(u))) return null;
+
+        Integer lower = sliceBoundOrNull(builder, node, st, invoke, 2);
+        Integer upper = sliceBoundOrNull(builder, node, st, invoke, 3);
+        Integer step = sliceBoundOrNull(builder, node, st, invoke, 4);
+        if (lower == UNRESOLVED_BOUND || upper == UNRESOLVED_BOUND || step == UNRESOLVED_BOUND)
+          return null; // Non-constant bound: the sub-list's rank is unknown.
+        if (step != null && step != 1) return null; // Non-unit step: unmodeled.
+
+        Set<List<Dimension<?>>> sliced = HashSetFactory.make();
+        for (List<Dimension<?>> dims : base) {
+          int n = dims.size();
+          int from = lower == null ? 0 : lower < 0 ? Math.max(0, n + lower) : Math.min(lower, n);
+          int to = upper == null ? n : upper < 0 ? Math.max(0, n + upper) : Math.min(upper, n);
+          sliced.add(from < to ? new ArrayList<>(dims.subList(from, to)) : new ArrayList<>());
+        }
+        return sliced;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  /**
+   * Structural companion of {@link #getShapesOfShapeVector}: returns whether the value's def-use
+   * chain has the shape of a shape vector ({@code t.shape}, {@code v.as_list()}, or a {@code slice}
+   * of one), without resolving any shapes or bounds. Used to decide whether a shape operand should
+   * be left to the generator-side provenance walk rather than pinned (wala/ML#703).
+   *
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to test.
+   * @return {@code true} iff the def-use chain matches a shape-vector form.
+   */
+  public static boolean isShapeVectorChain(CGNode node, int vn) {
+    if (vn <= 0 || node.getDU() == null || node.getIR() == null) return false;
+    SSAInstruction def = node.getDU().getDef(vn);
+    SymbolTable st = node.getIR().getSymbolTable();
+
+    if (def instanceof PythonPropertyRead) {
+      int memberVn = ((PythonPropertyRead) def).getMemberRef();
+      return st.isStringConstant(memberVn) && "shape".equals(st.getStringValue(memberVn));
+    }
+
+    if (def instanceof PythonInvokeInstruction) {
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
+      if (invoke.getNumberOfUses() < 1) return false;
+      SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
+      if (funcDef instanceof PythonPropertyRead) {
+        int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
+        return st.isStringConstant(memberVn)
+            && "as_list".equals(st.getStringValue(memberVn))
+            && isShapeVectorChain(node, ((PythonPropertyRead) funcDef).getObjectRef());
+      }
+      if (funcDef instanceof SSANewInstruction
+          && ((SSANewInstruction) funcDef)
+              .getNewSite()
+              .getDeclaredType()
+              .equals(PythonTypes.SLICE_BUILTIN)
+          && invoke.getNumberOfUses() >= 2) return isShapeVectorChain(node, invoke.getUse(1));
+      return false;
+    }
+    return false;
+  }
+
+  /**
+   * Sentinel returned by {@link #sliceBoundOrNull} for a bound that is present but not a
+   * compile-time constant. Distinct by identity from both {@code null} (absent/{@code None}) and
+   * any boxed constant value.
+   */
+  protected static final Integer UNRESOLVED_BOUND = Integer.valueOf(Integer.MIN_VALUE);
+
+  /**
+   * Resolves a slice bound at the given use index to a constant integer, {@code null} for an
+   * absent/{@code None} bound, or {@link #UNRESOLVED_BOUND} when the bound exists but isn't a
+   * compile-time constant. Reads the symbol table first (literal bounds), then a single {@code
+   * ConstantKey} in the bound's points-to set (propagated constants).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param node The {@link CGNode} whose IR contains the invoke.
+   * @param st The node's symbol table.
+   * @param invoke The slice-builtin invoke.
+   * @param useIndex The use index of the bound ({@code 2}=lower, {@code 3}=upper, {@code 4}=step).
+   * @return The constant bound, {@code null} for {@code None}/absent, or {@link #UNRESOLVED_BOUND}.
+   */
+  private static Integer sliceBoundOrNull(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      SymbolTable st,
+      PythonInvokeInstruction invoke,
+      int useIndex) {
+    if (useIndex >= invoke.getNumberOfUses()) return null; // Absent: Python default.
+    int vn = invoke.getUse(useIndex);
+    if (vn <= 0) return null;
+    if (st.isNullConstant(vn)) return null; // Explicit None.
+    if (st.isNumberConstant(vn)) return ((Number) st.getConstantValue(vn)).intValue();
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
+    Integer found = null;
+    for (InstanceKey ik : pts) {
+      if (!(ik instanceof ConstantKey)) return UNRESOLVED_BOUND;
+      Object value = ((ConstantKey<?>) ik).getValue();
+      if (value == null) return null; // Propagated None.
+      if (!(value instanceof Number)) return UNRESOLVED_BOUND;
+      int intValue = ((Number) value).intValue();
+      if (found != null && found != intValue) return UNRESOLVED_BOUND; // Ambiguous.
+      found = intValue;
+    }
+    return found == null ? UNRESOLVED_BOUND : found;
+  }
+
+  /**
+   * Returns whether the given value number is defined by a {@code slice(...)} object construction
+   * (an invoke whose function object is a {@link PythonTypes#SLICE_BUILTIN} allocation).
+   *
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to test.
+   * @return {@code true} iff {@code vn} is defined by a slice-object construction.
+   */
+  private static boolean isSliceObjectDef(CGNode node, int vn) {
+    if (vn <= 0) return false;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof SSAAbstractInvokeInstruction)) return false;
+    SSAAbstractInvokeInstruction inv = (SSAAbstractInvokeInstruction) def;
+    if (inv.getNumberOfUses() < 1) return false;
+    SSAInstruction funcDef = node.getDU().getDef(inv.getUse(0));
+    return funcDef instanceof SSANewInstruction
+        && ((SSANewInstruction) funcDef)
+            .getNewSite()
+            .getDeclaredType()
+            .equals(PythonTypes.SLICE_BUILTIN);
+  }
+
+  /**
    * Dtype twin of {@link #getShapeFromShapeAttributeArgument(PropagationCallGraphBuilder, int,
    * String)}: recovers an allocator's dtype when its dtype argument is another tensor's {@code
    * .dtype} (e.g. {@code tf.ones((2, 1), dtype=y.dtype)}). Such an argument is a {@link

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -78,6 +78,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
@@ -2829,7 +2830,7 @@ public abstract class TensorGenerator {
    */
   protected Set<List<Dimension<?>>> getShapesOfShapeVector(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
-    if (vn <= 0 || node.getDU() == null) return null;
+    if (vn <= 0 || node.getDU() == null || node.getIR() == null) return null;
     SSAInstruction def = node.getDU().getDef(vn);
     SymbolTable st = node.getIR().getSymbolTable();
 
@@ -2882,7 +2883,9 @@ public abstract class TensorGenerator {
         Integer lower = sliceBoundOrNull(builder, node, st, invoke, 2);
         Integer upper = sliceBoundOrNull(builder, node, st, invoke, 3);
         Integer step = sliceBoundOrNull(builder, node, st, invoke, 4);
-        if (lower == UNRESOLVED_BOUND || upper == UNRESOLVED_BOUND || step == UNRESOLVED_BOUND)
+        if (Objects.equals(lower, UNRESOLVED_BOUND)
+            || Objects.equals(upper, UNRESOLVED_BOUND)
+            || Objects.equals(step, UNRESOLVED_BOUND))
           return null; // Non-constant bound: the sub-list's rank is unknown.
         if (step != null && step != 1) return null; // Non-unit step: unmodeled.
 
@@ -2943,10 +2946,11 @@ public abstract class TensorGenerator {
 
   /**
    * Sentinel returned by {@link #sliceBoundOrNull} for a bound that is present but not a
-   * compile-time constant. Distinct by identity from both {@code null} (absent/{@code None}) and
-   * any boxed constant value.
+   * compile-time constant. Compared by value ({@link Objects#equals}), so a genuine {@link
+   * Integer#MIN_VALUE} bound in user code conservatively degrades to ⊤ along with actually
+   * unresolved bounds.
    */
-  protected static final Integer UNRESOLVED_BOUND = Integer.valueOf(Integer.MIN_VALUE);
+  protected static final Integer UNRESOLVED_BOUND = Integer.MIN_VALUE;
 
   /**
    * Resolves a slice bound at the given use index to a constant integer, {@code null} for an

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2977,6 +2977,7 @@ public abstract class TensorGenerator {
     if (st.isNullConstant(vn)) return null; // Explicit None.
     if (st.isNumberConstant(vn)) return ((Number) st.getConstantValue(vn)).intValue();
     PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    if (pk == null) return UNRESOLVED_BOUND;
     OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
     Integer found = null;
     for (InstanceKey ik : pts) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list.py
@@ -1,0 +1,17 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Shape-vector provenance (wala/ML#703): a tensor's full shape read into a
+# Python list via `.shape.as_list()` (no slice) and consumed as another op's
+# shape argument. The reshape's output shape is the source tensor's shape.
+t = tf.ones((4, 5, 6))
+x = tf.ones((120,))
+r = tf.reshape(x, t.shape.as_list())
+assert isinstance(r, tf.Tensor)
+assert r.shape == (4, 5, 6)
+assert r.dtype == tf.float32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list_slice.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list_slice.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Shape-vector provenance (wala/ML#703): a tensor's shape read into a Python
+# list via `.shape.as_list()`, sliced with a literal negative bound, and
+# consumed as another op's shape argument. The reshape's output shape is the
+# source tensor's trailing sub-shape.
+t = tf.ones((4, 5, 6))
+x = tf.ones((30,))
+r = tf.reshape(x, t.shape.as_list()[-2:])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5, 6)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Closes wala/ML#703.

A tensor shape read into a Python list via `.shape`/`.as_list()` and sliced has no points-to state (those members are unmodeled in the heap), so `tf.reshape(x, t.shape.as_list()[-2:])` previously typed as a fabricated scalar unioned with the input tensor's shape leaking through `Reshape`'s empty-PTS fallback. It now resolves to the source tensor's trailing sub-shape.

## What Changed

- **`TensorGenerator.getShapesOfShapeVector`** def-use walks a shape-derived value: a `shape` property read resolves the source tensor's shapes; an `as_list()` invoke peels to its receiver; a `slice` builtin with constant bounds takes the corresponding sub-list with Python negative-index semantics. Non-constant bounds, non-unit steps, and multi-dim subscripts fall back to ⊤ (the sub-list's rank is then unknown). `getShapesFromShapeVectorArgument` wraps the walk with direct-invoke and caller-walk arms, mirroring the existing `tf.ones(x.shape)` recovery.
- **`Reshape.getShapes`** consults the walk when the shape argument's points-to set is empty, before the input-tensor fallback.
- **The legacy `getShapeSourceCalls` pin** fabricated a scalar type for any opaque shape operand (`TensorType.shapeArg` reads element writes, which opaque operands don't have). It now pins `shapeArg` only for literal container constructions, skips shape-vector chains (the provenance walk is authoritative), and pins a tensor of unknown rank otherwise, preserving tensor classification without asserting a wrong shape.

## Coverage

`testShapeAsListSlice` and `testShapeAsList` pin the precise `(5, 6)` and `(4, 5, 6)`. Three capture-observed assertions tighten, with the fabricated scalar member becoming the honest unknown-rank tensor or dropping entirely: `testReshapeRuntimeShape` (`{⊤, ()}` to `{⊤}`), `testCollectionProbeVendoredConv1d` (`{()}` to `{⊤}`, classification preserved), and `testCollectionProbeReshapeComputedShape` (`{(), (2,3,16)}` to `{(2,3,16), ⊤}`).

## Context

The `use_einsum=False` path in NLPGNN's `einsum_via_matmul` additionally needs the slice bound `-num_inner_dims` (a negated parameter) to constant-fold, which the walk deliberately reports as ⊤ for now; literal bounds resolve fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)