### PR TITLE
Preserve the embedding path's dtype through the NLPGNN encoder (wala/ML#711)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2212,21 +2212,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
 
   /**
    * In-vivo anchor for the reopened wala/ML#704: the vendored NLPGNN {@code einsum_via_matmul}
-   * ({@code nlpgnn/layers/dense.py}). Its {@code input_tensor} parameter is ⊤ in every calling
-   * context — not because the type is lost at the layer-call boundary (the distilled compositions
-   * {@link #testDense3dMatmul()} and {@link #testDense3dMatmul2()} carry it through one and two
-   * trampoline hops), but because the ⊤ originates at the top of the encoder's dataflow: {@code
-   * WDEmbedding.call}'s trailing reshape targets {@code input_shape[0:-1] + [input_shape[-1] *
-   * self.embedding_size]} over the unknown-rank {@code input_ids}, the shape-vector walk soundly
-   * degrades the result to ⊤, and that ⊤ floods every downstream float tensor. The {@code w}
-   * parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
+   * ({@code nlpgnn/layers/dense.py}). The {@code input_tensor} parameter's shape is ⊤ in every
+   * calling context, not because the type is lost at the layer-call boundary (the distilled
+   * compositions {@link #testDense3dMatmul()} and {@link #testDense3dMatmul2()} carry it through
+   * one and two trampoline hops), but because the ⊤ originates at the top of the encoder's
+   * dataflow: {@code WDEmbedding.call}'s trailing reshape targets {@code input_shape[0:-1] +
+   * [input_shape[-1] * self.embedding_size]} over the unknown-rank {@code input_ids}, and the
+   * shape-vector walk soundly degrades the result's shape. The {@code float32} dtype survives that
+   * reshape ({@link #testEmbeddingOutput()}) and reaches most contexts here; the pure-⊤ member is
+   * contributed by the remaining contexts whose feed crosses ops that still lose the dtype. The
+   * {@code w} parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
    * dimensions, since {@code build}-computed head sizes also derive from the opaque {@code
-   * input_shape}.
+   * input_shape} through arithmetic the fold does not cover (wala/ML#714).
    *
    * <p>TODO: Expect static trailing dimensions here once <a
-   * href="https://github.com/wala/ML/issues/711">wala/ML#711</a> (embedding-reshape ⊤ genesis) and
-   * <a href="https://github.com/wala/ML/issues/712">wala/ML#712</a> ({@code build} {@code
-   * input_shape} opacity) are resolved.
+   * href="https://github.com/wala/ML/issues/711">wala/ML#711</a> (embedding-reshape shape ⊤) and <a
+   * href="https://github.com/wala/ML/issues/714">wala/ML#714</a> (arithmetic over {@code
+   * input_shape} subscripts) are resolved.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2245,7 +2247,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         13,
         Map.of(
             2,
-            Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE),
+            Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE, TENSOR_UNKNOWN_SHAPE_FLOAT32),
             3,
             Set.of(
                 new TensorType(
@@ -3111,7 +3113,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * that result does not propagate to the caller's {@code self.gc1(...)} local &mdash; the
    * user-subclass forward-result-typing gap (wala/ML#570, akin to <a
    * href="https://github.com/wala/ML/issues/595">wala/ML#595</a>). The decorated function's input
-   * signature, the analysis goal, is nonetheless exact.
+   * signature, the analysis goal, is nonetheless exact. The returned {@code tf.math.softmax} result
+   * counts as one more tracked variable since the {@code math.softmax} alias was wired
+   * (wala/ML#711).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -3136,7 +3140,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "GCNLayer.call",
         "gcn_proj",
         1,
-        6,
+        7,
         Map.of(3, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
@@ -3155,14 +3159,15 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * across the {@code driver→GAT→GATConv→MessagePassing} module boundaries. ({@code
    * adjacency_lists} is a Python list of edge tensors, not a tensor itself, so it is not a tensor
    * parameter.) As with {@link #testGcnCall()}, the decorated function's input signature &mdash;
-   * the analysis goal &mdash; is exact, while the internal layer-output locals stay ⊤. The four
+   * the analysis goal &mdash; is exact, while the internal layer-output locals stay ⊤. The five
    * tracked tensor variables are {@code node_embeddings} (vn=3) and the {@code dropout1} output
-   * (vn=11), both concrete {@code (4, 8) float32} (dropout preserves shape and dtype), plus the
-   * {@code gc1}/{@code gc2} attention-convolution outputs (vn=18, vn=38), both ⊤ on each axis. The
-   * layer outputs are ⊤ for the same reason as GCN: {@code GraphAttentionConvolution.call} unwraps
-   * its input from a {@code GNNInput} {@code NamedTuple} field, which is not tracked as a tensor
-   * (wala/ML#579), so the input arrives ⊤ and the attention aggregation through {@code
-   * tf.math.unsorted_segment_*} (wala/ML#570, wala/ML#582) inherits it.
+   * (vn=11), both concrete {@code (4, 8) float32} (dropout preserves shape and dtype), the {@code
+   * gc1}/{@code gc2} attention-convolution outputs (vn=18, vn=38), both ⊤ on each axis, plus the
+   * returned {@code tf.math.softmax} result, typed since the {@code math.softmax} alias was wired
+   * (wala/ML#711). The layer outputs are ⊤ for the same reason as GCN: {@code
+   * GraphAttentionConvolution.call} unwraps its input from a {@code GNNInput} {@code NamedTuple}
+   * field, which is not tracked as a tensor (wala/ML#579), so the input arrives ⊤ and the attention
+   * aggregation through {@code tf.math.unsorted_segment_*} (wala/ML#570, wala/ML#582) inherits it.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -3187,7 +3192,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "GATLayer.call",
         "gat_proj",
         1,
-        4,
+        5,
         Map.of(3, Set.of(TENSOR_4_8_FLOAT32)));
   }
 
@@ -13198,6 +13203,49 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 6))));
+  }
+
+  /**
+   * A reshape whose target is a shape-vector slice with an opaque bound (wala/ML#711): the walk
+   * cannot resolve {@code k}, so the output shape is soundly unknown, but the input's {@code
+   * float32} dtype must survive rather than degrading to full ⊤.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testReshapeOpaqueBound()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_opaque_bound.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * NLPGNN's {@code WDEmbedding} in miniature (wala/ML#711): the output reshape's target slices the
+   * unknown-arity input shape, so the walk fails and the output shape is soundly unknown, but the
+   * embedding table's {@code float32} must survive through both the {@code gather} arm and the
+   * {@code one_hot}/{@code matmul} arm.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEmbeddingOutput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_embedding_output.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -212,6 +212,8 @@
         <putfield class="LRoot" field="conv3d" fieldType="LRoot" ref="nn" value="conv3d"/>
         <new def="softmax" class="Ltensorflow/functions/softmax"/>
         <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="nn" value="softmax"/>
+        <!-- `tf.math.softmax` is the same op under the `math` namespace (wala/ML#711). -->
+        <putfield class="LRoot" field="softmax" fieldType="LRoot" ref="math" value="softmax"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
         <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/dropout. Typing-wise an identity: the output tensor has the input's shape and dtype (elements are zeroed or scaled, never reshaped or cast), so the shared `pass_through` model applies, as with `tf.nn.relu` above. Surfaced by the wala/ML#618 forward-path op audit. -->
@@ -439,6 +441,8 @@
         <putfield class="LRoot" field="Embedding" fieldType="LRoot" ref="layers" value="EmbeddingCls"/>
         <new def="DropoutLayerCls" class="Ltensorflow/keras/layers/class/Dropout"/>
         <putfield class="LRoot" field="Dropout" fieldType="LRoot" ref="layers" value="DropoutLayerCls"/>
+        <new def="LayerNormalizationLayerCls" class="Ltensorflow/keras/layers/class/LayerNormalization"/>
+        <putfield class="LRoot" field="LayerNormalization" fieldType="LRoot" ref="layers" value="LayerNormalizationLayerCls"/>
         <new def="Model" class="Ltensorflow/keras/models/class/Model"/>
         <putfield class="LRoot" field="Model" fieldType="LRoot" ref="keras" value="Model"/>
         <putfield class="LRoot" field="Model" fieldType="LRoot" ref="models" value="Model"/>
@@ -832,11 +836,12 @@
         <new def="cast" class="Ltensorflow/functions/cast"/>
         <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="cast"/>
         <putfield class="LRoot" field="cast" fieldType="LRoot" ref="dtypes" value="cast"/>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/backend. The `tf.keras.backend` module object, reached through aliases such as `import tensorflow.keras.backend as K` (wala/ML#666). The functions real subjects hit are wired to existing models: `cast` shares `tf.cast`; `equal` shares `tf.equal`; `gather` and `dropout` are typing-wise pass-throughs, mirroring `tf.gather` and `tf.nn.dropout`. -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/backend. The `tf.keras.backend` module object, reached through aliases such as `import tensorflow.keras.backend as K` (wala/ML#666). The functions real subjects hit are wired to existing models: `cast` shares `tf.cast`; `equal` shares `tf.equal`; `one_hot` shares `tf.one_hot` (wala/ML#711); `gather` and `dropout` are typing-wise pass-throughs, mirroring `tf.gather` and `tf.nn.dropout`. -->
         <new def="backend" class="Lobject"/>
         <putfield class="LRoot" field="backend" fieldType="LRoot" ref="keras" value="backend"/>
         <putfield class="LRoot" field="cast" fieldType="LRoot" ref="backend" value="cast"/>
         <putfield class="LRoot" field="equal" fieldType="LRoot" ref="backend" value="equal"/>
+        <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="backend" value="one_hot"/>
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="backend" value="pass_through"/>
         <putfield class="LRoot" field="dropout" fieldType="LRoot" ref="backend" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
@@ -2495,6 +2500,13 @@
           <return value="res"/>
         </method>
       </class>
+      <class name="LayerNormalization" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/LayerNormalization -->
+        <method name="do" descriptor="()LRoot;" numArgs="11" paramNames="self axis epsilon center scale beta_initializer gamma_initializer beta_regularizer gamma_regularizer beta_constraint gamma_constraint">
+          <new def="res" class="Ltensorflow/keras/layers/LayerNormalization"/>
+          <return value="res"/>
+        </method>
+      </class>
     </package>
     <package name="tensorflow/keras/layers">
       <!-- Declaring a `super` opts `Layer` in to being materialized as a class shell before the class hierarchy is built (wala/WALA#1957), so a source subclass such as `class MyLayer(tf.keras.layers.Layer)` resolves its base to this type instead of falling back to `object` (wala/ML#118). Shell-only: the class deliberately declares no methods, since a shell shadows same-named bypass method bodies (see the CAUTION on `tensorflow/keras/models/Model`), and no `<new>` targets it, so it is not `allocatable`. -->
@@ -2558,6 +2570,15 @@
         </method>
       </class>
       <class name="Dropout" allocatable="true">
+        <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
+          <return value="inputs"/>
+        </method>
+        <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
+          <return value="inputs"/>
+        </method>
+      </class>
+      <class name="LayerNormalization" allocatable="true">
+        <!-- Typing-wise identity: normalization preserves both shape and dtype, so the call is a genuine pass-through, mirroring `Dropout` (wala/ML#711). -->
         <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
           <return value="inputs"/>
         </method>

--- a/com.ibm.wala.cast.python.test/data/tf2_test_embedding_output.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_embedding_output.py
@@ -1,0 +1,56 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+# NLPGNN's WDEmbedding in miniature (wala/ML#711): the output reshape's target
+# slices the unknown-arity input shape, so the walk fails and the output shape
+# is soundly unknown, but the embedding table's dtype must survive through
+# both the `gather` arm and the `one_hot`/`matmul` arm.
+class WDEmbedding(tf.keras.layers.Layer):
+    def __init__(self, vocab_size, embedding_size, use_one_hot_embedding, **kwargs):
+        super(WDEmbedding, self).__init__(**kwargs)
+        self.vocab_size = vocab_size
+        self.embedding_size = embedding_size
+        self.use_one_hot_embedding = use_one_hot_embedding
+
+    def build(self, input_shape):
+        self.embedding_table = self.add_weight(
+            name="embeddings",
+            shape=[self.vocab_size, self.embedding_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_ids):
+        if input_ids.shape.ndims == 2:
+            input_ids = tf.expand_dims(input_ids, axis=[-1])
+        flat_input_ids = tf.reshape(input_ids, [-1])
+        if self.use_one_hot_embedding:
+            one_hot_input_ids = tf.keras.backend.one_hot(
+                flat_input_ids, self.vocab_size
+            )
+            output = tf.linalg.matmul(one_hot_input_ids, self.embedding_table)
+        else:
+            output = tf.gather(self.embedding_table, flat_input_ids)
+        input_shape = get_shape_list(input_ids)
+        output = tf.reshape(
+            output, input_shape[0:-1] + [input_shape[-1] * self.embedding_size]
+        )
+        return output
+
+
+layer = WDEmbedding(10, 8, False)
+ids = tf.constant([[1, 2], [3, 4]])
+out = layer(ids)
+
+assert out.shape == (2, 2, 8)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_opaque_bound.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_opaque_bound.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+# A reshape whose target is a shape-vector slice with an opaque bound
+# (wala/ML#711): the walk cannot resolve `k`, so the output shape is unknown,
+# but the input's dtype must survive.
+def f(t, k):
+    return tf.reshape(t, get_shape_list(t)[0:k])
+
+
+x = tf.ones((2, 4, 6))
+out = f(x, x.shape.ndims)
+
+assert out.shape == (2, 4, 6)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Works toward wala/ML#711 (its minimum clause) and wala/ML#704.

Three modeling gaps let the NLPGNN embedding path's dtype die even where the shape is soundly unknown:

- `tf.keras.backend.one_hot` was not wired to the existing `one_hot` model, so `WDEmbedding.call`'s one-hot arm poisoned the output φ.
- `tf.keras.layers.LayerNormalization` was unmodeled; it is a typing-wise identity, so it is modeled as a pass-through mirroring `Dropout`.
- `tf.math.softmax` was not wired (only `tf.nn.softmax` was), losing the attention-output chain that feeds `DenseLayer3dProj`.

With the three wired, the reshape machinery already preserves the value argument's dtype when the target-shape walk fails: `tf2_test_reshape_opaque_bound.py` pins the plain case and `tf2_test_embedding_output.py` pins NLPGNN's `WDEmbedding` in miniature (`{? of float32}`, not `{? of unknown}`). In vivo, the vendored `einsum_via_matmul`'s `input_tensor` now carries `float32` in twelve of its sixteen calling contexts (previously zero); the anchor pins the improved union, and the GAT/GCN guards absorb one newly typed `tf.math.softmax` result each. The remaining pure-⊤ contexts and the still-unknown shapes stay tracked by wala/ML#711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
