### PR TITLE
Pin the evidence-free side of the tf.shape classification

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13330,6 +13330,34 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Evidence-free twin of {@link #testReshapeTfShape()} (wala/ML#722): when the input's leading
+   * axes are fixed runtime sizes the analysis cannot compute, {@code tf.shape(x)[i]} carries no
+   * {@code None}-evidence and the reshape target's leading elements classify {@link UnresolvedDim}
+   * per the wala/ML#721 criterion, with the trailing constant exact. The pair pins the arm's
+   * discriminating variable: the input's own axis evidence, not the target's syntactic pattern.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testReshapeTfShapeUnresolved()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_tf_shape_unresolved.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))))));
+  }
+
+  /**
    * Pins the fold taint of the dimension-provenance split (wala/ML#721): {@code np.prod} over a
    * shape list whose leading axis is {@code None} stays {@link DynamicDim} — arithmetic over a
    * {@code None} axis is itself {@code None} at run time — rather than degrading to {@link

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_tf_shape_unresolved.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_tf_shape_unresolved.py
@@ -1,0 +1,32 @@
+import os
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# Evidence-free twin of `tf2_test_reshape_tf_shape.py` (wala/ML#722): the input's
+# leading axes are fixed runtime sizes the analysis cannot compute (environment
+# reads), so `tf.shape(x)[0]`/`[1]` carry *no* `None`-evidence and the reshape
+# target's leading elements classify `Unresolved` per the wala/ML#721 criterion,
+# while the trailing constant stays exact. Contrast the sibling fixture, where
+# the batch axis is declared `None` and the same pattern yields `Dynamic`.
+n = int(os.environ.get("ARIADNE_TEST_N", "2"))
+m = int(os.environ.get("ARIADNE_TEST_M", "4"))
+
+x = tf.ones((n, m, 6))
+
+batch = tf.shape(x)[0]
+seq = tf.shape(x)[1]
+
+h = tf.reshape(x, [-1, 6])
+w = tf.ones((6, 10))
+out = tf.matmul(h, w)
+out = tf.reshape(out, [batch, seq, 10])
+
+assert out.shape == (2, 4, 10)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Pins both sides of the wala/ML#722 classification with a discriminating fixture pair, answering the re-measure that reopened the issue (see the analysis there): the locals-bound reshape-target pattern reaches the `tf.shape` arm in both fixtures, and the classification tracks the input's own axis evidence. A `None`-declared batch axis yields `Dynamic`; environment-sourced fixed axes yield `Unresolved` per the wala/ML#721 criterion's documented zero-evidence boundary, which is the filed repro's situation (its input carries no axis evidence generator-side).

Whether the issue re-closes on this is the reopener's call, per the policy discussion on the thread.

Part of wala/ML#722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
