### PR TITLE
Compose definition-site-distinct types for redefined functions

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2301,17 +2301,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
-   * Captures the redefined-top-level-function collapse of <a
+   * The first definition of the redefined top-level function of <a
    * href="https://github.com/wala/ML/issues/719">wala/ML#719</a>: the script defines {@code
-   * compute} twice and calls each definition, but the CAst translation keys the function's
-   * synthetic class by name alone, so only the second definition's body survives and both call
-   * sites bind to it. The parameter therefore unions both calls' types — {@code (2, 2)} from the
-   * first call (which executes the lost {@code reduce_sum} definition at runtime) and {@code (3,
-   * 3)} from the second — on the single surviving method.
-   *
-   * <p>TODO: Once <a href="https://github.com/wala/ML/issues/719">wala/ML#719</a> lands
-   * definition-site-distinct synthetic classes, each definition should carry only its own call's
-   * type, and this test should split per definition.
+   * compute} twice and calls each definition. Definition-site-distinct synthetic classes keep both
+   * bodies, the module binding rebinds at the second {@code def}, and straight-line SSA binds each
+   * call to the definition in scope, so this definition's parameter carries exactly its own call's
+   * {@code (2, 2)} — where the pre-fix collapse lost this body entirely and bound its call to the
+   * second definition.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2326,7 +2322,28 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "compute",
         1,
         2,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 2), TensorType.of(FLOAT_32, 3, 3))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 2))));
+  }
+
+  /**
+   * The second definition of {@link #testRedefinedFunction()}'s redefined function (wala/ML#719):
+   * the definition at line 11 composes the position-disambiguated synthetic class {@code
+   * compute$11}, and its parameter carries exactly the second call's {@code (3, 3)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testRedefinedFunction2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_redefined_function.py",
+        "compute$11",
+        1,
+        2,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 3, 3))));
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -287,19 +287,36 @@ public class PythonCAstToIRTranslator extends AstTranslator {
   	}
   */
 
+  /**
+   * The source line owning each composed name, so a same-named sibling definition (a different
+   * source position) composes a distinct name instead of collapsing onto the first, while re-walks
+   * of the same definition (fresh {@link CAstEntity} instances at the same position) keep composing
+   * the same name (wala/ML#719).
+   */
+  private final Map<String, Integer> composedNameOwnerLines = HashMapFactory.make();
+
   @Override
   protected String composeEntityName(WalkContext parent, CAstEntity f) {
     // Use the entity signature here to resolve entities in files under different directories.
     if (f.getKind() == CAstEntity.SCRIPT_ENTITY) return f.getSignature();
     else {
-      String name;
-      // if (f.getType() instanceof CAstType.Method) {
-      //	name = ((CAstType.Method)f.getType()).getDeclaringType().getName() + "/" + f.getName();
-      // } else {
-      name = f.getName();
-      // }
+      String name = parent.getName() + "/" + f.getName();
 
-      return parent.getName() + "/" + name;
+      // Entities without positions (synthetic) cannot be distinguished by definition site; they
+      // keep the historical name-keyed behavior.
+      Position position = f.getPosition();
+      if (position == null) return name;
+
+      // A definition at a different source position already owns this name (e.g. the same
+      // top-level function name defined twice); key this definition by its line so both bodies
+      // survive rather than the later definition replacing the earlier in the loader
+      // (wala/ML#719). The suffix character cannot appear in a Python identifier, so user names
+      // cannot collide with it. The binding write keeps the plain name (see
+      // doMaterializeFunction) so a redefinition still rebinds.
+      int line = position.getFirstLine();
+      Integer ownerLine = composedNameOwnerLines.putIfAbsent(name, line);
+      if (ownerLine == null || ownerLine == line) return name;
+      return name + "$" + line;
     }
   }
 
@@ -461,7 +478,11 @@ public class PythonCAstToIRTranslator extends AstTranslator {
         .cfg()
         .unknownInstructions(
             () -> {
-              doGlobalWrite(context, fnName, PythonTypes.Root, result);
+              // The binding uses the plain composed name, not the position-disambiguated one, so
+              // a redefinition of the same name rebinds the same variable (wala/ML#719); the
+              // disambiguated name applies to the function's type and code body only.
+              doGlobalWrite(
+                  context, context.getName() + "/" + fn.getName(), PythonTypes.Root, result);
               FieldReference fnField =
                   FieldReference.findOrCreate(
                       PythonTypes.Root,


### PR DESCRIPTION
Closes wala/ML#719.

`PythonCAstToIRTranslator.composeEntityName` keyed a function's synthetic class purely by `parent + "/" + name`, so a script defining the same top-level function twice lost the first definition entirely (the later replaced it in the loader) and bound every call to the survivor — a misanalysis, since the first call executes the first body at runtime.

The composed name now disambiguates by the definition's source line when a definition at a different position already owns it (`compute` and `compute$11`; `$` cannot appear in a Python identifier). Two design points the issue trail documents from failed intermediate attempts:

- The def-site **binding write keeps the plain name** (`doMaterializeFunction`'s global write), so a redefinition still rebinds the module variable; the disambiguated name applies to the type, the code body, and the function-object allocation only.
- Ownership keys on **source lines rather than entity identity**, since walker passes create fresh `CAstEntity` instances for the same definition; position is the stable identity. Entities without positions keep the historical name-keyed behavior.

The result is stronger than the issue's minimum ask: with both bodies live and the binding rebinding, straight-line SSA binds each call directly to the definition in scope, so each definition's parameter carries exactly its own call's type — full flow-sensitive precision at module level, not the two-target over-approximation. The captured-behavior guard from #579 flips accordingly into two positive per-definition tests (`compute` pins `(2, 2)`, `compute$11` pins `(3, 3)`).

Front-end suite and the ml suite both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6