### PR TITLE
Model `tf.split` with a quotient-shape generator (wala/ML#717)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3699,6 +3699,31 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins the output shape of {@code tf.split} with an integer count (wala/ML#717): {@code
+   * tf.split(x, 3, 0)} over a {@code (3, 8, 100)} tensor unpacks to pieces of the quotient shape
+   * {@code (1, 8, 100)}, NLPGNN's ALBERT entry idiom in miniature.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSplit()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_split.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(1), new NumericDim(8), new NumericDim(100))))));
+  }
+
+  /**
    * Pins the output shape of {@code tf.squeeze} with no axis (wala/ML#513). {@code tf.squeeze(x)}
    * over a {@code (2, 1, 3, 1)} tensor drops every statically size-1 axis: {@code (2, 3)}.
    *

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3724,6 +3724,68 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * The absent-axis default of {@code tf.split} (wala/ML#717): {@code tf.split(x, 2)} over {@code
+   * (4, 6)} splits on axis 0, giving pieces of {@code (2, 6)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSplitDefaultAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_split.py",
+        "consume_default_axis",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 6))));
+  }
+
+  /**
+   * The size-list arm of {@code tf.split} (wala/ML#717): {@code tf.split(x, [1, 3], 0)} produces
+   * differently-shaped pieces, which the single-piece model soundly represents with a dynamic
+   * dimension at the axis; the other dimension still transfers.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSplitSizeList()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_split.py",
+        "consume_size_list",
+        1,
+        1,
+        Map.of(
+            2, Set.of(new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(6))))));
+  }
+
+  /**
+   * The non-constant-axis guard of {@code tf.split} (wala/ML#717): an opaque {@code axis} leaves
+   * the output shape soundly unknown while the dtype still inherits from {@code value}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSplitOpaqueAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_split.py",
+        "consume_opaque_axis",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
    * Pins the output shape of {@code tf.squeeze} with no axis (wala/ML#513). {@code tf.squeeze(x)}
    * over a {@code (2, 1, 3, 1)} tensor drops every statically size-1 axis: {@code (2, 3)}.
    *

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1922,13 +1922,14 @@
         </method>
       </class>
       <class name="split" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
-          <new def="x" class="Llist"/>
-          <new def="z" class="Ltensorflow/functions/constant"/>
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y"/>
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
-          <return value="x"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split. Returns a list of same-shaped pieces for an integer `num_or_size_splits`, so one fresh tensor stands for every piece; the `Split` generator computes the quotient shape and inherits the dtype from `value` (wala/ML#717). The piece is written to the first three indices to cover the common unpacking arities (NLPGNN's `a, b, c = tf.split(x, 3, 0)`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self value num_or_size_splits axis num name">
+          <new def="lst" class="Llist"/>
+          <new def="piece" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="lst" value="piece"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="lst" value="piece"/>
+          <putfield class="LRoot" field="2" fieldType="LRoot" ref="lst" value="piece"/>
+          <return value="lst"/>
         </method>
       </class>
       <class name="rank" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
@@ -1,0 +1,129 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code tf.split(value, num_or_size_splits, axis=0, ...)} with an integer {@code
+ * num_or_size_splits}: every piece has the {@code value} shape with the {@code axis} dimension
+ * divided by the split count, so the single modeled piece stands for all of them. Output dtype is
+ * inherited from {@code value}. A size-list {@code num_or_size_splits} produces differently-shaped
+ * pieces the single-piece model cannot represent, and a non-constant count or axis leaves the
+ * quotient unknown; in those cases the axis dimension degrades to dynamic (rank and the other
+ * dimensions still transfer) or, without a resolvable input shape, the result is ⊤. See <a
+ * href="https://github.com/wala/ML/issues/717">wala/ML#717</a>.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/split">tf.split</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Split extends PassThroughUnaryTensorGenerator {
+
+  private static final Logger LOGGER = Logger.getLogger(Split.class.getName());
+
+  public Split(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Split(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "value";
+  }
+
+  /**
+   * Derives each piece's shape from the {@code value} (arg 0) shape: the {@code axis} (arg 2,
+   * default 0) dimension is divided by the integer {@code num_or_size_splits} (arg 1); the other
+   * dimensions transfer unchanged.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible piece shapes, or {@code null} (⊤) when the {@code value} shape is
+   *     unknown or the {@code axis} is out of the shape's range.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = super.getDefaultShapes(builder);
+    if (inputShapes == null) return null;
+
+    Integer count = constantIntArgOrNull(builder, 1, "num_or_size_splits");
+    Integer axisArg = constantIntArgOrNull(builder, 2, "axis");
+
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> input : inputShapes) {
+      int rank = input.size();
+      if (rank == 0) return null; // Splitting a scalar is a runtime error.
+      Integer axis = axisArg;
+      if (axis == null) {
+        OrdinalSet<InstanceKey> axisPts = this.getArgumentPointsToSet(builder, 2, "axis");
+        // An absent axis defaults to 0; a present but non-constant one is unknown.
+        if (axisPts != null && !axisPts.isEmpty()) {
+          LOGGER.fine(
+              () -> "Non-constant axis for " + describe(this.getSource()) + "; returning ⊤.");
+          return null;
+        }
+        axis = 0;
+      }
+      int normalized = axis < 0 ? axis + rank : axis;
+      if (normalized < 0 || normalized >= rank) return null;
+
+      List<Dimension<?>> out = new ArrayList<>(input);
+      Dimension<?> axisDim = input.get(normalized);
+      if (count != null
+          && axisDim instanceof NumericDim
+          && count > 0
+          && ((NumericDim) axisDim).value() % count == 0)
+        out.set(normalized, new NumericDim(((NumericDim) axisDim).value() / count));
+      // A size-list split, a non-constant count, a non-numeric axis dimension, or a non-exact
+      // division: the quotient is unknown, but the rank and the other dimensions still hold.
+      else out.set(normalized, DynamicDim.INSTANCE);
+      ret.add(out);
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Resolves an argument to a constant integer via its points-to set.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} providing the pointer analysis.
+   * @param paramPos The argument's positional index, excluding {@code self}.
+   * @param paramName The argument's keyword name.
+   * @return The constant value, or {@code null} when the argument is absent, non-constant, or not
+   *     an integer.
+   */
+  private Integer constantIntArgOrNull(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPos, paramName);
+    if (pts == null || pts.isEmpty()) return null;
+    Integer found = null;
+    for (InstanceKey ik : pts) {
+      if (!(ik instanceof ConstantKey)) return null;
+      Object value = ((ConstantKey<?>) ik).getValue();
+      if (!(value instanceof Number)) return null;
+      int intValue = ((Number) value).intValue();
+      if (found != null && found != intValue) return null; // Ambiguous.
+      found = intValue;
+    }
+    return found;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
@@ -5,12 +5,15 @@ import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,23 +70,23 @@ public class Split extends PassThroughUnaryTensorGenerator {
     if (inputShapes == null) return null;
 
     Integer count = constantIntArgOrNull(builder, 1, "num_or_size_splits");
-    Integer axisArg = constantIntArgOrNull(builder, 2, "axis");
+
+    // An absent axis defaults to 0; a passed one must resolve to a constant, since an empty
+    // points-to set on a passed argument means a computed value (the PA does not fold
+    // arithmetic), not an absent one, and assuming 0 for it would be unsound.
+    Integer axis;
+    if (isAxisPassed(builder)) {
+      axis = constantIntArgOrNull(builder, 2, "axis");
+      if (axis == null) {
+        LOGGER.fine(() -> "Non-constant axis for " + describe(this.getSource()) + "; returning ⊤.");
+        return null;
+      }
+    } else axis = 0;
 
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     for (List<Dimension<?>> input : inputShapes) {
       int rank = input.size();
       if (rank == 0) return null; // Splitting a scalar is a runtime error.
-      Integer axis = axisArg;
-      if (axis == null) {
-        OrdinalSet<InstanceKey> axisPts = this.getArgumentPointsToSet(builder, 2, "axis");
-        // An absent axis defaults to 0; a present but non-constant one is unknown.
-        if (axisPts != null && !axisPts.isEmpty()) {
-          LOGGER.fine(
-              () -> "Non-constant axis for " + describe(this.getSource()) + "; returning ⊤.");
-          return null;
-        }
-        axis = 0;
-      }
       int normalized = axis < 0 ? axis + rank : axis;
       if (normalized < 0 || normalized >= rank) return null;
 
@@ -100,6 +103,27 @@ public class Split extends PassThroughUnaryTensorGenerator {
       ret.add(out);
     }
     return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Whether the {@code axis} argument is passed at the call site, positionally (a fourth use beyond
+   * the callable, {@code value}, and {@code num_or_size_splits}) or as a resolvable keyword. A
+   * keyword-passed <em>computed</em> axis is indistinguishable from an absent one here and is
+   * treated as absent.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @return {@code true} iff some call site passes {@code axis}.
+   */
+  private boolean isAxisPassed(PropagationCallGraphBuilder builder) {
+    PythonInvokeInstruction call = getInvokeInstruction();
+    if (call != null) return call.getNumberOfPositionalParameters() > 3;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode()))
+      if (callerInvoke.snd instanceof PythonInvokeInstruction
+          && ((PythonInvokeInstruction) callerInvoke.snd).getNumberOfPositionalParameters() > 3)
+        return true;
+    OrdinalSet<InstanceKey> keywordPts = this.getArgumentPointsToSet(builder, 2, "axis");
+    return keywordPts != null && !keywordPts.isEmpty();
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4497,7 +4497,9 @@ public abstract class TensorGenerator {
 
     LOGGER.fine("createManualGenerator checking sanitized type: " + type.getName());
 
-    if (type.equals(TensorFlowTypes.ONES.getDeclaringClass())) {
+    if (type.equals(TensorFlowTypes.SPLIT.getDeclaringClass())) {
+      return new Split(node);
+    } else if (type.equals(TensorFlowTypes.ONES.getDeclaringClass())) {
       return new Ones(node);
     } else if (type.equals(TensorFlowTypes.ZEROS.getDeclaringClass())) {
       return new Zeros(node);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -176,6 +176,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_FROM_DENS
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPARSE_TO_DENSE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SPLIT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQRT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUARE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.SQUEEZE;
@@ -1166,6 +1167,11 @@ public class TensorGeneratorFactory {
           }
         }
 
+        // `tf.split` returns a list of same-shaped pieces, and its generator is defined to
+        // describe one piece, so a subscript of the result is the piece itself; the generic
+        // `TensorElementGenerator` fallthrough would peel a real dimension (wala/ML#717).
+        if (effectiveGenerator instanceof Split) return effectiveGenerator;
+
         if (containerGenerator instanceof TensorElementGenerator
             && ((TensorElementGenerator) containerGenerator).getContainerGenerator()
                 instanceof EnumerateGenerator) {
@@ -1495,6 +1501,7 @@ public class TensorGeneratorFactory {
       return new BooleanMask(source);
     else if (isType(calledFunction, SLICE.getDeclaringClass())) return new Slice(source);
     else if (isType(calledFunction, SQUEEZE.getDeclaringClass())) return new Squeeze(source);
+    else if (isType(calledFunction, SPLIT.getDeclaringClass())) return new Split(source);
     else if (isType(calledFunction, EXTRACT_PATCHES.getDeclaringClass()))
       return new ExtractPatches(source);
     else if (isType(calledFunction, TAN.getDeclaringClass())) return new Tan(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1249,6 +1249,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String SQUEEZE_SIGNATURE = "tf.squeeze()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/split. */
+  public static final MethodReference SPLIT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/split")),
+          AstMethodReference.fnSelector);
+
+  private static final String SPLIT_SIGNATURE = "tf.split()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/image/extract_patches. */
   public static final MethodReference EXTRACT_PATCHES =
       MethodReference.findOrCreate(
@@ -2095,6 +2104,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(SLICE.getDeclaringClass(), SLICE_SIGNATURE),
           Map.entry(SQUEEZE.getDeclaringClass(), SQUEEZE_SIGNATURE),
+          Map.entry(SPLIT.getDeclaringClass(), SPLIT_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
           Map.entry(TAN.getDeclaringClass(), TAN_SIGNATURE),
           Map.entry(ASIN.getDeclaringClass(), ASIN_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_split.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_split.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# NLPGNN's ALBERT entry idiom in miniature (wala/ML#717): a stacked input is
+# split three ways on axis 0 and the pieces unpack; each piece carries the
+# quotient shape.
+x = tf.ones((3, 8, 100))
+a, b, c = tf.split(x, 3, 0)
+
+assert a.shape == (1, 8, 100)
+assert b.shape == (1, 8, 100)
+assert c.shape == (1, 8, 100)
+assert a.dtype == tf.float32
+
+consume(a)
+consume(c)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_split.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_split.py
@@ -18,3 +18,42 @@ assert a.dtype == tf.float32
 
 consume(a)
 consume(c)
+
+
+def consume_default_axis(t):
+    pass
+
+
+def consume_size_list(t):
+    pass
+
+
+# The axis defaults to 0 when absent; a size-list split produces
+# differently-shaped pieces, which the single-piece model soundly
+# represents with a dynamic dimension at the axis.
+x2 = tf.ones((4, 6))
+p, q = tf.split(x2, 2)
+r, s = tf.split(x2, [1, 3], 0)
+
+assert p.shape == (2, 6)
+assert q.shape == (2, 6)
+assert r.shape == (1, 6)
+assert s.shape == (3, 6)
+
+consume_default_axis(p)
+consume_size_list(s)
+
+
+def consume_opaque_axis(t):
+    pass
+
+
+# A non-constant axis leaves the output shape unknown, but the dtype still
+# inherits from the value.
+k = x2.shape.ndims - 2
+u, v = tf.split(x2, 2, k)
+
+assert u.shape == (2, 6)
+assert v.shape == (2, 6)
+
+consume_opaque_axis(u)


### PR DESCRIPTION
The first piece of wala/ML#717: `tf.split` had a placeholder model returning a constant-materialized first element, so NLPGNN's `input_ids, token_type_ids, input_mask = tf.split(inputs, 3, 0)` yielded ⊤ pieces.

The model now returns a list whose first three indices hold one fresh tensor standing for every piece (an integer `num_or_size_splits` makes all pieces congruent), and the new `Split` generator computes the quotient shape: the `axis` dimension divides by the split count when both resolve, degrades to dynamic when they don't (rank and the other dimensions still transfer), and the dtype inherits from `value`. Since the generator describes a piece rather than the returned list, the subscript dispatch returns it directly instead of routing through `TensorElementGenerator`'s dimension peel, mirroring the `DatasetGenerator` convention. `tf2_test_split.py` pins the ALBERT entry idiom with pieces of `(1, 8, 100)`.

The remaining wala/ML#717 pieces (the explicit `model.build(input_shape=...)` contract seed and the rank-guarded φ) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
