### PR TITLE
Resolve `build`'s `input_shape` subscripts from the call-site input shape (wala/ML#712)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13009,13 +13009,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Composition of {@link #testDense3dEinsum()} and {@link #testEinsumViaMatmul()} (wala/ML#704):
    * NLPGNN's {@code DenseLayer3d.call} delegates to the module-level {@code einsum_via_matmul}
    * helper. The {@code input_tensor} parameter carries the precise type across the layer-call
-   * boundary. The {@code w} parameter's trailing dimensions are the folded configuration fields,
-   * but its leading (hidden) dimension stays dynamic because {@code build}'s {@code input_shape}
-   * parameter is opaque, so {@code self.hidden_size = input_shape[2]} never resolves.
+   * boundary, and the {@code w} parameter's generator-side member is fully static: the trailing
+   * dimensions are the folded configuration fields and the leading (hidden) dimension resolves
+   * through {@code build}'s {@code input_shape} subscript ({@code self.hidden_size =
+   * input_shape[2]}, wala/ML#712). The all-symbolic member is the legacy literal-shape pin ({@code
+   * TensorType.shapeArg}), which folds neither field reads nor {@code build} subscripts.
    *
-   * <p>TODO: Expect {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/712">wala/ML#712</a> resolves {@code build}'s {@code
-   * input_shape} subscripts from the call-site input tensor's shape.
+   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
+   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13038,8 +13040,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                 new TensorType(
                     FLOAT_32,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                new TensorType(
-                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
+                TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**
@@ -13047,12 +13048,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code DenseLayer3d} is created in an outer attention layer's {@code build}, stored as an
    * attribute, and invoked through it in the outer {@code call} — two trampoline hops before {@code
    * einsum_via_matmul} sees the input tensor. The {@code input_tensor} parameter carries the
-   * precise type through both hops; the {@code w} parameter's leading (hidden) dimension stays
-   * dynamic exactly as in the one-hop composition.
+   * precise type through both hops, and the {@code w} parameter resolves exactly as in the one-hop
+   * composition, including the hidden dimension through {@code build}'s {@code input_shape}
+   * subscript (wala/ML#712).
    *
-   * <p>TODO: Expect {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/712">wala/ML#712</a> resolves {@code build}'s {@code
-   * input_shape} subscripts from the call-site input tensor's shape.
+   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
+   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13075,8 +13077,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                 new TensorType(
                     FLOAT_32,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                new TensorType(
-                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
+                TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13148,6 +13148,59 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Two-instance guard for the {@code build} subscript resolution (wala/ML#712): the class is
+   * instantiated on inputs with different hidden sizes, so the per-class attribute chase sees
+   * conflicting {@code hidden_size} stores and must bail; the weight's leading dimension stays
+   * dynamic (a sound conservative result) while the folded configuration fields keep their
+   * constants.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul5()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul5.py",
+        "einsum_via_matmul",
+        2,
+        14,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6), TensorType.of(FLOAT_32, 2, 4, 8)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                new TensorType(
+                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
+  }
+
+  /**
+   * A configuration attribute as a literal concat element (wala/ML#712): the reshape target
+   * concatenates a shape-vector slice with {@code [self.units]}, whose stored value is the
+   * constructor argument, exercising the constant fallback of the attribute chase.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeConcatAttr()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_concat_attr.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 6))));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13081,6 +13081,73 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Negative-index companion of {@link #testDense3dMatmul()} (wala/ML#712): {@code build} stores
+   * {@code input_shape[-1]}, exercising the Python negative-index arm of the shape-vector subscript
+   * resolution.
+   *
+   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
+   * pin path with the generator-side element folds.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul3.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                TensorType.of(FLOAT_32, 6, 3, 5))));
+  }
+
+  /**
+   * Explicit-{@code build} companion of {@link #testDense3dMatmul()} (wala/ML#712): the script
+   * calls {@code layer.build(x.shape)} before the layer call, so the {@code input_shape} parameter
+   * also receives a real argument, exercising the explicit-caller arm of the walk alongside the
+   * lazy-build trampoline hop.
+   *
+   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
+   * pin path with the generator-side element folds.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul4()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul4.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                TensorType.of(FLOAT_32, 6, 3, 5))));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -203,7 +203,7 @@ public abstract class TensorGenerator {
 
   /**
    * Memo of the {@code (class, attribute)} chase results of {@link
-   * #storedAttributeDimInClass(PropagationCallGraphBuilder, IClass, String)} per builder
+   * #resolveStoredAttributeDimInClass(PropagationCallGraphBuilder, IClass, String)} per builder
    * (wala/ML#712). The chase scans the whole call graph, so uncached re-runs are quadratic on large
    * analyses; the {@link Optional} payload caches the negative result too.
    */
@@ -775,9 +775,9 @@ public abstract class TensorGenerator {
       if (folded != null) return folded;
       folded = this.prodOfShapeVectorDim(builder, node, st, writtenVal);
       if (folded != null) return folded;
-      folded = this.shapeVectorElementDim(builder, node, st, writtenVal);
+      folded = this.resolveShapeVectorElementDim(builder, node, st, writtenVal);
       if (folded != null) return folded;
-      return this.storedAttributeDim(builder, node, writtenVal);
+      return this.resolveStoredAttributeDim(builder, node, writtenVal);
     }
     return null;
   }
@@ -793,7 +793,7 @@ public abstract class TensorGenerator {
    * @return The subscripted {@link Dimension}, or {@code null} when the value isn't a
    *     constant-indexed subscript of a resolvable shape vector or the index is out of range.
    */
-  private Dimension<?> shapeVectorElementDim(
+  private Dimension<?> resolveShapeVectorElementDim(
       PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     if (vn <= 0) return null;
     SSAInstruction def = node.getDU().getDef(vn);
@@ -840,7 +840,7 @@ public abstract class TensorGenerator {
    *     attribute read, no write site resolves, or distinct write sites resolve to different
    *     dimensions.
    */
-  private Dimension<?> storedAttributeDim(
+  private Dimension<?> resolveStoredAttributeDim(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
     if (vn <= 0 || node.getDU() == null || node.getIR() == null) return null;
     SSAInstruction def = node.getDU().getDef(vn);
@@ -885,10 +885,11 @@ public abstract class TensorGenerator {
         // through the shape machinery (a self-referential attribute), and the sentinel floors the
         // re-entry to "unresolved" (sound) instead of recursing.
         cache.put(key, Optional.empty());
-        Dimension<?> chased = this.storedAttributeDimInClass(builder, pythonClass, attributeName);
+        Dimension<?> chased =
+            this.resolveStoredAttributeDimInClass(builder, pythonClass, attributeName);
         LOGGER.fine(
             () ->
-                "storedAttributeDim: "
+                "resolveStoredAttributeDim: "
                     + pythonClass
                     + "."
                     + attributeName
@@ -915,7 +916,7 @@ public abstract class TensorGenerator {
    * @return The stored value's dimension, or {@code null} when no write resolves or distinct writes
    *     resolve to different dimensions.
    */
-  private Dimension<?> storedAttributeDimInClass(
+  private Dimension<?> resolveStoredAttributeDimInClass(
       PropagationCallGraphBuilder builder, IClass pythonClass, String attributeName) {
     String classPrefix = pythonClass.getReference().getName().toString() + "/";
     Dimension<?> found = null;
@@ -948,7 +949,8 @@ public abstract class TensorGenerator {
         Dimension<?> stored =
             TensorType.foldArithmeticDim(builder, candidate, st, candidate.getDU(), storedVn);
         if (stored == null) stored = this.prodOfShapeVectorDim(builder, candidate, st, storedVn);
-        if (stored == null) stored = this.shapeVectorElementDim(builder, candidate, st, storedVn);
+        if (stored == null)
+          stored = this.resolveShapeVectorElementDim(builder, candidate, st, storedVn);
         if (stored == null) {
           Integer constant = constantIntValueOrSentinel(builder, candidate, st, storedVn);
           if (constant != null && !Objects.equals(constant, UNRESOLVED_BOUND))
@@ -3356,9 +3358,9 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     Dimension<?> prod = this.prodOfShapeVectorDim(builder, node, st, vn);
     if (prod != null) return prod;
-    Dimension<?> subscript = this.shapeVectorElementDim(builder, node, st, vn);
+    Dimension<?> subscript = this.resolveShapeVectorElementDim(builder, node, st, vn);
     if (subscript != null) return subscript;
-    Dimension<?> attribute = this.storedAttributeDim(builder, node, vn);
+    Dimension<?> attribute = this.resolveStoredAttributeDim(builder, node, vn);
     if (attribute != null) return attribute;
     Integer constant = constantIntValueOrSentinel(builder, node, st, vn);
     if (constant == null) return DynamicDim.INSTANCE; // None: the dynamic-dim marker.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -14,7 +14,9 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FIELD_REFERENCE_
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.PLACEHOLDER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORFLOW_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TYPE_REFERENCE_TO_SIGNATURE;
+import static com.ibm.wala.cast.python.types.PythonTypes.CALLABLE_METHOD_NAME_FOR_KERAS_MODELS;
 import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
+import static com.ibm.wala.cast.python.types.PythonTypes.KERAS_BUILD_METHOD_NAME;
 import static com.ibm.wala.cast.python.types.PythonTypes.Root;
 import static com.ibm.wala.cast.python.types.PythonTypes.dict;
 import static com.ibm.wala.cast.python.types.PythonTypes.list;
@@ -29,6 +31,7 @@ import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.ir.ssa.CAstUnaryOp;
+import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
@@ -46,6 +49,7 @@ import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -62,6 +66,7 @@ import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
+import com.ibm.wala.ssa.SSAGetInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SSAPutInstruction;
@@ -83,6 +88,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
@@ -196,6 +202,16 @@ public abstract class TensorGenerator {
       DTYPES_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
+   * Memo of the {@code (class, attribute)} chase results of {@link
+   * #storedAttributeDimInClass(PropagationCallGraphBuilder, IClass, String)} per builder
+   * (wala/ML#712). The chase scans the whole call graph, so uncached re-runs are quadratic on large
+   * analyses; the {@link Optional} payload caches the negative result too.
+   */
+  private static final Map<
+          PropagationCallGraphBuilder, Map<Pair<IClass, String>, Optional<Dimension<?>>>>
+      STORED_ATTRIBUTE_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
    * Begins a new resolution round for the given builder (wala/ML#674): the current shape/dtype
    * results become the previous round's approximations (read on cycle re-entry), and the current
    * caches restart empty.
@@ -209,6 +225,8 @@ public abstract class TensorGenerator {
     if (dtypes != null) PREVIOUS_DTYPES_CACHE.put(builder, dtypes);
     SHAPES_IN_PROGRESS.remove(builder);
     DTYPES_IN_PROGRESS.remove(builder);
+    // The chase reads shape results that may change between rounds, so its memo restarts too.
+    STORED_ATTRIBUTE_CACHE.remove(builder);
   }
 
   /**
@@ -229,6 +247,7 @@ public abstract class TensorGenerator {
     PREVIOUS_DTYPES_CACHE.remove(builder);
     SHAPES_IN_PROGRESS.remove(builder);
     DTYPES_IN_PROGRESS.remove(builder);
+    STORED_ATTRIBUTE_CACHE.remove(builder);
   }
 
   /** The source of the tensor, represented by a points-to set variable. */
@@ -754,9 +773,193 @@ public abstract class TensorGenerator {
       // Shared with `TensorType.shapeArg` so the two shape-argument paths agree (wala/ML#581).
       Dimension<?> folded = TensorType.foldArithmeticDim(builder, node, st, du, writtenVal);
       if (folded != null) return folded;
-      return this.prodOfShapeVectorDim(builder, node, st, writtenVal);
+      folded = this.prodOfShapeVectorDim(builder, node, st, writtenVal);
+      if (folded != null) return folded;
+      folded = this.shapeVectorElementDim(builder, node, st, writtenVal);
+      if (folded != null) return folded;
+      return this.storedAttributeDim(builder, node, writtenVal);
     }
     return null;
+  }
+
+  /**
+   * Resolves a constant-indexed subscript of a shape vector (e.g. {@code input_shape[2]}) to the
+   * denoted dimension, with Python negative-index semantics (wala/ML#712).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The value number of the candidate subscript result.
+   * @return The subscripted {@link Dimension}, or {@code null} when the value isn't a
+   *     constant-indexed subscript of a resolvable shape vector or the index is out of range.
+   */
+  private Dimension<?> shapeVectorElementDim(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
+    if (vn <= 0) return null;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof PythonPropertyRead)) return null;
+    PythonPropertyRead read = (PythonPropertyRead) def;
+    int memberVn = read.getMemberRef();
+    Integer index;
+    if (st.isStringConstant(memberVn)) {
+      // Subscript indices can surface as string constants (like the index writes above); a
+      // non-numeric string is an attribute read, not a subscript.
+      try {
+        index = Integer.parseInt(st.getStringValue(memberVn));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    } else {
+      index = constantIntValueOrSentinel(builder, node, st, memberVn);
+      if (index == null || Objects.equals(index, UNRESOLVED_BOUND)) return null;
+    }
+
+    Set<List<Dimension<?>>> shapes =
+        this.getShapesOfShapeVector(builder, node, read.getObjectRef());
+    if (shapes == null || shapes.size() != 1) return null; // Ambiguous ranks: not resolvable.
+    List<Dimension<?>> dims = shapes.iterator().next();
+    int k = index < 0 ? dims.size() + index : index;
+    if (k < 0 || k >= dims.size()) return null;
+    return dims.get(k);
+  }
+
+  /**
+   * Resolves a bare instance-attribute read off the enclosing method's {@code self} (e.g. {@code
+   * self.hidden_size}) to a dimension by chasing the attribute's write sites in the receiver
+   * class's method bodies and resolving each stored value in its defining node. Covers {@code
+   * build}-computed sizes such as {@code self.hidden_size = input_shape[2]}, whose stored value has
+   * an empty points-to set, so the constant-propagation path cannot see it (wala/ML#712).
+   *
+   * <p>The chase is depth-one by construction: a stored value that is itself another bare attribute
+   * read does not resolve.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number of the candidate attribute read.
+   * @return The stored value's dimension, or {@code null} when the value isn't a {@code self}
+   *     attribute read, no write site resolves, or distinct write sites resolve to different
+   *     dimensions.
+   */
+  private Dimension<?> storedAttributeDim(
+      PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    if (vn <= 0 || node.getDU() == null || node.getIR() == null) return null;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof PythonPropertyRead) && !(def instanceof SSAGetInstruction)) return null;
+
+    String attributeName;
+    int objectVn;
+    if (def instanceof PythonPropertyRead) {
+      PythonPropertyRead read = (PythonPropertyRead) def;
+      SymbolTable st = node.getIR().getSymbolTable();
+      int memberVn = read.getMemberRef();
+      if (!st.isStringConstant(memberVn)) return null;
+      attributeName = st.getStringValue(memberVn);
+      objectVn = read.getObjectRef();
+    } else {
+      SSAGetInstruction get = (SSAGetInstruction) def;
+      if (get.isStatic()) return null;
+      attributeName = get.getDeclaredField().getName().toString();
+      objectVn = get.getRef();
+    }
+
+    // Only chase reads off the enclosing method's `self`.
+    if (node.getMethod().getNumberOfParameters() < 2 || objectVn != node.getIR().getParameter(1))
+      return null;
+
+    PointerKey selfPk =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, objectVn);
+    Dimension<?> found = null;
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(selfPk)) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin == null) return null;
+      // A user Python object allocates as `Lobject` inside its class's synthetic constructor, so
+      // the class identity lives in the allocating node's declaring class.
+      IClass pythonClass = asin.getNode().getMethod().getDeclaringClass();
+      Map<Pair<IClass, String>, Optional<Dimension<?>>> cache =
+          STORED_ATTRIBUTE_CACHE.computeIfAbsent(
+              builder, b -> Collections.synchronizedMap(new HashMap<>()));
+      Pair<IClass, String> key = Pair.make(pythonClass, attributeName);
+      Optional<Dimension<?>> memo = cache.get(key);
+      if (memo == null) {
+        // Seed an empty sentinel before computing: the chase can re-enter itself on the same key
+        // through the shape machinery (a self-referential attribute), and the sentinel floors the
+        // re-entry to "unresolved" (sound) instead of recursing.
+        cache.put(key, Optional.empty());
+        Dimension<?> chased = this.storedAttributeDimInClass(builder, pythonClass, attributeName);
+        LOGGER.fine(
+            () ->
+                "storedAttributeDim: "
+                    + pythonClass
+                    + "."
+                    + attributeName
+                    + " resolved to "
+                    + chased);
+        memo = Optional.ofNullable(chased);
+        cache.put(key, memo);
+      }
+      Dimension<?> stored = memo.orElse(null);
+      if (stored == null) return null;
+      if (found != null && !found.equals(stored)) return null; // Conflicting receivers.
+      found = stored;
+    }
+    return found;
+  }
+
+  /**
+   * Chases the write sites of {@code attributeName} on {@code self} across the given Python class's
+   * method-body nodes and resolves each stored value in its defining node.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param pythonClass The Python class whose method bodies are scanned.
+   * @param attributeName The attribute whose writes are chased.
+   * @return The stored value's dimension, or {@code null} when no write resolves or distinct writes
+   *     resolve to different dimensions.
+   */
+  private Dimension<?> storedAttributeDimInClass(
+      PropagationCallGraphBuilder builder, IClass pythonClass, String attributeName) {
+    String classPrefix = pythonClass.getReference().getName().toString() + "/";
+    Dimension<?> found = null;
+    for (CGNode candidate : builder.getCallGraph()) {
+      if (candidate.getIR() == null || candidate.getDU() == null) continue;
+      IMethod method = candidate.getMethod();
+      if (!(method instanceof AstMethod)) continue; // Only real method bodies hold user writes.
+      String declaringClassName = method.getDeclaringClass().getReference().getName().toString();
+      if (!declaringClassName.startsWith(classPrefix)) continue;
+      if (method.getNumberOfParameters() < 2) continue;
+      int selfVn = candidate.getIR().getParameter(1);
+      SymbolTable st = candidate.getIR().getSymbolTable();
+
+      for (SSAInstruction inst : candidate.getIR().getInstructions()) {
+        int storedVn = -1;
+        if (inst instanceof PythonPropertyWrite) {
+          PythonPropertyWrite write = (PythonPropertyWrite) inst;
+          int memberVn = write.getMemberRef();
+          if (write.getObjectRef() == selfVn
+              && st.isStringConstant(memberVn)
+              && attributeName.equals(st.getStringValue(memberVn))) storedVn = write.getValue();
+        } else if (inst instanceof SSAPutInstruction && !((SSAPutInstruction) inst).isStatic()) {
+          SSAPutInstruction put = (SSAPutInstruction) inst;
+          if (put.getRef() == selfVn
+              && attributeName.equals(put.getDeclaredField().getName().toString()))
+            storedVn = put.getVal();
+        }
+        if (storedVn <= 0) continue;
+
+        Dimension<?> stored =
+            TensorType.foldArithmeticDim(builder, candidate, st, candidate.getDU(), storedVn);
+        if (stored == null) stored = this.prodOfShapeVectorDim(builder, candidate, st, storedVn);
+        if (stored == null) stored = this.shapeVectorElementDim(builder, candidate, st, storedVn);
+        if (stored == null) {
+          Integer constant = constantIntValueOrSentinel(builder, candidate, st, storedVn);
+          if (constant != null && !Objects.equals(constant, UNRESOLVED_BOUND))
+            stored = new NumericDim(constant);
+        }
+        if (stored == null) return null; // An unresolvable write makes the attribute unresolvable.
+        if (found != null && !found.equals(stored)) return null; // Conflicting writes.
+        found = stored;
+      }
+    }
+    return found;
   }
 
   /**
@@ -2720,6 +2923,24 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Returns whether the given node is a synthetic instance-method trampoline for a method of the
+   * given name (e.g. the {@code build} or {@code call} trampoline of a Keras layer).
+   *
+   * @param node The {@link CGNode} to test.
+   * @param methodName The trampolined method's Python-level name.
+   * @return {@code true} iff {@code node} is a trampoline whose target method has the given name.
+   */
+  protected static boolean isTrampolineFor(CGNode node, String methodName) {
+    return node.getMethod().getName().toString().startsWith("trampoline")
+        && node.getMethod()
+            .getDeclaringClass()
+            .getReference()
+            .getName()
+            .toString()
+            .endsWith("/" + methodName);
+  }
+
+  /**
    * Returns the calling invocations of the given node: for each call-graph predecessor, the invoke
    * instructions at the sites that can dispatch to it. Derived from call-graph edges rather than a
    * {@code CALL_STRING} lookup, so it works for any {@link com.ibm.wala.ipa.callgraph.Context}
@@ -2900,6 +3121,63 @@ public abstract class TensorGenerator {
     SSAInstruction def = node.getDU().getDef(vn);
     SymbolTable st = node.getIR().getSymbolTable();
 
+    // The `input_shape` parameter of a Keras `build` method denotes the shape of the layer-call
+    // input, but the lazy-build machinery invokes `build` through the method's own trampoline
+    // with `self` as the only argument (wala/ML#595), so the parameter never receives a shape in
+    // the PA. Resolve it via the callers: the build body's caller is the build trampoline, whose
+    // own caller is either the layer-call trampoline (the lazy-build pattern — its second
+    // parameter is the layer call's first positional argument, the input tensor) or a real method
+    // body issuing an explicit `x.build(shape)` call, whose argument is walked as a shape vector
+    // (wala/ML#712).
+    if (def == null
+        && node.getMethod()
+            .getDeclaringClass()
+            .getReference()
+            .getName()
+            .toString()
+            .endsWith("/" + KERAS_BUILD_METHOD_NAME)
+        && node.getMethod().getNumberOfParameters() >= 3
+        && vn == node.getIR().getParameter(2)) {
+      LOGGER.fine(
+          () ->
+              "getShapesOfShapeVector: resolving the build input_shape parameter in "
+                  + describe(node));
+      Set<List<Dimension<?>>> combined = null;
+      for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+          getCallerInvokes(builder, node)) {
+        CGNode buildTrampoline = callerInvoke.fst;
+        if (!isTrampolineFor(buildTrampoline, KERAS_BUILD_METHOD_NAME)) return null;
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> outerInvoke :
+            getCallerInvokes(builder, buildTrampoline)) {
+          CGNode outerCaller = outerInvoke.fst;
+          SSAAbstractInvokeInstruction outerCall = outerInvoke.snd;
+          Set<List<Dimension<?>>> shapes = null;
+          if (isTrampolineFor(outerCaller, CALLABLE_METHOD_NAME_FOR_KERAS_MODELS)
+              && outerCaller.getIR() != null
+              && outerCaller.getMethod().getNumberOfParameters() >= 2) {
+            try {
+              shapes = this.getShapes(builder, outerCaller, outerCaller.getIR().getParameter(1));
+            } catch (IllegalArgumentException e) {
+              LOGGER.log(
+                  Level.FINE,
+                  "getShapesOfShapeVector: could not resolve the layer-call input via caller="
+                      + describe(outerCaller),
+                  e);
+            }
+          } else if (outerCall.getNumberOfUses() >= 2 && visited.add(outerCaller))
+            // An explicit `x.build(shape)` call: walk the actual argument.
+            shapes =
+                this.getShapesOfShapeVector(builder, outerCaller, outerCall.getUse(1), visited);
+          // Any unresolved caller makes the parameter's denotation unknown (⊤): the parameter
+          // unions all callers.
+          if (shapes == null || shapes.isEmpty()) return null;
+          if (combined == null) combined = HashSetFactory.make();
+          combined.addAll(shapes);
+        }
+      }
+      return combined;
+    }
+
     if (def instanceof PythonPropertyRead) {
       PythonPropertyRead read = (PythonPropertyRead) def;
       int memberVn = read.getMemberRef();
@@ -3078,6 +3356,10 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     Dimension<?> prod = this.prodOfShapeVectorDim(builder, node, st, vn);
     if (prod != null) return prod;
+    Dimension<?> subscript = this.shapeVectorElementDim(builder, node, st, vn);
+    if (subscript != null) return subscript;
+    Dimension<?> attribute = this.storedAttributeDim(builder, node, vn);
+    if (attribute != null) return attribute;
     Integer constant = constantIntValueOrSentinel(builder, node, st, vn);
     if (constant == null) return DynamicDim.INSTANCE; // None: the dynamic-dim marker.
     if (Objects.equals(constant, UNRESOLVED_BOUND)) return null;

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul3.py
@@ -1,0 +1,65 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 5)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Negative-index variant of tf2_test_dense3d_matmul.py (wala/ML#712): the
+# layer's `call` reshapes the flat weight to rank 3 and delegates to the
+# module-level `einsum_via_matmul` helper.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[-1]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3, 5)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul4.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul4.py
@@ -1,0 +1,66 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 5)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Explicit-`build` variant of tf2_test_dense3d_matmul.py (wala/ML#712):
+# `build` is invoked explicitly with `x.shape` before the layer call, so the
+# `input_shape` parameter also has a real argument to walk.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3, 5)
+x = tf.ones((2, 4, 6))
+layer.build(x.shape)
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 5)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul5.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul5.py
@@ -1,0 +1,70 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Two-instance variant of tf2_test_dense3d_matmul.py (wala/ML#712): the class
+# is instantiated on inputs with different hidden sizes, so the per-class
+# attribute chase sees conflicting `hidden_size` stores and must bail.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer1 = DenseLayer3d(3, 5)
+x1 = tf.ones((2, 4, 6))
+out1 = layer1(x1)
+
+layer2 = DenseLayer3d(3, 5)
+x2 = tf.ones((2, 4, 8))
+out2 = layer2(x2)
+
+assert out1.shape == (2, 4, 3, 5)
+assert out1.dtype == tf.float32
+assert out2.shape == (2, 4, 3, 5)
+assert out2.dtype == tf.float32
+
+consume(out1)
+consume(out2)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_concat_attr.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_concat_attr.py
@@ -1,0 +1,31 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+# A configuration attribute as a literal concat element (wala/ML#712): the
+# reshape target concatenates a shape-vector slice with `[self.units]`, whose
+# stored value is the constructor argument.
+class Proj(tf.keras.layers.Layer):
+    def __init__(self, units, **kwargs):
+        super(Proj, self).__init__(**kwargs)
+        self.units = units
+
+    def call(self, t):
+        return tf.reshape(t, get_shape_list(t)[:-1] + [self.units])
+
+
+layer = Proj(6)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 6)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Closes wala/ML#712.

A Keras `build`'s `input_shape` parameter never receives a shape in the PA: the lazy-build machinery (wala/ML#595) routes `self.build(...)` through the method's own trampoline with `self` as the only argument. Three additions to `TensorGenerator` make its subscripts resolve:

- The shape-vector walk resolves the `build` parameter through the caller chain (build body, then build trampoline, then layer-call trampoline, whose second parameter is the layer call's first positional argument: the input tensor). An explicit `x.build(shape)` caller's argument is walked directly.
- `shapeVectorElementDim` resolves a constant-indexed subscript of a shape vector (including string-encoded and negative indices) to the denoted dimension.
- `storedAttributeDim` chases a bare `self.X` read to the receiver class's write sites and resolves the stored value in its defining node; the stored subscript has an empty points-to set, so constant propagation cannot see it. The class chase is memoized per `(class, attribute)` with a re-entry sentinel, keeping the FINEST diagnostic volume within the wala/ML#697 bound.

`tf2_test_dense3d_matmul.py`/`tf2_test_dense3d_matmul2.py` now type `einsum_via_matmul`'s `w` parameter fully static `(6, 3, 5)` on the generator side. The residual all-symbolic union member is the `shapeArg` pin path, tracked by wala/ML#713; the arithmetic witness form `int(input_shape[k]/c)` is split to wala/ML#714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
