### PR TITLE
Register reshape/squeeze producers and descend into callee returns

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
@@ -46,10 +46,12 @@ public class DiagnosticLoggingVolumeTest {
     // Fixed code emitted ~0.6 GB of formatted FINEST volume for this analysis when the guard was
     // calibrated (wala/ML#697, July 8); the shape-provenance machinery merged since (wala/ML#703
     // through wala/ML#714) organically grew that to ~2.2 GB measured in-suite on a clean master,
-    // with run-to-run variance around the old 2 GB bound (wala/ML#715). A bare `Context` render,
-    // the failure mode this guard exists to catch, measured ~14 GB. 4 GB sits well above the
-    // organic level and still far below the failure mode.
-    final long maxFormattedChars = 4_000_000_000L;
+    // with run-to-run variance around the old 2 GB bound (wala/ML#715), and the tf.reshape /
+    // tf.squeeze producer registrations plus the callee-return descent (wala/ML#718) grew it again
+    // to ~5.6 GB — the same messages over roughly 2.5x the delegation traversals, no new render
+    // sites. A bare `Context` render, the failure mode this guard exists to catch, measured ~14 GB
+    // before that growth and scales with the same traversal count, so 8 GB keeps the gap.
+    final long maxFormattedChars = 8_000_000_000L;
 
     Logger pkg = Logger.getLogger("com.ibm.wala.cast.python");
     DiscardingFormattingHandler handler = new DiscardingFormattingHandler();

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2222,9 +2222,13 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * self.embedding_size} element dynamic, since the factor comes from a checkpoint config the
    * analysis cannot read; dynamic is the sound static answer there. The rank-2 {@code (8, D)}
    * member is the embedding guard-φ's path-insensitive phantom (the pre-{@code expand_dims}
