### PR TITLE
Reuse `TENSOR_4_6_FLOAT32` and align the stride-fallback comment (wala/ML#709)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13011,12 +13011,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testShapeSliceStep()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_shape_slice_step.py",
-        "f",
-        1,
-        1,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 6))));
+    test("tf2_test_shape_slice_step.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_4_6_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2949,8 +2949,9 @@ public abstract class TensorGenerator {
             || Objects.equals(upper, UNRESOLVED_BOUND)
             || Objects.equals(step, UNRESOLVED_BOUND))
           return null; // Non-constant bound: the sub-list's rank is unknown.
-        // A constant positive step strides the bounded range; negative steps (which also
-        // reverse) keep the ⊤ fallback (wala/ML#709).
+        // A constant positive step strides the bounded range; a non-positive one keeps the ⊤
+        // fallback, covering negative steps (which also reverse) and the invalid zero
+        // (wala/ML#709).
         int stride = step == null ? 1 : step;
         if (stride < 1) return null;
 


### PR DESCRIPTION
Follow-up to #561, whose branch the merge queue had locked: the strided-slice assertion duplicated the existing `TENSOR_4_6_FLOAT32` constant, and the stride-fallback comment mentioned only negative steps though the check also rejects the invalid zero. One test assertion and one comment; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)