### PR TITLE
Seed tensor parameters with a first-class `PARAMETER` origin

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.test;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.nCopies;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -8,35 +9,62 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
+import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import org.junit.Test;
 
 /**
- * Tests for the numpy-origin vs TensorFlow-origin record on tensor-typed values (wala/ML#724).
+ * Tests for the origin record on tensor-typed values (wala/ML#724, wala/ML#726).
  *
- * <p>Assertions target the first parameter (value number 2) of a sink function, per the
- * calling-context convention: the fixture routes each value of interest through {@code
- * consume_np(x)} or {@code consume_tf(x)}, and the parameter's origins are the union across calling
- * contexts, mirroring the type-assertion semantics of {@code TestTensorflow2Model.test}.
+ * <p>The fixture routes each value of interest through a sink function ({@code consume_np(x)}
+ * etc.), per the calling-context convention. A sink's <em>parameter</em> pins the wala/ML#726
+ * boundary semantics: it reads exactly its seeded {@link TensorOrigin#PARAMETER}, since the
+ * parameter barrier blocks caller-side origin inflow. The routed value's <em>producing</em> origin
+ * is therefore observed on the caller-side argument local at each sink call site &mdash; the
+ * parameter's immediate dataflow predecessor, and the consumer's view of a def in the calling
+ * function's body.
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class TestTensorOrigins extends TestPythonMLCallGraphShape {
 
   /**
+   * The origins observed at a fixture's sink functions.
+   *
+   * @param parameterOrigins Per sink, the first parameter's origins (value number 2), unioned
+   *     across calling contexts; a sink absent from the map received no tensor-typed state at all.
+   * @param argumentOrigins Per sink, the first argument's origins at each call site of the sink, in
+   *     source order.
+   */
+  private record SinkOrigins(
+      Map<String, Set<TensorOrigin>> parameterOrigins,
+      Map<String, List<Set<TensorOrigin>>> argumentOrigins) {}
+
+  /**
    * The three instruction shapes from wala/ML#724 flow to {@code consume_np}: a binary operator
-   * over numpy operands ({@code a + b}), an ndarray method ({@code m.reshape(...)}), and an
-   * interprocedural return of {@code np.array(...)}. All are numpy-origin. The mixed binary
-   * operator ({@code ndarray + Tensor}) flows to {@code consume_tf}: runtime dispatch makes it a
-   * TensorFlow operation and its result a {@code tf.Tensor}.
+   * ({@code a + b}), an ndarray method ({@code m.reshape(...)}), and an interprocedural return of
+   * {@code np.array(...)}. The invoke-produced values are numpy-origin; the operator cases run over
+   * their enclosing helpers' parameters, so under wala/ML#726 their results carry the
+   * hybridization-frame origin instead (the traced operator is a TensorFlow op whatever the eager
+   * feeds). The mixed binary operator ({@code a + t} in {@code mixed}) likewise runs over
+   * parameters now that they classify first; the local-level mixed-dispatch pin lives in {@code
+   * tf2_test_parameter_origin.py}.
    *
    * @throws ClassHierarchyException If the class hierarchy cannot be built.
    * @throws CancelException If the analysis is canceled.
@@ -44,38 +72,87 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
    */
   @Test
   public void testNumpyOrigin() throws ClassHierarchyException, CancelException, IOException {
-    Map<String, Set<TensorOrigin>> sinkParameterOrigins =
-        getSinkParameterOrigins(
+    SinkOrigins sinkOrigins =
+        getSinkOrigins(
             "tf2_test_numpy_origin.py",
             "consume_np",
             "consume_np_opaque",
             "consume_np_loader",
             "consume_tf");
 
-    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np"));
-    // The opaque sink receives an unknown-shape ndarray: provenance must survive even though the
-    // shape does not resolve, since a consumer needs the origin most exactly when the type is ⊤.
-    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np_opaque"));
+    // Every sink parameter reads exactly its seed: the barrier blocks the callers' origins
+    // (wala/ML#726), including the six loaders' numpy inflow.
+    for (String sink :
+        List.of("consume_np", "consume_np_opaque", "consume_np_loader", "consume_tf"))
+      assertEquals(EnumSet.of(TensorOrigin.PARAMETER), sinkOrigins.parameterOrigins().get(sink));
+
+    assertEquals(
+        List.of(
+            EnumSet.of(TensorOrigin.PARAMETER), // np_add(m, m): `a + b` over parameters
+            EnumSet.of(TensorOrigin.NUMPY), // np_method(m): `m.reshape(...)`
+            EnumSet.of(TensorOrigin.NUMPY), // make_array(): `np.array(...)` returned
+            EnumSet.of(TensorOrigin.PARAMETER), // np_add3(m, m, m): nested operator over parameters
+            EnumSet.of(TensorOrigin.PARAMETER)), // scale(m): scalar co-operand keeps `m`'s origin
+        sinkOrigins.argumentOrigins().get("consume_np"));
+    // The opaque value is an unknown-shape ndarray: provenance must survive even though the shape
+    // does not resolve, since a consumer needs the origin most exactly when the type is ⊤.
+    assertEquals(
+        List.of(EnumSet.of(TensorOrigin.NUMPY)),
+        sinkOrigins.argumentOrigins().get("consume_np_opaque"));
     // All six Keras dataset loaders route here: `load_data` returns ndarrays, so their results
     // are numpy-origin by the consumer-ratified runtime-type rule.
-    assertEquals(EnumSet.of(TensorOrigin.NUMPY), sinkParameterOrigins.get("consume_np_loader"));
-    assertEquals(EnumSet.of(TensorOrigin.TENSORFLOW), sinkParameterOrigins.get("consume_tf"));
+    assertEquals(
+        nCopies(6, EnumSet.of(TensorOrigin.NUMPY)),
+        sinkOrigins.argumentOrigins().get("consume_np_loader"));
+    assertEquals(
+        List.of(EnumSet.of(TensorOrigin.PARAMETER)),
+        sinkOrigins.argumentOrigins().get("consume_tf"));
   }
 
   /**
-   * Runs the tensor analysis on the given file and collects the origins of each named sink
-   * function's first parameter (value number 2), unioned across calling contexts.
+   * The wala/ML#726 pins. The {@code f(x): return x + 1} distillation fed {@code np.ones(...)}
+   * carries the hybridization-frame origin: under {@code tf.function} tracing the parameter is a
+   * symbolic tensor and the {@code +} lowers to {@code tf.add}, so the eager numpy feed must not
+   * classify the result numpy-only. The numpy-body counter-case (numpy literals, an operator over
+   * locals, an interprocedural numpy return &mdash; no parameter provenance in any def) keeps
+   * reading pure numpy, pinning the decline a consumer still needs. The local-level mixed operator
+   * ({@code ndarray + Tensor}) pins runtime dispatch below the parameter boundary.
    *
-   * @param filename The Python test file to analyze.
-   * @param sinkFunctionNames The sink functions whose first-parameter origins are collected.
-   * @return A map from sink function name to the union of its first parameter's origins; a sink
-   *     absent from the map received no tensor-typed state at all.
    * @throws ClassHierarchyException If the class hierarchy cannot be built.
    * @throws CancelException If the analysis is canceled.
    * @throws IOException If the test file cannot be read.
    */
-  private Map<String, Set<TensorOrigin>> getSinkParameterOrigins(
-      String filename, String... sinkFunctionNames)
+  @Test
+  public void testParameterOrigin() throws ClassHierarchyException, CancelException, IOException {
+    SinkOrigins sinkOrigins =
+        getSinkOrigins("tf2_test_parameter_origin.py", "consume_param", "consume_np", "consume_tf");
+
+    for (String sink : List.of("consume_param", "consume_np", "consume_tf"))
+      assertEquals(EnumSet.of(TensorOrigin.PARAMETER), sinkOrigins.parameterOrigins().get(sink));
+
+    assertEquals(
+        List.of(EnumSet.of(TensorOrigin.PARAMETER)),
+        sinkOrigins.argumentOrigins().get("consume_param"));
+    assertEquals(
+        List.of(EnumSet.of(TensorOrigin.NUMPY)), sinkOrigins.argumentOrigins().get("consume_np"));
+    assertEquals(
+        List.of(EnumSet.of(TensorOrigin.TENSORFLOW)),
+        sinkOrigins.argumentOrigins().get("consume_tf"));
+  }
+
+  /**
+   * Runs the tensor analysis on the given file and collects, for each named sink function, the
+   * origins of its first parameter (value number 2, unioned across calling contexts) and of the
+   * caller-side argument local at each of its call sites (in source order).
+   *
+   * @param filename The Python test file to analyze.
+   * @param sinkFunctionNames The sink functions to observe.
+   * @return The origins observed at the sinks.
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test file cannot be read.
+   */
+  private SinkOrigins getSinkOrigins(String filename, String... sinkFunctionNames)
       throws ClassHierarchyException, CancelException, IOException {
     PythonTensorAnalysisEngine engine = makeEngine(emptyList(), filename);
     PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
@@ -85,10 +162,13 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
 
     TensorTypeAnalysis analysis = engine.performAnalysis(builder);
 
-    Map<String, Set<TensorOrigin>> ret = new HashMap<>();
+    Map<PointerKey, Set<TensorOrigin>> origins = new HashMap<>();
+    Map<String, Set<TensorOrigin>> parameterOrigins = new HashMap<>();
 
     analysis.forEach(
         pt -> {
+          origins.put(pt.fst, pt.snd.getOrigins());
+
           if (!(pt.fst instanceof LocalPointerKey)) return;
           LocalPointerKey localPointerKey = (LocalPointerKey) pt.fst;
 
@@ -100,10 +180,49 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
           for (String sink : sinkFunctionNames)
             // Signatures render scope separators as dots: `script f.py.consume_np.do()LRoot;`.
             if (signature.contains("." + sink + ".do("))
-              ret.computeIfAbsent(sink, k -> EnumSet.noneOf(TensorOrigin.class))
+              parameterOrigins
+                  .computeIfAbsent(sink, k -> EnumSet.noneOf(TensorOrigin.class))
                   .addAll(pt.snd.getOrigins());
         });
 
-    return ret;
+    // The caller-side argument local at each sink call site, keyed by instruction index for
+    // source order and unioned across the caller's calling contexts.
+    Map<String, SortedMap<Integer, Set<TensorOrigin>>> argumentsBySite = new HashMap<>();
+
+    for (CGNode node : CG) {
+      IR ir = node.getIR();
+      if (ir == null) continue;
+
+      SSAInstruction[] instructions = ir.getInstructions();
+
+      for (int i = 0; i < instructions.length; i++) {
+        if (!(instructions[i] instanceof SSAAbstractInvokeInstruction)) continue;
+        SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) instructions[i];
+
+        for (CGNode target : CG.getPossibleTargets(node, call.getCallSite())) {
+          String signature = target.getMethod().getSignature();
+
+          for (String sink : sinkFunctionNames)
+            if (signature.contains("." + sink + ".do(")) {
+              // Use 0 is the callee function object; use 1 is the first positional argument.
+              PointerKey argument =
+                  builder
+                      .getPointerAnalysis()
+                      .getHeapModel()
+                      .getPointerKeyForLocal(node, call.getUse(1));
+              argumentsBySite
+                  .computeIfAbsent(sink, k -> new TreeMap<>())
+                  .computeIfAbsent(i, k -> EnumSet.noneOf(TensorOrigin.class))
+                  .addAll(origins.getOrDefault(argument, EnumSet.noneOf(TensorOrigin.class)));
+            }
+        }
+      }
+    }
+
+    Map<String, List<Set<TensorOrigin>>> argumentOrigins = new HashMap<>();
+    argumentsBySite.forEach(
+        (sink, bySite) -> argumentOrigins.put(sink, new ArrayList<>(bySite.values())));
+
+    return new SinkOrigins(parameterOrigins, argumentOrigins);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -219,6 +219,45 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
     }
   }
 
