### PR TITLE
Degrade dimension arithmetic with an unresolvable co-operand to dynamic

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13466,6 +13466,29 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Single-member counterpart of {@link #testEmbeddingDynamicSize()} (wala/ML#717): dimension
+   * arithmetic over a plain (non-φ) shape-vector subscript with a config-sourced factor exercises
+   * the singleton fold's degradation, so that element's value is dynamic while the rank and the
+   * literal element survive.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testReshapeDynamicFactor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_dynamic_factor.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2, Set.of(new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(6))))));
+  }
+
+  /**
    * Guard companion of {@link #testShapeProd()} (wala/ML#707): {@code np.prod} with an extra
    * argument ({@code axis=0}) can change the result's rank, so the fold refuses it and the shape
    * position degrades to a dynamic dimension in the walk-side contexts. The interpreter path

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2211,24 +2211,20 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * In-vivo anchor for the reopened wala/ML#704: the vendored NLPGNN {@code einsum_via_matmul}
-   * ({@code nlpgnn/layers/dense.py}). The {@code input_tensor} parameter's shape is ⊤ in every
-   * calling context, not because the type is lost at the layer-call boundary (the distilled
-   * compositions {@link #testDense3dMatmul()} and {@link #testDense3dMatmul2()} carry it through
-   * one and two trampoline hops), but because the ⊤ originates at the top of the encoder's
-   * dataflow: {@code WDEmbedding.call}'s trailing reshape targets {@code input_shape[0:-1] +
-   * [input_shape[-1] * self.embedding_size]} over the unknown-rank {@code input_ids}, and the
-   * shape-vector walk soundly degrades the result's shape. The {@code float32} dtype survives that
-   * reshape ({@link #testEmbeddingOutput()}) and reaches most contexts here; the pure-⊤ member is
-   * contributed by the remaining contexts whose feed crosses ops that still lose the dtype. The
-   * {@code w} parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
-   * dimensions, since {@code build}-computed head sizes also derive from the opaque {@code
-   * input_shape} through arithmetic the fold does not cover (wala/ML#714).
-   *
-   * <p>TODO: Expect static trailing dimensions here once <a
-   * href="https://github.com/wala/ML/issues/711">wala/ML#711</a> (embedding-reshape shape ⊤) and <a
-   * href="https://github.com/wala/ML/issues/714">wala/ML#714</a> (arithmetic over {@code
-   * input_shape} subscripts) are resolved.
+   * In-vivo anchor for wala/ML#704: the vendored NLPGNN {@code einsum_via_matmul} ({@code
+   * nlpgnn/layers/dense.py}). The {@code input_tensor} parameter now carries concrete batch and
+   * sequence dimensions with a dynamic trailing (hidden) dimension, delivered from the entry
+   * scripts' explicit {@code model.build} contracts through the embedding's output reshape
+   * (wala/ML#716, wala/ML#717): {@code (8, 100)} and {@code (8, 10)} leading pairs from the entries
+   * whose pipelines reach this layer, each with the trailing {@code input_shape[-1] *
+   * self.embedding_size} element dynamic, since the factor comes from a checkpoint config the
+   * analysis cannot read; dynamic is the sound static answer there. The rank-2 {@code (8, D)}
+   * member is the embedding guard-φ's path-insensitive phantom (the pre-{@code expand_dims}
+   * member), and the pure-⊤ member is the residual contexts whose feed crosses the points-to
+   * substrate gaps of <a href="https://github.com/wala/ML/issues/661">wala/ML#661</a> and <a
+   * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>. The {@code w} parameter keeps
+   * rank 3 and {@code float32} (its chain is layer-local) but no numeric dimensions, since the
+   * {@code build}-computed head sizes also derive from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2247,7 +2243,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         13,
         Map.of(
             2,
-            Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE, TENSOR_UNKNOWN_SHAPE_FLOAT32),
+            Set.of(
+                TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE,
+                new TensorType(FLOAT_32, asList(new NumericDim(8), DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(8), new NumericDim(10), DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(8), new NumericDim(100), DynamicDim.INSTANCE))),
             3,
             Set.of(
                 new TensorType(
@@ -13432,6 +13434,35 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                 TensorType.of(FLOAT_32, 2, 8),
                 TensorType.of(FLOAT_32, 2, 2, 16),
                 TensorType.of(FLOAT_32, 2, 2, 8))));
+  }
+
+  /**
+   * Opaque-size variant of {@link #testEmbeddingOutput()} (wala/ML#717), mirroring the vendored
+   * NLPGNN embedding, whose table size comes from a checkpoint config the analysis cannot read. The
+   * output reshape's trailing element {@code input_shape[-1] * self.embedding_size} then has an
+   * unresolvable factor, but arithmetic over a shape-vector subscript is one scalar dimension, so
+   * the value degrades to dynamic while the rank and the leading dimensions survive, per guard-φ
+   * member.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEmbeddingDynamicSize()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_embedding_dynamic_size.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(FLOAT_32, asList(new NumericDim(2), DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(2), new NumericDim(2), DynamicDim.INSTANCE)))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -869,9 +869,18 @@ public abstract class TensorGenerator {
     if (def instanceof SSABinaryOpInstruction) {
       SSABinaryOpInstruction binOp = (SSABinaryOpInstruction) def;
       Integer left = this.scalarOperandOrNull(builder, node, st, binOp.getUse(0));
-      if (left == null) return null;
       Integer right = this.scalarOperandOrNull(builder, node, st, binOp.getUse(1));
-      if (right == null) return null;
+      if (left == null || right == null) {
+        // When exactly one operand resolves and that operand derives from a shape vector, the
+        // expression is dimension arithmetic and the result is one scalar dimension whose value
+        // is unknown, so the value degrades rather than the element (wala/ML#717). NLPGNN's
+        // `input_shape[-1] * self.embedding_size` with a config-sourced factor is the witness.
+        if ((left == null) != (right == null)
+            && this.derivesFromShapeVector(
+                builder, node, st, left == null ? binOp.getUse(1) : binOp.getUse(0)))
+          return DynamicDim.INSTANCE;
+        return null;
+      }
       if (binOp.getOperator() == IBinaryOpInstruction.Operator.DIV
           && !truncated
           && (right == 0 || left % right != 0)) return null; // Non-exact bare float division.
@@ -886,6 +895,25 @@ public abstract class TensorGenerator {
       return this.prodOfShapeVectorDim(builder, node, st, peeled);
     }
     return null;
+  }
+
+  /**
+   * Decides whether a value derives from a shape vector: a shape-vector subscript (single- or
+   * multi-member) or an {@code np.prod} fold. Evidence that arithmetic over the value is dimension
+   * arithmetic (wala/ML#717).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param st The node's symbol table.
+   * @param vn The value number to test.
+   * @return {@code true} iff the value resolves through a shape-vector path.
+   */
+  private boolean derivesFromShapeVector(
+      PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
+    int peeled = peelIntBuiltin(builder, node, vn);
+    if (this.resolveShapeVectorElementDim(builder, node, st, peeled) != null) return true;
+    if (this.resolveShapeVectorElementDims(builder, node, st, peeled) != null) return true;
+    return this.prodOfShapeVectorDim(builder, node, st, peeled) != null;
   }
 
   /**
@@ -3921,9 +3949,16 @@ public abstract class TensorGenerator {
     SSABinaryOpInstruction binOp = (SSABinaryOpInstruction) def;
 
     Set<Integer> lefts = this.scalarOperandOptionsOrNull(builder, node, st, binOp.getUse(0));
-    if (lefts == null) return null;
     Set<Integer> rights = this.scalarOperandOptionsOrNull(builder, node, st, binOp.getUse(1));
-    if (rights == null) return null;
+    if (lefts == null || rights == null) {
+      // Mirror of the singleton path's degradation (wala/ML#717): dimension arithmetic with an
+      // unresolvable co-operand is one scalar dimension of unknown value.
+      if ((lefts == null) != (rights == null)
+          && this.derivesFromShapeVector(
+              builder, node, st, lefts == null ? binOp.getUse(1) : binOp.getUse(0)))
+        return Collections.singleton(DynamicDim.INSTANCE);
+      return null;
+    }
     if (lefts.size() < 2 && rights.size() < 2) return null; // The singleton path covers this.
 
     Set<Dimension<?>> options = HashSetFactory.make();

--- a/com.ibm.wala.cast.python.test/data/tf2_test_embedding_dynamic_size.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_embedding_dynamic_size.py
@@ -1,0 +1,60 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+config = {"embedding_size": 8}
+
+
+# The vendored NLPGNN embedding sizes its table from a checkpoint config the
+# analysis cannot read (wala/ML#717): the output reshape's trailing element
+# `input_shape[-1] * self.embedding_size` has an unresolvable factor, but the
+# expression is still one scalar dimension, so the rank and the leading
+# dimensions survive and only the trailing value degrades to dynamic.
+class WDEmbedding(tf.keras.layers.Layer):
+    def __init__(self, vocab_size, use_one_hot_embedding, **kwargs):
+        super(WDEmbedding, self).__init__(**kwargs)
+        self.vocab_size = vocab_size
+        self.embedding_size = config.get("embedding_size", 8)
+        self.use_one_hot_embedding = use_one_hot_embedding
+
+    def build(self, input_shape):
+        self.embedding_table = self.add_weight(
+            name="embeddings",
+            shape=[self.vocab_size, self.embedding_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_ids):
+        if input_ids.shape.ndims == 2:
+            input_ids = tf.expand_dims(input_ids, axis=[-1])
+        flat_input_ids = tf.reshape(input_ids, [-1])
+        if self.use_one_hot_embedding:
+            one_hot_input_ids = tf.keras.backend.one_hot(
+                flat_input_ids, self.vocab_size
+            )
+            output = tf.linalg.matmul(one_hot_input_ids, self.embedding_table)
+        else:
+            output = tf.gather(self.embedding_table, flat_input_ids)
+        input_shape = get_shape_list(input_ids)
+        output = tf.reshape(
+            output, input_shape[0:-1] + [input_shape[-1] * self.embedding_size]
+        )
+        return output
+
+
+layer = WDEmbedding(10, False)
+ids = tf.constant([[1, 2], [3, 4]])
+out = layer(ids)
+
+assert out.shape == (2, 2, 8)
+assert out.dtype == tf.float32
+
+consume(out)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_dynamic_factor.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_dynamic_factor.py
@@ -1,0 +1,30 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+config = {"factor": 2}
+
+
+# Single-member counterpart of tf2_test_embedding_dynamic_size.py
+# (wala/ML#717): dimension arithmetic over a plain (non-φ) shape-vector
+# subscript with a config-sourced factor degrades that element's value to
+# dynamic while the rank and the literal element survive.
+def widen(t):
+    factor = config.get("factor", 2)
+    shape = get_shape_list(t)
+    return tf.reshape(t, [shape[0] * factor, 6])
+
+
+out = widen(tf.ones((4, 12)))
+
+assert out.shape == (8, 6)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Advances wala/ML#717 and wala/ML#704: the in-vivo shape tier now moves.

## The Break

The IR of the vendored NLPGNN `WDEmbedding.call` located the einsum-boundary residual precisely: the returned output was ⊤ because its reshape target `input_shape[0:-1] + [input_shape[-1] * self.embedding_size]` nulled entirely on one unresolvable factor. `self.embedding_size` comes from `param.get("hidden_size", ...)`, a checkpoint config the analysis cannot read, so the factor is genuinely statically unknown; but nulling the whole target list discarded the rank and the leading dimensions that were known.

## The Fix

When exactly one operand of a binary expression resolves and that operand derives from a shape vector (a subscript or an `np.prod` fold), the expression is dimension arithmetic and its result is provably one scalar dimension; an unresolvable co-operand now degrades the value to dynamic rather than the element to null, in both the singleton and the multi-member fold.

## In Vivo

`einsum_via_matmul`'s `input_tensor` goes from `{⊤ unknown, ⊤ float32}` to `{(8, 100, D) float32, (8, 10, D) float32, (8, D) float32, ⊤ unknown}`: the entry `model.build` contracts' concrete batch and sequence dimensions arrive end to end, the trailing hidden dimension is dynamic (the sound static answer for a config-sourced size), the rank-2 member is the embedding guard-φ's path-insensitive phantom, and the remaining ⊤ member is the wala/ML#661/wala/ML#570 substrate residual. The distilled fixture `tf2_test_embedding_dynamic_size.py` (runtime-verified) pins the mechanism and the in-vivo anchor is updated to the improved types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6