### PR TITLE
Pin the `einsum_via_matmul` boundary transport and the in-vivo ⊤ (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12960,6 +12960,80 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Composition of {@link #testDense3dEinsum()} and {@link #testEinsumViaMatmul()} (wala/ML#704):
+   * NLPGNN's {@code DenseLayer3d.call} delegates to the module-level {@code einsum_via_matmul}
+   * helper. The {@code input_tensor} parameter carries the precise type across the layer-call
+   * boundary. The {@code w} parameter's trailing dimensions are the folded configuration fields,
+   * but its leading (hidden) dimension stays dynamic because {@code build}'s {@code input_shape}
+   * parameter is opaque, so {@code self.hidden_size = input_shape[2]} never resolves.
+   *
+   * <p>TODO: Expect {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/712">wala/ML#712</a> resolves {@code build}'s {@code
+   * input_shape} subscripts from the call-site input tensor's shape.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                new TensorType(
+                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
+  }
+
+  /**
+   * Escalation of {@link #testDense3dMatmul()} to NLPGNN's real dispatch shape (wala/ML#704): the
+   * {@code DenseLayer3d} is created in an outer attention layer's {@code build}, stored as an
+   * attribute, and invoked through it in the outer {@code call} — two trampoline hops before {@code
+   * einsum_via_matmul} sees the input tensor. The {@code input_tensor} parameter carries the
+   * precise type through both hops; the {@code w} parameter's leading (hidden) dimension stays
+   * dynamic exactly as in the one-hop composition.
+   *
+   * <p>TODO: Expect {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/712">wala/ML#712</a> resolves {@code build}'s {@code
+   * input_shape} subscripts from the call-site input tensor's shape.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul2.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                new TensorType(
+                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2211,6 +2211,52 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * In-vivo anchor for the reopened wala/ML#704: the vendored NLPGNN {@code einsum_via_matmul}
+   * ({@code nlpgnn/layers/dense.py}). Its {@code input_tensor} parameter is ⊤ in every calling
+   * context — not because the type is lost at the layer-call boundary (the distilled compositions
+   * {@link #testDense3dMatmul()} and {@link #testDense3dMatmul2()} carry it through one and two
+   * trampoline hops), but because the ⊤ originates at the top of the encoder's dataflow: {@code
+   * WDEmbedding.call}'s trailing reshape targets {@code input_shape[0:-1] + [input_shape[-1] *
+   * self.embedding_size]} over the unknown-rank {@code input_ids}, the shape-vector walk soundly
+   * degrades the result to ⊤, and that ⊤ floods every downstream float tensor. The {@code w}
+   * parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
+   * dimensions, since {@code build}-computed head sizes also derive from the opaque {@code
+   * input_shape}.
+   *
+   * <p>TODO: Expect static trailing dimensions here once <a
+   * href="https://github.com/wala/ML/issues/711">wala/ML#711</a> (embedding-reshape ⊤ genesis) and
+   * <a href="https://github.com/wala/ML/issues/712">wala/ML#712</a> ({@code build} {@code
+   * input_shape} opacity) are resolved.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNlpgnnFullEinsumViaMatmul()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        NLPGNN_FULL_PROJECT_FILES,
+        "nlpgnn/layers/dense.py",
+        "einsum_via_matmul",
+        "nlpgnn_full_proj",
+        2,
+        13,
+        Map.of(
+            2,
+            Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+  }
+
+  /**
    * Sibling half of {@link #testNlpgnnFullGeneration()} (wala/ML#690) — the {@code interactive}
    * entry script, the one whose {@code predict}/{@code call} nodes vanished in the consumer's
    * whole-project run. Its {@code predict} parameter typing must be symmetric with the generation

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul.py
@@ -1,0 +1,65 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 5)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# NLPGNN's DenseLayer3d matmul (use_einsum=False) path (wala/ML#704): the
+# layer's `call` reshapes the flat weight to rank 3 and delegates to the
+# module-level `einsum_via_matmul` helper.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3, 5)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul2.py
@@ -1,0 +1,80 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 5)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+# NLPGNN's attention dispatch (wala/ML#704) in miniature: the DenseLayer3d is
+# created in the *outer* layer's `build` (lazy), stored as an attribute, and
+# invoked through it in the outer `call` — two trampoline hops before
+# `einsum_via_matmul` sees the input tensor.
+class Attention(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(Attention, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.q = DenseLayer3d(self.num_attention_heads, self.head_size)
+        self.built = True
+
+    def call(self, from_tensor):
+        return self.q(from_tensor)
+
+
+layer = Attention(3, 5)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Triage artifacts for the reopened wala/ML#704.

Two distilled fixtures compose NLPGNN's dispatch shape around `einsum_via_matmul`: the layer delegating directly (`tf2_test_dense3d_matmul.py`) and the layer built lazily in an outer attention layer's `build`, stored as an attribute, and invoked through it (`tf2_test_dense3d_matmul2.py`). Both carry the precise `input_tensor` type into the helper, establishing that the layer-call boundary transports what it is given; the `w` parameter pins the `build`-`input_shape` opacity of wala/ML#712.

A third test anchors the in-vivo state on the vendored whole-project fixture: `einsum_via_matmul`'s `input_tensor` is ⊤ in every context because the ⊤ is born at `WDEmbedding.call`'s trailing reshape (wala/ML#711) and floods the encoder, not because of the call boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
