### PR TITLE
Fold arithmetic over shape-vector subscripts (wala/ML#714)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13220,6 +13220,66 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Bare-division guard companion of {@link #testDense3dMatmul6()} (wala/ML#714): a branch the
+   * runtime never takes stores {@code input_shape[2] / 4}, a bare float division the fold must
+   * refuse (its non-exact truncation is undefined without the {@code int(...)} wrapper), so the
+   * attribute is unresolvable and the weight's trailing dimension soundly stays dynamic.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul7()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul7.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(6), new NumericDim(3), DynamicDim.INSTANCE)))));
+  }
+
+  /**
+   * Nested-arithmetic companion of {@link #testDense3dMatmul6()} (wala/ML#714): the divisor is
+   * itself an arithmetic expression over a configuration field ({@code
+   * int(input_shape[2]/(self.num_attention_heads - 1))}), so the operand resolution recurses.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul8()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul8.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                TensorType.of(FLOAT_32, 6, 3, 3))));
+  }
+
+  /**
    * A configuration attribute as a literal concat element (wala/ML#712): the reshape target
    * concatenates a shape-vector slice with {@code [self.units]}, whose stored value is the
    * constructor argument, exercising the constant fallback of the attribute chase.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13185,6 +13185,41 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Arithmetic-over-subscript companion of {@link #testDense3dMatmul()} (wala/ML#714): {@code
+   * build} derives the head size the way NLPGNN's {@code ALBERTAttention.build} does, dividing a
+   * shape subscript by a configuration field under an {@code int(...)} wrapper ({@code
+   * self.head_size = int(input_shape[2]/self.num_attention_heads)}), so the reshaped weight's
+   * dimensions all fold.
+   *
+   * <p>TODO: Expect only {@code (6, 3, 2)} for the {@code w} parameter once <a
+   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
+   * pin path with the generator-side element folds.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dMatmul6()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_matmul6.py",
+        "einsum_via_matmul",
+        2,
+        9,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
+                TensorType.of(FLOAT_32, 6, 3, 2))));
+  }
+
+  /**
    * A configuration attribute as a literal concat element (wala/ML#712): the reshape target
    * concatenates a shape-vector slice with {@code [self.units]}, whose stored value is the
    * constructor argument, exercising the constant fallback of the attribute chase.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -103,10 +103,16 @@ public class ExpandDims extends PassThroughUnaryTensorGenerator {
     if (axisPts == null || axisPts.isEmpty()) return null;
     Set<Integer> axisValues = new HashSet<>();
     for (InstanceKey ik : axisPts) {
-      if (!(ik instanceof ConstantKey)) return null;
-      Object val = ((ConstantKey<?>) ik).getValue();
-      if (!(val instanceof Number)) return null;
-      axisValues.add(((Number) val).intValue());
+      Integer axisValue = null;
+      if (ik instanceof ConstantKey) {
+        Object val = ((ConstantKey<?>) ik).getValue();
+        if (val instanceof Number) axisValue = ((Number) val).intValue();
+      } else
+        // The list form `axis=[-1]` (as in NLPGNN's `WDEmbedding.call`): a single-element
+        // list/tuple whose only element is a constant is equivalent to the scalar (wala/ML#714).
+        axisValue = singleElementConstant(builder, ik);
+      if (axisValue == null) return null;
+      axisValues.add(axisValue);
     }
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -777,6 +777,8 @@ public abstract class TensorGenerator {
       if (folded != null) return folded;
       folded = this.resolveShapeVectorElementDim(builder, node, st, writtenVal);
       if (folded != null) return folded;
+      folded = this.resolveArithmeticOverSubscriptDim(builder, node, st, writtenVal);
+      if (folded != null) return folded;
       return this.resolveStoredAttributeDim(builder, node, writtenVal);
     }
     return null;
@@ -821,6 +823,159 @@ public abstract class TensorGenerator {
     int k = index < 0 ? dims.size() + index : index;
     if (k < 0 || k >= dims.size()) return null;
     return dims.get(k);
+  }
+
+  /**
+   * Folds an arithmetic expression whose operands may be shape-vector subscripts (e.g. {@code
+   * int(input_shape[2] / self.num_attention_heads)}, NLPGNN's {@code ALBERTAttention.build}) to a
+   * {@link NumericDim} (wala/ML#714). An {@code int(...)} builtin wrapper is peeled first; a
+   * division only folds when the wrapper marked the truncation or the division is exact, since a
+   * bare {@code /} is Python float division.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The value number of the candidate expression result.
+   * @return The folded {@link NumericDim}, or {@code null} when the expression doesn't resolve.
+   */
+  private Dimension<?> resolveArithmeticOverSubscriptDim(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
+    if (vn <= 0 || node.getDU() == null) return null;
+    int peeled = peelIntBuiltin(builder, node, vn);
+    boolean truncated = peeled != vn;
+    SSAInstruction def = node.getDU().getDef(peeled);
+
+    if (def instanceof SSABinaryOpInstruction) {
+      SSABinaryOpInstruction binOp = (SSABinaryOpInstruction) def;
+      Integer left = this.scalarOperandOrNull(builder, node, st, binOp.getUse(0));
+      if (left == null) return null;
+      Integer right = this.scalarOperandOrNull(builder, node, st, binOp.getUse(1));
+      if (right == null) return null;
+      if (binOp.getOperator() == IBinaryOpInstruction.Operator.DIV
+          && !truncated
+          && (right == 0 || left % right != 0)) return null; // Non-exact bare float division.
+      Integer value = TensorType.applyIntBinOp(binOp.getOperator(), left, right);
+      return value == null ? null : new NumericDim(value);
+    }
+
+    // A bare int(x) wrapper over a directly resolvable scalar.
+    if (truncated) {
+      Dimension<?> dim = this.resolveShapeVectorElementDim(builder, node, st, peeled);
+      if (dim != null) return dim;
+      return this.prodOfShapeVectorDim(builder, node, st, peeled);
+    }
+    return null;
+  }
+
+  /**
+   * Resolves an arithmetic operand to a constant integer: a points-to constant, a numeric
+   * shape-vector subscript, an {@code np.prod} fold, or a nested arithmetic expression
+   * (wala/ML#714).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The operand's value number.
+   * @return The operand's integer value, or {@code null} when it doesn't resolve.
+   */
+  private Integer scalarOperandOrNull(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
+    int peeled = peelIntBuiltin(builder, node, vn);
+    Integer constant = constantIntValueOrSentinel(builder, node, st, peeled);
+    if (constant != null && !Objects.equals(constant, UNRESOLVED_BOUND)) return constant;
+    Dimension<?> dim = this.resolveShapeVectorElementDim(builder, node, st, peeled);
+    if (dim == null) dim = this.prodOfShapeVectorDim(builder, node, st, peeled);
+    if (dim == null) dim = this.resolveArithmeticOverSubscriptDim(builder, node, st, peeled);
+    return dim instanceof NumericDim ? ((NumericDim) dim).value() : null;
+  }
+
+  /**
+   * Resolves a single-element list/tuple allocation to its constant integer element (e.g. the
+   * {@code axis=[-1]} form of {@code tf.expand_dims}, as in NLPGNN's {@code WDEmbedding.call}).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for PA lookup.
+   * @param ik The candidate container {@link InstanceKey}.
+   * @return The single element's constant value, or {@code null} when the key isn't a
+   *     single-element list/tuple allocation of a resolvable constant (wala/ML#714).
+   */
+  protected static Integer singleElementConstant(
+      PropagationCallGraphBuilder builder, InstanceKey ik) {
+    AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+    if (asin == null) return null;
+    TypeReference type = asin.getSite().getDeclaredType();
+    if (!type.equals(list) && !type.equals(tuple)) return null;
+    CGNode node = asin.getNode();
+    if (node.getIR() == null || node.getDU() == null) return null;
+    SSANewInstruction alloc = node.getIR().getNew(asin.getSite());
+    if (alloc == null) return null;
+    int containerVn = alloc.getDef();
+    SymbolTable st = node.getIR().getSymbolTable();
+    Integer element = null;
+    for (Iterator<SSAInstruction> uses = node.getDU().getUses(containerVn); uses.hasNext(); ) {
+      SSAInstruction use = uses.next();
+      int writtenVal;
+      Integer index = null;
+      if (use instanceof PythonPropertyWrite) {
+        PythonPropertyWrite write = (PythonPropertyWrite) use;
+        if (write.getObjectRef() != containerVn) continue;
+        int memberVn = write.getMemberRef();
+        if (st.isNumberConstant(memberVn))
+          index = ((Number) st.getConstantValue(memberVn)).intValue();
+        else if (st.isStringConstant(memberVn)) {
+          try {
+            index = Integer.parseInt(st.getStringValue(memberVn));
+          } catch (NumberFormatException e) {
+            continue;
+          }
+        }
+        writtenVal = write.getValue();
+      } else if (use instanceof SSAPutInstruction && !((SSAPutInstruction) use).isStatic()) {
+        SSAPutInstruction put = (SSAPutInstruction) use;
+        if (put.getRef() != containerVn) continue;
+        try {
+          index = Integer.parseInt(put.getDeclaredField().getName().toString());
+        } catch (NumberFormatException e) {
+          continue;
+        }
+        writtenVal = put.getVal();
+      } else continue;
+      if (index == null) continue;
+      if (index != 0 || element != null) return null; // Not a single-element container.
+      Integer constant = constantIntValueOrSentinel(builder, node, st, writtenVal);
+      if (constant == null || Objects.equals(constant, UNRESOLVED_BOUND)) return null;
+      element = constant;
+    }
+    return element;
+  }
+
+  /**
+   * Peels an {@code int(...)} builtin wrapper: for an invoke of the {@code int} builtin with a
+   * single positional argument, returns the argument's value number; otherwise returns {@code vn}
+   * unchanged (wala/ML#714).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the target.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to peel.
+   * @return The wrapped argument's value number, or {@code vn} when it isn't an {@code int(x)}
+   *     call.
+   */
+  private static int peelIntBuiltin(PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    if (vn <= 0 || node.getDU() == null) return vn;
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (!(def instanceof PythonInvokeInstruction)) return vn;
+    PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
+    if (invoke.getNumberOfUses() != 2) return vn; // Exactly `int(x)`: the callable plus one arg.
+    Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+    if (targets == null || targets.isEmpty()) return vn;
+    for (CGNode target : targets)
+      if (!target
+          .getMethod()
+          .getDeclaringClass()
+          .getReference()
+          .getName()
+          .toString()
+          .equals("Lwala/builtin/int")) return vn;
+    return invoke.getUse(1);
   }
 
   /**
@@ -951,6 +1106,8 @@ public abstract class TensorGenerator {
         if (stored == null) stored = this.prodOfShapeVectorDim(builder, candidate, st, storedVn);
         if (stored == null)
           stored = this.resolveShapeVectorElementDim(builder, candidate, st, storedVn);
+        if (stored == null)
+          stored = this.resolveArithmeticOverSubscriptDim(builder, candidate, st, storedVn);
         if (stored == null) {
           Integer constant = constantIntValueOrSentinel(builder, candidate, st, storedVn);
           if (constant != null && !Objects.equals(constant, UNRESOLVED_BOUND))
@@ -3360,6 +3517,8 @@ public abstract class TensorGenerator {
     if (prod != null) return prod;
     Dimension<?> subscript = this.resolveShapeVectorElementDim(builder, node, st, vn);
     if (subscript != null) return subscript;
+    Dimension<?> arithmetic = this.resolveArithmeticOverSubscriptDim(builder, node, st, vn);
+    if (arithmetic != null) return arithmetic;
     Dimension<?> attribute = this.resolveStoredAttributeDim(builder, node, vn);
     if (attribute != null) return attribute;
     Integer constant = constantIntValueOrSentinel(builder, node, st, vn);

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul6.py
@@ -40,7 +40,7 @@ class DenseLayer3d(tf.keras.layers.Layer):
         self.num_attention_heads = num_attention_heads
 
     def build(self, input_shape):
-        self.hidden_size = input_shape[2]
+        self.hidden_size = int(input_shape[2])
         self.head_size = int(input_shape[2] / self.num_attention_heads)
         self.w = self.add_weight(
             name="kernel",

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul6.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul6.py
@@ -1,0 +1,66 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 2)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Arithmetic-over-subscript variant of tf2_test_dense3d_matmul.py (wala/ML#714):
+# `build` derives the head size from the input shape the way NLPGNN's
+# `ALBERTAttention.build` does, dividing a shape subscript by a configuration
+# field under an `int(...)` wrapper.
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[2]
+        self.head_size = int(input_shape[2] / self.num_attention_heads)
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 2)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul7.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul7.py
@@ -1,0 +1,70 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 2)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Bare-division guard variant of tf2_test_dense3d_matmul6.py (wala/ML#714): the
+# untaken branch stores a bare float division, which the fold must refuse,
+# making the attribute unresolvable and the weight dimension dynamic.
+
+
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+
+    def build(self, input_shape):
+        self.hidden_size = int(input_shape[2])
+        if input_shape[2] % self.num_attention_heads == 0:
+            self.head_size = int(input_shape[2] / self.num_attention_heads)
+        else:
+            self.head_size = input_shape[2] / 4
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 2)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul8.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_matmul8.py
@@ -1,0 +1,67 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def einsum_via_matmul(input_tensor, w, num_inner_dims):
+    assert input_tensor.shape == (2, 4, 6)
+    assert w.shape == (6, 3, 3)
+    input_shape = get_shape_list(input_tensor)
+    w_shape = get_shape_list(w)
+    batch_dims = input_shape[:-num_inner_dims]
+    inner_dims = input_shape[-num_inner_dims:]
+    outer_dims = w_shape[num_inner_dims:]
+    inner_dim = np.prod(inner_dims)
+    outer_dim = np.prod(outer_dims)
+    if num_inner_dims > 1:
+        input_tensor = tf.reshape(input_tensor, batch_dims + [inner_dim])
+    if len(w_shape) > 2:
+        w = tf.reshape(w, [inner_dim, outer_dim])
+    ret = tf.matmul(input_tensor, w)
+    if len(outer_dims) > 1:
+        ret = tf.reshape(ret, batch_dims + outer_dims)
+    return ret
+
+
+# Nested-arithmetic variant of tf2_test_dense3d_matmul6.py (wala/ML#714): the
+# divisor is itself an arithmetic expression over a configuration field, so
+# the operand resolution recurses.
+
+
+class DenseLayer3d(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, **kwargs):
+        super(DenseLayer3d, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+
+    def build(self, input_shape):
+        self.hidden_size = int(input_shape[2])
+        self.head_size = int(input_shape[2] / (self.num_attention_heads - 1))
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.hidden_size, self.num_attention_heads, self.head_size]
+        )
+        return einsum_via_matmul(input_tensor, w, 1)
+
+
+layer = DenseLayer3d(3)
+x = tf.ones((2, 4, 6))
+out = layer(x)
+
+assert out.shape == (2, 4, 3, 3)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Closes wala/ML#714.

`resolveArithmeticOverSubscriptDim` folds an arithmetic expression whose operands may be shape-vector subscripts, peeling an `int(...)` builtin wrapper first; a division only folds when the wrapper marked the truncation or the division is exact, since a bare `/` is Python float division. The fold is wired into the stored-attribute chase, the walk-side element fold, and the shape-argument element fold, so NLPGNN's `ALBERTAttention.build` idiom `size_per_head = int(input_shape[2]/self.num_attention_heads)` resolves; `tf2_test_dense3d_matmul6.py` pins it with the reshaped weight folding to `(6, 3, 2)`.

The new fold surfaced two adjacent items:

- `ExpandDims` could not resolve NLPGNN's list-valued `axis=[-1]` form, leaving the expansion's shape unresolvable; a single-element list/tuple whose element is a constant now unwraps to the scalar. Without this, the fold composed a wrong `(2, 16)` for the wala/ML#711 embedding fixture because the unresolvable φ member silently vanished from the shape union.
- That silent-drop union semantics is a latent pre-existing soundness gap independent of this change, filed as wala/ML#716 with the witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
