### PR TITLE
Record the producing library of tensor-typed values

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -45,9 +45,13 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
   @Test
   public void testNumpyOrigin() throws ClassHierarchyException, CancelException, IOException {
     Map<String, Set<TensorOrigin>> sinkParameterOrigins =
-        getSinkParameterOrigins("tf2_test_numpy_origin.py", "consume_np", "consume_tf");
+        getSinkParameterOrigins(
+            "tf2_test_numpy_origin.py", "consume_np", "consume_np_opaque", "consume_tf");
 
     assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np"));
+    // The opaque sink receives an unknown-shape ndarray: provenance must survive even though the
+    // shape does not resolve, since a consumer needs the origin most exactly when the type is ⊤.
+    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np_opaque"));
     assertEquals(EnumSet.of(TensorOrigin.TENSORFLOW), sinkParameterOrigins.get("consume_tf"));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -46,12 +46,19 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
   public void testNumpyOrigin() throws ClassHierarchyException, CancelException, IOException {
     Map<String, Set<TensorOrigin>> sinkParameterOrigins =
         getSinkParameterOrigins(
-            "tf2_test_numpy_origin.py", "consume_np", "consume_np_opaque", "consume_tf");
+            "tf2_test_numpy_origin.py",
+            "consume_np",
+            "consume_np_opaque",
+            "consume_np_loader",
+            "consume_tf");
 
     assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np"));
     // The opaque sink receives an unknown-shape ndarray: provenance must survive even though the
     // shape does not resolve, since a consumer needs the origin most exactly when the type is ⊤.
     assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np_opaque"));
+    // All six Keras dataset loaders route here: `load_data` returns ndarrays, so their results
+    // are numpy-origin by the consumer-ratified runtime-type rule.
+    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np_loader"));
     assertEquals(EnumSet.of(TensorOrigin.TENSORFLOW), sinkParameterOrigins.get("consume_tf"));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -87,7 +87,8 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
           String signature = localPointerKey.getNode().getMethod().getSignature();
 
           for (String sink : sinkFunctionNames)
-            if (signature.contains("/" + sink + ".do("))
+            // Signatures render scope separators as dots: `script f.py.consume_np.do()LRoot;`.
+            if (signature.contains("." + sink + ".do("))
               ret.computeIfAbsent(sink, k -> EnumSet.noneOf(TensorOrigin.class))
                   .addAll(pt.snd.getOrigins());
         });

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -1,0 +1,97 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Tests for the numpy-origin vs TensorFlow-origin record on tensor-typed values (wala/ML#724).
+ *
+ * <p>Assertions target the first parameter (value number 2) of a sink function, per the
+ * calling-context convention: the fixture routes each value of interest through {@code
+ * consume_np(x)} or {@code consume_tf(x)}, and the parameter's origins are the union across calling
+ * contexts, mirroring the type-assertion semantics of {@code TestTensorflow2Model.test}.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TestTensorOrigins extends TestPythonMLCallGraphShape {
+
+  /**
+   * The three instruction shapes from wala/ML#724 flow to {@code consume_np}: a binary operator
+   * over numpy operands ({@code a + b}), an ndarray method ({@code m.reshape(...)}), and an
+   * interprocedural return of {@code np.array(...)}. All are numpy-origin. The mixed binary
+   * operator ({@code ndarray + Tensor}) flows to {@code consume_tf}: runtime dispatch makes it a
+   * TensorFlow operation and its result a {@code tf.Tensor}.
+   *
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test file cannot be read.
+   */
+  @Test
+  public void testNumpyOrigin() throws ClassHierarchyException, CancelException, IOException {
+    Map<String, Set<TensorOrigin>> sinkParameterOrigins =
+        getSinkParameterOrigins("tf2_test_numpy_origin.py", "consume_np", "consume_tf");
+
+    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np"));
+    assertEquals(EnumSet.of(TensorOrigin.TENSORFLOW), sinkParameterOrigins.get("consume_tf"));
+  }
+
+  /**
+   * Runs the tensor analysis on the given file and collects the origins of each named sink
+   * function's first parameter (value number 2), unioned across calling contexts.
+   *
+   * @param filename The Python test file to analyze.
+   * @param sinkFunctionNames The sink functions whose first-parameter origins are collected.
+   * @return A map from sink function name to the union of its first parameter's origins; a sink
+   *     absent from the map received no tensor-typed state at all.
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test file cannot be read.
+   */
+  private Map<String, Set<TensorOrigin>> getSinkParameterOrigins(
+      String filename, String... sinkFunctionNames)
+      throws ClassHierarchyException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine = makeEngine(emptyList(), filename);
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+
+    TensorTypeAnalysis analysis = engine.performAnalysis(builder);
+
+    Map<String, Set<TensorOrigin>> ret = new HashMap<>();
+
+    analysis.forEach(
+        pt -> {
+          if (!(pt.fst instanceof LocalPointerKey)) return;
+          LocalPointerKey localPointerKey = (LocalPointerKey) pt.fst;
+
+          // The first explicit parameter (value number 2; value number 1 is the function object).
+          if (localPointerKey.getValueNumber() != 2) return;
+
+          String signature = localPointerKey.getNode().getMethod().getSignature();
+
+          for (String sink : sinkFunctionNames)
+            if (signature.contains("/" + sink + ".do("))
+              ret.computeIfAbsent(sink, k -> EnumSet.noneOf(TensorOrigin.class))
+                  .addAll(pt.snd.getOrigins());
+        });
+
+    return ret;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -475,6 +475,11 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                       changed |= lhs.origins.addAll(rhs.origins);
                       return changed ? CHANGED : NOT_CHANGED;
                     }
+                  } else if (rhs != null && lhs != null) {
+                    // A null-state (unknown tensor, ⊤) predecessor contributes no types, but its
+                    // producing library is still evidence and must flow: provenance matters most
+                    // exactly when the shape is unknown (wala/ML#724).
+                    return lhs.origins.addAll(rhs.origins) ? CHANGED : NOT_CHANGED;
                   } else {
                     return NOT_CHANGED;
                   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -466,23 +466,25 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               new UnaryOperator<TensorVariable>() {
                 @Override
                 public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
-                  if (rhs != null && rhs.state != null) {
-                    if (lhs == null || lhs.state == null) {
+                  // The solver constructs every node variable, so a null endpoint has nothing to
+                  // update; the guard also keeps the null tests below honest (the previous
+                  // `lhs == null || lhs.state == null` guard dereferenced `lhs` in its own arm).
+                  if (lhs == null || rhs == null) return NOT_CHANGED;
+
+                  if (rhs.state != null) {
+                    if (lhs.state == null) {
                       lhs.copyState(rhs);
                       return CHANGED;
-                    } else {
-                      boolean changed = lhs.state.addAll(rhs.state);
-                      changed |= lhs.origins.addAll(rhs.origins);
-                      return changed ? CHANGED : NOT_CHANGED;
                     }
-                  } else if (rhs != null && lhs != null) {
-                    // A null-state (unknown tensor, ⊤) predecessor contributes no types, but its
-                    // producing library is still evidence and must flow: provenance matters most
-                    // exactly when the shape is unknown (wala/ML#724).
-                    return lhs.origins.addAll(rhs.origins) ? CHANGED : NOT_CHANGED;
-                  } else {
-                    return NOT_CHANGED;
+                    boolean changed = lhs.state.addAll(rhs.state);
+                    changed |= lhs.origins.addAll(rhs.origins);
+                    return changed ? CHANGED : NOT_CHANGED;
                   }
+
+                  // A null-state (unknown tensor, ⊤) predecessor contributes no types, but its
+                  // producing library is still evidence and must flow: provenance matters most
+                  // exactly when the shape is unknown (wala/ML#724).
+                  return lhs.origins.addAll(rhs.origins) ? CHANGED : NOT_CHANGED;
                 }
 
                 @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -12,6 +12,7 @@ package com.ibm.wala.cast.python.ml.analysis;
 
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.lsp.AnalysisError;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -186,11 +187,20 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
     @Override
     public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
-      if (lhs != null && lhs.state != null && !lhs.state.isEmpty()) {
-        lhs.state.clear();
-        return CHANGED_AND_FIXED;
+      boolean changed = false;
+      if (lhs != null) {
+        if (lhs.state != null && !lhs.state.isEmpty()) {
+          lhs.state.clear();
+          changed = true;
+        }
+        // A dropped destination is semantically non-tensor; leaked origin evidence goes with the
+        // leaked types (wala/ML#724).
+        if (!lhs.origins.isEmpty()) {
+          lhs.origins.clear();
+          changed = true;
+        }
       }
-      return NOT_CHANGED_AND_FIXED;
+      return changed ? CHANGED_AND_FIXED : NOT_CHANGED_AND_FIXED;
     }
 
     @Override
@@ -279,12 +289,19 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               // previous `add`-only semantics caused the cast result's Cast-generator-seeded
               // `(?, dtype)` to leak into the post-set_shape state alongside the asserted shape.
               // Clear-then-add mirrors `DropOp`'s clear-state pattern with CHANGED_AND_FIXED.
-              if (lhs.state.size() == 1 && lhs.state.contains(setShapeTo)) {
-                return NOT_CHANGED_AND_FIXED;
+              boolean changed = false;
+              if (!(lhs.state.size() == 1 && lhs.state.contains(setShapeTo))) {
+                lhs.state.clear();
+                lhs.state.add(setShapeTo);
+                changed = true;
               }
-              lhs.state.clear();
-              lhs.state.add(setShapeTo);
-              return CHANGED_AND_FIXED;
+              // Pinning replaces the SHAPE, not the provenance: the destination's value is still
+              // produced by whatever produced the incoming flow (a `set_shape` receiver keeps its
+              // pre-assertion origins; a subscript result routed here by the wala/ML#405 reroute
+              // keeps its container's), so origins union from the predecessor as everywhere else
+              // (wala/ML#724).
+              if (rhs != null) changed |= lhs.origins.addAll(rhs.origins);
+              return changed ? CHANGED_AND_FIXED : NOT_CHANGED_AND_FIXED;
             }
 
             @Override
@@ -333,6 +350,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                         new ConvError(t, dimensions, pos, getTargetDef(v.getPointerKey())));
                   }
                 }
