### PR TITLE
Mask producer-graph cycles and register the cyclic producers

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2229,13 +2229,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * tf.reshape}/{@code tf.squeeze} producer registrations and the callee-return descent for
    * layer-call results add the degraded-rank members ({@code (D, D)}, {@code (D, D, D)}, {@code (8,
    * D, D)}): the einsum body's own reshapes now compute generator-side through the {@code
-   * get_shape_list} walk, whose non-entry contexts resolve rank but not every dimension. The
-   * shape-⊤ {@code float32} member is the four {@code DenseLayer3dProj} contexts (fed by the
-   * attention's return value): the dtype now relays through the descent, but the shared-transformer
-   * loop's fixed point still keeps their shapes fully unknown, as does the pure-⊤ member — TODO: <a
-   * href="https://github.com/wala/ML/issues/718">wala/ML#718</a>. The {@code w} parameter keeps
-   * rank 3 and {@code float32} (its chain is layer-local) but no numeric dimensions, since the
-   * {@code build}-computed head sizes also derive from the config.
+   * get_shape_list} walk, whose non-entry contexts resolve rank but not every dimension. The rank-4
+   * {@code (8, 100, U, U)}/{@code (8, 10, U, U)} members are the {@code DenseLayer3dProj} contexts'
+   * inputs (the attention's return value), delivered once the producer-cycle mask lets the
+   * loop-carried union converge from its non-cyclic base: three of the four proj contexts carry
+   * them. One entry's proj context and the pure-⊤/shape-⊤ members remain the loop fixed point's
+   * last residue—TODO: <a href="https://github.com/wala/ML/issues/718">wala/ML#718</a>. The {@code
+   * w} parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
+   * dimensions, since the {@code build}-computed head sizes also derive from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2270,7 +2271,21 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                     asList(new NumericDim(8), new NumericDim(10), UnresolvedDim.INSTANCE)),
                 new TensorType(
                     FLOAT_32,
-                    asList(new NumericDim(8), new NumericDim(100), UnresolvedDim.INSTANCE))),
+                    asList(new NumericDim(8), new NumericDim(100), UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        new NumericDim(8),
+                        new NumericDim(10),
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        new NumericDim(8),
+                        new NumericDim(100),
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE))),
             3,
             Set.of(
                 new TensorType(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Constant.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import java.util.Locale;
 
@@ -31,6 +32,15 @@ public class Constant extends ValueExtractingTensorGenerator {
 
   public Constant(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Constant(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ConvertToTensor.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ConvertToTensor.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -52,6 +53,15 @@ public class ConvertToTensor extends ValueExtractingTensorGenerator {
 
   public ConvertToTensor(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ConvertToTensor(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TYPE_REFERENCE_T
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
@@ -51,6 +52,15 @@ public class Fill extends Constant {
 
   public Fill(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Fill(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OneHot.java
@@ -11,6 +11,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -42,6 +43,15 @@ public class OneHot extends TensorTypeAllocator {
 
   public OneHot(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public OneHot(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMean.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.HashSet;
@@ -18,6 +19,15 @@ public class ReduceMean extends Reduction {
 
   public ReduceMean(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceMean(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reduction.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.python.ml.client;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
@@ -45,6 +46,15 @@ public abstract class Reduction extends TensorGenerator {
 
   public Reduction(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Reduction(CGNode node) {
+    super(node);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -212,6 +212,20 @@ public abstract class TensorGenerator {
       DTYPES_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
+   * The allocation sites whose producer delegations are currently on the recursion stack, per
+   * builder; membership marks a cycle in the value's producer graph (e.g., a loop-carried tensor
+   * whose points-to union includes its own downstream producers). Re-entry masks just that member
+   * (⊤), so the caller's union keeps its non-cyclic members with the remainder marked instead of
+   * recursing without bound (wala/ML#718).
+   */
+  private static final Map<PropagationCallGraphBuilder, Set<InstanceKey>>
+      SHAPE_DELEGATIONS_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /** Dtype counterpart of {@link #SHAPE_DELEGATIONS_IN_PROGRESS}. */
+  private static final Map<PropagationCallGraphBuilder, Set<InstanceKey>>
+      DTYPE_DELEGATIONS_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
    * Memo of the {@code (class, attribute)} chase results of {@link
    * #resolveStoredAttributeDimInClass(PropagationCallGraphBuilder, IClass, String)} per builder
    * (wala/ML#712). The chase scans the whole call graph, so uncached re-runs are quadratic on large
@@ -245,6 +259,8 @@ public abstract class TensorGenerator {
     if (dtypes != null) PREVIOUS_DTYPES_CACHE.put(builder, dtypes);
     SHAPES_IN_PROGRESS.remove(builder);
     DTYPES_IN_PROGRESS.remove(builder);
+    SHAPE_DELEGATIONS_IN_PROGRESS.remove(builder);
+    DTYPE_DELEGATIONS_IN_PROGRESS.remove(builder);
     // The chase reads shape results that may change between rounds, so its memo restarts too.
     STORED_ATTRIBUTE_CACHE.remove(builder);
     BUILD_CONTRACT_CACHE.remove(builder);
@@ -268,6 +284,8 @@ public abstract class TensorGenerator {
     PREVIOUS_DTYPES_CACHE.remove(builder);
     SHAPES_IN_PROGRESS.remove(builder);
     DTYPES_IN_PROGRESS.remove(builder);
+    SHAPE_DELEGATIONS_IN_PROGRESS.remove(builder);
+    DTYPE_DELEGATIONS_IN_PROGRESS.remove(builder);
     STORED_ATTRIBUTE_CACHE.remove(builder);
     BUILD_CONTRACT_CACHE.remove(builder);
   }
@@ -2388,6 +2406,16 @@ public abstract class TensorGenerator {
                   + reference.getName()
                   + ". Attempting to retrieve shape from producer.");
           ShapeResult fromTensor = this.getShapeResultFromTensor(builder, asin, exact);
+          LOGGER.fine(
+              () ->
+                  "DIAG creator [alloc="
+                      + asin.getNode().getMethod().getDeclaringClass().getName()
+                      + "@"
+                      + asin.getSite().getProgramCounter()
+                      + "] => members="
+                      + fromTensor.members().size()
+                      + " unk="
+                      + fromTensor.hasUnknown());
           // An empty result means no producer resolved for this member, not a scalar.
           if (fromTensor.hasUnknown() || fromTensor.isBottom()) {
             if (exact) hasUnknown = true; // The union is incomplete, wala/ML#718.
@@ -2452,6 +2480,35 @@ public abstract class TensorGenerator {
    * @return the resolution result; ⊥ when no producer resolves
    */
   private ShapeResult getShapeResultFromTensor(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode asin, boolean exact) {
+    // A producer chain that re-encounters an allocation site is a cycle in the value's producer
+    // graph (a loop-carried tensor whose points-to union includes its own downstream producers).
+    // Mask just this member (⊤): the caller's union keeps its non-cyclic members with the
+    // remainder marked, and the round loop can then converge upward from that base instead of
+    // recursing without bound or inheriting a whole-read ⊤ (wala/ML#718).
+    Set<InstanceKey> delegationsInProgress =
+        SHAPE_DELEGATIONS_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
+    if (!delegationsInProgress.add(asin)) {
+      LOGGER.fine(() -> "Producer-cycle re-entry on allocation: " + describe(asin) + "; masking.");
+      return ShapeResult.unknown();
+    }
+    try {
+      return this.doGetShapeResultFromTensor(builder, asin, exact);
+    } finally {
+      delegationsInProgress.remove(asin);
+    }
+  }
+
+  /**
+   * Body of {@link #getShapeResultFromTensor(PropagationCallGraphBuilder, AllocationSiteInNode,
+   * boolean)}, running under its producer-cycle mask.
+   *
+   * @param builder the propagation call graph builder
+   * @param asin the allocation site of the tensor
+   * @param exact whether an unresolvable member marks the unknown remainder
+   * @return the resolution result; ⊥ when no producer resolves
+   */
+  private ShapeResult doGetShapeResultFromTensor(
       PropagationCallGraphBuilder builder, AllocationSiteInNode asin, boolean exact) {
     boolean hasUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
@@ -3206,6 +3263,33 @@ public abstract class TensorGenerator {
   }
 
   private Set<DType> getDTypesFromTensor(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode asin) {
+    // Dtype counterpart of the producer-cycle mask in `getShapeResultFromTensor` (wala/ML#718).
+    // The mask contributes nothing rather than UNKNOWN: an in-band UNKNOWN would collapse the
+    // caller's union to {UNKNOWN} under the lattice normalization, erasing the sibling members'
+    // resolved dtypes.
+    Set<InstanceKey> delegationsInProgress =
+        DTYPE_DELEGATIONS_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
+    if (!delegationsInProgress.add(asin)) {
+      LOGGER.fine(() -> "Producer-cycle re-entry on allocation: " + describe(asin) + "; masking.");
+      return EnumSet.noneOf(DType.class);
+    }
+    try {
+      return this.doGetDTypesFromTensor(builder, asin);
+    } finally {
+      delegationsInProgress.remove(asin);
+    }
+  }
+
+  /**
+   * Body of {@link #getDTypesFromTensor(PropagationCallGraphBuilder, AllocationSiteInNode)},
+   * running under its producer-cycle mask.
+   *
+   * @param builder the propagation call graph builder
+   * @param asin the allocation site of the tensor
+   * @return the resolved dtypes; empty when no producer resolves
+   */
+  private Set<DType> doGetDTypesFromTensor(
       PropagationCallGraphBuilder builder, AllocationSiteInNode asin) {
     Set<DType> ret = EnumSet.noneOf(DType.class);
     CGNode readDataNode = asin.getNode();
@@ -5408,6 +5492,16 @@ public abstract class TensorGenerator {
       return new Reshape(node);
     } else if (type.equals(TensorFlowTypes.SQUEEZE.getDeclaringClass())) {
       return new Squeeze(node);
+    } else if (type.equals(TensorFlowTypes.CONCAT.getDeclaringClass())) {
+      return new Concat(node);
+    } else if (type.equals(TensorFlowTypes.FILL.getDeclaringClass())) {
+      return new Fill(node);
+    } else if (type.equals(TensorFlowTypes.ONE_HOT.getDeclaringClass())) {
+      return new OneHot(node);
+    } else if (type.equals(TensorFlowTypes.REDUCE_MEAN.getDeclaringClass())) {
+      return new ReduceMean(node);
+    } else if (type.equals(TensorFlowTypes.CONVERT_TO_TENSOR.getDeclaringClass())) {
+      return new ConvertToTensor(node);
     } else if (type.equals(TensorFlowTypes.SIGMOID.getDeclaringClass())) {
       return new Sigmoid(node);
     } else if (type.equals(TensorFlowTypes.SOFTMAX.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ValueExtractingTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ValueExtractingTensorGenerator.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -39,6 +40,15 @@ public abstract class ValueExtractingTensorGenerator extends TensorGenerator {
 
   public ValueExtractingTensorGenerator(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ValueExtractingTensorGenerator(CGNode node) {
+    super(node);
   }
 
   @Override


### PR DESCRIPTION
Implements the terminal fix from the wala/ML#718 diagnosis trail: the loop-fed contexts' shape reads were starving on producer-graph cycles.

## Registrations

`tf.concat`, `tf.fill`, `tf.one_hot`, `tf.reduce_mean`, and `tf.convert_to_tensor` allocate generic `Tensor`s but were missing from `createManualGenerator` (the reshape/squeeze gap class from #583); the `fill` dead end surfaced directly in the stuck `get_shape_list` reads' per-creator trace. Node-anchored constructors thread through `Constant`, `ValueExtractingTensorGenerator`, and `Reduction`.

## Producer-Cycle Mask

A loop-carried value's points-to union includes its own downstream producers, so registering those producers exposes unbounded recursion through the unmemoized manual paths (raw `Concat` registration StackOverflows on the subject). The per-builder `SHAPE`/`DTYPE_DELEGATIONS_IN_PROGRESS` sets mask a re-entered allocation site to ⊤ (shapes) or no contribution (dtypes; an in-band `UNKNOWN` would collapse the union's resolved siblings), so the union keeps its non-cyclic members and the round loop converges upward from that base: exactly the missing induction base identified on the issue.

## Vivo Effect

Three of the four `DenseLayer3dProj` contexts move from fully unknown to `{⊤ float32, (8, 100, U, U), (8, 10, U, U)}`: the runtime-true-shaped rank-4 members flow through the shared-transformer loop for the first time. One entry's proj context remains ⊤ (the fixed point's last residue), tracked on wala/ML#718.

Part of wala/ML#718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
