### PR TITLE
Remodel tf.range as an allocating tensor with a registered producer

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3666,8 +3666,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * types. Function body mirrors {@code crf_binary_score} from {@code
    * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage.
    *
-   * <p>The local count captures one {@code tf.shape}-scalar arithmetic intermediate regressing to ⊥
-   * when the wala/ML#722 arm made its chain live — TODO: <a
+   * <p>The local count captures one {@code tf.shape}-scalar arithmetic intermediate at ⊥; its
+   * gather-fixture siblings recovered with the {@code tf.range} remodel, but this one did not, and
+   * its cause is unidentified—TODO: <a
    * href="https://github.com/wala/ML/issues/723">wala/ML#723</a>.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
@@ -4098,14 +4099,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * runtime-dimensioned final {@code tf.reshape} leaves the local <em>result</em> symbolic, but the
    * parameters themselves are exact.)
    *
-   * <p>The local tensor-variable count is {@code 8}: the {@code tf.shape} shape-vector arm
-   * (wala/ML#722) made the previously-⊤ {@code range}/{@code expand_dims}/{@code tile} chain live,
-   * and it currently misresolves — {@code tf.range(num_row)} folds a leaked constant as its bound
-   * (typing {@code (1,)} where the runtime is {@code (2,)}), and the {@code row_indices *
-   * num_column + column_indices} arithmetic and its {@code [-1]} reshape regressed to ⊥ (both are
-   * genuine runtime tensors) — TODO: <a
-   * href="https://github.com/wala/ML/issues/723">wala/ML#723</a>. The function's final reshape, by
-   * contrast, now types its exact runtime {@code (2, 3)} through the same arm.
+   * <p>The local tensor-variable count is {@code 10}. The {@code tf.shape} shape-vector arm
+   * (wala/ML#722) types the final reshape to its exact runtime {@code (2, 3)}, and the {@code
+   * tf.range} remodel (wala/ML#723) types the {@code range}/{@code expand_dims} chain soundly
+   * ({@code (Unresolved,)} and {@code (Unresolved, 1)}); the tile and the flat-index arithmetic
+   * stay at sound unknowns, since a fold over an {@code Unresolved} axis has no numeric value.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -4119,7 +4117,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_gather_elements_along_row.py",
         "_gather_elements_along_row",
         2,
-        8,
+        10,
         Map.of(
             2, Set.of(TENSOR_2_4_FLOAT32),
             3, Set.of(TENSOR_2_3_INT32)));

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -1955,13 +1955,10 @@
         </method>
       </class>
       <class name="range" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/range returns a 1-D tensor. Modeled as `<new>+<return>` (fresh allocation) paired with the `Range` generator, which computes the length from the bounds; the previous stub returned a one-element `Llist` whose catalog fabricated a phantom `(1,)` shape for every consumer of the result (wala/ML#723). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start limit delta dtype name">
-          <new def="x" class="Llist"/>
-          <new def="z" class="Ltensorflow/functions/constant"/>
-          <constant name="p" type="int" value="1"/> <!-- FIXME: The type may actually depend on the arguments passed to `tf.range()`. It may not necessarily be `int`. -->
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="p" numArgs="2" def="y"/>
-          <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y"/>
-          <return value="x"/>
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="Tensor" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Range.java
@@ -64,6 +64,15 @@ public class Range extends TensorGenerator {
     super(source);
   }
 
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Range(CGNode node) {
+    super(node);
+  }
+
   @Override
   protected Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
     Set<List<Dimension<?>>> ret = HashSetFactory.make();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -5541,6 +5541,8 @@ public abstract class TensorGenerator {
       return new ReduceMean(node);
     } else if (type.equals(TensorFlowTypes.CONVERT_TO_TENSOR.getDeclaringClass())) {
       return new ConvertToTensor(node);
+    } else if (type.equals(TensorFlowTypes.RANGE.getDeclaringClass())) {
+      return new Range(node);
     } else if (type.equals(TensorFlowTypes.SIGMOID.getDeclaringClass())) {
       return new Sigmoid(node);
     } else if (type.equals(TensorFlowTypes.SOFTMAX.getDeclaringClass())) {


### PR DESCRIPTION
Fixes the shape fabrication diagnosed on wala/ML#723 at its true source.

## The Remodel

`tf.range`'s XML stub returned a one-element `Llist` holding `constant(1)` (with a `FIXME` from its own era), so every consumer of a `tf.range` result read the list's catalog as the value's structure: a phantom `(1,)` that the (individually correct) `expand_dims`/`tile` compositions amplified to `(1, 1)`/`(1, 3)` in the gather fixture once the wala/ML#722 arm made the chain live. The model becomes the standard `<new>+<return>` of a fresh tensor per the allocating-API doctrine, paired with the `Range` generator through its new node-anchored constructor and `createManualGenerator` registration, so the result types from its bounds: `(Unresolved,)` when they are runtime scalars, the folded constant when they are static.

## Effects

The gather guard returns to its sound state with no TODO: `(Unresolved,)` → `(Unresolved, 1)` through the chain, the two elementwise intermediates the phantom's conflicts had erased to ⊥ come back, and the recognition count reverts. `Range` itself was exonerated during diagnosis (both bound-resolution paths behave; the instrumentation is not retained). The CRF guard keeps one unexplained ⊥ intermediate under the wala/ML#723 TODO, and the issue stays open scoped to it.

Part of wala/ML#723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