+  /**
+   * A transfer function for parameter destinations (wala/ML#726): tensor types flow through
+   * unchanged, but the origins union is skipped, so a parameter keeps its seeded {@link
+   * TensorOrigin#PARAMETER} instead of inheriting its call sites' origins. Mirrors the plain node
+   * transfer's state handling minus the provenance; in particular a ⊤-state (unknown tensor)
+   * predecessor contributes nothing here, since its only contribution in the plain transfer is its
+   * origins.
+   */
+  static final class ParameterBarrierOp extends UnaryOperator<TensorVariable> {
+    static final ParameterBarrierOp INSTANCE = new ParameterBarrierOp();
+
+    private ParameterBarrierOp() {}
+
+    @Override
+    public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+      if (lhs == null || rhs == null || rhs.state == null) return NOT_CHANGED;
+      if (lhs.state == null) {
+        lhs.state = HashSetFactory.make(rhs.state);
+        return CHANGED;
+      }
+      return lhs.state.addAll(rhs.state) ? CHANGED : NOT_CHANGED;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x726BA44E; // arbitrary constant; this is a singleton
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof ParameterBarrierOp;
+    }
+
+    @Override
+    public String toString() {
+      return "propagate tensor types, block origin inflow (parameter boundary)";
+    }
+  }
+
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, TensorType> reshapeNodes,
@@ -226,6 +265,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
+      Set<PointsToSetVariable> parameters,
       Map<PointerKey, AnalysisError> errorLog) {
     return new IKilldallFramework<PointsToSetVariable, TensorVariable>() {
 
@@ -513,6 +553,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return new ConvOp(2, node);
             } else if (conv3ds.contains(node)) {
               return new ConvOp(3, node);
+            } else if (parameters.contains(node)) {
+              return ParameterBarrierOp.INSTANCE;
             } else {
               return nodeOp;
             }
@@ -530,6 +572,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return DropOp.INSTANCE;
             } else if (set_shapes.containsKey(dst)) {
               return new SetShapeOp(set_shapes.get(dst));
+            } else if (parameters.contains(dst)) {
+              return ParameterBarrierOp.INSTANCE;
             } else {
               return nodeOp;
             }
