### PR TITLE
Merge the generator-side type into the literal-shape pin (wala/ML#713)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestMNISTExamples.java
@@ -124,7 +124,7 @@ public class TestMNISTExamples extends TestPythonMLCallGraphShape {
               cgBuilder.getPointerAnalysis(),
               CG);
 
-          String in = "[{[D:Symbolic,?, D:Constant,784] of " + FLOAT32.name().toLowerCase() + "}]";
+          String in = "[{[D:Dynamic, D:Constant,784] of " + FLOAT32.name().toLowerCase() + "}]";
           String out =
               "[{[D:Symbolic,?, D:Constant,28, D:Constant,28, D:Constant,1] of "
                   + FLOAT32.name().toLowerCase()
@@ -264,7 +264,7 @@ public class TestMNISTExamples extends TestPythonMLCallGraphShape {
     checkTensorOps(
         Ex5URL,
         (PropagationCallGraphBuilder cgBuilder, CallGraph CG, TensorTypeAnalysis result) -> {
-          String in = "[{[D:Symbolic,?, D:Constant,784] of " + FLOAT32.name().toLowerCase() + "}]";
+          String in = "[{[D:Dynamic, D:Constant,784] of " + FLOAT32.name().toLowerCase() + "}]";
           String out =
               "[{[D:Symbolic,?, D:Constant,28, D:Constant,28, D:Constant,1] of "
                   + FLOAT32.name().toLowerCase()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5418,9 +5418,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(
                 new TensorType(
                     UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(100))),
-                new TensorType(
-                    UNKNOWN,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
                 TensorType.of(INT_32, 2, 2))));
   }
 
@@ -5485,10 +5482,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(
                 new TensorType(
                     UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
-                TENSOR_UNKNOWN_SHAPE_FLOAT32,
-                new TensorType(
-                    UNKNOWN,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+                TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**
@@ -5764,9 +5758,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(
                 new TensorType(
                     UNKNOWN, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(100))),
-                new TensorType(
-                    UNKNOWN,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
                 TensorType.of(INT_32, 2, 2))));
   }
 
@@ -11081,10 +11072,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(
                 TensorType.of(FLOAT_32, 2, 3, 8),
                 new TensorType(
-                    INT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
-                new TensorType(
                     INT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))))));
   }
 
   /**
@@ -11270,9 +11259,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(
                 TENSOR_UNKNOWN_SHAPE_FLOAT32,
-                new TensorType(
-                    UNKNOWN,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
                 new TensorType(
                     UNKNOWN,
                     asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))))));
@@ -13014,15 +13000,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Composition of {@link #testDense3dEinsum()} and {@link #testEinsumViaMatmul()} (wala/ML#704):
    * NLPGNN's {@code DenseLayer3d.call} delegates to the module-level {@code einsum_via_matmul}
    * helper. The {@code input_tensor} parameter carries the precise type across the layer-call
-   * boundary, and the {@code w} parameter's generator-side member is fully static: the trailing
-   * dimensions are the folded configuration fields and the leading (hidden) dimension resolves
-   * through {@code build}'s {@code input_shape} subscript ({@code self.hidden_size =
-   * input_shape[2]}, wala/ML#712). The all-symbolic member is the legacy literal-shape pin ({@code
-   * TensorType.shapeArg}), which folds neither field reads nor {@code build} subscripts.
-   *
-   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
-   * pin path with the generator-side element folds.
+   * boundary, and the {@code w} parameter is fully static: the trailing dimensions are the folded
+   * configuration fields, the leading (hidden) dimension resolves through {@code build}'s {@code
+   * input_shape} subscript ({@code self.hidden_size = input_shape[2]}, wala/ML#712), and the
+   * literal-shape pin agrees with the generator-side result (wala/ML#713), so the union is a single
+   * member.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13041,11 +13023,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 5))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**
@@ -13056,10 +13034,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * precise type through both hops, and the {@code w} parameter resolves exactly as in the one-hop
    * composition, including the hidden dimension through {@code build}'s {@code input_shape}
    * subscript (wala/ML#712).
-   *
-   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
-   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13078,21 +13052,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 5))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**
    * Negative-index companion of {@link #testDense3dMatmul()} (wala/ML#712): {@code build} stores
    * {@code input_shape[-1]}, exercising the Python negative-index arm of the shape-vector subscript
    * resolution.
-   *
-   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
-   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13111,11 +13077,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 5))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**
@@ -13123,10 +13085,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * calls {@code layer.build(x.shape)} before the layer call, so the {@code input_shape} parameter
    * also receives a real argument, exercising the explicit-caller arm of the walk alongside the
    * lazy-build trampoline hop.
-   *
-   * <p>TODO: Expect only {@code (6, 3, 5)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
-   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13145,11 +13103,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 5))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 5))));
   }
 
   /**
@@ -13178,9 +13132,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             3,
             Set.of(
                 new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                new TensorType(
                     FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(5))))));
   }
 
@@ -13190,10 +13141,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * shape subscript by a configuration field under an {@code int(...)} wrapper ({@code
    * self.head_size = int(input_shape[2]/self.num_attention_heads)}), so the reshaped weight's
    * dimensions all fold.
-   *
-   * <p>TODO: Expect only {@code (6, 3, 2)} for the {@code w} parameter once <a
-   * href="https://github.com/wala/ML/issues/713">wala/ML#713</a> reconciles the {@code shapeArg}
-   * pin path with the generator-side element folds.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13212,11 +13159,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 2))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 2))));
   }
 
   /**
@@ -13244,9 +13187,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             3,
             Set.of(
                 new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                new TensorType(
                     FLOAT_32, asList(new NumericDim(6), new NumericDim(3), DynamicDim.INSTANCE)))));
   }
 
@@ -13272,11 +13212,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
             3,
-            Set.of(
-                new TensorType(
-                    FLOAT_32,
-                    asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))),
-                TensorType.of(FLOAT_32, 6, 3, 3))));
+            Set.of(TensorType.of(FLOAT_32, 6, 3, 3))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -20,6 +20,10 @@ import com.ibm.wala.cast.python.ipa.callgraph.TrampolineReceiverContextSelector;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.cast.python.types.PythonTypes;
@@ -66,6 +70,7 @@ import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -910,6 +915,55 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     }
   }
 
+  /**
+   * Pointwise merge of the two literal-shape pin candidates (wala/ML#713): the generator-side type
+   * and the {@code TensorType.shapeArg} type approximate the same shape, so each dimension takes
+   * the more useful of the two. Numeric wins, and disagreeing numeric dimensions degrade to dynamic
+   * rather than trusting either. Between the unresolved kinds, symbolic wins over dynamic only when
+   * the generator resolved no numeric dimension at all: {@code SetShapeOp}'s reshape transfer later
+   * fills a lone symbolic dimension from the input's element count (the {@code np.prod(...,
+   * axis=0)} pin owes its precision to that), whereas when the generator did resolve structure, its
+   * seeded member already carries it and a symbolic-flavored pin would only add a duplicate union
+   * member. An unknown-rank generator result yields the {@code shapeArg} type, a rank mismatch
+   * yields the generator type, and the cell type prefers the generator's unless it is unknown.
+   *
+   * @param generatorType The generator-side pin candidate.
+   * @param shapeArgType The {@code shapeArg} pin candidate.
+   * @return The merged pin type.
+   */
+  private static TensorType mergePinnedTypes(TensorType generatorType, TensorType shapeArgType) {
+    LOGGER.fine(
+        () -> "mergePinnedTypes: generator=" + generatorType + ", shapeArg=" + shapeArgType);
+    List<Dimension<?>> generatorDims = generatorType.getDims();
+    List<Dimension<?>> shapeArgDims = shapeArgType.getDims();
+    if (generatorDims == null) return shapeArgType;
+    if (shapeArgDims == null || shapeArgDims.size() != generatorDims.size()) return generatorType;
+
+    boolean generatorHasNumeric = generatorDims.stream().anyMatch(d -> d instanceof NumericDim);
+    List<Dimension<?>> merged = new ArrayList<>(generatorDims.size());
+    for (int i = 0; i < generatorDims.size(); i++) {
+      Dimension<?> fromGenerator = generatorDims.get(i);
+      Dimension<?> fromShapeArg = shapeArgDims.get(i);
+      if (fromGenerator instanceof NumericDim && fromShapeArg instanceof NumericDim)
+        merged.add(fromGenerator.equals(fromShapeArg) ? fromGenerator : DynamicDim.INSTANCE);
+      else if (fromGenerator instanceof NumericDim) merged.add(fromGenerator);
+      else if (fromShapeArg instanceof NumericDim) merged.add(fromShapeArg);
+      else if (!generatorHasNumeric && fromShapeArg instanceof SymbolicDim)
+        merged.add(fromShapeArg);
+      else merged.add(fromGenerator);
+    }
+
+    String cellType =
+        generatorType.getCellType() == null
+                || TensorFlowTypes.DType.UNKNOWN
+                    .name()
+                    .toLowerCase(java.util.Locale.ROOT)
+                    .equals(generatorType.getCellType())
+            ? shapeArgType.getCellType()
+            : generatorType.getCellType();
+    return new TensorType(cellType, merged);
+  }
+
   private Map<PointsToSetVariable, TensorType> getShapeSourceCalls(
       MethodReference op, PropagationCallGraphBuilder builder, int param) {
     Map<PointsToSetVariable, TensorType> targets = HashMapFactory.make();
@@ -939,12 +993,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                             .getNewSite()
                             .getDeclaredType()
                             .equals(PythonTypes.tuple));
