### PR TITLE
Refine a shared einsum label's dynamic occurrence with a known one (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12866,6 +12866,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * NLPGNN's {@code DenseLayer3d} einsum path in miniature (wala/ML#704): the weight is built flat
+   * from configuration fields, reshaped to rank 3 in {@code call} (the {@code hidden} leading dim
+   * stays dynamic since {@code build}'s {@code input_shape} subscript doesn't resolve), and
+   * consumed by {@code einsum("BFH,HND->BFND", ...)}. The parser refines the contracted {@code H}
+   * label's dynamic occurrence with the input's known {@code 6} and composes the precise runtime
+   * {@code (2, 4, 3, 5)}: the trailing head dims are static, per the issue's expectation.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dEinsum()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_einsum.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 3, 5))));
+  }
+
+  /**
    * NLPGNN's {@code einsum_via_matmul} matmul path in miniature, end to end (wala/ML#704): the
    * {@code get_shape_list} hop, the negated-parameter slice bounds, the {@code np.prod} folds, and
    * the {@code batch_dims + outer_dims} concatenation (wala/ML#708) all resolve, so the reshape arm

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12914,6 +12914,30 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * The two-inner-dims variant of {@link #testEinsumViaMatmul()} (NLPGNN's {@code DenseLayer3dProj}
+   * shape, {@code einsum_via_matmul(input_tensor, w, 2)}): exercises the {@code batch_dims +
+   * [inner_dim]} concatenation of a shape vector with a literal list whose element is an {@code
+   * np.prod} fold (wala/ML#708). The reshape-then-matmul arm types as the precise runtime {@code
+   * (2, 4, 6)}; the {@code (3, 6)} member is the untaken arm of the {@code num_inner_dims > 1}
+   * guard's φ (the rank-2 matmul of the unreshaped input), which flows statically.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumViaMatmul2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_via_matmul2.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 6), TensorType.of(FLOAT_32, 3, 6))));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -224,9 +224,9 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
    * (see {@code TensorType.RaggedDim}'s Javadoc and wala/ML#414). Presence in the label map is
    * therefore tracked with {@code containsKey}, never by a null-check on the value: a label whose
    * occurrences are all {@code null} stays {@code null} (unknown size) in the output, preserving
-   * the output's rank instead of degrading the whole shape to ⊤, and a label seen with both a
-   * {@code null} and a concrete dimension merges to {@code null} (statically unagreed) rather than
-   * letting either occurrence win.
+   * the output's rank instead of degrading the whole shape to ⊤. A shared label names the same
+   * dimension and the runtime requires the sizes equal, so a statically-known occurrence refines an
+   * unknown or dynamic one (wala/ML#704); two known occurrences that disagree fall back to ⊤.
    *
    * @param parsed The parsed equation.
    * @param inputShapes The resolved shape of each input, in input order.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -251,10 +252,17 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
         if (!labelToDim.containsKey(label)) labelToDim.put(label, dim);
         else {
           Dimension<?> previous = labelToDim.get(label);
-          // An unknown (null) occurrence keeps the label unknown; conflicting known dims mean the
-          // equation's same-dimension constraint isn't satisfied statically, so fall back to ⊤.
-          if (previous == null || dim == null) labelToDim.put(label, null);
-          else if (!previous.equals(dim)) return null;
+          // A shared label names the same dimension, and einsum requires the sizes equal at
+          // runtime, so a statically-known occurrence refines an unknown or dynamic one
+          // (wala/ML#704: the contracted hidden dim is known on the input but dynamic on the
+          // reshaped weight). Two known occurrences that disagree mean the constraint isn't
+          // satisfiable, so fall back to ⊤.
+          boolean previousKnown = previous instanceof NumericDim;
+          boolean dimKnown = dim instanceof NumericDim;
+          if (previousKnown && dimKnown) {
+            if (!previous.equals(dim)) return null;
+          } else if (dimKnown) labelToDim.put(label, dim);
+          else if (!previousKnown && previous == null && dim != null) labelToDim.put(label, dim);
         }
       }
     }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_einsum.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_einsum.py
@@ -1,0 +1,40 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# NLPGNN's DenseLayer3d einsum path (wala/ML#704) in miniature: the weight is
+# built flat in `build` from configuration fields, reshaped to rank 3 in
+# `call`, and consumed by an explicit-output einsum.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return tf.einsum("BFH,HND->BFND", input_tensor, w)
+
+
+layer = DenseLayer3d(3, 5)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_via_matmul2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_via_matmul2.py
@@ -1,0 +1,42 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# The two-inner-dims variant (NLPGNN's `DenseLayer3dProj` shape,
+# `einsum_via_matmul(input_tensor, w, 2)`): exercises the
+# `batch_dims + [inner_dim]` concatenation of a shape vector with a literal
+# list whose element is an `np.prod` fold (wala/ML#708).
+x = tf.ones((2, 4, 3, 5))
+w = tf.ones((3, 5, 6))
+out = einsum_via_matmul(x, w, 2)
+
+assert out.shape == (2, 4, 6)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Closes wala/ML#704.

A shared einsum label names the same dimension, and the runtime requires the sizes equal, so a statically-known occurrence now refines a dynamic or unknown one instead of collapsing the composition to ⊤; two known occurrences that disagree still do. This resolves the contracted hidden label in NLPGNN's `DenseLayer3d` einsum path, where the input carries the known size but the reshaped weight's leading dim stays dynamic (`build`'s `input_shape` subscript doesn't resolve).

## Coverage

`testDense3dEinsum` pins the precise `(2, 4, 3, 5)` on a distilled `DenseLayer3d` (`use_einsum=True`); with `testEinsumViaMatmul`'s precise reshape arm (#557), both of the layer's code paths now meet the issue's expectation that the trailing head dims resolve statically. A second commit adds `testEinsumViaMatmul2` (NLPGNN's `DenseLayer3dProj` shape, two inner dims), covering the `batch_dims + [inner_dim]` literal-list concatenation arm that the one-inner-dim fixture skips; the merge queue had locked #557's branch, so the fixture rides here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)