### PR TITLE
Pin the `np.prod` axis guard and measure `einsum_via_matmul` end to end (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12866,6 +12866,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
+   * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
+   * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path
+   * evaluates the call concretely and contributes the precise {@code (30,)} in its context, so the
+   * union carries both.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeProdAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_prod_axis.py",
+        "f",
+        1,
+        1,
+        Map.of(
+            2, Set.of(TENSOR_30_FLOAT32, new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE)))));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12866,6 +12866,32 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * End-to-end measurement of NLPGNN's {@code einsum_via_matmul} matmul path in miniature
+   * (wala/ML#704): the {@code get_shape_list} hop, slices, and {@code np.prod} folds all resolve,
+   * but the final {@code tf.reshape(ret, batch_dims + outer_dims)} concatenates two shape vectors,
+   * which the walk doesn't model, so the result is the union of the pre-reshape rank-2 matmul
+   * {@code (4, 5)} and ⊤ rather than the runtime {@code (2, 4, 3, 5)}.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/708">wala/ML#708</a>): tighten to the
+   * precise {@code (2, 4, 3, 5)} once shape-vector concatenation is modeled.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumViaMatmul()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_via_matmul.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 5), TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_via_matmul.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_via_matmul.py
@@ -1,0 +1,40 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# NLPGNN's DenseLayer3d matmul path (wala/ML#704) in miniature: rank-3 input,
+# rank-3 weight [hidden, heads, head_size], one inner dim.
+x = tf.ones((2, 4, 6))
+w = tf.ones((6, 3, 5))
+out = einsum_via_matmul(x, w, 1)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_prod_axis.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_prod_axis.py
@@ -1,0 +1,23 @@
+import numpy as np
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+# Guard fixture (wala/ML#707): `np.prod` with an extra argument (`axis=...`)
+# has different semantics (the result's rank can change), so the analysis must
+# refuse to fold it even though this 1-D case happens to produce the same
+# scalar at runtime.
+t = tf.ones((4, 5, 6))
+x = tf.ones((2, 15))
+r = tf.reshape(x, [np.prod(get_shape(t)[-2:], axis=0)])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (30,)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Two test-only additions.

## Coverage

`testShapeProdAxis` covers the `np.prod` fold's extra-argument rejection (the acknowledged coverage gap from #555): the walk-side contexts degrade the position to a dynamic dimension, while the interpreter path evaluates the call concretely, so the union carries both.

## Measurement

`testEinsumViaMatmul` pins the current end-to-end result on a distilled NLPGNN `einsum_via_matmul`: the `get_shape_list` hop, the slices, and the `np.prod` folds all resolve, but the final `tf.reshape(ret, batch_dims + outer_dims)` concatenates two shape vectors, which the walk doesn't model, so the result unions the pre-reshape rank-2 matmul `(4, 5)` with ⊤ rather than the runtime `(2, 4, 3, 5)`. Tighten once wala/ML#708 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)