### PR TITLE
Cover the refine-second-occurrence branch with a swapped-operand fixture (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12890,6 +12890,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Operand-order companion of {@link #testDense3dEinsum()} (wala/ML#704): the weight, whose
+   * contracted dim is dynamic, comes first in the equation ({@code "HND,BFH->BFND"}), so the
+   * input's statically-known occurrence of the shared {@code H} label arrives second and refines
+   * the earlier dynamic one. The composed shape is the same precise {@code (2, 4, 3, 5)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dEinsum2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_einsum2.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 3, 5))));
+  }
+
+  /**
    * NLPGNN's {@code einsum_via_matmul} matmul path in miniature, end to end (wala/ML#704): the
    * {@code get_shape_list} hop, the negated-parameter slice bounds, the {@code np.prod} folds, and
    * the {@code batch_dims + outer_dims} concatenation (wala/ML#708) all resolve, so the reshape arm

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_einsum2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_einsum2.py
@@ -1,0 +1,41 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# Operand-order companion of `tf2_test_dense3d_einsum.py` (wala/ML#704): the
+# weight (whose contracted dim is dynamic) comes FIRST in the equation, so the
+# input's statically-known occurrence of the shared label arrives second and
+# must refine the earlier dynamic one.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return tf.einsum("HND,BFH->BFND", w, input_tensor)
+
+
+layer = DenseLayer3d(3, 5)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Test-only follow-up to #558, whose branch the merge queue had locked.

`testDense3dEinsum` only exercises the known-first operand order, where the einsum label merge keeps the known dimension; the branch that refines an earlier dynamic occurrence when the statically-known one arrives second was unexecuted. `testDense3dEinsum2` swaps the einsum operands (`"HND,BFH->BFND"`) and pins the same precise `(2, 4, 3, 5)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)