### PR TITLE
Stride shape-vector slices with a constant positive step (wala/ML#709)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12999,12 +12999,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Guard companion of {@link #testShapeAsListSlice()} (wala/ML#703): a non-unit step over a shape
-   * list ({@code [::2]}) is unmodeled, so the walk soundly reports an unknown ({@code ⊤}) shape
-   * while keeping the dtype precise. The Python runtime shape is {@code (4, 6)}.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/709">wala/ML#709</a>): tighten to the
-   * precise {@code (4, 6)} once constant non-unit steps are modeled.
+   * Strided companion of {@link #testShapeAsListSlice()} (wala/ML#703, wala/ML#709): a constant
+   * positive step over a shape list ({@code [::2]}) strides the resolved dimensions, composing the
+   * precise {@code (4, 6)}. Negative steps keep the ⊤ fallback.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13015,7 +13012,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testShapeSliceStep()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
-        "tf2_test_shape_slice_step.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        "tf2_test_shape_slice_step.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 6))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13003,6 +13003,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * list ({@code [::2]}) is unmodeled, so the walk soundly reports an unknown ({@code ⊤}) shape
    * while keeping the dtype precise. The Python runtime shape is {@code (4, 6)}.
    *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/709">wala/ML#709</a>): tighten to the
+   * precise {@code (4, 6)} once constant non-unit steps are modeled.
+   *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
    * @throws CancelException if the analysis is cancelled.
@@ -13021,6 +13024,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * assert either slicing; the walk soundly reports an unknown ({@code ⊤}) shape. A bound that is a
    * distinct constant per calling context stays precise (context sensitivity disambiguates it); the
    * φ forces the ambiguity into a single context.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/710">wala/ML#710</a>): tighten to the union
+   * of the candidate slicings ({@code {(1, 30), (30)}}) once ambiguous constant bounds enumerate.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2949,14 +2949,19 @@ public abstract class TensorGenerator {
             || Objects.equals(upper, UNRESOLVED_BOUND)
             || Objects.equals(step, UNRESOLVED_BOUND))
           return null; // Non-constant bound: the sub-list's rank is unknown.
-        if (step != null && step != 1) return null; // Non-unit step: unmodeled.
+        // A constant positive step strides the bounded range; negative steps (which also
+        // reverse) keep the ⊤ fallback (wala/ML#709).
+        int stride = step == null ? 1 : step;
+        if (stride < 1) return null;
 
         Set<List<Dimension<?>>> sliced = HashSetFactory.make();
         for (List<Dimension<?>> dims : base) {
           int n = dims.size();
           int from = lower == null ? 0 : lower < 0 ? Math.max(0, n + lower) : Math.min(lower, n);
           int to = upper == null ? n : upper < 0 ? Math.max(0, n + upper) : Math.min(upper, n);
-          sliced.add(from < to ? new ArrayList<>(dims.subList(from, to)) : new ArrayList<>());
+          List<Dimension<?>> taken = new ArrayList<>();
+          for (int i = from; i < to; i += stride) taken.add(dims.get(i));
+          sliced.add(taken);
         }
         return sliced;
       }


### PR DESCRIPTION
Advances wala/ML#709 (negative steps remain, so no closing keyword).

A constant positive step now strides the bounded range of a resolved shape vector, so `t.shape.as_list()[::2]` composes the precise sub-shape instead of falling back to ⊤. Negative steps, whose defaults flip and reverse, keep the fallback. `testShapeSliceStep` tightens from ⊤ to the precise `(4, 6)`.

A first commit carries the capture-observed TODOs for the two guard tests (wala/ML#709, wala/ML#710), which the merge queue's lock kept out of #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)