### PR TITLE
Re-baseline the diagnostic-volume guard to 4 GB (wala/ML#715)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
@@ -25,13 +25,15 @@ public class DiagnosticLoggingVolumeTest {
    * com.ibm.wala.cast.python} logger at {@code FINEST}, routing records through {@link
    * DiscardingFormattingHandler}, which formats and discards them while summing their volume.
    *
-   * <p>Correct code renders diagnostics through the bounded {@code Loggables.describe(...)} (~0.6
-   * GB of formatted {@code FINEST} output for this analysis); a bare render of a {@code
-   * Context}-bearing value inflates that by more than an order of magnitude (~14 GB measured),
-   * which this bound catches. The failure is invisible at CI's {@code WARNING} level (the message
-   * strings are never built), so this test is the pipeline's guard against its return. See {@code
-   * CONTRIBUTING.md}'s Diagnostic Logging section and <a
-   * href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992</a> for the upstream root cause.
+   * <p>Correct code renders diagnostics through the bounded {@code Loggables.describe(...)} (~2.2
+   * GB of formatted {@code FINEST} output for this analysis as of wala/ML#714; ~0.6 GB at the
+   * wala/ML#697 calibration); a bare render of a {@code Context}-bearing value inflates that by an
+   * order of magnitude (~14 GB measured), which this bound catches. The failure is invisible at
+   * CI's {@code WARNING} level (the message strings are never built), so this test is the
+   * pipeline's guard against its return. See {@code CONTRIBUTING.md}'s Diagnostic Logging section,
+   * <a href="https://github.com/wala/WALA/issues/1992">wala/WALA#1992</a> for the upstream root
+   * cause, and <a href="https://github.com/wala/ML/issues/715">wala/ML#715</a> for the
+   * re-baselining.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -41,9 +43,13 @@ public class DiagnosticLoggingVolumeTest {
   @Test
   public void testDiagnosticLoggingVolumeBounded()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // Fixed code emits ~0.6 GB of formatted FINEST volume for this analysis; a bare `Context`
-    // render measured ~14 GB. 2 GB sits well above the former and far below the latter.
-    final long maxFormattedChars = 2_000_000_000L;
+    // Fixed code emitted ~0.6 GB of formatted FINEST volume for this analysis when the guard was
+    // calibrated (wala/ML#697, July 8); the shape-provenance machinery merged since (wala/ML#703
+    // through wala/ML#714) organically grew that to ~2.2 GB measured in-suite on a clean master,
+    // with run-to-run variance around the old 2 GB bound (wala/ML#715). A bare `Context` render,
+    // the failure mode this guard exists to catch, measured ~14 GB. 4 GB sits well above the
+    // organic level and still far below the failure mode.
+    final long maxFormattedChars = 4_000_000_000L;
 
     Logger pkg = Logger.getLogger("com.ibm.wala.cast.python");
     DiscardingFormattingHandler handler = new DiscardingFormattingHandler();


### PR DESCRIPTION
Closes wala/ML#715.

The wala/ML#697 calibration measured ~0.6 GB of formatted `FINEST` volume for the nlpgnn generation analysis; the shape-provenance machinery merged since (wala/ML#703 through wala/ML#714) organically grew that to ~2.2 GB in-suite on a clean master, flaking around the old 2 GB bound while passing standalone and on CI. The re-baselined 4 GB bound sits well above the organic level and still an order of magnitude below the ~14 GB bare-`Context` render the guard exists to catch; the calibration comments now record both measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