-            TensorType pinned =
-                literalContainer
-                    ? TensorType.shapeArg(src, shapeVn, builder)
-                    : new TensorType(
-                        TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),
-                        null);
             PointerKey defKey =
                 builder
                     .getPointerAnalysis()
@@ -953,8 +1001,30 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // Materializing an implicitly-represented key would make WALA dump the entire call
             // graph's IR (an unconditional debug print), so skip it; implicit keys carry no
             // explicit dataflow variable to pin (wala/ML#573).
-            if (!builder.getPropagationSystem().isImplicit(defKey))
-              targets.put(builder.getPropagationSystem().findOrCreatePointsToSet(defKey), pinned);
+            if (builder.getPropagationSystem().isImplicit(defKey)) return;
+            PointsToSetVariable defVariable =
+                builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
+            TensorType pinned = null;
+            if (literalContainer) {
+              // Merge the generator-side computation into the pinned type so the pin agrees with
+              // the seeded result instead of contributing a weaker parallel member (wala/ML#713).
+              // Neither path subsumes the other: `shapeArg` folds literal source text through the
+              // embedded interpreter (e.g. an `np.prod(..., axis=0)` the provenance walk refuses),
+              // while the generator side also resolves field reads, shape-vector subscripts, and
+              // `build`-computed attributes; the pointwise merge keeps the more precise dimension
+              // from each.
+              TensorType shapeArgType = TensorType.shapeArg(src, shapeVn, builder);
+              Set<TensorType> generatorTypes = this.getTensorTypes(defVariable, builder);
+              pinned =
+                  generatorTypes != null && generatorTypes.size() == 1
+                      ? mergePinnedTypes(generatorTypes.iterator().next(), shapeArgType)
+                      : shapeArgType;
+            } else
+              pinned =
+                  new TensorType(
+                      TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),
+                      null);
+            targets.put(defVariable, pinned);
           }
         });
     return targets;


### PR DESCRIPTION
Closes wala/ML#713.

The literal-shape pin (`getShapeSourceCalls`) now merges the generator-side type into its pinned type instead of pinning `TensorType.shapeArg`'s weaker result as a parallel union member. The merge is pointwise: a numeric dimension wins, disagreeing numerics degrade to dynamic, and between the unresolved kinds the `shapeArg` side's symbolic flavor is kept only when the generator resolved no numeric dimension at all, because `SetShapeOp`'s reshape transfer later fills a lone symbolic dimension from the input's element count (`testShapeProdAxis`'s precise `(30,)` owes its existence to exactly that, which is also why generator-first-without-merge regressed it).

The `w`-parameter unions across the `tf2_test_dense3d_matmul*` family collapse to their single precise members, the two guard fixtures keep their sound dynamic dimensions, and the vendored GPT-2/collection-probe unions each lose their all-symbolic member; the corresponding capture-observed expectations are tightened and the delivered wala/ML#713 TODOs removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
