### PR TITLE
Constant-fold negated slice bounds and harden the bound resolver (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12779,6 +12779,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Variable-bound companion of {@link #testShapeAsListSlice()} (wala/ML#703, wala/ML#704): the
+   * slice bound is a negated local ({@code shape[-k:]} with a constant {@code k}), mirroring
+   * NLPGNN's {@code einsum_via_matmul} idiom ({@code input_shape[-num_inner_dims:]}). The unary
+   * negation is constant-folded by the slice-bound resolver, so the trailing sub-shape resolves to
+   * the precise {@code (5, 6)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeAsListSliceVar()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_as_list_slice_var.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -92,6 +92,11 @@ public class Reshape extends TensorGenerator {
           this.getShapesFromShapeVectorArgument(
               builder, this.getShapeParameterPosition(), this.getShapeParameterName());
       if (vectorShapes != null && !vectorShapes.isEmpty()) rawShapes = vectorShapes;
+      // Soundness: a structurally-recognized shape vector whose walk fails (e.g. a bound that
+      // isn't statically constant) determines the output shape but is unknown, so the output is ⊤;
+      // falling through to input-shape inference would leak the input's shape (wala/ML#704).
+      else if (this.isShapeVectorArgument(
+          builder, this.getShapeParameterPosition(), this.getShapeParameterName())) return null;
     }
 
     if (rawShapes != null && !rawShapes.isEmpty()) {
@@ -139,7 +144,10 @@ public class Reshape extends TensorGenerator {
               }
 
               List<Dimension<?>> refinedShape = new ArrayList<>(shape);
-              if (inputKnown) {
+              // The -1 dimension is only inferable when the division is exact; a zero known
+              // product (any inferred value satisfies 0 * k == 0) or a non-exact division leaves
+              // it symbolic.
+              if (inputKnown && productKnown != 0 && inputSize % productKnown == 0) {
                 long inferredDim = inputSize / productKnown;
                 refinedShape.set(unknownIndex, new NumericDim((int) inferredDim));
               } else {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -145,10 +145,13 @@ public class Reshape extends TensorGenerator {
 
               List<Dimension<?>> refinedShape = new ArrayList<>(shape);
               // The -1 dimension is only inferable when the division is exact; a zero known
-              // product (any inferred value satisfies 0 * k == 0) or a non-exact division leaves
-              // it symbolic.
-              if (inputKnown && productKnown != 0 && inputSize % productKnown == 0) {
-                long inferredDim = inputSize / productKnown;
+              // product (any inferred value satisfies 0 * k == 0), a non-exact division, or a
+              // quotient outside the non-negative int range leaves it symbolic.
+              long inferredDim =
+                  inputKnown && productKnown != 0 && inputSize % productKnown == 0
+                      ? inputSize / productKnown
+                      : -1;
+              if (inferredDim >= 0 && inferredDim <= Integer.MAX_VALUE) {
                 refinedShape.set(unknownIndex, new NumericDim((int) inferredDim));
               } else {
                 refinedShape.set(unknownIndex, new SymbolicDim("?"));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -28,6 +28,7 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.ir.ssa.CAstUnaryOp;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
@@ -63,6 +64,7 @@ import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SSAPutInstruction;
+import com.ibm.wala.ssa.SSAUnaryOpInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
@@ -2904,6 +2906,47 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Returns whether this generator's shape argument is structurally a shape vector (see {@link
+   * #isShapeVectorChain}), regardless of whether the provenance walk can resolve it. Consumers use
+   * this to distinguish "the shape is determined by a shape vector we couldn't resolve" (output is
+   * ⊤) from "no shape information at all" (an input-derived fallback may apply). Mirrors {@link
+   * #getShapesFromShapeVectorArgument}'s direct-invoke and caller-walk arms.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph lookup.
+   * @param paramPos The 0-based positional index of the shape parameter (excluding {@code self}).
+   * @param paramName The shape parameter's keyword name, or {@code null}.
+   * @return {@code true} iff the shape argument's def-use chain matches a shape-vector form.
+   */
+  protected boolean isShapeVectorArgument(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    PythonInvokeInstruction call = getInvokeInstruction();
+    if (call != null) {
+      int argVn = -1;
+      if (paramName != null) argVn = call.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numKeywords = call.getKeywords() != null ? call.getKeywords().size() : 0;
+        int numPosParams = call.getNumberOfUses() - 1 - numKeywords;
+        if (paramPos < numPosParams) argVn = call.getUse(paramPos + 1);
+      }
+      return argVn > 0 && isShapeVectorChain(this.getNode(), argVn);
+    }
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (paramName != null) argVn = pyCall.getUse(paramName);
+      if (argVn == -1 && paramPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+      }
+      if (argVn > 0 && isShapeVectorChain(caller, argVn)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Structural companion of {@link #getShapesOfShapeVector}: returns whether the value's def-use
    * chain has the shape of a shape vector ({@code t.shape}, {@code v.as_list()}, or a {@code slice}
    * of one), without resolving any shapes or bounds. Used to decide whether a shape operand should
@@ -2972,23 +3015,58 @@ public abstract class TensorGenerator {
       PythonInvokeInstruction invoke,
       int useIndex) {
     if (useIndex >= invoke.getNumberOfUses()) return null; // Absent: Python default.
-    int vn = invoke.getUse(useIndex);
+    return constantIntValueOrSentinel(builder, node, st, invoke.getUse(useIndex));
+  }
+
+  /**
+   * Resolves a value number to a constant integer, {@code null} for {@code None}, or {@link
+   * #UNRESOLVED_BOUND}. Reads the symbol table first (literals), then constant-folds a unary
+   * negation of a resolvable operand ({@code -k} for a constant {@code k}, the {@code
+   * shape[-num_inner_dims:]} idiom — the PA does not fold arithmetic, so the negated value itself
+   * has an empty points-to set), then falls back to a single {@code ConstantKey} in the value's
+   * points-to set (propagated constants).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The value number to resolve.
+   * @return The constant value, {@code null} for {@code None}, or {@link #UNRESOLVED_BOUND}.
+   */
+  private static Integer constantIntValueOrSentinel(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     if (vn <= 0) return null;
     if (st.isNullConstant(vn)) return null; // Explicit None.
     if (st.isNumberConstant(vn)) return ((Number) st.getConstantValue(vn)).intValue();
+
+    // Constant-fold a unary minus of a resolvable operand.
+    SSAInstruction def = node.getDU() != null ? node.getDU().getDef(vn) : null;
+    if (def instanceof SSAUnaryOpInstruction
+        && CAstUnaryOp.MINUS.equals(((SSAUnaryOpInstruction) def).getOpcode())) {
+      Integer operand = constantIntValueOrSentinel(builder, node, st, def.getUse(0));
+      if (operand == null || Objects.equals(operand, UNRESOLVED_BOUND)) return UNRESOLVED_BOUND;
+      return -operand;
+    }
+
     PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
     if (pk == null) return UNRESOLVED_BOUND;
     OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
     Integer found = null;
+    boolean sawNone = false;
     for (InstanceKey ik : pts) {
       if (!(ik instanceof ConstantKey)) return UNRESOLVED_BOUND;
       Object value = ((ConstantKey<?>) ik).getValue();
-      if (value == null) return null; // Propagated None.
+      if (value == null) { // Propagated None.
+        sawNone = true;
+        continue;
+      }
       if (!(value instanceof Number)) return UNRESOLVED_BOUND;
       int intValue = ((Number) value).intValue();
       if (found != null && found != intValue) return UNRESOLVED_BOUND; // Ambiguous.
       found = intValue;
     }
+    // A points-to set holding both None and a numeric constant is ambiguous; collapsing it to
+    // either would assert a bound the other execution violates.
+    if (sawNone) return found == null ? null : UNRESOLVED_BOUND;
     return found == null ? UNRESOLVED_BOUND : found;
   }
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_compr.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_layer_list_compr.py
@@ -33,7 +33,8 @@ def consume(t):
 layer = Outer()
 x = tf.ones((2, 3))
 out = layer(x)
-consume(out)
 
 assert out.shape == (6, 1)
 assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list_slice_var.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_as_list_slice_var.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+# Shape-vector provenance (wala/ML#703, wala/ML#704): the slice bound is a
+# negated local variable rather than a literal, mirroring NLPGNN's
+# `einsum_via_matmul(input_tensor, w, num_inner_dims)` idiom
+# (`input_shape[-num_inner_dims:]`). The negation must be constant-folded for
+# the trailing sub-shape to resolve.
+t = tf.ones((4, 5, 6))
+x = tf.ones((30,))
+k = 2
+r = tf.reshape(x, t.shape.as_list()[-k:])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5, 6)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
The slice bound in `shape[-k:]` is a unary minus over a local, which the PA does not constant-fold, so the shape-vector walk (wala/ML#703, #552) reported ⊤ for NLPGNN's `einsum_via_matmul` idiom (`input_shape[-num_inner_dims:]`) even when `k` is a compile-time constant. The bound resolver now peels `CAstUnaryOp.MINUS` definitions and negates a resolvable operand, recursively.

## Soundness Fixes

- `Reshape` no longer leaks the input tensor's shape when the shape argument is structurally a shape vector whose walk fails: the output is determined by the unresolvable vector, so it is ⊤ (`isShapeVectorArgument`). Before this change the variable-bound fixture typed as the input's `(30,)`.
- A points-to set holding both a propagated `None` and a numeric constant was collapsed to `None`; it now resolves to an unresolved bound, since either choice would assert a bound the other execution violates (post-merge review of #552).
- `Reshape`'s `-1` inference divided without guarding a zero known product or a non-exact division; both now leave the dimension symbolic (post-merge review of #552).

## Coverage

`testShapeAsListSliceVar` pins the precise `(5, 6)` for a `[-k:]` slice with a constant `k`. A second commit moves `tf2_test_layer_list_compr.py`'s runtime asserts before its `consume` sink (review feedback on #551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)