### PR TITLE
Fold `np.prod` over a resolvable shape vector into a constant dimension (wala/ML#707)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -366,6 +366,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   private static final TensorType TENSOR_5_6_FLOAT32 = TensorType.of(FLOAT_32, 5, 6);
 
+  private static final TensorType TENSOR_30_FLOAT32 = TensorType.of(FLOAT_32, 30);
+
   private static final TensorType TENSOR_4_5_6_FLOAT32 = TensorType.of(FLOAT_32, 4, 5, 6);
 
   private static final TensorType TENSOR_7_5_2_FLOAT32 = TensorType.of(FLOAT_32, 7, 5, 2);
@@ -12844,6 +12846,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testShapeHelperSliceVar()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_shape_helper_slice_var.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
+   * {@code np.prod} over a shape-derived list (wala/ML#707): {@code [np.prod(get_shape(t)[-2:])]}
+   * folds the product of the static trailing dimensions ({@code 5 * 6}) into the reshape target, so
+   * the result is the precise {@code (30,)}. Mirrors NLPGNN's {@code einsum_via_matmul} ({@code
+   * inner_dim = np.prod(input_shape[-num_inner_dims:])}).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeProd()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_prod.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_30_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -750,9 +750,48 @@ public abstract class TensorGenerator {
       if (objRef != listVn || index == null || index.intValue() != fieldIndex) continue;
 
       // Shared with `TensorType.shapeArg` so the two shape-argument paths agree (wala/ML#581).
-      return TensorType.foldArithmeticDim(builder, node, st, du, writtenVal);
+      Dimension<?> folded = TensorType.foldArithmeticDim(builder, node, st, du, writtenVal);
+      if (folded != null) return folded;
+      return this.prodOfShapeVectorDim(builder, node, st, writtenVal);
     }
     return null;
+  }
+
+  /**
+   * Folds an {@code np.prod(v)} call over a resolvable shape vector into a {@link NumericDim}
+   * holding the product of its static dimensions (wala/ML#707). Mirrors NLPGNN's {@code
+   * einsum_via_matmul}, where {@code inner_dim = np.prod(input_shape[-num_inner_dims:])} feeds a
+   * {@code tf.reshape} target shape.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The value number of the candidate {@code np.prod} result.
+   * @return The folded {@link NumericDim}, or {@code null} when the value isn't an {@code np.prod}
+   *     call, its argument doesn't resolve to a single shape, any dimension is non-static, or the
+   *     product exceeds the int range.
+   */
+  private Dimension<?> prodOfShapeVectorDim(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
+    if (vn <= 0) return null;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof PythonInvokeInstruction)) return null;
+    PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
+    if (invoke.getNumberOfUses() < 2) return null;
+    SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
+    if (!(funcDef instanceof PythonPropertyRead)) return null;
+    int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
+    if (!st.isStringConstant(memberVn) || !"prod".equals(st.getStringValue(memberVn))) return null;
+
+    Set<List<Dimension<?>>> shapes = this.getShapesOfShapeVector(builder, node, invoke.getUse(1));
+    if (shapes == null || shapes.size() != 1) return null;
+    long product = 1;
+    for (Dimension<?> d : shapes.iterator().next()) {
+      if (!(d instanceof NumericDim)) return null; // A dynamic or unknown axis: not foldable.
+      product *= ((NumericDim) d).value();
+      if (product < 0 || product > Integer.MAX_VALUE) return null;
+    }
+    return new NumericDim((int) product);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -791,7 +791,11 @@ public abstract class TensorGenerator {
     long product = 1;
     for (Dimension<?> d : shapes.iterator().next()) {
       if (!(d instanceof NumericDim)) return null; // A dynamic or unknown axis: not foldable.
-      product *= ((NumericDim) d).value();
+      try {
+        product = Math.multiplyExact(product, ((NumericDim) d).value());
+      } catch (ArithmeticException e) {
+        return null; // The product overflows long: not representable.
+      }
       if (product < 0 || product > Integer.MAX_VALUE) return null;
     }
     return new NumericDim((int) product);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -777,7 +777,10 @@ public abstract class TensorGenerator {
     SSAInstruction def = node.getDU().getDef(vn);
     if (!(def instanceof PythonInvokeInstruction)) return null;
     PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
-    if (invoke.getNumberOfUses() < 2) return null;
+    // Fold only the plain `np.prod(v)` form: an extra positional or keyword argument (e.g.
+    // `axis=...`) changes the semantics, including the result's rank.
+    int numKeywords = invoke.getKeywords() != null ? invoke.getKeywords().size() : 0;
+    if (invoke.getNumberOfUses() - numKeywords != 2 || numKeywords != 0) return null;
     SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
     if (!(funcDef instanceof PythonPropertyRead)) return null;
     int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_prod.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_prod.py
@@ -1,0 +1,23 @@
+import numpy as np
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+# np.prod over a shape-derived list (wala/ML#707): the product of the static
+# trailing dimensions folds to a constant, so the reshape's target shape is
+# concrete. Mirrors NLPGNN's `einsum_via_matmul`
+# (`inner_dim = np.prod(input_shape[-num_inner_dims:])`).
+t = tf.ones((4, 5, 6))
+x = tf.ones((2, 15))
+r = tf.reshape(x, [np.prod(get_shape(t)[-2:])])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (30,)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Closes wala/ML#707.

`np.prod(shape_vector)` as a shape-list element now folds to a `NumericDim` holding the product of the vector's static dimensions, resolved through the wala/ML#703/#706 provenance walk. A dynamic or unknown axis, a multi-shape argument, extra `np.prod` arguments (e.g. `axis=...`), or an overflowing product leaves the element unfolded (the position degrades as before). The hook sits beside the wala/ML#581 arithmetic fold in `foldArithmeticShapeDim`, so the two shape-argument element paths stay aligned.

## Coverage

`testShapeProd` pins the precise `(30,)` for `tf.reshape(x, [np.prod(get_shape(t)[-2:])])`, mirroring NLPGNN's `einsum_via_matmul` (`inner_dim = np.prod(input_shape[-num_inner_dims:])`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)