### PR TITLE
Represent partially unknown shape sets explicitly

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ShapeResult.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ShapeResult.java
@@ -1,0 +1,112 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The result of a shape resolution: the resolvable shape members plus whether an unresolvable
+ * remainder exists (wala/ML#718). The legacy convention represents ⊤ as {@code null} and ⊥ as an
+ * empty set, which cannot express a partially resolved value set (some members concrete, some
+ * unknown), so a set read over, e.g., a loop-carried φ collapses entirely on one unknown member.
+ * This record makes the unknown remainder explicit, mirroring how dtype sets already carry {@code
+ * DType.UNKNOWN} in band.
+ *
+ * @param members The resolvable shape members. Never {@code null}; possibly empty.
+ * @param hasUnknown Whether an unresolvable remainder exists alongside {@code members}.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public record ShapeResult(Set<List<Dimension<?>>> members, boolean hasUnknown) {
+
+  /** The fully unknown result (⊤): no resolvable members and an unknown remainder. */
+  private static final ShapeResult UNKNOWN = new ShapeResult(Collections.emptySet(), true);
+
+  /** The not-a-tensor result (⊥): no members and no unknown remainder. */
+  private static final ShapeResult BOTTOM = new ShapeResult(Collections.emptySet(), false);
+
+  /**
+   * Wraps fully resolved members.
+   *
+   * @param members The resolved shape members.
+   * @return The fully resolved result.
+   */
+  public static ShapeResult of(Set<List<Dimension<?>>> members) {
+    return new ShapeResult(members, false);
+  }
+
+  /**
+   * Returns the fully unknown result (⊤).
+   *
+   * @return The fully unknown result.
+   */
+  public static ShapeResult unknown() {
+    return UNKNOWN;
+  }
+
+  /**
+   * Returns the not-a-tensor result (⊥).
+   *
+   * @return The not-a-tensor result.
+   */
+  public static ShapeResult bottom() {
+    return BOTTOM;
+  }
+
+  /**
+   * Lifts a legacy shape set into a result: {@code null} lifts to ⊤, an empty set to ⊥, and any
+   * other set to a fully resolved result.
+   *
+   * @param shapes The legacy shape set, with {@code null} meaning ⊤ and empty meaning ⊥.
+   * @return The lifted result.
+   */
+  public static ShapeResult fromLegacy(Set<List<Dimension<?>>> shapes) {
+    if (shapes == null) return UNKNOWN;
+    if (shapes.isEmpty()) return BOTTOM;
+    return new ShapeResult(shapes, false);
+  }
+
+  /**
+   * Collapses this result to the legacy convention: any unknown remainder collapses the whole
+   * result to {@code null} (⊤), which over-approximates a partial result soundly; otherwise the
+   * members stand, with an empty set meaning ⊥.
+   *
+   * @return The legacy shape set view.
+   */
+  public Set<List<Dimension<?>>> toLegacy() {
+    if (this.hasUnknown()) return null;
+    return this.members();
+  }
+
+  /**
+   * Unions this result with another: members union and the unknown remainders disjoin.
+   *
+   * @param other The result to union with.
+   * @return The union.
+   */
+  public ShapeResult union(ShapeResult other) {
+    if (this.equals(other)) return this;
+    Set<List<Dimension<?>>> combined = HashSetFactory.make(this.members());
+    combined.addAll(other.members());
+    return new ShapeResult(combined, this.hasUnknown() || other.hasUnknown());
+  }
+
+  /**
+   * Decides whether this result is ⊥ (not a tensor).
+   *
+   * @return {@code true} iff there are no members and no unknown remainder.
+   */
+  public boolean isBottom() {
+    return this.members().isEmpty() && !this.hasUnknown();
+  }
+
+  /**
+   * Decides whether this result is partial: some members resolved alongside an unknown remainder.
+   *
+   * @return {@code true} iff there are members and an unknown remainder.
+   */
+  public boolean isPartial() {
+    return !this.members().isEmpty() && this.hasUnknown();
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -166,8 +166,8 @@ public abstract class TensorGenerator {
    *       PythonTensorAnalysisEngine#performAnalysis} invokes it.
    * </ul>
    */
-  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, Set<List<Dimension<?>>>>>
-      SHAPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
+  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, ShapeResult>> SHAPES_CACHE =
+      Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
    * A shape-resolution cache key (wala/ML#716): the queried value plus the resolution mode.
@@ -192,7 +192,7 @@ public abstract class TensorGenerator {
    * PythonTensorAnalysisEngine#performAnalysis} drives rounds via {@link
    * #advanceRound(PropagationCallGraphBuilder)} until the per-source types stabilize.
    */
-  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, Set<List<Dimension<?>>>>>
+  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, ShapeResult>>
       PREVIOUS_SHAPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
 
   /** Dtype counterpart of {@link #PREVIOUS_SHAPES_CACHE}. */
@@ -238,7 +238,7 @@ public abstract class TensorGenerator {
    * @param builder The builder whose caches should advance.
    */
   public static void advanceRound(PropagationCallGraphBuilder builder) {
-    Map<ShapeQuery, Set<List<Dimension<?>>>> shapes = SHAPES_CACHE.remove(builder);
+    Map<ShapeQuery, ShapeResult> shapes = SHAPES_CACHE.remove(builder);
     if (shapes != null) PREVIOUS_SHAPES_CACHE.put(builder, shapes);
     Map<Pair<CGNode, Integer>, Set<DType>> dtypes = DTYPES_CACHE.remove(builder);
     if (dtypes != null) PREVIOUS_DTYPES_CACHE.put(builder, dtypes);
@@ -1573,12 +1573,27 @@ public abstract class TensorGenerator {
    */
   protected Set<List<Dimension<?>>> getShapes(
       PropagationCallGraphBuilder builder, CGNode node, int valueNumber, boolean exact) {
-    Map<ShapeQuery, Set<List<Dimension<?>>>> cache =
+    return this.getShapeResult(builder, node, valueNumber, exact).toLegacy();
+  }
+
+  /**
+   * Record-carrying core of {@link #getShapes(PropagationCallGraphBuilder, CGNode, int, boolean)}
+   * (wala/ML#718): the {@link ShapeResult} keeps an unresolvable remainder explicit alongside the
+   * resolvable members instead of collapsing the whole result to ⊤.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code valueNumber}.
+   * @param valueNumber The value number to resolve.
+   * @param exact Whether an unresolvable union member poisons the result rather than dropping.
+   * @return The resolution result.
+   */
+  protected ShapeResult getShapeResult(
+      PropagationCallGraphBuilder builder, CGNode node, int valueNumber, boolean exact) {
+    Map<ShapeQuery, ShapeResult> cache =
         SHAPES_CACHE.computeIfAbsent(builder, b -> Collections.synchronizedMap(new HashMap<>()));
     ShapeQuery key = new ShapeQuery(node, valueNumber, exact);
     // Atomic check-compute-put: concurrent threads hitting the same key will serialize on the
-    // cache's mutex so exactly one `computeShapes` call runs. The null result is cached too
-    // (null = ⊤), which `Map.computeIfAbsent` cannot express, so we use `containsKey` instead.
+    // cache's mutex so exactly one `computeShapes` call runs.
     // Reentrant synchronization: `SynchronizedMap`'s own methods acquire the same mutex, so the
     // inner `containsKey` / `get` / `put` calls are no-op re-entries.
     synchronized (cache) {
@@ -1589,8 +1604,11 @@ public abstract class TensorGenerator {
       Set<ShapeQuery> inProgress =
           SHAPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
       if (!inProgress.add(key)) {
-        Map<ShapeQuery, Set<List<Dimension<?>>>> previous = PREVIOUS_SHAPES_CACHE.get(builder);
-        Set<List<Dimension<?>>> approximation = previous == null ? null : previous.get(key);
+        Map<ShapeQuery, ShapeResult> previous = PREVIOUS_SHAPES_CACHE.get(builder);
+        ShapeResult approximation =
+            previous == null || !previous.containsKey(key)
+                ? ShapeResult.unknown()
+                : previous.get(key);
         LOGGER.fine(
             () ->
                 "Shape cycle re-entry on key: "
@@ -1601,7 +1619,8 @@ public abstract class TensorGenerator {
         return approximation;
       }
       try {
-        Set<List<Dimension<?>>> result = computeShapes(builder, node, valueNumber, exact);
+        ShapeResult result =
+            ShapeResult.fromLegacy(computeShapes(builder, node, valueNumber, exact));
         cache.put(key, result);
         return result;
       } finally {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -312,28 +312,25 @@ public abstract class TensorGenerator {
    * @return A set of possible {@link TensorType}s, or {@code null} if the shape is unknown.
    */
   public Set<TensorType> getTensorTypes(PropagationCallGraphBuilder builder) {
-    Set<List<Dimension<?>>> shapes = this.getShapes(builder);
+    ShapeResult shapes = ShapeResult.fromLegacy(this.getShapes(builder));
     Set<DType> dTypes = this.getDTypes(builder);
 
     // If we have no dtype info at all, fall back to signaling "unknown tensor" when shapes are
     // also unknown, otherwise produce an empty set (⊥, not a tensor).
     if (dTypes == null || dTypes.isEmpty()) {
-      return shapes == null ? null : HashSetFactory.make();
+      return shapes.members().isEmpty() && shapes.hasUnknown() ? null : HashSetFactory.make();
     }
 
     Set<TensorType> ret = HashSetFactory.make();
 
     final Layout layout = this.producesSparseTensor() ? Layout.SPARSE : Layout.DENSE;
 
-    if (shapes == null) {
-      // Shape is unknown (⊤), but dtype info may still be available. Emit TensorTypes with null
-      // dims so the dtype information is preserved.
-      for (DType dtype : dTypes) ret.add(TensorType.of(dtype, null, layout));
-    } else {
-      // Create a tensor type for each possible shape and dtype combination.
-      for (List<Dimension<?>> dimensionList : shapes)
-        for (DType dtype : dTypes) ret.add(TensorType.of(dtype, dimensionList, layout));
-    }
+    // Create a tensor type for each resolved shape and dtype combination; an unknown remainder
+    // additionally emits null-dims (⊤-shape) types so the dtype information is preserved and a
+    // partially resolved set keeps its concrete members alongside the unknown one (wala/ML#718).
+    if (shapes.hasUnknown()) for (DType dtype : dTypes) ret.add(TensorType.of(dtype, null, layout));
+    for (List<Dimension<?>> dimensionList : shapes.members())
+      for (DType dtype : dTypes) ret.add(TensorType.of(dtype, dimensionList, layout));
 
     LOGGER.fine("Generator " + this.getClass().getSimpleName() + " produced types: " + ret);
 


### PR DESCRIPTION
Implements wala/ML#718 in phases; this draft carries the first two, both behavior-neutral and suite-gated:

1. **`ShapeResult` record at the memoized core**: `(members, hasUnknown)` replaces the null-value convention in the shape caches, keeping an unresolvable remainder explicit alongside the resolvable members; the legacy `getShapes` view collapses an unknown remainder to ⊤. Mirrors how dtype sets already carry `DType.UNKNOWN` in band.
2. **Partial-aware `getTensorTypes`**: a partial result emits a tensor type per resolved member plus the null-dims types for the unknown remainder, instead of choosing between them.

Remaining phases before this leaves draft:

3. Produce partial results at the resolution side: the exact-mode value-union reads (`getShapesOfValue`, the caller walk) collect resolvable members and set `hasUnknown` instead of poisoning to ⊤, and the shape-vector walk propagates the remainder through slices, subscripts, and folds.
4. Re-measure the in-vivo anchor: the four `DenseLayer3dProj` contexts (fed through the shared-transformer loop's fixed point) should gain concrete members, with only the honest loop-carried ⊤ surviving alongside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6