+                // A convolution is a TensorFlow operation; its result is TensorFlow-origin
+                // whatever produced the input (wala/ML#724).
+                changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
               }
               return changed ? CHANGED_AND_FIXED : NOT_CHANGED;
             }
@@ -418,6 +438,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                         new ReshapeError(t, reshapeTo, pos, getTargetDef(v.getPointerKey())));
                   }
                 }
+                // `tf.reshape` is a TensorFlow operation; its result is TensorFlow-origin
+                // whatever produced the input (wala/ML#724).
+                changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
               }
               return changed ? CHANGED_AND_FIXED : NOT_CHANGED;
             }
@@ -448,7 +471,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                       lhs.copyState(rhs);
                       return CHANGED;
                     } else {
-                      return lhs.state.addAll(rhs.state) ? CHANGED : NOT_CHANGED;
+                      boolean changed = lhs.state.addAll(rhs.state);
+                      changed |= lhs.origins.addAll(rhs.origins);
+                      return changed ? CHANGED : NOT_CHANGED;
                     }
                   } else {
                     return NOT_CHANGED;
@@ -517,6 +542,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                 boolean changed = false;
                 for (TensorVariable r : rhs) {
                   changed |= lhs.state.addAll(r.state);
+                  changed |= lhs.origins.addAll(r.origins);
                 }
                 return changed ? CHANGED : NOT_CHANGED;
               }
