### PR TITLE
Pin the non-unit-step and ambiguous-bound guards with fixtures (wala/ML#703)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12977,6 +12977,46 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Guard companion of {@link #testShapeAsListSlice()} (wala/ML#703): a non-unit step over a shape
+   * list ({@code [::2]}) is unmodeled, so the walk soundly reports an unknown ({@code ⊤}) shape
+   * while keeping the dtype precise. The Python runtime shape is {@code (4, 6)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeSliceStep()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_slice_step.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Guard companion of {@link #testShapeAsListSlice()} (wala/ML#703): the slice bound is a φ of two
+   * constants, so within one context its points-to set is ambiguous and the bound resolver must not
+   * assert either slicing; the walk soundly reports an unknown ({@code ⊤}) shape. A bound that is a
+   * distinct constant per calling context stays precise (context sensitivity disambiguates it); the
+   * φ forces the ambiguity into a single context.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeSliceAmbiguous()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_slice_ambiguous.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_ambiguous.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_ambiguous.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+def tail(t, flag):
+    k = 1 if flag else 2
+    return tf.reshape(tf.ones((30,)), get_shape(t)[k:])
+
+
+# Guard fixture (wala/ML#703): the slice bound `k` is a φ of two constants, so
+# within one context its points-to set is ambiguous and the analysis must not
+# assert either slicing; it soundly reports an unknown (⊤) shape. The asserts
+# document the Python runtime truth for the taken branch.
+t = tf.ones((4, 1, 30))
+a = tail(t, True)
+assert a.shape == (1, 30)
+assert a.dtype == tf.float32
+f(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_step.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_step.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+# Guard fixture (wala/ML#703): a non-unit step over a shape list is unmodeled,
+# so the analysis soundly reports an unknown (⊤) shape. The asserts document
+# the Python runtime truth ((4, 6), every other dim), not the analysis result.
+t = tf.ones((4, 5, 6))
+x = tf.ones((24,))
+r = tf.reshape(x, get_shape(t)[::2])
+assert r.shape == (4, 6)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Test-only follow-up to the coverage discussion on #552.

Two soundness guards of the shape-vector walk gain behavioral coverage: `testShapeSliceStep` pins the ⊤ fallback for a non-unit step (`[::2]` over a shape list), and `testShapeSliceAmbiguous` pins the ⊤ fallback for a slice bound that is a φ of two constants, whose single-context points-to set is ambiguous. A regression in the latter guard would assert a wrong concrete slicing rather than degrade, so it is the soundness-critical one. Probing also confirmed that a bound that is a distinct constant per calling context stays precise: context sensitivity disambiguates it, so only the φ form forces the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)