### PR TITLE
Follow the shape-vector provenance walk through user-function returns (wala/ML#706)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12812,6 +12812,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Interprocedural shape-vector provenance (wala/ML#706): the shape list is produced by a user
+   * helper ({@code def get_shape(t): return t.shape.as_list()}, the BERT/ALBERT {@code
+   * get_shape_list} pattern), so the def-use walk follows the helper invoke to its returned {@code
+   * .shape.as_list()} chain; the callee parameter's interprocedural points-to set resolves the
+   * source tensor. The {@code [-2:]} slice of {@code (4, 5, 6)} is the precise {@code (5, 6)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeHelperSlice()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_helper_slice.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
+   * Combines {@link #testShapeHelperSlice()}'s interprocedural hop with {@link
+   * #testShapeAsListSliceVar()}'s negated variable bound: {@code get_shape(t)[-k:]} with a constant
+   * {@code k} is structurally NLPGNN's {@code einsum_via_matmul} shape read ({@code
+   * get_shape_list(input_tensor)[-num_inner_dims:]}). See wala/ML#706 and wala/ML#704.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeHelperSliceVar()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_helper_slice_var.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -927,7 +927,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // type for it; pin a tensor of unknown rank instead, which keeps the result
             // tensor-classified without asserting a wrong shape.
             int shapeVn = call.getUse(param);
-            if (TensorGenerator.isShapeVectorChain(src, shapeVn)) return;
+            if (TensorGenerator.isShapeVectorChain(builder, src, shapeVn)) return;
             SSAInstruction shapeDef = src.getDU().getDef(shapeVn);
             boolean literalContainer =
                 shapeDef instanceof SSANewInstruction

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2957,7 +2957,9 @@ public abstract class TensorGenerator {
           SSAInstruction instruction = it.next();
           if (!(instruction instanceof SSAReturnInstruction)) continue;
           SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
-          if (ret.getResult() < 0) continue; // A bare `return`.
+          // A bare `return` means the helper can produce no value (None) on some path, so the
+          // call's result isn't a resolvable shape vector.
+          if (ret.getResult() < 0) return null;
           sawReturn = true;
           Set<List<Dimension<?>>> shapes =
               this.getShapesOfShapeVector(builder, callee, ret.getResult(), visited);
@@ -3085,7 +3087,9 @@ public abstract class TensorGenerator {
             SSAInstruction instruction = it.next();
             if (!(instruction instanceof SSAReturnInstruction)) continue;
             SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
-            if (ret.getResult() < 0) continue; // A bare `return`.
+            // A bare `return` means the helper can produce None on some path, so the call isn't
+            // a shape-vector chain.
+            if (ret.getResult() < 0) return false;
             sawReturn = true;
             if (!isShapeVectorChain(builder, callee, ret.getResult(), visited)) return false;
           }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -64,6 +64,7 @@ import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SSAPutInstruction;
+import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.ssa.SSAUnaryOpInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.FieldReference;
@@ -2832,6 +2833,21 @@ public abstract class TensorGenerator {
    */
   protected Set<List<Dimension<?>>> getShapesOfShapeVector(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    return getShapesOfShapeVector(builder, node, vn, HashSetFactory.make());
+  }
+
+  /**
+   * Core of {@link #getShapesOfShapeVector(PropagationCallGraphBuilder, CGNode, int)} threading the
+   * set of callee nodes already on the walk, guarding recursive helpers (wala/ML#706).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to resolve.
+   * @param visited The callee nodes already on the walk.
+   * @return The union of the denoted (sub-)shapes, or {@code null} (⊤); see the wrapper.
+   */
+  private Set<List<Dimension<?>>> getShapesOfShapeVector(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<CGNode> visited) {
     if (vn <= 0 || node.getDU() == null || node.getIR() == null) return null;
     SSAInstruction def = node.getDU().getDef(vn);
     SymbolTable st = node.getIR().getSymbolTable();
@@ -2863,7 +2879,7 @@ public abstract class TensorGenerator {
         PythonPropertyRead funcRead = (PythonPropertyRead) funcDef;
         int memberVn = funcRead.getMemberRef();
         if (st.isStringConstant(memberVn) && "as_list".equals(st.getStringValue(memberVn)))
-          return this.getShapesOfShapeVector(builder, node, funcRead.getObjectRef());
+          return this.getShapesOfShapeVector(builder, node, funcRead.getObjectRef(), visited);
         return null;
       }
 
@@ -2874,7 +2890,8 @@ public abstract class TensorGenerator {
               .getDeclaredType()
               .equals(PythonTypes.SLICE_BUILTIN)
           && invoke.getNumberOfUses() >= 2) {
-        Set<List<Dimension<?>>> base = this.getShapesOfShapeVector(builder, node, invoke.getUse(1));
+        Set<List<Dimension<?>>> base =
+            this.getShapesOfShapeVector(builder, node, invoke.getUse(1), visited);
         if (base == null || base.isEmpty()) return null;
 
         // A nested slice object as a bound means a multi-dim subscript; a shape vector is 1-D, so
@@ -2900,9 +2917,60 @@ public abstract class TensorGenerator {
         }
         return sliced;
       }
-      return null;
+
+      // A call to a user helper (the BERT/ALBERT get_shape_list pattern): follow each callee's
+      // returned value. The callee's parameters carry the caller's arguments in their points-to
+      // sets (the PA is interprocedural), so the .shape base case resolves across the boundary
+      // without an explicit parameter-to-argument mapping (wala/ML#706).
+      return this.shapesOfCalleeReturns(builder, node, invoke, visited);
     }
     return null;
+  }
+
+  /**
+   * Follows an invoke into each callee the call graph resolves for it and walks every returned
+   * value's def-use chain via {@link #getShapesOfShapeVector}, unioning the results (wala/ML#706).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @param node The calling {@link CGNode}.
+   * @param invoke The invoke instruction to follow.
+   * @param visited The callee nodes already on the walk, guarding recursive helpers.
+   * @return The union of the callees' returned (sub-)shapes, or {@code null} (⊤) when there are no
+   *     resolvable targets or any return doesn't resolve to a shape vector.
+   */
+  private Set<List<Dimension<?>>> shapesOfCalleeReturns(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      PythonInvokeInstruction invoke,
+      Set<CGNode> visited) {
+    Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+    if (targets == null || targets.isEmpty()) return null;
+
+    Set<List<Dimension<?>>> combined = HashSetFactory.make();
+    for (CGNode callee : targets) {
+      if (callee.getIR() == null || callee.getDU() == null) return null;
+      if (!visited.add(callee)) return null; // Recursive helper: unmodeled.
+      try {
+        boolean sawReturn = false;
+        for (Iterator<SSAInstruction> it = callee.getIR().iterateAllInstructions();
+            it.hasNext(); ) {
+          SSAInstruction instruction = it.next();
+          if (!(instruction instanceof SSAReturnInstruction)) continue;
+          SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
+          if (ret.getResult() < 0) continue; // A bare `return`.
+          sawReturn = true;
+          Set<List<Dimension<?>>> shapes =
+              this.getShapesOfShapeVector(builder, callee, ret.getResult(), visited);
+          // Every return must resolve; a single unresolvable return makes the union unsound.
+          if (shapes == null || shapes.isEmpty()) return null;
+          combined.addAll(shapes);
+        }
+        if (!sawReturn) return null;
+      } finally {
+        visited.remove(callee);
+      }
+    }
+    return combined.isEmpty() ? null : combined;
   }
 
   /**
@@ -2928,7 +2996,7 @@ public abstract class TensorGenerator {
         int numPosParams = call.getNumberOfUses() - 1 - numKeywords;
         if (paramPos < numPosParams) argVn = call.getUse(paramPos + 1);
       }
-      return argVn > 0 && isShapeVectorChain(this.getNode(), argVn);
+      return argVn > 0 && isShapeVectorChain(builder, this.getNode(), argVn);
     }
     for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
         getCallerInvokes(builder, this.getNode())) {
@@ -2941,7 +3009,7 @@ public abstract class TensorGenerator {
         int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
         if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
       }
-      if (argVn > 0 && isShapeVectorChain(caller, argVn)) return true;
+      if (argVn > 0 && isShapeVectorChain(builder, caller, argVn)) return true;
     }
     return false;
   }
@@ -2956,7 +3024,23 @@ public abstract class TensorGenerator {
    * @param vn The value number to test.
    * @return {@code true} iff the def-use chain matches a shape-vector form.
    */
-  public static boolean isShapeVectorChain(CGNode node, int vn) {
+  public static boolean isShapeVectorChain(
+      PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    return isShapeVectorChain(builder, node, vn, HashSetFactory.make());
+  }
+
+  /**
+   * Core of {@link #isShapeVectorChain(PropagationCallGraphBuilder, CGNode, int)} threading the set
+   * of callee nodes already on the walk, guarding recursive helpers (wala/ML#706).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves helper calls.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to test.
+   * @param visited The callee nodes already on the walk.
+   * @return {@code true} iff the def-use chain matches a shape-vector form.
+   */
+  private static boolean isShapeVectorChain(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<CGNode> visited) {
     if (vn <= 0 || node.getDU() == null || node.getIR() == null) return false;
     SSAInstruction def = node.getDU().getDef(vn);
     SymbolTable st = node.getIR().getSymbolTable();
@@ -2974,15 +3058,41 @@ public abstract class TensorGenerator {
         int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
         return st.isStringConstant(memberVn)
             && "as_list".equals(st.getStringValue(memberVn))
-            && isShapeVectorChain(node, ((PythonPropertyRead) funcDef).getObjectRef());
+            && isShapeVectorChain(
+                builder, node, ((PythonPropertyRead) funcDef).getObjectRef(), visited);
       }
       if (funcDef instanceof SSANewInstruction
           && ((SSANewInstruction) funcDef)
               .getNewSite()
               .getDeclaredType()
               .equals(PythonTypes.SLICE_BUILTIN)
-          && invoke.getNumberOfUses() >= 2) return isShapeVectorChain(node, invoke.getUse(1));
-      return false;
+          && invoke.getNumberOfUses() >= 2)
+        return isShapeVectorChain(builder, node, invoke.getUse(1), visited);
+
+      // A call to a user helper: the chain is a shape vector iff every callee's every returned
+      // value is (wala/ML#706).
+      Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+      if (targets == null || targets.isEmpty()) return false;
+      for (CGNode callee : targets) {
+        if (callee.getIR() == null || callee.getDU() == null) return false;
+        if (!visited.add(callee)) return false; // Recursive helper: unmodeled.
+        try {
+          boolean sawReturn = false;
+          for (Iterator<SSAInstruction> it = callee.getIR().iterateAllInstructions();
+              it.hasNext(); ) {
+            SSAInstruction instruction = it.next();
+            if (!(instruction instanceof SSAReturnInstruction)) continue;
+            SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
+            if (ret.getResult() < 0) continue; // A bare `return`.
+            sawReturn = true;
+            if (!isShapeVectorChain(builder, callee, ret.getResult(), visited)) return false;
+          }
+          if (!sawReturn) return false;
+        } finally {
+          visited.remove(callee);
+        }
+      }
+      return true;
     }
     return false;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3020,6 +3020,8 @@ public abstract class TensorGenerator {
    * of one), without resolving any shapes or bounds. Used to decide whether a shape operand should
    * be left to the generator-side provenance walk rather than pinned (wala/ML#703).
    *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves helper calls
+   *     (wala/ML#706).
    * @param node The {@link CGNode} whose IR defines {@code vn}.
    * @param vn The value number to test.
    * @return {@code true} iff the def-use chain matches a shape-vector form.

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_slice.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_slice.py
@@ -1,0 +1,22 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+# Interprocedural shape-vector provenance (wala/ML#706): the shape list is
+# produced by a user helper (the BERT/ALBERT `get_shape_list` pattern), so the
+# def-use walk must follow the helper's return to `t.shape.as_list()` and map
+# the callee parameter back to the caller argument.
+t = tf.ones((4, 5, 6))
+x = tf.ones((30,))
+r = tf.reshape(x, get_shape(t)[-2:])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5, 6)
+assert r.dtype == tf.float32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_slice_var.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_slice_var.py
@@ -1,0 +1,22 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+# Combines wala/ML#706's interprocedural hop with wala/ML#704's negated
+# variable bound: `get_shape(t)[-k:]` is structurally NLPGNN's
+# `einsum_via_matmul` shape read (`get_shape_list(input_tensor)[-num_inner_dims:]`).
+t = tf.ones((4, 5, 6))
+x = tf.ones((30,))
+k = 2
+r = tf.reshape(x, get_shape(t)[-k:])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5, 6)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Closes wala/ML#706.

The shape-vector provenance walk (wala/ML#703, #552) was intraprocedural, so a shape list produced by a user helper (the BERT/ALBERT `get_shape_list` pattern) stopped it at the helper's invoke and reported ⊤; one context additionally leaked the input tensor's shape through `Reshape`'s fallback because the chain check didn't recognize the helper form.

## What Changed

- `getShapesOfShapeVector` resolves a helper invoke's call-graph targets and walks every callee's returned value through the same chain recognition, unioning across callees and returns and falling back to ⊤ when any return doesn't resolve. No explicit parameter-to-argument mapping is needed: the callee parameter's interprocedural points-to set already holds the caller's allocation, so the `.shape` base case resolves across the boundary. A visited set threaded through the recursion guards recursive helpers.
- `isShapeVectorChain` mirrors the interprocedural case (and now takes the builder), so the legacy pin's skip case and `Reshape`'s ⊤-guard recognize the helper form.

## Coverage

`testShapeHelperSlice` pins the precise `(5, 6)` for `get_shape(t)[-2:]`. `testShapeHelperSliceVar` combines the hop with the negated variable bound from #553 (`get_shape(t)[-k:]`), which is structurally NLPGNN's `einsum_via_matmul` shape read (`get_shape_list(input_tensor)[-num_inner_dims:]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)