@@ -544,9 +570,26 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
   private final Map<PointsToSetVariable, Set<TensorType>> init;
 
+  private final Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins;
+
+  /**
+   * Constructs the tensor type dataflow analysis over the PA assignment graph.
+   *
+   * @param G The dataflow graph (the PA assignment graph including implicit constraints).
+   * @param init The per-source seeded tensor types; a {@code null} value seeds an unknown tensor.
+   * @param initOrigins The per-source seeded producing libraries (wala/ML#724), unioned along the
+   *     same edges as the types.
+   * @param reshapeTypes Destinations pinned by an explicit reshape target shape.
+   * @param set_shapes Destinations pinned by an {@code x.set_shape(s)} assertion (wala/ML#509).
+   * @param conv2ds Destinations of 2D convolutions, rank-checked by {@code ConvOp}.
+   * @param conv3ds Destinations of 3D convolutions, rank-checked by {@code ConvOp}.
+   * @param drops Destinations pinned to empty-and-fixed (wala/ML#409).
+   * @param errorLog The sink for shape-mismatch diagnostics.
+   */
   public TensorTypeAnalysis(
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, Set<TensorType>> init,
+      Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
       Map<PointsToSetVariable, TensorType> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Set<PointsToSetVariable> conv2ds,
@@ -555,6 +598,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointerKey, AnalysisError> errorLog) {
     super(createProblem(G, reshapeTypes, set_shapes, conv2ds, conv3ds, drops, errorLog));
     this.init = init;
+    this.initOrigins = initOrigins;
   }
 
   @Override
@@ -583,6 +627,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
         getOut(src).state = null; // unknown tensor — distinguishable from empty (not-a-tensor)
       }
     }
+    for (PointsToSetVariable src : initOrigins.keySet())
+      getOut(src).origins.addAll(initOrigins.get(src));
   }
 
   public String toString() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorVariable.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorVariable.java
