### PR TITLE
Run the `TFRecordDataset.map` fixture with a real record and assert its types

### DIFF
--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
@@ -20,26 +20,31 @@ def parse_example(serialized):
 
 
 # The gpt-2 input pipeline shape (wala/ML#618): a TFRecordDataset mapped by a VarLenFeature parser.
-# TFRecordDataset is now a chainable dataset, so .map resolves. Write a real record so this runs.
-path = os.path.join(tempfile.gettempdir(), "tf2_test_tfrecord_map.tfrecord")
-with tf.io.TFRecordWriter(path) as writer:
-    example = tf.train.Example(
-        features=tf.train.Features(
-            feature={
-                "inputs": tf.train.Feature(int64_list=tf.train.Int64List(value=[1, 2])),
-                "targets": tf.train.Feature(
-                    int64_list=tf.train.Int64List(value=[3, 4, 5])
-                ),
-            }
+# TFRecordDataset is now a chainable dataset, so .map resolves. Write a real record (into a unique,
+# auto-cleaned temporary directory) so this runs; the iteration stays in the scope so the file is
+# available.
+with tempfile.TemporaryDirectory() as tmp:
+    path = os.path.join(tmp, "tf2_test_tfrecord_map.tfrecord")
+    with tf.io.TFRecordWriter(path) as writer:
+        example = tf.train.Example(
+            features=tf.train.Features(
+                feature={
+                    "inputs": tf.train.Feature(
+                        int64_list=tf.train.Int64List(value=[1, 2])
+                    ),
+                    "targets": tf.train.Feature(
+                        int64_list=tf.train.Int64List(value=[3, 4, 5])
+                    ),
+                }
+            )
         )
-    )
-    writer.write(example.SerializeToString())
+        writer.write(example.SerializeToString())
 
-ds = tf.data.TFRecordDataset(path).map(parse_example)
-for inputs, targets in ds:
-    # Runtime shape is the concrete (3,) from the record; the static analysis recovers only the
-    # rank-1 dynamic (?,), since the variable-length length is lost across serialize/parse. dtype is
-    # int32 after the cast.
-    assert targets.shape == (3,)
-    assert targets.dtype == tf.int32
-    consume(targets)
+    ds = tf.data.TFRecordDataset(path).map(parse_example)
+    for inputs, targets in ds:
+        # Runtime shape is the concrete (3,) from the record; the static analysis recovers only
+        # the rank-1 dynamic (?,), since the variable-length length is lost across
+        # serialize/parse. dtype is int32 after the cast.
+        assert targets.shape == (3,)
+        assert targets.dtype == tf.int32
+        consume(targets)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import tensorflow as tf
 
 
@@ -17,8 +20,26 @@ def parse_example(serialized):
 
 
 # The gpt-2 input pipeline shape (wala/ML#618): a TFRecordDataset mapped by a VarLenFeature parser.
-# TFRecordDataset is now a chainable dataset, so .map resolves and the parsed targets type to
-# (?,) int32. Static-analysis-only (no real tfrecord at runtime).
-ds = tf.data.TFRecordDataset("x").map(parse_example)
+# TFRecordDataset is now a chainable dataset, so .map resolves. Write a real record so this runs.
+path = os.path.join(tempfile.gettempdir(), "tf2_test_tfrecord_map.tfrecord")
+with tf.io.TFRecordWriter(path) as writer:
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                "inputs": tf.train.Feature(int64_list=tf.train.Int64List(value=[1, 2])),
+                "targets": tf.train.Feature(
+                    int64_list=tf.train.Int64List(value=[3, 4, 5])
+                ),
+            }
+        )
+    )
+    writer.write(example.SerializeToString())
+
+ds = tf.data.TFRecordDataset(path).map(parse_example)
 for inputs, targets in ds:
+    # Runtime shape is the concrete (3,) from the record; the static analysis recovers only the
+    # rank-1 dynamic (?,), since the variable-length length is lost across serialize/parse. dtype is
+    # int32 after the cast.
+    assert targets.shape == (3,)
+    assert targets.dtype == tf.int32
     consume(targets)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_map.py
@@ -41,10 +41,13 @@ with tempfile.TemporaryDirectory() as tmp:
         writer.write(example.SerializeToString())
 
     ds = tf.data.TFRecordDataset(path).map(parse_example)
+    seen = 0
     for inputs, targets in ds:
         # Runtime shape is the concrete (3,) from the record; the static analysis recovers only
-        # the rank-1 dynamic (?,), since the variable-length length is lost across
-        # serialize/parse. dtype is int32 after the cast.
+        # the rank-1 dynamic (?,), since a VarLenFeature's element count is lost across
+        # serialization and parsing. dtype is int32 after the cast.
         assert targets.shape == (3,)
         assert targets.dtype == tf.int32
         consume(targets)
+        seen += 1
+    assert seen == 1


### PR DESCRIPTION
Revives the orphaned `fix-tfrecord-fixture-asserts` branch (June 30): `tf2_test_tfrecord_map.py` now writes a real record and asserts its parsed types at runtime, per the fixture convention that the Python runtime truth should cross-check the JUnit expectation (wala/ML#641's theme). `testTfrecordMap`'s expectation is unchanged and passes against the updated fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)