-   * member), and the pure-⊤ member is the shared-transformer loop's fixed point: the layer's ⊤
-   * output feeds back into its input, and a set read whose members include ⊤ collapses, so the four
-   * {@code DenseLayer3dProj} contexts (fed by the attention's return value) stay fully unknown — <a
+   * member). The {@code tf.reshape}/{@code tf.squeeze} producer registrations and the callee-return
+   * descent for layer-call results add the degraded-rank members ({@code (D, D)}, {@code (D, D,
+   * D)}, {@code (8, D, D)}): the einsum body's own reshapes now compute generator-side through the
+   * {@code get_shape_list} walk, whose non-entry contexts resolve rank but not every dimension. The
+   * shape-⊤ {@code float32} member is the four {@code DenseLayer3dProj} contexts (fed by the
+   * attention's return value): the dtype now relays through the descent, but the shared-transformer
+   * loop's fixed point still keeps their shapes fully unknown, as does the pure-⊤ member — TODO: <a
    * href="https://github.com/wala/ML/issues/718">wala/ML#718</a>. The {@code w} parameter keeps
    * rank 3 and {@code float32} (its chain is layer-local) but no numeric dimensions, since the
    * {@code build}-computed head sizes also derive from the config.
@@ -2248,7 +2252,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(
                 TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE,
+                TENSOR_UNKNOWN_SHAPE_FLOAT32,
                 new TensorType(FLOAT_32, asList(new NumericDim(8), DynamicDim.INSTANCE)),
+                new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32, asList(new NumericDim(8), DynamicDim.INSTANCE, DynamicDim.INSTANCE)),
                 new TensorType(
                     FLOAT_32, asList(new NumericDim(8), new NumericDim(10), DynamicDim.INSTANCE)),
                 new TensorType(
@@ -2287,7 +2298,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "WDEmbedding.call",
         "nlpgnn_full_proj",
         1,
-        10,
+        12,
         Map.of(
             3,
             Set.of(
@@ -3139,7 +3150,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_masked_sparse_ce.py",
         "MaskSparseCategoricalCrossentropy.__call__",
         3,
-        6,
+        7,
         Map.of(
             3, Set.of(TENSOR_4_INT32),
             4, Set.of(TENSOR_4_10_FLOAT32),
@@ -4462,7 +4473,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   @Test
   public void testAutoencoder3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("autoencoder.py", "run_optimization", 1, 5, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
+    test("autoencoder.py", "run_optimization", 1, 6, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
   }
 
   /**
@@ -13157,7 +13168,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * arm of the {@code len(outer_dims) > 1} guard's φ: the raw matmul result, which flows statically
    * even though the runtime always takes the reshape arm here, and which the batched {@code
    * tf.matmul} semantics type as the runtime-true intermediate {@code matmul((2, 4, 6), (6, 15))}
-   * (wala/ML#718; previously the rank-collapsed artifact {@code (4, 5)}).
+   * (wala/ML#718; previously the rank-collapsed artifact {@code (4, 5)}). The {@code (2, 4, 5)}
+   * member is the same φ's other pairing: {@code w}'s points-to set carries both its defs (the
+   * original {@code (6, 3, 5)} and the {@code len(w_shape) > 2} arm's reshape to {@code (6, 15)}),
+   * so the batched product also composes against the un-reshaped def, taking its trailing {@code
+   * 5}. Both extras are path-insensitive unions, not miscomputations.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13172,17 +13187,24 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 3, 5), TensorType.of(FLOAT_32, 2, 4, 15))));
+        Map.of(
+            2,
+            Set.of(
+                TensorType.of(FLOAT_32, 2, 4, 3, 5),
+                TensorType.of(FLOAT_32, 2, 4, 15),
+                TensorType.of(FLOAT_32, 2, 4, 5))));
   }
 
   /**
    * The two-inner-dims variant of {@link #testEinsumViaMatmul()} (NLPGNN's {@code DenseLayer3dProj}
    * shape, {@code einsum_via_matmul(input_tensor, w, 2)}): exercises the {@code batch_dims +
    * [inner_dim]} concatenation of a shape vector with a literal list whose element is an {@code
-   * np.prod} fold (wala/ML#708). The result types as exactly the precise runtime {@code (2, 4, 6)}:
-   * the batched {@code tf.matmul} semantics (wala/ML#718) type every guard-arm pairing to the same
-   * runtime-true product, eliminating the rank-collapsed {@code (3, 6)} artifact this test
-   * previously pinned.
+   * np.prod} fold (wala/ML#708). The result types the precise runtime {@code (2, 4, 6)} (the
+   * batched {@code tf.matmul} semantics, wala/ML#718, eliminated the rank-collapsed {@code (3, 6)}
+   * artifact this test previously pinned) plus the {@code (2, 4, 3, 6)} phantom: {@code
+   * input_tensor}'s points-to set carries both its defs (the original {@code (2, 4, 3, 5)} and the
+   * {@code num_inner_dims > 1} arm's reshape to {@code (2, 4, 15)}), so the batched product also
+   * composes against the un-reshaped def — a path-insensitive union, not a miscomputation.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -13197,7 +13219,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 6))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 6), TensorType.of(FLOAT_32, 2, 4, 3, 6))));
   }
 
   /**
@@ -13265,7 +13287,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13294,7 +13316,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul2.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13319,7 +13341,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul3.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13345,7 +13367,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul4.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13401,7 +13423,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul6.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13427,7 +13449,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul7.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),
@@ -13454,7 +13476,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_dense3d_matmul8.py",
         "einsum_via_matmul",
         2,
-        9,
+        14,
         Map.of(
             2,
             Set.of(TensorType.of(FLOAT_32, 2, 4, 6)),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -4,6 +4,7 @@ import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -49,6 +50,15 @@ public class Reshape extends TensorGenerator {
 
   public Reshape(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Reshape(CGNode node) {
+    super(node);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -5318,6 +5318,10 @@ public abstract class TensorGenerator {
       return new ElementWiseOperation(node);
     } else if (type.equals(TensorFlowTypes.TRANSPOSE.getDeclaringClass())) {
       return new Transpose(node);
+    } else if (type.equals(TensorFlowTypes.RESHAPE.getDeclaringClass())) {
+      return new Reshape(node);
+    } else if (type.equals(TensorFlowTypes.SQUEEZE.getDeclaringClass())) {
+      return new Squeeze(node);
     } else if (type.equals(TensorFlowTypes.SIGMOID.getDeclaringClass())) {
       return new Sigmoid(node);
     } else if (type.equals(TensorFlowTypes.SOFTMAX.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1772,6 +1772,20 @@ public abstract class TensorGenerator {
 
     // No direct generator. Try tracing the definition or parameters.
     SSAInstruction def = node.getDU().getDef(valueNumber);
+
+    // A value defined by an invoke that neither the points-to set nor the factory resolved is
+    // typically a Python-callable result whose allocation the PA lost through a synthetic return
+    // (e.g., a chained layer-call result in a `call` body). The callee's own return value still
+    // resolves per context — recursing through a trampoline body reaches the underlying op result
+    // and its generator — so descend into each callee's returns (wala/ML#718).
+    if (def instanceof SSAAbstractInvokeInstruction) {
+      ShapeResult fromCallees =
+          this.shapeResultOfCalleeReturnValues(
+              builder, node, (SSAAbstractInvokeInstruction) def, exact);
+      if (!fromCallees.members().isEmpty()) return fromCallees;
+      if (fromCallees.hasUnknown() && partial == null) partial = ShapeResult.unknown();
+    }
+
     if (def == null) {
       // It's a parameter. Trace back to call sites.
       int paramPos = -1;
@@ -4343,6 +4357,66 @@ public abstract class TensorGenerator {
       } finally {
         visited.remove(callee);
       }
+    }
+    return combined.isEmpty() ? ShapeResult.unknown() : new ShapeResult(combined, hasUnknown);
+  }
+
+  /**
+   * Tensor-value twin of {@link #shapeResultOfCalleeReturns}: follows an invoke into each callee
+   * the call graph resolves for it and reads every returned value's shape via {@link
+   * #getShapeResult(PropagationCallGraphBuilder, CGNode, int, boolean)}, unioning the results
+   * (wala/ML#718). Unlike the shape-vector walk, whose folds assert per-member facts and must
+   * resolve every return, a tensor-value read is partial-friendly: an unresolvable return (or a
+   * bare {@code return}, whose {@code None} is not a tensor) marks the unknown remainder while the
+   * resolvable returns' members stand.
+   *
+   * <p>Recursion through cyclic call chains is bounded by the memoized core's in-progress guard,
+   * which answers a re-entered {@code (node, vn)} with the previous round's approximation.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @param node The calling {@link CGNode}.
+   * @param invoke The invoke instruction whose result is being read.
+   * @param exact Whether the read is exact (see {@link #getShapeResult(PropagationCallGraphBuilder,
+   *     CGNode, int, boolean)}).
+   * @return The union of the callees' return-value shapes; ⊤ when nothing resolves.
+   */
+  private ShapeResult shapeResultOfCalleeReturnValues(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      SSAAbstractInvokeInstruction invoke,
+      boolean exact) {
+    Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+    if (targets == null || targets.isEmpty()) return ShapeResult.unknown();
+
+    boolean hasUnknown = false;
+    Set<List<Dimension<?>>> combined = HashSetFactory.make();
+    for (CGNode callee : targets) {
+      if (callee.getIR() == null || callee.getDU() == null) return ShapeResult.unknown();
+      boolean sawReturn = false;
+      for (Iterator<SSAInstruction> it = callee.getIR().iterateAllInstructions(); it.hasNext(); ) {
+        SSAInstruction instruction = it.next();
+        if (!(instruction instanceof SSAReturnInstruction)) continue;
+        SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
+        sawReturn = true;
+        if (ret.getResult() < 0) {
+          hasUnknown = true;
+          continue;
+        }
+        ShapeResult shapes;
+        try {
+          shapes = this.getShapeResult(builder, callee, ret.getResult(), exact);
+        } catch (IllegalArgumentException e) {
+          LOGGER.log(
+              Level.FINE,
+              e,
+              () -> "shapeResultOfCalleeReturnValues: IAE reading a return of " + describe(callee));
+          hasUnknown = true;
+          continue;
+        }
+        if (shapes.hasUnknown() || shapes.isBottom()) hasUnknown = true;
+        combined.addAll(shapes.members());
+      }
+      if (!sawReturn) hasUnknown = true;
     }
     return combined.isEmpty() ? ShapeResult.unknown() : new ShapeResult(combined, hasUnknown);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3203,7 +3203,10 @@ public abstract class TensorGenerator {
             return ret;
           }
           LOGGER.fine("Delegating dtype inference to: " + generator);
-          ret.addAll(generator.getDTypes(builder));
+          Set<DType> delegated = generator.getDTypes(builder);
+          // A null delegation result is ⊤ (e.g., an argument dtype that resolves through neither
+          // the points-to set nor the caller walk); contribute UNKNOWN rather than NPE-ing.
+          ret.addAll(delegated == null ? EnumSet.of(UNKNOWN) : delegated);
         } else if (defSource != null) {
           if (this.getSource() != null && this.getSource().equals(defSource)) {
             return ret;
@@ -3218,7 +3221,9 @@ public abstract class TensorGenerator {
           }
           if (generator != null) {
             LOGGER.fine("Delegating dtype inference to: " + generator);
-            ret.addAll(generator.getDTypes(builder));
+            Set<DType> delegated = generator.getDTypes(builder);
+            // A null delegation result is ⊤; contribute UNKNOWN rather than NPE-ing.
+            ret.addAll(delegated == null ? EnumSet.of(UNKNOWN) : delegated);
           }
         }
       }


### PR DESCRIPTION
Two mechanisms that unblock the generator-side shape chain into NLPGNN's `einsum_via_matmul`, plus the defect they exposed and the widened captures.

## Producer Registrations

`tf.reshape` and `tf.squeeze` allocate generic `Tensor`s in their summaries but were missing from `createManualGenerator`, dead-ending producer delegation for every value they feed (the same gap class as the `tf.multiply`/`tf.transpose` registrations in #578). In the vendored subject this starved `get_shape_list`'s `.shape` read of the einsum inputs, so the einsum body's reshape targets never resolved: with the registrations, `get_shape_list`'s walk resolves concrete member sets where it returned pure ⊤ before.

## Callee-Return Descent

`computeShapes` had no arm for a value defined by an invoke of a Python callable when both the points-to set and the factory come up empty; a chained layer-call result in a `call` body fell straight to the ⊥ floor. `shapeResultOfCalleeReturnValues` is the tensor-value twin of the shape-vector walk's callee-return hop (#706): it reads each callee's returned value, recursing through trampoline bodies to the underlying op result, partial-friendly per wala/ML#718's read contract.

## Exposed Defect

The new delegation paths reach `getDTypesFromTensor` with delegates whose dtype resolvers legally return `null` (⊤); both `addAll` sites now treat that as `UNKNOWN` instead of NPE-ing.

## Vivo Effect

On the einsum anchor, `input_tensor`'s union gains the degraded-rank members of the now-computing reshape chain, and the four `DenseLayer3dProj` contexts move from fully unknown to shape-⊤ `float32`; the dtype now relays end to end; their shapes remain the wala/ML#718 residual. The distilled einsum guards pin the un-reshaped-def φ phantoms as documented path-insensitive unions, and the FINEST-volume bound re-baselines to 8 GB (same messages, ~2.5x traversals, no new render sites).

Part of wala/ML#718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6