@@ -591,6 +635,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param conv2ds Destinations of 2D convolutions, rank-checked by {@code ConvOp}.
    * @param conv3ds Destinations of 3D convolutions, rank-checked by {@code ConvOp}.
    * @param drops Destinations pinned to empty-and-fixed (wala/ML#409).
+   * @param parameters Parameter destinations, whose types flow normally but whose origins are
+   *     pinned to their {@link TensorOrigin#PARAMETER} seed by blocking caller-side origin inflow
+   *     (wala/ML#726).
    * @param errorLog The sink for shape-mismatch diagnostics.
    */
   public TensorTypeAnalysis(
@@ -602,8 +649,10 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
+      Set<PointsToSetVariable> parameters,
       Map<PointerKey, AnalysisError> errorLog) {
-    super(createProblem(G, reshapeTypes, set_shapes, conv2ds, conv3ds, drops, errorLog));
+    super(
+        createProblem(G, reshapeTypes, set_shapes, conv2ds, conv3ds, drops, parameters, errorLog));
     this.init = init;
     this.initOrigins = initOrigins;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -111,15 +111,16 @@ public class ElementWiseOperation extends TensorGenerator {
   }
 
   /**
-   * Returns the producing library of a binary operator's result by classifying its operands
-   * (wala/ML#724). Runtime binary-operator dispatch decides the result's library: {@code ndarray +
-   * ndarray} stays numpy, while any TensorFlow operand makes the operation a TensorFlow one and the
-   * result a {@code tf.Tensor}. Each operand classifies through its producing generator (via {@link
-   * TensorGeneratorFactory#getGenerator}), recursing structurally through nested binary operators
-   * (whose results have no points-to set to dispatch on); a statically opaque scalar operand is
-   * skipped, since it keeps the tensor operand's library. An operand without origin evidence
-   * contributes {@link TensorOrigin#TENSORFLOW}, preserving the pre-wala/ML#724 reading where the
-   * analysis cannot prove numpy provenance.
+   * Returns the origin of a binary operator's result by classifying its operands (wala/ML#724).
+   * Runtime binary-operator dispatch decides the result's origin: {@code ndarray + ndarray} stays
+   * numpy, any TensorFlow operand makes the operation a TensorFlow one and the result a {@code
+   * tf.Tensor}, and otherwise a parameter operand makes the traced operator a TensorFlow op whose
+   * result is the frame's symbolic value (wala/ML#726). Each non-parameter operand classifies
+   * through its producing generator (via {@link TensorGeneratorFactory#getGenerator}), recursing
+   * structurally through nested binary operators (whose results have no points-to set to dispatch
+   * on); a statically opaque scalar operand is skipped, since it keeps the tensor operand's
+   * library. An operand without origin evidence contributes {@link TensorOrigin#TENSORFLOW},
+   * preserving the pre-wala/ML#724 reading where the analysis cannot prove numpy provenance.
    *
    * <p>A manual anchor models a TensorFlow API call ({@code tf.multiply.do()} etc.), so the default
    * applies there.
@@ -139,15 +140,16 @@ public class ElementWiseOperation extends TensorGenerator {
 
   /**
    * Classifies a binary operator's result by the per-execution dispatch product of its operands'
-   * origins: an execution pairing a TensorFlow operand with anything yields a TensorFlow result,
-   * and only a numpy-with-numpy pairing yields an ndarray. The product is more precise than a plain
-   * union: {@code {NUMPY} + {TENSORFLOW}} is {@code {TENSORFLOW}}, while {@code {NUMPY} + {NUMPY,
-   * TENSORFLOW}} keeps both.
+   * origins: an execution pairing a TensorFlow operand with anything yields a TensorFlow result, a
+   * parameter operand paired with anything but TensorFlow yields the hybridization frame's symbolic
+   * value, and only a numpy-with-numpy pairing yields an ndarray. The product is more precise than
+   * a plain union: {@code {NUMPY} + {TENSORFLOW}} is {@code {TENSORFLOW}}, while {@code {NUMPY} +
+   * {NUMPY, TENSORFLOW}} keeps both.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param node The node whose IR defines the operator.
    * @param binop The binary operator instruction.
-   * @return The producing libraries of the operator's result.
+   * @return The origins of the operator's result.
    */
   private Set<TensorOrigin> getBinaryOperationOrigins(
       PropagationCallGraphBuilder builder, CGNode node, SSABinaryOpInstruction binop) {
@@ -160,19 +162,36 @@ public class ElementWiseOperation extends TensorGenerator {
     if (y == null) return x;
 
     Set<TensorOrigin> ret = EnumSet.noneOf(TensorOrigin.class);
-    for (TensorOrigin ox : x)
-      for (TensorOrigin oy : y)
-        ret.add(
-            ox == TensorOrigin.TENSORFLOW || oy == TensorOrigin.TENSORFLOW
-                ? TensorOrigin.TENSORFLOW
-                : TensorOrigin.NUMPY);
+    for (TensorOrigin ox : x) for (TensorOrigin oy : y) ret.add(getDispatchedOrigin(ox, oy));
     return ret;
   }
 
   /**
-   * Classifies one binary-operator operand's origins. A nested binary operator recurses
-   * structurally (its result has no points-to set to dispatch on); any other operand classifies
-   * through the generator its points-to chain dispatches to.
+   * Returns the origin a binary operator's runtime dispatch assigns to one pairing of operand
+   * origins, under the dominance order {@link TensorOrigin#TENSORFLOW} &gt; {@link
+   * TensorOrigin#PARAMETER} &gt; {@link TensorOrigin#NUMPY}: any TensorFlow operand makes the
+   * operation a TensorFlow one and the result a {@code tf.Tensor}; otherwise a parameter operand
+   * makes the traced operator a TensorFlow op whose result is the frame's symbolic value
+   * (wala/ML#726); only numpy with numpy stays an ndarray.
+   *
+   * @param x One operand's origin.
+   * @param y The other operand's origin.
+   * @return The origin of the operator's result for this pairing.
+   */
+  private static TensorOrigin getDispatchedOrigin(TensorOrigin x, TensorOrigin y) {
+    if (x == TensorOrigin.TENSORFLOW || y == TensorOrigin.TENSORFLOW)
+      return TensorOrigin.TENSORFLOW;
+    if (x == TensorOrigin.PARAMETER || y == TensorOrigin.PARAMETER) return TensorOrigin.PARAMETER;
+    return TensorOrigin.NUMPY;
+  }
+
+  /**
+   * Classifies one binary-operator operand's origins. A parameter of the defining frame carries the
+   * hybridization-frame origin (wala/ML#726): under tracing it is a symbolic tensor whatever its
+   * eager feeds, so it classifies as {@link TensorOrigin#PARAMETER} rather than through the
+   * creators its call sites feed it. A nested binary operator recurses structurally (its result has
+   * no points-to set to dispatch on); any other operand classifies through the generator its
+   * points-to chain dispatches to.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param node The node whose IR defines the operand.
@@ -183,6 +202,8 @@ public class ElementWiseOperation extends TensorGenerator {
   private Set<TensorOrigin> getOperandOrigins(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
     if (this.isScalarExpression(builder, node, vn)) return null;
+
+    if (node.getIR().getSymbolTable().isParameter(vn)) return EnumSet.of(TensorOrigin.PARAMETER);
 
     SSAInstruction def = node.getDU().getDef(vn);
     if (def instanceof SSABinaryOpInstruction)

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1365,9 +1365,33 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       for (PointsToSetVariable d : drops)
         LOGGER.fine(() -> "  drop: " + describe(d.getPointerKey()));
 
+      // Parameter destinations get the hybridization-frame origin and a barrier against
+      // caller-side origin inflow (wala/ML#726): under `tf.function` tracing a tensor parameter is
+      // a symbolic tensor regardless of the library that produced its eager feeds, so its
+      // provenance is first-class rather than inherited. Types still flow into parameters; only
+      // provenance stops at the boundary. Seeding every parameter unconditionally is safe:
+      // non-tensor parameters never surface, since the solution iterator filters empty-state
+      // variables.
+      Set<PointsToSetVariable> parameters = HashSetFactory.make();
+      for (PointsToSetVariable v : dataflow)
+        if (v.getPointerKey() instanceof LocalPointerKey
+            && ((LocalPointerKey) v.getPointerKey()).isParameter()) parameters.add(v);
+      LOGGER.fine(() -> "wala/ML#726 parameter destinations: " + parameters.size());
+      for (PointsToSetVariable p : parameters)
+        initOrigins.put(p, EnumSet.of(TensorOrigin.PARAMETER));
+
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
-              dataflow, init, initOrigins, shapeOps, setCalls, conv2ds, conv3ds, drops, errorLog);
+              dataflow,
+              init,
+              initOrigins,
+              shapeOps,
+              setCalls,
+              conv2ds,
+              conv3ds,
+              drops,
+              parameters,
+              errorLog);
 
       tt.solve(new NullProgressMonitor());
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
@@ -1,7 +1,8 @@
 package com.ibm.wala.cast.python.ml.types;
 
 /**
- * The library whose operation produced a tensor-typed value (wala/ML#724).
+ * The provenance of a tensor-typed value: the library whose operation produced it, or the function
+ * boundary it crossed (wala/ML#724, wala/ML#726).
  *
  * <p>The tensor type analysis intentionally types numpy arrays as tensors: an ndarray is
  * tensor-convertible, so tracking what can flow into a tensor parameter requires typing it. The
@@ -10,13 +11,16 @@ package com.ibm.wala.cast.python.ml.types;
  * TensorFlow computation) from one produced by a TensorFlow operation. This enum is that record; it
  * is seeded per dataflow source from the dispatched {@link
  * com.ibm.wala.cast.python.ml.client.TensorGenerator} and propagated along the same dataflow edges
- * as the tensor types, so a control-flow merge of both origins conservatively carries both
- * constants.
+ * as the tensor types, so a control-flow merge of different origins conservatively carries all the
+ * merged constants.
  *
  * <p>Classification is by the <em>runtime type of the produced value</em>, not the namespace of the
  * invoked API: a mixed binary operator ({@code ndarray + Tensor}) dispatches to TensorFlow and
  * yields a {@code tf.Tensor}, so it is {@link #TENSORFLOW}; {@code tf.keras.datasets}' {@code
  * load_data} returns ndarrays, so its results are {@link #NUMPY}.
+ *
+ * <p>Function parameters are the one exception to producer classification: a parameter reads {@link
+ * #PARAMETER} regardless of what its call sites feed it (wala/ML#726).
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
@@ -26,5 +30,14 @@ public enum TensorOrigin {
   NUMPY,
 
   /** The value is a tensor produced by a TensorFlow operation. */
-  TENSORFLOW
+  TENSORFLOW,
+
+  /**
+   * The value is a function parameter: the hybridization-frame origin (wala/ML#726). Under {@code
+   * tf.function} tracing a tensor parameter is a symbolic tensor regardless of the library that
+   * produced its eager feeds, so parameter provenance is first-class rather than inherited: the
+   * parameter boundary blocks caller-side origin inflow, and a value derived from a parameter
+   * carries this constant rather than the feeds' libraries.
+   */
+  PARAMETER
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_parameter_origin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_parameter_origin.py
@@ -1,0 +1,56 @@
+# Test the first-class parameter origin (wala/ML#726). A tensor parameter is the hybridization
+# frame's symbolic value: under `tf.function` tracing it is a tensor regardless of the library
+# that produced its eager feeds, so a parameter reads PARAMETER (not its call sites' origins), an
+# operator over a parameter stays PARAMETER, and locally-derived numpy values keep reading NUMPY.
+import numpy as np
+import tensorflow as tf
+
+
+def f(x):
+    # The wala/ML#726 distillation: fed an ndarray, `x + 1` still lowers to `tf.add` under
+    # tracing, so the result carries the parameter origin, not numpy.
+    return x + 1
+
+
+def numpy_body():
+    # The counter-case: numpy literals, a binary operator over locals, and an interprocedural
+    # numpy return, with no parameter provenance in any def; pure numpy origin must survive the
+    # parameter machinery.
+    m = np.zeros((2, 3), dtype=np.float32)
+    y = m + m
+    return np.array(y)
+
+
+def consume_param(x):
+    pass
+
+
+def consume_np(x):
+    pass
+
+
+def consume_tf(x):
+    pass
+
+
+a = f(np.ones((2, 3)))
+assert isinstance(a, np.ndarray)
+assert a.shape == (2, 3)
+
+b = numpy_body()
+assert isinstance(b, np.ndarray)
+assert b.shape == (2, 3)
+assert b.dtype == np.float32
+
+# A mixed operator over locals pins the runtime-dispatch rule below the parameter boundary:
+# `ndarray + Tensor` dispatches to TensorFlow and yields a `tf.Tensor`.
+m = np.zeros((3,), dtype=np.float32)
+t = tf.constant([1.0, 2.0, 3.0])
+w = m + t
+assert isinstance(w, tf.Tensor)
+assert w.shape == (3,)
+assert w.dtype == tf.float32
+
+consume_param(a)
+consume_np(b)
+consume_tf(w)


### PR DESCRIPTION
Closes wala/ML#726. Follow-on to wala/ML#724 (#592); design confirmed by the consumer on the wala/ML#724 thread.

A parameter fed a numpy value read `NUMPY` on 0.52.28, so `f(x): return x + 1` called as `f(np.ones((2, 3)))` classified as numpy-only, although under `tf.function` tracing the parameter is symbolic and the `+` lowers to `tf.add`. Origin-free parameters are not viable either: the numpy-data-prep bodies a consumer must keep declining also operate on numpy-fed parameters ([wala/ML#726](https://github.com/wala/ML/issues/726) has both pulling cases).

## Changes

- **`TensorOrigin.PARAMETER`**: the hybridization-frame origin. A parameter is a tensor under `tf.function` tracing regardless of its eager feeds, so its provenance is first-class rather than inherited.
- **Parameter-Origin Barrier** (`TensorTypeAnalysis.ParameterBarrierOp`): parameter destinations are collected in `PythonTensorAnalysisEngine.performAnalysis` (wired like `drops`/`setCalls`) and seeded `{PARAMETER}` unconditionally (safe: non-tensor parameters never surface, since the solution iterator filters empty-state variables). Tensor types still flow through the boundary; only caller-side origin inflow stops, so a parameter reads exactly its seed. Trampoline and synthetic frames need no special casing: their parameter destinations hit the same barrier.
- **`ElementWiseOperation`**: a parameter operand classifies as `PARAMETER` before generator dispatch (its call sites' creators no longer decide), and the dispatch product extends to the dominance order `TENSORFLOW` > `PARAMETER` > `NUMPY`, since the traced operator is a TensorFlow op whenever a parameter operand is involved; `x + 1` over a parameter stays `{PARAMETER}` while locally-derived numpy values stay `{NUMPY}`.

The consumer rule "count unless the origin set is exactly `{NUMPY}`" needs no change: `{PARAMETER}` and mixed sets count, pure `{NUMPY}` declines.

## Tests

Sink parameters now read exactly their `PARAMETER` seed, so `TestTensorOrigins` observes producing origins on the caller-side argument local at each sink call site (the parameter's immediate dataflow predecessor, and the consumer's view of a def in the calling function's body) while pinning the boundary semantics on the sink parameters themselves. The new `tf2_test_parameter_origin.py` fixture pins the `f(x): return x + 1` recovery, the pure-numpy-body decline (numpy literals, an operator over locals, an interprocedural numpy return), and the local-level mixed-operator dispatch (`ndarray + Tensor` → `TENSORFLOW`) that moved out of `tf2_test_numpy_origin.py`'s parameter-operand cases; the fixture runs to completion under Python 3.10 with runtime shape/dtype asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6