### PR TITLE
Make the worklist engine the default type resolution (wala/ML#365 Phase 3)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2231,11 +2231,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * D, D)}): the einsum body's own reshapes now compute generator-side through the {@code
    * get_shape_list} walk, whose non-entry contexts resolve rank but not every dimension. The rank-4
    * {@code (8, 100, U, U)}/{@code (8, 10, U, U)} members are the {@code DenseLayer3dProj} contexts'
-   * inputs (the attention's return value), delivered once the producer-cycle mask lets the
-   * loop-carried union converge from its non-cyclic base: three of the four proj contexts carry
-   * them. One entry's proj context and the pure-⊤/shape-⊤ members remain the loop fixed point's
-   * last residue—TODO: <a href="https://github.com/wala/ML/issues/718">wala/ML#718</a>. The {@code
-   * w} parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
+   * inputs (the attention's return value): the worklist engine converges the loop-carried union
+   * from its non-cyclic base and all four proj contexts carry them (wala/ML#365 Phase 3 resolved
+   * the fourth, the wala/ML#718 residual under the retired round-based resolution). The remaining
+   * pure-⊤/shape-⊤ members come from the guard-φ phantom and non-entry contexts. The {@code w}
+   * parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
    * dimensions, since the {@code build}-computed head sizes also derive from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
@@ -6,20 +6,20 @@ import java.io.IOException;
 import org.junit.Test;
 
 /**
- * Order-independence guard for the worklist engine (wala/ML#365, Phase 2): the whole-project NLPGNN
- * generation analysis must satisfy its type assertions under the engine regardless of the seeding
- * order. The round-based resolution cannot make this guarantee (its cycle guards return
- * stack-dependent approximations, so the first reader fixes each round's cached value); the
- * engine's chaotic iteration to a fixpoint can, and this test keeps it honest by running the same
- * analysis with the seeding order forward and reversed.
+ * Order-independence guard for the worklist engine (wala/ML#365): the whole-project NLPGNN
+ * generation analysis must satisfy its type assertions regardless of the seeding order. The retired
+ * round-based resolution could not make this guarantee (its cycle guards returned stack-dependent
+ * approximations, so the first reader fixed each round's cached value); the engine's chaotic
+ * iteration to a fixpoint can, and this test keeps it honest by running the same analysis with the
+ * seeding order forward and reversed.
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class WorklistOrderInvarianceTest {
 
   /**
-   * Runs the NLPGNN generation analysis under the engine with both seeding orders; both runs must
-   * satisfy the same assertions.
+   * Runs the NLPGNN generation analysis with both seeding orders; both runs must satisfy the same
+   * assertions.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -29,13 +29,11 @@ public class WorklistOrderInvarianceTest {
   @Test
   public void testSeedOrderInvariance()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    System.setProperty("ariadne.typeResolution.worklist", "true");
+    new TestTensorflow2Model().runNlpgnnFullGeneration();
+    System.setProperty("ariadne.typeResolution.reverseSeeds", "true");
     try {
       new TestTensorflow2Model().runNlpgnnFullGeneration();
-      System.setProperty("ariadne.typeResolution.reverseSeeds", "true");
-      new TestTensorflow2Model().runNlpgnnFullGeneration();
     } finally {
-      System.clearProperty("ariadne.typeResolution.worklist");
       System.clearProperty("ariadne.typeResolution.reverseSeeds");
     }
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -95,13 +95,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   public static final int DEFAULT_TARGETED_CFA_DEPTH = 2;
 
   /**
-   * Upper bound on source-type resolution rounds (wala/ML#674). Convergence normally takes two to
-   * three rounds (one to seed, one for cycle members to see each other's approximations, one to
-   * confirm stability); the bound only guards against oscillation.
-   */
-  private static final int MAX_TYPE_RESOLUTION_ROUNDS = 5;
-
-  /**
    * The recommended targeted k-CFA depth for consumers analyzing the <em>model-forward
    * archetype</em>: {@code tf.keras.Model} subclasses whose {@code call}/{@code predict} chain
    * layer invocations ({@code x = self.layer1(x); x = self.layer2(x)}). Such a model invoked from
@@ -1247,6 +1240,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   @Override
   public TensorTypeAnalysis performAnalysis(PropagationCallGraphBuilder builder)
       throws CancelException {
+    // The wala/ML#365 worklist engine is installed for the whole analysis, not just the seeding
+    // loop: post-seeding passes (origin classification, the set_shape/subscript recognizers)
+    // dispatch generators whose evidence gates read shapes and dtypes, and those reads need the
+    // engine's memoization and cycle convergence just as the seeds do (an unguarded read recurses
+    // unboundedly through producer delegation on cyclic subjects).
+    WorklistTypeResolver.install(builder);
     try {
       Graph<PointsToSetVariable> dataflow =
           SlowSparseNumberedGraph.duplicate(
@@ -1254,56 +1253,26 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       Set<PointsToSetVariable> sources = getDataflowSources(builder, dataflow);
 
-      // Resolve the per-source types in rounds until they stabilize (wala/ML#674): a cycle in a
-      // value's producer graph (e.g. a loop-carried variable) makes single-pass resolution depend
-      // on which cycle member is computed first, since the re-entered member floors to ⊤. Each
-      // round recomputes against the previous round's approximations (read on cycle re-entry in
-      // `TensorGenerator.getShapes`/`getDTypes`), so the result converges to an entry-order-
-      // independent fixed point. The bound is a safety net against oscillation; convergence is
-      // logged at FINE.
+      // Resolve the per-source types with the wala/ML#365 worklist engine: a single fixpoint over
+      // the recorded query-dependency graph replaces the historical round-based resolution
+      // (retired in Phase 3), the memo layers divert to the engine, and the seeding reads
+      // stabilized values, so the results are independent of the seeding order.
       Map<PointsToSetVariable, Set<TensorType>> init = HashMapFactory.make();
-      Map<PointsToSetVariable, Set<TensorType>> previousRound = null;
 
-      // Phase 2 of the wala/ML#365 design: under the flag, a single worklist fixpoint replaces
-      // the round loop; the memo layers divert to the engine and the seeding reads stabilized
-      // values, so the results are independent of the seeding order.
-      if (WorklistTypeResolver.enabled()) {
-        LOGGER.fine("Type resolution: worklist engine (wala/ML#365 Phase 2).");
-        WorklistTypeResolver.install(builder);
-        try {
-          // The engine's results are order-independent; the reverse-seeds property exists so the
-          // invariance is a tested property rather than a design claim (wala/ML#365, Phase 2).
-          List<PointsToSetVariable> ordered = new ArrayList<>(sources);
-          if (Boolean.getBoolean("ariadne.typeResolution.reverseSeeds")
-              || "true".equals(System.getenv("ARIADNE_REVERSE_SEEDS")))
-            Collections.reverse(ordered);
-          for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
+      // The engine's results are order-independent; the reverse-seeds property exists so the
+      // invariance is a tested property rather than a design claim (wala/ML#365, Phase 2).
+      List<PointsToSetVariable> ordered = new ArrayList<>(sources);
+      if (Boolean.getBoolean("ariadne.typeResolution.reverseSeeds")
+          || "true".equals(System.getenv("ARIADNE_REVERSE_SEEDS"))) Collections.reverse(ordered);
+      for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
 
-          // Second pass: a seed materialized early in the first pass predates the constraints
-          // later roots add, and the engine's state converges monotonically across the whole
-          // loop — the early snapshot can carry half-resolved members (e.g. an unknown-dtype
-          // twin of a member the converged state types fully). After the first pass every query
-          // is evaluated, so this pass adds no keys, edges, or evaluations; it only re-reads
-          // each seed's composition against the final fixpoint.
-          for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
-        } finally {
-          WorklistTypeResolver.uninstall(builder);
-        }
-      } else
-        for (int round = 0; round < MAX_TYPE_RESOLUTION_ROUNDS; round++) {
-          init = HashMapFactory.make();
-          for (PointsToSetVariable v : sources) init.put(v, getTensorTypes(v, builder));
-
-          if (init.equals(previousRound)) {
-            final int stableRound = round;
-            LOGGER.fine(
-                () -> "Source-type resolution stabilized after round: " + stableRound + ".");
-            break;
-          }
-
-          previousRound = init;
-          TensorGenerator.advanceRound(builder);
-        }
+      // Second pass: a seed materialized early in the first pass predates the constraints
+      // later roots add, and the engine's state converges monotonically across the whole
+      // loop — the early snapshot can carry half-resolved members (e.g. an unknown-dtype
+      // twin of a member the converged state types fully). After the first pass every query
+      // is evaluated, so this pass adds no keys, edges, or evaluations; it only re-reads
+      // each seed's composition against the final fixpoint.
+      for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
 
       // Seed each source's producing library beside its types (wala/ML#724). Origins ride the
       // same dataflow edges as the types, so the seeds are the only generator-side contribution;
@@ -1418,12 +1387,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       return tt;
     } finally {
-      // `TensorGenerator.getShapes`/`getDTypes` memoize per-builder. Clear those caches now that
-      // the analysis is done rather than waiting for the builder to be garbage-collected &mdash;
-      // this keeps memory predictable in long-running clients (LSP server, repeated-analysis
-      // daemons) where builders may be held in other caches after their analysis completes. The
-      // `finally` ensures the caches are cleared and the interpreter-miss counter is reset even
-      // when the analysis exits early via `CancelException`, so neither leaks into the next run.
+      // The engine (with its query state) is uninstalled and the remaining per-builder memos are
+      // cleared now that the analysis is done rather than waiting for the builder to be
+      // garbage-collected &mdash; this keeps memory predictable in long-running clients (LSP
+      // server, repeated-analysis daemons) where builders may be held in other caches after their
+      // analysis completes. The `finally` ensures the state is released and the interpreter-miss
+      // counter is reset even when the analysis exits early via `CancelException`, so neither
+      // leaks into the next run.
+      WorklistTypeResolver.uninstall(builder);
       QueryDependencyGraph.of(builder).summarize();
       TensorGenerator.clearCaches(builder);
       reportAndResetInterpreterUnavailableMisses();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -146,101 +146,15 @@ public abstract class TensorGenerator {
   private static final Logger LOGGER = Logger.getLogger(TensorGenerator.class.getName());
 
   /**
-   * Per-builder memoization cache for {@link #getShapes(PropagationCallGraphBuilder, CGNode, int)}.
-   * Branch-267's caller-walk + SSA-DU chain fallback paths recursively re-query the same {@code
-   * (node, vn)} pairs many times during a single analysis (e.g., autoencoder's chained layers
-   * trigger a walk from the final Dense that repeatedly lands on the same intermediate vns). Since
-   * the pointer analysis is already stable by the time {@link TensorGenerator} methods run, {@code
-   * getShapes(builder, node, vn)} is a pure function of its inputs for the duration of a single
-   * analysis, so caching is safe.
-   *
-   * <p>Lifecycle:
-   *
-   * <ul>
-   *   <li>Keyed by the {@link PropagationCallGraphBuilder} so distinct analyses do not share state.
-   *   <li>Wrapped in {@link Collections#synchronizedMap} to accommodate clients that invoke {@link
-   *       #getShapes(PropagationCallGraphBuilder, CGNode, int)} from multiple threads (rare but not
-   *       unreasonable for a long-running analysis service).
-   *   <li>Stored in a {@link WeakHashMap} so builder entries become eligible for GC automatically,
-   *       but clients should prefer the explicit {@link #clearCaches(PropagationCallGraphBuilder)}
-   *       hook at analysis end for deterministic cleanup (especially important in long-running
-   *       processes where builders may be retained beyond their analysis). {@link
-   *       PythonTensorAnalysisEngine#performAnalysis} invokes it.
-   * </ul>
-   */
-  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, ShapeResult>> SHAPES_CACHE =
-      Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * A shape-resolution cache key (wala/ML#716): the queried value plus the resolution mode.
+   * A shape-resolution query key (wala/ML#716): the queried value plus the resolution mode.
    * Exact-mode results poison to ⊤ whenever any points-to member fails to resolve, so they cannot
-   * share cache entries with the default partial-union results.
+   * share engine state entries with the default partial-union results.
    *
    * @param node The {@link CGNode} whose IR defines the value.
    * @param valueNumber The queried value number.
    * @param exact Whether an unresolvable union member poisons the result to ⊤.
    */
   private record ShapeQuery(CGNode node, int valueNumber, boolean exact) {}
-
-  /** Dtype counterpart of {@link #SHAPES_CACHE}. */
-  private static final Map<PropagationCallGraphBuilder, Map<Pair<CGNode, Integer>, Set<DType>>>
-      DTYPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * The previous resolution round's shape results (wala/ML#674). A recursive re-entry on the same
-   * {@code (node, vn)} key (a cycle in the value's producer graph, e.g. a loop-carried variable)
-   * reads the previous round's approximation instead of flooring to ⊤, so the resolved result no
-   * longer depends on which cycle member happens to be computed first. {@link
-   * PythonTensorAnalysisEngine#performAnalysis} drives rounds via {@link
-   * #advanceRound(PropagationCallGraphBuilder)} until the per-source types stabilize.
-   */
-  private static final Map<PropagationCallGraphBuilder, Map<ShapeQuery, ShapeResult>>
-      PREVIOUS_SHAPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /** Dtype counterpart of {@link #PREVIOUS_SHAPES_CACHE}. */
-  private static final Map<PropagationCallGraphBuilder, Map<Pair<CGNode, Integer>, Set<DType>>>
-      PREVIOUS_DTYPES_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * The {@code (node, vn)} shape computations currently on the recursion stack, per builder;
-   * membership marks a cycle re-entry (wala/ML#674).
-   */
-  private static final Map<PropagationCallGraphBuilder, Set<ShapeQuery>> SHAPES_IN_PROGRESS =
-      Collections.synchronizedMap(new WeakHashMap<>());
-
-  /** Dtype counterpart of {@link #SHAPES_IN_PROGRESS}. */
-  private static final Map<PropagationCallGraphBuilder, Set<Pair<CGNode, Integer>>>
-      DTYPES_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * The allocation sites whose producer delegations are currently on the recursion stack, per
-   * builder; membership marks a cycle in the value's producer graph (e.g., a loop-carried tensor
-   * whose points-to union includes its own downstream producers). Re-entry masks just that member
-   * (⊤), so the caller's union keeps its non-cyclic members with the remainder marked instead of
-   * recursing without bound (wala/ML#718).
-   */
-  private static final Map<PropagationCallGraphBuilder, Set<InstanceKey>>
-      SHAPE_DELEGATIONS_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /** Dtype counterpart of {@link #SHAPE_DELEGATIONS_IN_PROGRESS}. */
-  private static final Map<PropagationCallGraphBuilder, Set<InstanceKey>>
-      DTYPE_DELEGATIONS_IN_PROGRESS = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * Memo of whole-generator shape evaluations per builder, keyed on the generator's identity: its
-   * concrete class plus its anchor (the source's {@link PointerKey} for source-anchored instances,
-   * the synthetic {@link CGNode} for manual ones). Completes the wala/ML#365 memoization to the
-   * 1-arg evaluation layer: seeding, factory recovery, and producer delegation re-evaluate the same
-   * generator many times per round, and each evaluation recursively re-walks its arguments. Cleared
-   * per round alongside the {@code (node, vn)} caches, since evaluations legitimately change as the
-   * round guards' approximations advance.
-   */
-  private static final Map<PropagationCallGraphBuilder, Map<Object, ShapeResult>>
-      GENERATOR_SHAPE_EVALS = Collections.synchronizedMap(new WeakHashMap<>());
-
-  /** Dtype counterpart of {@link #GENERATOR_SHAPE_EVALS}. */
-  private static final Map<PropagationCallGraphBuilder, Map<Object, Set<DType>>>
-      GENERATOR_DTYPE_EVALS = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
    * Returns the memo key identifying a generator evaluation (wala/ML#365).
@@ -257,41 +171,26 @@ public abstract class TensorGenerator {
   }
 
   /**
-   * Evaluates the generator's shapes through the per-builder evaluation memo (wala/ML#365). Atomic
-   * check-compute-put under the cache's mutex, mirroring the {@code (node, vn)} layer.
+   * Evaluates the generator's shapes through the worklist engine (wala/ML#365), which memoizes,
+   * records the dependency edge, and converges cycles.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
    * @param generator The generator to evaluate.
-   * @return The (possibly cached) evaluation result.
+   * @return The evaluation result.
    */
   static ShapeResult memoizedShapeResult(
       PropagationCallGraphBuilder builder, TensorGenerator generator) {
-    Map<Object, ShapeResult> cache =
-        GENERATOR_SHAPE_EVALS.computeIfAbsent(
-            builder, b -> Collections.synchronizedMap(new HashMap<>()));
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      Object key = Pair.make("shape-eval", evaluationKey(generator));
-      java.util.function.Supplier<Object> transfer = () -> generator.getShapeResult(builder);
-      return (ShapeResult)
-          (engine.isEvaluating()
-              ? engine.read(key, transfer, true)
-              : engine.demand(key, transfer, true));
-    }
-    synchronized (cache) {
-      Object key = evaluationKey(generator);
-      QueryDependencyGraph graph = QueryDependencyGraph.of(builder);
-      graph.access(key);
-      if (cache.containsKey(key)) return cache.get(key);
-      try {
-        graph.enter(key);
-        ShapeResult result = generator.getShapeResult(builder);
-        cache.put(key, result);
-        return result;
-      } finally {
-        graph.exit(key);
-      }
-    }
+    // The engine is installed for every analysis run's resolution (wala/ML#365, Phase 3); a null
+    // engine occurs only for direct generator use outside one (e.g. unit tests) and computes
+    // unmemoized.
+    if (engine == null) return generator.getShapeResult(builder);
+    Object key = Pair.make("shape-eval", evaluationKey(generator));
+    java.util.function.Supplier<Object> transfer = () -> generator.getShapeResult(builder);
+    return (ShapeResult)
+        (engine.isEvaluating()
+            ? engine.read(key, transfer, true)
+            : engine.demand(key, transfer, true));
   }
 
   /**
@@ -300,39 +199,21 @@ public abstract class TensorGenerator {
    *
    * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
    * @param generator The generator to evaluate.
-   * @return The (possibly cached) evaluation result; may be {@code null} (⊤) per the legacy dtype
-   *     convention.
+   * @return The evaluation result; may be {@code null} (⊤) per the legacy dtype convention.
    */
   static Set<DType> memoizedDTypes(PropagationCallGraphBuilder builder, TensorGenerator generator) {
-    Map<Object, Set<DType>> cache =
-        GENERATOR_DTYPE_EVALS.computeIfAbsent(
-            builder, b -> Collections.synchronizedMap(new HashMap<>()));
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      Object key = Pair.make("dtype-eval", evaluationKey(generator));
-      java.util.function.Supplier<Object> transfer = () -> generator.getDTypes(builder);
-      @SuppressWarnings("unchecked")
-      Set<DType> diverted =
-          (Set<DType>)
-              (engine.isEvaluating()
-                  ? engine.read(key, transfer, false)
-                  : engine.demand(key, transfer, false));
-      return diverted;
-    }
-    synchronized (cache) {
-      Object key = evaluationKey(generator);
-      QueryDependencyGraph graph = QueryDependencyGraph.of(builder);
-      graph.access(key);
-      if (cache.containsKey(key)) return cache.get(key);
-      try {
-        graph.enter(key);
-        Set<DType> result = generator.getDTypes(builder);
-        cache.put(key, result);
-        return result;
-      } finally {
-        graph.exit(key);
-      }
-    }
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return generator.getDTypes(builder);
+    Object key = Pair.make("dtype-eval", evaluationKey(generator));
+    java.util.function.Supplier<Object> transfer = () -> generator.getDTypes(builder);
+    @SuppressWarnings("unchecked")
+    Set<DType> diverted =
+        (Set<DType>)
+            (engine.isEvaluating()
+                ? engine.read(key, transfer, false)
+                : engine.demand(key, transfer, false));
+    return diverted;
   }
 
   /**
@@ -356,29 +237,6 @@ public abstract class TensorGenerator {
       BUILD_CONTRACT_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
-   * Begins a new resolution round for the given builder (wala/ML#674): the current shape/dtype
-   * results become the previous round's approximations (read on cycle re-entry), and the current
-   * caches restart empty.
-   *
-   * @param builder The builder whose caches should advance.
-   */
-  public static void advanceRound(PropagationCallGraphBuilder builder) {
-    Map<ShapeQuery, ShapeResult> shapes = SHAPES_CACHE.remove(builder);
-    if (shapes != null) PREVIOUS_SHAPES_CACHE.put(builder, shapes);
-    Map<Pair<CGNode, Integer>, Set<DType>> dtypes = DTYPES_CACHE.remove(builder);
-    if (dtypes != null) PREVIOUS_DTYPES_CACHE.put(builder, dtypes);
-    SHAPES_IN_PROGRESS.remove(builder);
-    DTYPES_IN_PROGRESS.remove(builder);
-    SHAPE_DELEGATIONS_IN_PROGRESS.remove(builder);
-    DTYPE_DELEGATIONS_IN_PROGRESS.remove(builder);
-    GENERATOR_SHAPE_EVALS.remove(builder);
-    GENERATOR_DTYPE_EVALS.remove(builder);
-    // The chase reads shape results that may change between rounds, so its memo restarts too.
-    STORED_ATTRIBUTE_CACHE.remove(builder);
-    BUILD_CONTRACT_CACHE.remove(builder);
-  }
-
-  /**
    * Drops the shape/dtype caches for the given builder. Intended to be called at the end of an
    * analysis to release cache memory deterministically, rather than waiting for the builder to be
    * garbage-collected. Safe to call more than once.
@@ -390,16 +248,6 @@ public abstract class TensorGenerator {
    *     small and the goal is "make each gap audible once," not "track gaps per analysis."
    */
   public static void clearCaches(PropagationCallGraphBuilder builder) {
-    SHAPES_CACHE.remove(builder);
-    DTYPES_CACHE.remove(builder);
-    PREVIOUS_SHAPES_CACHE.remove(builder);
-    PREVIOUS_DTYPES_CACHE.remove(builder);
-    SHAPES_IN_PROGRESS.remove(builder);
-    DTYPES_IN_PROGRESS.remove(builder);
-    SHAPE_DELEGATIONS_IN_PROGRESS.remove(builder);
-    DTYPE_DELEGATIONS_IN_PROGRESS.remove(builder);
-    GENERATOR_SHAPE_EVALS.remove(builder);
-    GENERATOR_DTYPE_EVALS.remove(builder);
     STORED_ATTRIBUTE_CACHE.remove(builder);
     BUILD_CONTRACT_CACHE.remove(builder);
     QueryDependencyGraph.clear(builder);
@@ -1761,9 +1609,9 @@ public abstract class TensorGenerator {
    * specified node. This method uses a multi-staged approach, falling back to interprocedural
    * generator-based tracing if standard points-to analysis fails.
    *
-   * <p>Memoized on {@code (node, valueNumber)} per builder via {@link #SHAPES_CACHE} to eliminate
-   * redundant recomputation across caller-walk / SSA-DU chain fallback recursion. The PA is stable
-   * when {@link TensorGenerator} runs, so caching is correctness-safe.
+   * <p>Memoized on {@code (node, valueNumber)} per builder by the worklist engine (wala/ML#365) to
+   * eliminate redundant recomputation across caller-walk / SSA-DU chain fallback recursion. The PA
+   * is stable when {@link TensorGenerator} runs, so caching is correctness-safe.
    */
   protected Set<List<Dimension<?>>> getShapes(
       PropagationCallGraphBuilder builder, CGNode node, int valueNumber) {
@@ -1805,55 +1653,16 @@ public abstract class TensorGenerator {
    */
   protected ShapeResult getShapeResult(
       PropagationCallGraphBuilder builder, CGNode node, int valueNumber, boolean exact) {
-    Map<ShapeQuery, ShapeResult> cache =
-        SHAPES_CACHE.computeIfAbsent(builder, b -> Collections.synchronizedMap(new HashMap<>()));
     ShapeQuery key = new ShapeQuery(node, valueNumber, exact);
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      java.util.function.Supplier<Object> transfer =
-          () -> computeShapes(builder, node, valueNumber, exact);
-      return (ShapeResult)
-          (engine.isEvaluating()
-              ? engine.read(key, transfer, true)
-              : engine.demand(key, transfer, true));
-    }
-    // Atomic check-compute-put: concurrent threads hitting the same key will serialize on the
-    // cache's mutex so exactly one `computeShapes` call runs.
-    // Reentrant synchronization: `SynchronizedMap`'s own methods acquire the same mutex, so the
-    // inner `containsKey` / `get` / `put` calls are no-op re-entries.
-    synchronized (cache) {
-      QueryDependencyGraph.of(builder).access(key);
-      if (cache.containsKey(key)) return cache.get(key);
-      // A same-key re-entry is a cycle in the value's producer graph (e.g. a loop-carried
-      // variable). Return the previous round's approximation instead of recursing — flooring
-      // here made the result depend on which cycle member was computed first (wala/ML#674).
-      Set<ShapeQuery> inProgress =
-          SHAPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
-      if (!inProgress.add(key)) {
-        Map<ShapeQuery, ShapeResult> previous = PREVIOUS_SHAPES_CACHE.get(builder);
-        ShapeResult approximation =
-            previous == null || !previous.containsKey(key)
-                ? ShapeResult.unknown()
-                : previous.get(key);
-        LOGGER.fine(
-            () ->
-                "Shape cycle re-entry on key: "
-                    + key
-                    + "; returning previous-round approximation: "
-                    + approximation
-                    + ".");
-        return approximation;
-      }
-      try {
-        QueryDependencyGraph.of(builder).enter(key);
-        ShapeResult result = computeShapes(builder, node, valueNumber, exact);
-        cache.put(key, result);
-        return result;
-      } finally {
-        QueryDependencyGraph.of(builder).exit(key);
-        inProgress.remove(key);
-      }
-    }
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return computeShapes(builder, node, valueNumber, exact);
+    java.util.function.Supplier<Object> transfer =
+        () -> computeShapes(builder, node, valueNumber, exact);
+    return (ShapeResult)
+        (engine.isEvaluating()
+            ? engine.read(key, transfer, true)
+            : engine.demand(key, transfer, true));
   }
 
   private ShapeResult computeShapes(
@@ -2610,38 +2419,23 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, AllocationSiteInNode asin, boolean exact) {
     // A producer chain that re-encounters an allocation site is a cycle in the value's producer
     // graph (a loop-carried tensor whose points-to union includes its own downstream producers).
-    // Mask just this member (⊤): the caller's union keeps its non-cyclic members with the
-    // remainder marked, and the round loop can then converge upward from that base instead of
-    // recursing without bound or inheriting a whole-read ⊤ (wala/ML#718).
+    // The engine converges the cycle from its non-cyclic base instead of recursing without bound
+    // or inheriting a whole-read ⊤ (wala/ML#718).
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      Object key = Pair.make("shape-delegation", asin);
-      java.util.function.Supplier<Object> transfer =
-          () -> this.doGetShapeResultFromTensor(builder, asin, exact);
-      return (ShapeResult)
-          (engine.isEvaluating()
-              ? engine.read(key, transfer, true)
-              : engine.demand(key, transfer, true));
-    }
-    Set<InstanceKey> delegationsInProgress =
-        SHAPE_DELEGATIONS_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
-    QueryDependencyGraph.of(builder).access(Pair.make("shape-delegation", asin));
-    if (!delegationsInProgress.add(asin)) {
-      LOGGER.fine(() -> "Producer-cycle re-entry on allocation: " + describe(asin) + "; masking.");
-      return ShapeResult.unknown();
-    }
-    try {
-      QueryDependencyGraph.of(builder).enter(Pair.make("shape-delegation", asin));
-      return this.doGetShapeResultFromTensor(builder, asin, exact);
-    } finally {
-      QueryDependencyGraph.of(builder).exit(Pair.make("shape-delegation", asin));
-      delegationsInProgress.remove(asin);
-    }
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return this.doGetShapeResultFromTensor(builder, asin, exact);
+    Object key = Pair.make("shape-delegation", asin);
+    java.util.function.Supplier<Object> transfer =
+        () -> this.doGetShapeResultFromTensor(builder, asin, exact);
+    return (ShapeResult)
+        (engine.isEvaluating()
+            ? engine.read(key, transfer, true)
+            : engine.demand(key, transfer, true));
   }
 
   /**
    * Body of {@link #getShapeResultFromTensor(PropagationCallGraphBuilder, AllocationSiteInNode,
-   * boolean)}, running under its producer-cycle mask.
+   * boolean)}, running as its engine query's transfer.
    *
    * @param builder the propagation call graph builder
    * @param asin the allocation site of the tensor
@@ -3065,54 +2859,24 @@ public abstract class TensorGenerator {
 
   /**
    * Returns the possible dtypes of the tensor represented by the given value number in the
-   * specified node. Memoized on {@code (node, valueNumber)} per builder via {@link #DTYPES_CACHE};
-   * see {@link #getShapes(PropagationCallGraphBuilder, CGNode, int)} for the rationale.
+   * specified node. Memoized on {@code (node, valueNumber)} per builder by the worklist engine
+   * (wala/ML#365); see {@link #getShapes(PropagationCallGraphBuilder, CGNode, int)} for the
+   * rationale.
    */
   protected Set<DType> getDTypes(
       PropagationCallGraphBuilder builder, CGNode node, int valueNumber) {
-    Map<Pair<CGNode, Integer>, Set<DType>> cache =
-        DTYPES_CACHE.computeIfAbsent(builder, b -> Collections.synchronizedMap(new HashMap<>()));
     Pair<CGNode, Integer> key = Pair.make(node, valueNumber);
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      java.util.function.Supplier<Object> transfer =
-          () -> computeDTypes(builder, node, valueNumber);
-      @SuppressWarnings("unchecked")
-      Set<DType> diverted =
-          (Set<DType>)
-              (engine.isEvaluating()
-                  ? engine.read(key, transfer, false)
-                  : engine.demand(key, transfer, false));
-      return diverted;
-    }
-    // See `getShapes` above — same atomic check-compute-put pattern, same null-cache rationale,
-    // and the same previous-round approximation on a same-key cycle re-entry (wala/ML#674).
-    synchronized (cache) {
-      if (cache.containsKey(key)) return cache.get(key);
-      Set<Pair<CGNode, Integer>> inProgress =
-          DTYPES_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
-      if (!inProgress.add(key)) {
-        Map<Pair<CGNode, Integer>, Set<DType>> previous = PREVIOUS_DTYPES_CACHE.get(builder);
-        Set<DType> approximation = previous == null ? null : previous.get(key);
-        LOGGER.fine(
-            () ->
-                "Dtype cycle re-entry on key: "
-                    + key
-                    + "; returning previous-round approximation: "
-                    + approximation
-                    + ".");
-        return approximation;
-      }
-      try {
-        QueryDependencyGraph.of(builder).enter(key);
-        Set<DType> result = computeDTypes(builder, node, valueNumber);
-        cache.put(key, result);
-        return result;
-      } finally {
-        QueryDependencyGraph.of(builder).exit(key);
-        inProgress.remove(key);
-      }
-    }
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return computeDTypes(builder, node, valueNumber);
+    java.util.function.Supplier<Object> transfer = () -> computeDTypes(builder, node, valueNumber);
+    @SuppressWarnings("unchecked")
+    Set<DType> diverted =
+        (Set<DType>)
+            (engine.isEvaluating()
+                ? engine.read(key, transfer, false)
+                : engine.demand(key, transfer, false));
+    return diverted;
   }
 
   private Set<DType> computeDTypes(
@@ -3442,41 +3206,27 @@ public abstract class TensorGenerator {
 
   private Set<DType> getDTypesFromTensor(
       PropagationCallGraphBuilder builder, AllocationSiteInNode asin) {
-    // Dtype counterpart of the producer-cycle mask in `getShapeResultFromTensor` (wala/ML#718).
-    // The mask contributes nothing rather than UNKNOWN: an in-band UNKNOWN would collapse the
-    // caller's union to {UNKNOWN} under the lattice normalization, erasing the sibling members'
-    // resolved dtypes.
+    // Dtype counterpart of the producer-cycle handling in `getShapeResultFromTensor`
+    // (wala/ML#718): the engine's bottom for an unconverged dtype read is the empty set rather
+    // than UNKNOWN, since an in-band UNKNOWN would collapse the caller's union to {UNKNOWN} under
+    // the lattice normalization, erasing the sibling members' resolved dtypes.
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    if (engine != null) {
-      Object key = Pair.make("dtype-delegation", asin);
-      java.util.function.Supplier<Object> transfer =
-          () -> this.doGetDTypesFromTensor(builder, asin);
-      @SuppressWarnings("unchecked")
-      Set<DType> diverted =
-          (Set<DType>)
-              (engine.isEvaluating()
-                  ? engine.read(key, transfer, false)
-                  : engine.demand(key, transfer, false));
-      return diverted;
-    }
-    Set<InstanceKey> delegationsInProgress =
-        DTYPE_DELEGATIONS_IN_PROGRESS.computeIfAbsent(builder, b -> HashSetFactory.make());
-    if (!delegationsInProgress.add(asin)) {
-      LOGGER.fine(() -> "Producer-cycle re-entry on allocation: " + describe(asin) + "; masking.");
-      return EnumSet.noneOf(DType.class);
-    }
-    try {
-      QueryDependencyGraph.of(builder).enter(Pair.make("dtype-delegation", asin));
-      return this.doGetDTypesFromTensor(builder, asin);
-    } finally {
-      QueryDependencyGraph.of(builder).exit(Pair.make("dtype-delegation", asin));
-      delegationsInProgress.remove(asin);
-    }
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return this.doGetDTypesFromTensor(builder, asin);
+    Object key = Pair.make("dtype-delegation", asin);
+    java.util.function.Supplier<Object> transfer = () -> this.doGetDTypesFromTensor(builder, asin);
+    @SuppressWarnings("unchecked")
+    Set<DType> diverted =
+        (Set<DType>)
+            (engine.isEvaluating()
+                ? engine.read(key, transfer, false)
+                : engine.demand(key, transfer, false));
+    return diverted;
   }
 
   /**
    * Body of {@link #getDTypesFromTensor(PropagationCallGraphBuilder, AllocationSiteInNode)},
-   * running under its producer-cycle mask.
+   * running as its engine query's transfer.
    *
    * @param builder the propagation call graph builder
    * @param asin the allocation site of the tensor
@@ -4698,8 +4448,8 @@ public abstract class TensorGenerator {
    * bare {@code return}, whose {@code None} is not a tensor) marks the unknown remainder while the
    * resolvable returns' members stand.
    *
-   * <p>Recursion through cyclic call chains is bounded by the memoized core's in-progress guard,
-   * which answers a re-entered {@code (node, vn)} with the previous round's approximation.
+   * <p>Recursion through cyclic call chains is bounded by the worklist engine, which answers a
+   * re-entered {@code (node, vn)} read with its current state and converges the cycle.
    *
    * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
    * @param node The calling {@link CGNode}.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -40,8 +40,8 @@ import java.util.logging.Logger;
  * promotion step). Widenings bound divergence: a member-set cardinality cap and a rank cap, both
  * logged when they fire.
  *
- * <p>Enabled by the {@code ariadne.typeResolution.worklist} system property; the default remains
- * the round-based resolution.
+ * <p>The default resolution engine since Phase 3, installed per analysis run by {@link
+ * PythonTensorAnalysisEngine#performAnalysis}; the historical round-based resolution is retired.
  */
 final class WorklistTypeResolver {
 
@@ -66,7 +66,7 @@ final class WorklistTypeResolver {
   /** Rank beyond which a member widens away. */
   private static final int RANK_WIDENING_CAP = 12;
 
-  /** The per-builder active engine; non-null only while the flag-gated resolution runs. */
+  /** The per-builder active engine; non-null only while an analysis run's resolution is active. */
   private static final Map<PropagationCallGraphBuilder, WorklistTypeResolver> ACTIVE =
       Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -109,17 +109,7 @@ final class WorklistTypeResolver {
   private WorklistTypeResolver() {}
 
   /**
-   * Returns whether the flag-gated engine should run.
-   *
-   * @return {@code true} iff the {@code ariadne.typeResolution.worklist} property is set.
-   */
-  static boolean enabled() {
-    return Boolean.getBoolean("ariadne.typeResolution.worklist")
-        || "true".equals(System.getenv("ARIADNE_WORKLIST"));
-  }
-
-  /**
-   * Returns the builder's active engine, or {@code null} when the round-based resolution runs.
+   * Returns the builder's active engine, or {@code null} outside an analysis run's resolution.
    *
    * @param builder The builder whose engine to return.
    * @return The active engine or {@code null}.


### PR DESCRIPTION
Closes wala/ML#365. Closes wala/ML#718.

Phase 3 of the wala/ML#365 redesign: the flag-gated worklist fixpoint engine (Phase 2, #593) becomes the only resolution path, and the round-based machinery is retired (-423/+132 lines).

## Changes

- **Default Flip**: `PythonTensorAnalysisEngine.performAnalysis` installs the engine unconditionally; `WorklistTypeResolver.enabled()` and the `ariadne.typeResolution.worklist`/`ARIADNE_WORKLIST` flag are gone. The `reverseSeeds` property stays for the invariance test.
- **Rounds Machinery Retired**: the round loop and its `MAX_TYPE_RESOLUTION_ROUNDS` bound, `TensorGenerator.advanceRound`, the previous-round approximation caches, the `(node, vn)` and delegation in-progress re-entry guards, the producer-delegation masks, and the per-round generator-evaluation memos. The memo layers now divert to the engine only, with a direct-compute fallback reachable solely outside an analysis run (e.g. unit tests). The sentinel-guarded `STORED_ATTRIBUTE_CACHE`/`BUILD_CONTRACT_CACHE` memos are engine-independent and stay.
- **Whole-Analysis Install Window**: the engine covers all of `performAnalysis`, not just the seeding loop. Post-seeding passes (origin classification, the `set_shape`/subscript recognizers) dispatch generators whose evidence gates read shapes and dtypes; outside the window those reads recursed unboundedly through producer delegation on cyclic subjects (`StackOverflowError` on the vendored NLPGNN tests, caught by the first flip attempt's suite run).

## Flip-Time Gate (In-Repo, per the Phase 3 Deferral Criteria)

- Flag-on suite before the flip: 1072/0 at 1:31, wall-clock parity with the round-based default's 1:32 (the earlier ~1.5x overhead concern does not reproduce at suite level).
- Suite after the flip: 1072/0 at 1:24.
- The einsum anchor resolves all four `DenseLayer3dProj` contexts (the fourth was the wala/ML#718 residual under the rounds engine), and `WorklistOrderInvarianceTest` pins seeding-order independence as the default behavior.
- Corroborating consumer signal: the byte-identical six-subject corpus run under the flag on 0.52.28 (Hybridize#772).

## Follow-Up

The wala/ML#591 query-dependency-graph recorder was fed only by the retired arms; under the engine it records nothing and `summarize()` reports an empty census (the behavior flag-on runs already had). Re-pointing it at the engine or retiring it is filed as wala/ML#727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6

