### PR TITLE
Register the numpy.array and unsorted-segment producers

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -6090,8 +6090,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * Companion to {@link #testNpArrayBareParam()} for the non-literal-source floor of <a
    * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: when {@code x} is itself an
    * {@code np.ndarray} rather than a Python literal, numpy preserves the source's dtype, which the
-   * walk does not model, so it floors to ⊤. The nested-array shape does not propagate through the
-   * outer {@code np.array} either, so both axes are ⊤.
+   * walk does not model, so the dtype floors to ⊤. The nested-array {@code (2,)} shape now
+   * propagates through the outer {@code np.array} via the producer registration (wala/ML#625); the
+   * dtype residue stays with wala/ML#626.
    */
   @Test
   public void testNpArrayArraySource()
@@ -6101,7 +6102,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(2))))));
   }
 
   /**
@@ -6110,11 +6111,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * It currently types to {@code ⊤} unknown, coarser than the bare form's {@code (3,)} because
    * {@code tf.constant} drops the array shape.
    *
-   * <p>TODO: This pins the current imprecise shape. Once <a
-   * href="https://github.com/wala/ML/issues/625">wala/ML#625</a> lands, the parameter should type
-   * to {@code (3,)} {@code float64} (the bare form's result now that <a
-   * href="https://github.com/wala/ML/issues/626">wala/ML#626</a> models numpy dtype promotion), and
-   * this assertion should be updated accordingly.
+   * <p>The {@code numpy.array} producer registration (wala/ML#625) delivers the concrete type: the
+   * wrapped array's {@code (3,)} shape survives {@code tf.constant}, and the dtype is numpy's
+   * {@code float64} default for float literals.
    */
   @Test
   public void testNpArrayWrappedParam()
@@ -6124,7 +6123,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "f",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
+        Map.of(2, Set.of(TensorType.of(FLOAT_64, 3))));
   }
 
   /**
@@ -15644,6 +15643,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * floors to ⊤ over the {@code np.ndarray} row (the unmodeled ragged rank over a tensor element).
    * Delegating the element to its producer generator would recover the shape (<a
    * href="https://github.com/wala/ML/issues/652">wala/ML#652</a>).
+   *
+   * <p>The {@code numpy.array} producer registration (wala/ML#625) adds the ⊤ {@code int64} member:
+   * the {@code np.ndarray} row's own type (numpy's integer default) joins the union through the
+   * flow-insensitive points-to substrate, alongside the ragged result's runtime {@code int32}.
    */
   @Test
   public void testRaggedConstantUnresolvableDepth()
@@ -15653,7 +15656,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE)));
+        Map.of(2, Set.of(TENSOR_INT32_UNKNOWN_SHAPE, new TensorType(INT_64, null))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -11,6 +11,7 @@ import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -40,6 +41,15 @@ public class NpArray extends TensorGenerator {
 
   public NpArray(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public NpArray(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -5543,6 +5543,12 @@ public abstract class TensorGenerator {
       return new ConvertToTensor(node);
     } else if (type.equals(TensorFlowTypes.RANGE.getDeclaringClass())) {
       return new Range(node);
+    } else if (type.equals(NumpyTypes.ARRAY.getDeclaringClass())) {
+      return new NpArray(node);
+    } else if (type.equals(TensorFlowTypes.UNSORTED_SEGMENT_SUM.getDeclaringClass())
+        || type.equals(TensorFlowTypes.UNSORTED_SEGMENT_MAX.getDeclaringClass())
+        || type.equals(TensorFlowTypes.UNSORTED_SEGMENT_MEAN.getDeclaringClass())) {
+      return new UnsortedSegmentReduction(node);
     } else if (type.equals(TensorFlowTypes.SIGMOID.getDeclaringClass())) {
       return new Sigmoid(node);
     } else if (type.equals(TensorFlowTypes.SOFTMAX.getDeclaringClass())) {


### PR DESCRIPTION
Continues the producer-registration census from #583/#585/#587: `numpy.array` and the three `tf.math.unsorted_segment_*` reductions allocate generic tensors without `createManualGenerator` entries, dead-ending delegation for every value they feed.

## Effects

`tf.constant` of a `numpy.array` no longer loses the array's statically available shape: the wrapped-param guard's wala/ML#625 TODO resolves to the runtime-exact `(3,) float64` (numpy's float default), and the array-source guard recovers the nested `(2,)` shape, with the dtype residue staying on wala/ML#626. The unresolvable-depth ragged guard gains the `np.ndarray` row's own ⊤ `int64` union member through the flow-insensitive substrate, documented in place.

Closes wala/ML#625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
