### PR TITLE
Seed a Keras `call` input from an explicit `model.build` contract (wala/ML#717)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3786,6 +3786,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * The explicit {@code model.build(input_shape=...)} contract seed (wala/ML#717), NLPGNN's ALBERT
+   * entry idiom in miniature: the runtime inputs are opaque, so the declared {@code (3, 8, 100)}
+   * contract seeds the {@code call} input, and the {@code split}/{@code squeeze}/{@code cast} chain
+   * carries it to the returned piece: {@code (8, 100) int32}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testBuildContract()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_contract.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 8, 100))));
+  }
+
+  /**
    * Pins the output shape of {@code tf.squeeze} with no axis (wala/ML#513). {@code tf.squeeze(x)}
    * over a {@code (2, 1, 3, 1)} tensor drops every statically size-1 axis: {@code (2, 3)}.
    *

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -949,6 +949,82 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Resolves the input contract an explicitly invoked {@code model.build(input_shape=(...))}
+   * declares for the given Keras {@code call} body (wala/ML#717). The Keras contract ties a built
+   * layer's call inputs to the built shape, so when the runtime arguments do not resolve, the
+   * declared literal is a sound seed for the {@code call} input's shape. Only non-trampoline
+   * (user-written) {@code build} invocations count; the lazy-build trampoline passes no shape.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param callNode The code body of the Keras {@code call} whose input is being resolved.
+   * @return The union of the declared shapes across explicit {@code build} callers, or {@code null}
+   *     when there is none or none resolves.
+   */
+  private Set<List<Dimension<?>>> explicitBuildContractShapes(
+      PropagationCallGraphBuilder builder, CGNode callNode) {
+    String className = callNode.getMethod().getDeclaringClass().getReference().getName().toString();
+    String callSuffix = "/" + CALLABLE_METHOD_NAME_FOR_KERAS_MODELS;
+    if (!className.endsWith(callSuffix)) return null;
+    String pythonClassName = className.substring(0, className.length() - callSuffix.length());
+
+    // The receiving class commonly defines no `build` of its own (the explicit call hits Keras's
+    // base implementation, which the analysis does not model), so the contract is recognized
+    // syntactically: an invoke whose callable is a `build` attribute read off an instance of the
+    // class, mirroring the `set_shape` recognizer.
+    Set<List<Dimension<?>>> combined = null;
+    for (CGNode caller : builder.getCallGraph()) {
+      if (caller.getIR() == null || caller.getDU() == null) continue;
+      if (!(caller.getMethod() instanceof AstMethod)) continue;
+      SymbolTable st = caller.getIR().getSymbolTable();
+      for (Iterator<SSAInstruction> it = caller.getIR().iterateAllInstructions(); it.hasNext(); ) {
+        SSAInstruction inst = it.next();
+        if (!(inst instanceof PythonInvokeInstruction)) continue;
+        PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+        if (call.getNumberOfUses() < 1) continue;
+        SSAInstruction targetDef = caller.getDU().getDef(call.getUse(0));
+        if (!(targetDef instanceof PythonPropertyRead)) continue;
+        PythonPropertyRead prop = (PythonPropertyRead) targetDef;
+        int memberVn = prop.getMemberRef();
+        if (!st.isStringConstant(memberVn)
+            || !KERAS_BUILD_METHOD_NAME.equals(st.getStringValue(memberVn))) continue;
+
+        // The receiver must be an instance of the `call` body's class.
+        PointerKey receiverKey =
+            builder
+                .getPointerAnalysis()
+                .getHeapModel()
+                .getPointerKeyForLocal(caller, prop.getObjectRef());
+        boolean receiverMatches = false;
+        for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(receiverKey)) {
+          AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+          if (asin != null
+              && asin.getNode()
+                  .getMethod()
+                  .getDeclaringClass()
+                  .getReference()
+                  .getName()
+                  .toString()
+                  .equals(pythonClassName)) {
+            receiverMatches = true;
+            break;
+          }
+        }
+        if (!receiverMatches) continue;
+
+        int argVn = call.getUse("input_shape");
+        if (argVn <= 0 && call.getNumberOfUses() >= 2) argVn = call.getUse(1);
+        if (argVn <= 0) continue;
+        Set<List<Dimension<?>>> declared =
+            this.shapesOfShapeVectorOrLiteralList(builder, caller, argVn, HashSetFactory.make());
+        if (declared == null || declared.isEmpty()) continue;
+        if (combined == null) combined = HashSetFactory.make();
+        combined.addAll(declared);
+      }
+    }
+    return combined;
+  }
+
+  /**
    * Peels an {@code int(...)} builtin wrapper: for an invoke of the {@code int} builtin with a
    * single positional argument, returns the argument's value number; otherwise returns {@code vn}
    * unchanged (wala/ML#714).
@@ -1433,6 +1509,15 @@ public abstract class TensorGenerator {
           }
         }
         if (!combinedRet.isEmpty()) return combinedRet;
+
+        // The runtime arguments did not resolve. For a Keras `call`'s first input, an explicitly
+        // invoked `model.build(input_shape=(...))` with a resolvable literal declares the input
+        // contract (built layers validate call inputs against the built shape), so seed the
+        // parameter from it (wala/ML#717).
+        if (paramPos == 1) {
+          Set<List<Dimension<?>>> contract = this.explicitBuildContractShapes(builder, node);
+          if (contract != null && !contract.isEmpty()) return contract;
+        }
       }
     }
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_build_contract.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_build_contract.py
@@ -1,0 +1,42 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+def opaque(t):
+    return tf.reshape(t, get_shape_list(t)[0 : t.shape.ndims])
+
+
+# NLPGNN's ALBERT entry idiom (wala/ML#717): the model's input contract is
+# declared explicitly and statically via `model.build`, while the runtime
+# inputs come from an opaque pipeline; the declared contract seeds the `call`
+# input, and the split/squeeze/cast chain carries it to the pieces.
+class StackedInput(tf.keras.Model):
+    def call(self, inputs, training=None):
+        input_ids, token_type_ids, input_mask = tf.split(inputs, 3, 0)
+        input_ids = tf.cast(tf.squeeze(input_ids, axis=0), tf.int32)
+        return input_ids
+
+
+batch_size = 8
+maxlen = 100
+
+model = StackedInput()
+model.build(input_shape=(3, batch_size, maxlen))
+
+X = opaque(tf.ones((batch_size, maxlen)))
+token_type_id = opaque(tf.zeros((batch_size, maxlen)))
+input_mask = opaque(tf.ones((batch_size, maxlen)))
+
+predict = model([X, token_type_id, input_mask])
+
+assert predict.shape == (batch_size, maxlen)
+assert predict.dtype == tf.int32
+
+consume(predict)


### PR DESCRIPTION
The second piece of wala/ML#717: an explicitly invoked `model.build(input_shape=(...))` with a resolvable literal declares the call input's contract (built layers validate call inputs against the built shape), so when a Keras `call`'s first input cannot be resolved from its runtime arguments, the declared shape seeds it.

The recognition is syntactic, mirroring the `set_shape` recognizer: the receiving class commonly defines no `build` of its own (NLPGNN's entry hits Keras's base implementation), so there is no user `build` body or trampoline to dispatch through; the contract is found as an invoke whose callable is a `build` attribute read off an instance of the `call` body's class, and the `input_shape` argument resolves through the literal-container machinery (constants, attribute reads, and the wala/ML#712/wala/ML#714 folds).

`tf2_test_build_contract.py` pins NLPGNN's ALBERT entry idiom end to end with opaque runtime inputs: the declared `(3, 8, 100)` seeds the `call` input and the `split`/`squeeze`/`cast` chain (the wala/ML#717 piece-1 generator) carries it to the returned piece, `(8, 100) int32`. The remaining piece is the rank-guarded φ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