@@ -14,10 +14,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.fixpoint.IVariable;
 import com.ibm.wala.util.collections.HashSetFactory;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,6 +27,15 @@ public class TensorVariable implements IVariable<TensorVariable> {
   private int graphNodeId = -1;
   private int orderNumber = -1;
   Set<TensorType> state = HashSetFactory.make();
+
+  /**
+   * The libraries whose operations produced this variable's value (wala/ML#724). Seeded from the
+   * dispatched generator per dataflow source and unioned along the same edges as {@link #state}; a
+   * merge of numpy-origin and TensorFlow-origin flows carries both constants. Unlike {@link
+   * #state}, this set is never {@code null}: an empty set means no origin evidence reached the
+   * variable.
+   */
+  Set<TensorOrigin> origins = EnumSet.noneOf(TensorOrigin.class);
 
   public String toFormattedString(TensorType.Format fmt) {
     switch (fmt) {
@@ -90,6 +101,16 @@ public class TensorVariable implements IVariable<TensorVariable> {
     return Collections.unmodifiableSet(state);
   }
 
+  /**
+   * Returns the libraries whose operations produced this variable's value (wala/ML#724).
+   *
+   * @return The producing libraries; empty when no origin evidence reached the variable, both
+   *     constants when numpy-origin and TensorFlow-origin flows merged.
+   */
+  public Set<TensorOrigin> getOrigins() {
+    return Collections.unmodifiableSet(origins);
+  }
+
   @Override
   public int getGraphNodeId() {
     return graphNodeId;
@@ -113,6 +134,8 @@ public class TensorVariable implements IVariable<TensorVariable> {
   @Override
   public void copyState(TensorVariable v) {
     this.state = v.state == null ? null : HashSetFactory.make(v.state);
+    this.origins = EnumSet.noneOf(TensorOrigin.class);
+    this.origins.addAll(v.origins);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/AstypeOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/AstypeOperation.java
@@ -3,11 +3,13 @@ package com.ibm.wala.cast.python.ml.client;
 import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ssa.SSAInstruction;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -53,7 +55,8 @@ public class AstypeOperation extends TensorGenerator {
         // branch for implicit keys and falls through to IAE. Catch and return `null` (⊤ unknown
         // shape) so dtype inference still proceeds and the result flows downstream as a tensor
         // instead of being dropped entirely. For the non-chained mnist case, the factory
-        // recursion fires successfully via `MnistInputData`, so the shape is recovered and this
+        // recursion fires successfully via `MnistInputData{@code , so the shape is recovered and
+        // this
         // catch doesn't fire. See wala/ML#356, wala/WALA#1889.
         LOGGER.log(
             Level.FINE,
@@ -107,5 +110,17 @@ public class AstypeOperation extends TensorGenerator {
   @Override
   protected String getDTypeParameterName() {
     return null;
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an }ndarray.astype(...)` call, so the value
+   * is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BostonHousingInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BostonHousingInputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -114,4 +115,16 @@ public class BostonHousingInputData extends TensorGenerator {
 
   /** Shape of {@code boston_housing.load_data()[1][1]}: {@code (102,)} of {@code float64}. */
   public static final List<Dimension<?>> Y_TEST_SHAPE = targetsShape(NUM_TEST_EXAMPLES);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar100InputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar100InputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -144,4 +145,16 @@ public class Cifar100InputData extends TensorGenerator {
 
   /** Dtype set for cifar100's {@code y_*} label arrays: {@code int64}. */
   public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar10InputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Cifar10InputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -128,4 +129,16 @@ public class Cifar10InputData extends TensorGenerator {
 
   /** Shape of {@code cifar10.load_data()[1][1]}: {@code (10000, 1)} of {@code uint8}. */
   public static final List<Dimension<?>> Y_TEST_SHAPE = labelsShape(NUM_TEST_EXAMPLES);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -8,6 +8,7 @@ import static java.util.Collections.singleton;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -107,6 +108,98 @@ public class ElementWiseOperation extends TensorGenerator {
     }
     return this.getArgumentValueNumber(
         builder, this.getYParameterPosition(), this.getYParameterName(), false);
+  }
+
+  /**
+   * Returns the producing library of a binary operator's result by classifying its operands
+   * (wala/ML#724). Runtime binary-operator dispatch decides the result's library: {@code ndarray +
+   * ndarray} stays numpy, while any TensorFlow operand makes the operation a TensorFlow one and the
+   * result a {@code tf.Tensor}. Each operand classifies through its producing generator (via {@link
+   * TensorGeneratorFactory#getGenerator}), recursing structurally through nested binary operators
+   * (whose results have no points-to set to dispatch on); a statically opaque scalar operand is
+   * skipped, since it keeps the tensor operand's library. An operand without origin evidence
+   * contributes {@link TensorOrigin#TENSORFLOW}, preserving the pre-wala/ML#724 reading where the
+   * analysis cannot prove numpy provenance.
+   *
+   * <p>A manual anchor models a TensorFlow API call ({@code tf.multiply.do()} etc.), so the default
+   * applies there.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The producing libraries of the operation's result.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    if (this.source == null || !(this.source.getPointerKey() instanceof LocalPointerKey))
+      return super.getOrigins(builder);
+    LocalPointerKey lpk = (LocalPointerKey) this.source.getPointerKey();
+    SSAInstruction def = lpk.getNode().getDU().getDef(lpk.getValueNumber());
+    if (!(def instanceof SSABinaryOpInstruction)) return super.getOrigins(builder);
+    return this.getBinaryOperationOrigins(builder, lpk.getNode(), (SSABinaryOpInstruction) def);
+  }
+
+  /**
+   * Classifies a binary operator's result by the per-execution dispatch product of its operands'
+   * origins: an execution pairing a TensorFlow operand with anything yields a TensorFlow result,
+   * and only a numpy-with-numpy pairing yields an ndarray. The product is more precise than a plain
+   * union: {@code {NUMPY} + {TENSORFLOW}} is {@code {TENSORFLOW}}, while {@code {NUMPY} + {NUMPY,
+   * TENSORFLOW}} keeps both.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The node whose IR defines the operator.
+   * @param binop The binary operator instruction.
+   * @return The producing libraries of the operator's result.
+   */
+  private Set<TensorOrigin> getBinaryOperationOrigins(
+      PropagationCallGraphBuilder builder, CGNode node, SSABinaryOpInstruction binop) {
+    Set<TensorOrigin> x = this.getOperandOrigins(builder, node, binop.getUse(0));
+    Set<TensorOrigin> y = this.getOperandOrigins(builder, node, binop.getUse(1));
+
+    // A scalar (or otherwise skipped) operand keeps the other operand's origins.
+    if (x == null && y == null) return EnumSet.of(TensorOrigin.TENSORFLOW);
+    if (x == null) return y;
+    if (y == null) return x;
+
+    Set<TensorOrigin> ret = EnumSet.noneOf(TensorOrigin.class);
+    for (TensorOrigin ox : x)
+      for (TensorOrigin oy : y)
+        ret.add(
+            ox == TensorOrigin.TENSORFLOW || oy == TensorOrigin.TENSORFLOW
+                ? TensorOrigin.TENSORFLOW
+                : TensorOrigin.NUMPY);
+    return ret;
+  }
+
+  /**
+   * Classifies one binary-operator operand's origins. A nested binary operator recurses
+   * structurally (its result has no points-to set to dispatch on); any other operand classifies
+   * through the generator its points-to chain dispatches to.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The node whose IR defines the operand.
+   * @param vn The operand's value number.
+   * @return The operand's origins, or {@code null} when the operand contributes no origin evidence
+   *     (a scalar expression, or an unresolvable points-to chain).
+   */
+  private Set<TensorOrigin> getOperandOrigins(
+      PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    if (this.isScalarExpression(builder, node, vn)) return null;
+
+    SSAInstruction def = node.getDU().getDef(vn);
+    if (def instanceof SSABinaryOpInstruction)
+      return this.getBinaryOperationOrigins(builder, node, (SSABinaryOpInstruction) def);
+
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    if (builder.getPropagationSystem().isImplicit(pk)) return null;
+    PointsToSetVariable operand = builder.getPropagationSystem().findOrCreatePointsToSet(pk);
+    if (operand == null) return null;
+
+    TensorGenerator generator;
+    try {
+      generator = TensorGeneratorFactory.getGenerator(operand, builder);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+    return generator == null ? null : generator.getOrigins(builder);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImdbInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImdbInputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -128,4 +129,16 @@ public class ImdbInputData extends TensorGenerator {
 
   /** Dtype set for the binary-label {@code y_*} arrays. */
   public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MnistInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MnistInputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -115,4 +116,16 @@ public class MnistInputData extends TensorGenerator {
 
   /** Shape of {@code mnist.load_data()[1][1]}: {@code (10000,)} of {@code uint8}. */
   public static final List<Dimension<?>> Y_TEST_SHAPE = labelsShape(NUM_TEST_EXAMPLES);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
@@ -13,6 +14,7 @@ import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -201,7 +203,7 @@ public class NdarrayReshape extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    // `reshape` preserves the receiver's dtype.
+    // `reshape{@code  preserves the receiver's dtype.
     int receiverVn = getReceiverVn();
     if (receiverVn > 0) {
       Set<DType> dtypes = getDTypes(builder, receiverVn);
@@ -228,5 +230,17 @@ public class NdarrayReshape extends TensorGenerator {
   @Override
   protected String getDTypeParameterName() {
     return null;
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an }ndarray.reshape(...)` call, so the
+   * value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarraySubscriptOperation.java
@@ -10,6 +10,7 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -28,6 +29,7 @@ import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -338,5 +340,17 @@ public class NdarraySubscriptOperation extends TensorGenerator {
   private enum SubscriptField {
     ELLIPSIS,
     NEWAXIS
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an ndarray subscript, so the value is an
+   * ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -9,6 +9,7 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -155,7 +156,7 @@ public class NpArray extends TensorGenerator {
         else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
         else if (value instanceof String) leaves.add(DType.STRING);
         else if (value != null && "org.python.core.PyComplex".equals(value.getClass().getName()))
-          // A Python complex literal, which the Jython front-end represents as a `PyComplex`.
+          // A Python complex literal, which the Jython front-end represents as a `PyComplex{@code .
           // Matched by class name to avoid a compile-time dependency on the Jython runtime.
           leaves.add(DType.COMPLEX128);
         else return false; // Unrecognized scalar.
@@ -211,5 +212,17 @@ public class NpArray extends TensorGenerator {
   @Override
   protected String getDTypeParameterName() {
     return "dtype";
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an }np.array(...)` call, so the value is an
+   * ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpOnes.java
@@ -5,6 +5,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
 import static java.util.logging.Logger.getLogger;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -55,5 +56,17 @@ public class NpOnes extends Ones {
                 + ".");
 
     return EnumSet.of(FLOAT64);
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an {@code np.ones(...)} call, so the value
+   * is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpReshape.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
@@ -10,6 +11,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -105,5 +107,17 @@ public class NpReshape extends Reshape {
       }
     }
     return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an {@code np.reshape(...)} call, so the
+   * value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -19,6 +19,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ipa.callgraph.TrampolineReceiverContextSelector;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
@@ -73,6 +74,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1282,12 +1284,26 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           TensorGenerator.advanceRound(builder);
         }
 
+      // Seed each source's producing library beside its types (wala/ML#724). Origins ride the
+      // same dataflow edges as the types, so the seeds are the only generator-side contribution;
+      // everything downstream (operators, merges) is the analysis's union.
+      Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins = HashMapFactory.make();
+      for (PointsToSetVariable v : sources) {
+        Set<TensorType> types = init.get(v);
+        if (types != null && types.isEmpty()) continue; // ⊥: not a tensor, no origin to record
+        Set<TensorOrigin> origins = getTensorOrigins(v, builder);
+        if (!origins.isEmpty()) initOrigins.put(v, origins);
+      }
+
       Map<PointsToSetVariable, TensorType> placeholders =
           handleShapeSourceOp(builder, dataflow, placeholder, 2);
       LOGGER.fine("Placeholders: " + placeholders);
 
-      for (Map.Entry<PointsToSetVariable, TensorType> e : placeholders.entrySet())
+      for (Map.Entry<PointsToSetVariable, TensorType> e : placeholders.entrySet()) {
         init.put(e.getKey(), Set.of(e.getValue()));
+        // `tf.compat.v1.placeholder` is a TensorFlow API (wala/ML#724).
+        initOrigins.put(e.getKey(), EnumSet.of(TensorOrigin.TENSORFLOW));
+      }
 
       // wala/ML#509: recognize `x.set_shape(s)` via IR scanning rather than call-graph dispatch on
       // the `Ltensorflow/functions/set_shape` synthetic class. The legacy dispatch path requires
@@ -1299,7 +1315,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       // the receiver. Remove receivers from `init` so the SetShapeOp edge transfer is the sole
       // source of state for those variables; otherwise the meet-time union re-introduces the
       // generator-seeded type (e.g., Cast generator's (?, float32) on the cast-result variable).
-      for (PointsToSetVariable recv : setCalls.keySet()) init.remove(recv);
+      for (PointsToSetVariable recv : setCalls.keySet()) {
+        init.remove(recv);
+        // The SetShapeOp edge transfer pins the receiver's origin too (wala/ML#724).
+        initOrigins.remove(recv);
+      }
 
       // Route subscript results through `setCalls` so `TensorTypeAnalysis`'s edge-transfer replaces
       // predecessor types rather than unioning them — the receiver's pre-subscript shape would
@@ -1347,7 +1367,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
-              dataflow, init, shapeOps, setCalls, conv2ds, conv3ds, drops, errorLog);
+              dataflow, init, initOrigins, shapeOps, setCalls, conv2ds, conv3ds, drops, errorLog);
 
       tt.solve(new NullProgressMonitor());
 
@@ -1420,6 +1440,27 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           e,
           () -> "Source " + describe(source) + " is not a recognized tensor generator.");
       return HashSetFactory.make();
+    }
+  }
+
+  /**
+   * Returns the libraries whose operations produce the given dataflow source's value (wala/ML#724),
+   * classified by the source's dispatched {@link TensorGenerator}.
+   *
+   * @param source The dataflow source to classify.
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph and pointer
+   *     analysis.
+   * @return The producing libraries; empty when the source dispatches to no generator (so there is
+   *     no origin evidence to seed).
+   */
+  private Set<TensorOrigin> getTensorOrigins(
+      PointsToSetVariable source, PropagationCallGraphBuilder builder) {
+    try {
+      TensorGenerator generator = getGenerator(source, builder);
+      if (generator == null) return EnumSet.noneOf(TensorOrigin.class);
+      return generator.getOrigins(builder);
+    } catch (IllegalArgumentException e) {
+      return EnumSet.noneOf(TensorOrigin.class);
     }
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReutersInputData.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReutersInputData.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -128,4 +129,16 @@ public class ReutersInputData extends TensorGenerator {
 
   /** Dtype set for the topic-label {@code y_*} arrays. */
   public static final Set<DType> Y_DTYPES = EnumSet.of(DType.INT64);
+
+  /**
+   * Returns the producing library of the modeled value: {@code load_data} returns numpy arrays, not
+   * tensors, so the value is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -36,6 +36,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -2994,6 +2995,30 @@ public abstract class TensorGenerator {
    *     cannot be determined.
    */
   protected abstract Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder);
+
+  /**
+   * Returns the libraries whose operations produce the value modeled by this generator
+   * (wala/ML#724).
+   *
+   * <p>The default is {@link TensorOrigin#TENSORFLOW}: generators model TensorFlow APIs unless they
+   * specifically model numpy ones ({@link NpArray}, {@link AstypeOperation}, etc.), which override
+   * this to {@link TensorOrigin#NUMPY}. A generator implementing {@link DelegatingTensorGenerator}
+   * answers with its underlying generator's origins, since the modeled value (a collection element,
+   * an enumerated item) is produced by whatever produced the underlying container's contents.
+   *
+   * <p>Classification is by the runtime type of the produced value, not the namespace of the
+   * invoked API; see {@link TensorOrigin}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The producing libraries of the modeled value.
+   */
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    if (this instanceof DelegatingTensorGenerator) {
+      TensorGenerator underlying = ((DelegatingTensorGenerator) this).getUnderlying();
+      if (underlying != null && underlying != this) return underlying.getOrigins(builder);
+    }
+    return EnumSet.of(TensorOrigin.TENSORFLOW);
+  }
 
   /**
    * Returns the value number for the dtype argument in the function call.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
@@ -1,0 +1,30 @@
+package com.ibm.wala.cast.python.ml.types;
+
+/**
+ * The library whose operation produced a tensor-typed value (wala/ML#724).
+ *
+ * <p>The tensor type analysis intentionally types numpy arrays as tensors: an ndarray is
+ * tensor-convertible, so tracking what can flow into a tensor parameter requires typing it. The
+ * resulting {@link TensorType} carries no record of which library produced the value, but some
+ * consumers must distinguish a value produced by a numpy operation (convertible, but not yet a
+ * TensorFlow computation) from one produced by a TensorFlow operation. This enum is that record; it
+ * is seeded per dataflow source from the dispatched {@link
+ * com.ibm.wala.cast.python.ml.client.TensorGenerator} and propagated along the same dataflow edges
+ * as the tensor types, so a control-flow merge of both origins conservatively carries both
+ * constants.
+ *
+ * <p>Classification is by the <em>runtime type of the produced value</em>, not the namespace of the
+ * invoked API: a mixed binary operator ({@code ndarray + Tensor}) dispatches to TensorFlow and
+ * yields a {@code tf.Tensor}, so it is {@link #TENSORFLOW}; {@code tf.keras.datasets}' {@code
+ * load_data} returns ndarrays, so its results are {@link #NUMPY}.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public enum TensorOrigin {
+
+  /** The value is an ndarray produced by a numpy operation. */
+  NUMPY,
+
+  /** The value is a tensor produced by a TensorFlow operation. */
+  TENSORFLOW
+}

--- a/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
@@ -1,0 +1,58 @@
+# Test numpy-origin vs TensorFlow-origin tensor values (wala/ML#724). Each of the three
+# instruction shapes from the issue produces a tensor-typed value whose producing library the
+# analysis should record: a binary operator over numpy operands, an ndarray method call, and an
+# interprocedural return of `np.array(...)`. The mixed binary operator dispatches to TensorFlow
+# at runtime and therefore counts as TensorFlow-origin.
+import numpy as np
+import tensorflow as tf
+
+
+def np_add(a, b):
+    return a + b
+
+
+def np_method(m):
+    return m.reshape((1, 3))
+
+
+def make_array():
+    return np.array([1.0, 2.0, 3.0])
+
+
+def mixed(a, t):
+    return a + t
+
+
+def consume_np(x):
+    pass
+
+
+def consume_tf(x):
+    pass
+
+
+m = np.zeros((3,), dtype=np.float32)
+
+y = np_add(m, m)
+assert isinstance(y, np.ndarray)
+assert y.shape == (3,)
+
+r = np_method(m)
+assert isinstance(r, np.ndarray)
+assert r.shape == (1, 3)
+
+z = make_array()
+assert isinstance(z, np.ndarray)
+assert z.shape == (3,)
+
+t = tf.constant([1.0, 2.0, 3.0])
+
+w = mixed(m, t)
+assert isinstance(w, tf.Tensor)
+assert w.shape == (3,)
+assert w.dtype == tf.float32
+
+consume_np(y)
+consume_np(r)
+consume_np(z)
+consume_tf(w)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
@@ -23,7 +23,18 @@ def mixed(a, t):
     return a + t
 
 
+def make_opaque(k):
+    # The shape argument is a non-constant expression, so the analysis cannot resolve the array's
+    # shape (an unknown tensor, ⊤); only the numpy origin is known. Exercises origin propagation
+    # through a null-state predecessor.
+    return np.zeros((k * 1,), dtype=np.float32)
+
+
 def consume_np(x):
+    pass
+
+
+def consume_np_opaque(x):
     pass
 
 
@@ -52,7 +63,12 @@ assert isinstance(w, tf.Tensor)
 assert w.shape == (3,)
 assert w.dtype == tf.float32
 
+o = make_opaque(4)
+assert isinstance(o, np.ndarray)
+assert o.shape == (4,)
+
 consume_np(y)
 consume_np(r)
 consume_np(z)
+consume_np_opaque(o)
 consume_tf(w)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_numpy_origin.py
@@ -23,6 +23,17 @@ def mixed(a, t):
     return a + t
 
 
+def np_add3(a, b, c):
+    # A nested binary operator: the outer operand is itself a binop result with no points-to set,
+    # exercising the structural recursion in the origin classification.
+    return a + b + c
+
+
+def scale(m):
+    # A statically opaque scalar co-operand keeps the tensor operand's library.
+    return m * 2.0
+
+
 def make_opaque(k):
     # The shape argument is a non-constant expression, so the analysis cannot resolve the array's
     # shape (an unknown tensor, ⊤); only the numpy origin is known. Exercises origin propagation
@@ -35,6 +46,10 @@ def consume_np(x):
 
 
 def consume_np_opaque(x):
+    pass
+
+
+def consume_np_loader(x):
     pass
 
 
@@ -67,8 +82,39 @@ o = make_opaque(4)
 assert isinstance(o, np.ndarray)
 assert o.shape == (4,)
 
+s3 = np_add3(m, m, m)
+assert isinstance(s3, np.ndarray)
+assert s3.shape == (3,)
+
+sc = scale(m)
+assert isinstance(sc, np.ndarray)
+assert sc.shape == (3,)
+
+# Keras dataset loaders return plain ndarrays at runtime, so their results are numpy-origin (the
+# consumer-ratified runtime-type rule).
+(mn_x, mn_y), _ = tf.keras.datasets.mnist.load_data()
+assert isinstance(mn_x, np.ndarray)
+(c10_x, c10_y), _ = tf.keras.datasets.cifar10.load_data()
+assert isinstance(c10_x, np.ndarray)
+(c100_x, c100_y), _ = tf.keras.datasets.cifar100.load_data()
+assert isinstance(c100_x, np.ndarray)
+(im_x, im_y), _ = tf.keras.datasets.imdb.load_data()
+assert isinstance(im_x, np.ndarray)
+(re_x, re_y), _ = tf.keras.datasets.reuters.load_data()
+assert isinstance(re_x, np.ndarray)
+(bh_x, bh_y), _ = tf.keras.datasets.boston_housing.load_data()
+assert isinstance(bh_x, np.ndarray)
+
 consume_np(y)
 consume_np(r)
 consume_np(z)
+consume_np(s3)
+consume_np(sc)
 consume_np_opaque(o)
+consume_np_loader(mn_x)
+consume_np_loader(c10_x)
+consume_np_loader(c100_x)
+consume_np_loader(im_x)
+consume_np_loader(re_x)
+consume_np_loader(bh_x)
 consume_tf(w)


### PR DESCRIPTION
Implements the numpy-origin vs TensorFlow-origin record per the triage's recommended shape (origin bits on the tensor variable, seeded generator-side, propagated along the type dataflow).

Closes wala/ML#724.

## Design

- `TensorOrigin` (`NUMPY`/`TENSORFLOW`) classifies by the runtime type of the produced value, not the invoked API's namespace: a mixed binary operator (`ndarray + Tensor`) dispatches to TensorFlow and is `TENSORFLOW`; `tf.keras.datasets`' `load_data` returns ndarrays and is `NUMPY`.
- `TensorVariable.origins` is seeded per dataflow source from the dispatched generator and unioned along the same dataflow edges as the types, so a merge of both origins conservatively carries both constants. Consumers read `TensorVariable.getOrigins()` off the same solution they already consume.
- `DropOp` clears origins with the state. `SetShapeOp` propagates the predecessor's origins rather than pinning TensorFlow: its destinations include ndarray-subscript results via the wala/ML#405 reroute, which a TensorFlow pin would misclassify. `ConvOp` and `ReshapeOp` pin `TENSORFLOW`, their destinations being `tf.nn.conv*`/`tf.reshape` results by construction.
- `TensorGenerator.getOrigins` defaults to `TENSORFLOW` and delegates through `DelegatingTensorGenerator`; the numpy generators (`NpArray`, `NpOnes`/`NpZeros`, `NpReshape`, `AstypeOperation`, `NdarrayReshape`, `NdarraySubscriptOperation`) override to `NUMPY`.
- `ElementWiseOperation` classifies a binary operator by the per-execution dispatch product of its operands' origins: numpy with numpy stays numpy, any TensorFlow operand dominates, a statically opaque scalar keeps the tensor operand's library, nested operators recurse structurally (their results have no points-to set to dispatch on), and an operand without evidence contributes `TENSORFLOW`, preserving the pre-wala/ML#724 reading.

## Resolved Question

The Keras datasets input generators (`MnistInputData` and siblings) are classified `NUMPY` because `load_data` returns ndarrays. The consumer ratified this reading (https://github.com/ponder-lab/ML/pull/592#issuecomment-4959746814): a pure load-and-prep body performs no TensorFlow computation, and the readings diverge only for loader values that never reach a TensorFlow op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
