### PR TITLE
Cover the `build` `input_shape` helpers' untested arms (wala/ML#725)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13670,6 +13670,189 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Attribute-read arm of the {@code build} stored-attribute resolution (wala/ML#725): the stored
+   * value is an attribute read off a same-body holder object whose attribute holds an {@code
+   * input_shape} subscript (an empty-points-to-set chain), so the subscript resolver must classify
+   * the non-numeric string member as an attribute read rather than an index. The chase is depth-one
+   * by construction, so the holder's attribute does not resolve and the weight's leading dimension
+   * soundly degrades.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredAttrRead()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_attr_read",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Numeric-string subscript arm of the {@code build} stored-attribute resolution (wala/ML#725):
+   * the stored value is a dict subscript whose key is the numeric string {@code "2"} and whose held
+   * value is an {@code input_shape} subscript (an empty-points-to-set chain), so the subscript
+   * resolver's string-index parse succeeds and the dict is rejected as a shape vector (its rank
+   * never resolves). The depth-one chase then leaves the attribute unresolved and the weight's
+   * leading dimension soundly degrades.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredDictKey()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_dict_key",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Nested-class config idiom for the {@code build} stored-attribute resolution (wala/ML#725): a
+   * class declared in the method body writes its member as a field-put on the class object's local,
+   * so the receiver-class write scan must recognize the put's non-{@code self} receiver and skip it
+   * rather than misattributing it; the depth-one chase then leaves the attribute unresolved and the
+   * weight's leading dimension soundly degrades.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredNestedCfg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_nested_cfg",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Direct companion of {@link #testBuildStoredNestedCfg()} (wala/ML#725): the nested config
+   * class's member is read directly in the weight-shape literal, with no intermediate stored
+   * attribute, exercising the read-side handling of the class-object member access.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredDirectNestedCfg()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_direct_nested_cfg",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Unresolvable-index arm of the {@code build} stored-attribute resolution (wala/ML#725): the
+   * subscript index is a runtime int the analysis cannot resolve, so the constant-index sentinel
+   * guard rejects the subscript and the weight's leading dimension degrades.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredOpaqueIndex()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_opaque_index",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Out-of-bounds subscript arm of the {@code build} stored-attribute resolution (wala/ML#725): the
+   * first write's index is beyond the resolved rank (a runtime-guarded {@code try}/{@code except}
+   * read), so the bounds check rejects it and the unresolvable write makes the attribute
+   * unresolvable, degrading the weight's leading dimension.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredOobIndex()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_oob_index",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
+   * Negative out-of-bounds companion of {@link #testBuildStoredOobIndex()} (wala/ML#725): the
+   * normalized index falls below zero.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testBuildStoredNegativeOobIndex()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_build_stored_attr.py",
+        "apply_negative_oob_index",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 2, 6)),
+            3,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(5))))));
+  }
+
+  /**
    * A configuration attribute as a literal concat element (wala/ML#712): the reshape target
    * concatenates a shape-vector slice with {@code [self.units]}, whose stored value is the
    * constructor argument, exercising the constant fallback of the attribute chase.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -68,7 +68,6 @@ import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
-import com.ibm.wala.ssa.SSAGetInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
 import com.ibm.wala.ssa.SSAPutInstruction;
@@ -1167,23 +1166,17 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
     if (vn <= 0 || node.getDU() == null || node.getIR() == null) return null;
     SSAInstruction def = node.getDU().getDef(vn);
-    if (!(def instanceof PythonPropertyRead) && !(def instanceof SSAGetInstruction)) return null;
+    // A user attribute read is always a PythonPropertyRead: the front end emits
+    // SSAGetInstruction only for the inherited-member propagation of a class declaration, whose
+    // temporaries never surface as chased stored values (wala/ML#725).
+    if (!(def instanceof PythonPropertyRead)) return null;
 
-    String attributeName;
-    int objectVn;
-    if (def instanceof PythonPropertyRead) {
-      PythonPropertyRead read = (PythonPropertyRead) def;
-      SymbolTable st = node.getIR().getSymbolTable();
-      int memberVn = read.getMemberRef();
-      if (!st.isStringConstant(memberVn)) return null;
-      attributeName = st.getStringValue(memberVn);
-      objectVn = read.getObjectRef();
-    } else {
-      SSAGetInstruction get = (SSAGetInstruction) def;
-      if (get.isStatic()) return null;
-      attributeName = get.getDeclaredField().getName().toString();
-      objectVn = get.getRef();
-    }
+    PythonPropertyRead read = (PythonPropertyRead) def;
+    SymbolTable st = node.getIR().getSymbolTable();
+    int memberVn = read.getMemberRef();
+    if (!st.isStringConstant(memberVn)) return null;
+    String attributeName = st.getStringValue(memberVn);
+    int objectVn = read.getObjectRef();
 
     // Chase reads off the enclosing method's `self` through the receiver class's method bodies;
     // for any other local object, chase the write sites in the same code body (e.g. a
@@ -1261,17 +1254,17 @@ public abstract class TensorGenerator {
 
       for (SSAInstruction inst : candidate.getIR().getInstructions()) {
         int storedVn = -1;
+        // A `self` attribute write is always a PythonPropertyWrite: the front end emits
+        // SSAPutInstruction only for module, function-binding, and class-declaration member
+        // writes, whose receiver is the script or class object and can never be `self` (a method
+        // body declaring a nested config class carries such puts, and they must be skipped, which
+        // `tf2_test_build_stored_attr.py`'s nested-class cases pin). See wala/ML#725.
         if (inst instanceof PythonPropertyWrite) {
           PythonPropertyWrite write = (PythonPropertyWrite) inst;
           int memberVn = write.getMemberRef();
           if (write.getObjectRef() == selfVn
               && st.isStringConstant(memberVn)
               && attributeName.equals(st.getStringValue(memberVn))) storedVn = write.getValue();
-        } else if (inst instanceof SSAPutInstruction && !((SSAPutInstruction) inst).isStatic()) {
-          SSAPutInstruction put = (SSAPutInstruction) inst;
-          if (put.getRef() == selfVn
-              && attributeName.equals(put.getDeclaredField().getName().toString()))
-            storedVn = put.getVal();
         }
         if (storedVn <= 0) continue;
 
@@ -1308,17 +1301,15 @@ public abstract class TensorGenerator {
     for (Iterator<SSAInstruction> uses = node.getDU().getUses(objectVn); uses.hasNext(); ) {
       SSAInstruction use = uses.next();
       int storedVn = -1;
+      // A user attribute write is always a PythonPropertyWrite: the front end emits
+      // SSAPutInstruction only for module, function-binding, and class-declaration member writes,
+      // whose receiver is the script or class object rather than a chased local (wala/ML#725).
       if (use instanceof PythonPropertyWrite) {
         PythonPropertyWrite write = (PythonPropertyWrite) use;
         int memberVn = write.getMemberRef();
         if (write.getObjectRef() == objectVn
             && st.isStringConstant(memberVn)
             && attributeName.equals(st.getStringValue(memberVn))) storedVn = write.getValue();
-      } else if (use instanceof SSAPutInstruction && !((SSAPutInstruction) use).isStatic()) {
-        SSAPutInstruction put = (SSAPutInstruction) use;
-        if (put.getRef() == objectVn
-            && attributeName.equals(put.getDeclaredField().getName().toString()))
-          storedVn = put.getVal();
       }
       if (storedVn <= 0) continue;
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_build_stored_attr.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_build_stored_attr.py
@@ -1,0 +1,195 @@
+# Fixtures for wala/ML#725: the rejection and alternate arms of the `build` stored-attribute
+# resolution helpers. Every targeted stored value derives from an `input_shape` subscript, whose
+# result has an empty points-to set, so resolution must go through the helper chain rather than
+# the constant-propagation path. Each layer routes its weight through a per-case sink so the
+# JUnit test can pin the resolved (or deliberately degraded) weight type.
+import tensorflow as tf
+
+
+class Box:
+    pass
+
+
+def apply_attr_read(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_dict_key(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_opaque_index(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_oob_index(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_negative_oob_index(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_nested_cfg(x, w):
+    return tf.matmul(x, w)
+
+
+def apply_direct_nested_cfg(x, w):
+    return tf.matmul(x, w)
+
+
+class AttrReadLayer(tf.keras.layers.Layer):
+    # The stored value is an attribute read off a same-body holder object: the subscript
+    # resolver must classify the non-numeric string member ("size") as an attribute read, not an
+    # index, and the same-body write chase then recovers the subscript-derived value.
+    def build(self, input_shape):
+        box = Box()
+        box.size = input_shape[1]
+        self.hidden_size = box.size
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_attr_read(input_tensor, self.w)
+
+
+class DictKeyLayer(tf.keras.layers.Layer):
+    # The stored value is a dict subscript whose key is the numeric string "2": subscript
+    # indices can surface as string constants, so the parse must succeed, the dict must be
+    # rejected as a shape vector, and the same-body write chase then recovers the
+    # subscript-derived value.
+    def build(self, input_shape):
+        table = {"2": input_shape[1]}
+        self.hidden_size = table["2"]
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_dict_key(input_tensor, self.w)
+
+
+class OpaqueIndexLayer(tf.keras.layers.Layer):
+    # The subscript index is a runtime int the analysis cannot resolve, so the subscript
+    # resolver's constant-index sentinel guard must reject it.
+    def __init__(self, idx, **kwargs):
+        super(OpaqueIndexLayer, self).__init__(**kwargs)
+        self.idx = idx
+
+    def build(self, input_shape):
+        self.hidden_size = input_shape[self.idx]
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_opaque_index(input_tensor, self.w)
+
+
+class OobIndexLayer(tf.keras.layers.Layer):
+    # The first write's subscript index is beyond the resolved rank (a runtime-guarded
+    # `try`/`except` read; a TensorShape subscript raises IndexError through its dimension
+    # list), so the bounds check rejects it and the unresolvable write makes the attribute
+    # unresolvable.
+    def build(self, input_shape):
+        try:
+            self.hidden_size = input_shape[5]
+        except IndexError:
+            self.hidden_size = input_shape[1]
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_oob_index(input_tensor, self.w)
+
+
+class NegativeOobIndexLayer(tf.keras.layers.Layer):
+    # Negative-index companion of OobIndexLayer: the normalized index falls below zero.
+    def build(self, input_shape):
+        try:
+            self.hidden_size = input_shape[-5]
+        except IndexError:
+            self.hidden_size = input_shape[-1]
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_negative_oob_index(input_tensor, self.w)
+
+
+class NestedCfgLayer(tf.keras.layers.Layer):
+    # The stored value is a member of a class declared in the method body (a config-class
+    # idiom); the member's class-declaration write is a field-put on the class object's local,
+    # and its value derives from an `input_shape` subscript through the closure.
+    def build(self, input_shape):
+        class Cfg:
+            size = input_shape[1]
+
+        self.hidden_size = Cfg.size
+        self.w = self.add_weight(
+            name="kernel", shape=[self.hidden_size, 5], trainable=True
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_nested_cfg(input_tensor, self.w)
+
+
+class DirectNestedCfgLayer(tf.keras.layers.Layer):
+    # Companion of NestedCfgLayer that reads the config member directly in the weight shape,
+    # with no intermediate stored attribute.
+    def build(self, input_shape):
+        class Cfg:
+            size = input_shape[1]
+
+        self.w = self.add_weight(name="kernel", shape=[Cfg.size, 5], trainable=True)
+        self.built = True
+
+    def call(self, input_tensor):
+        return apply_direct_nested_cfg(input_tensor, self.w)
+
+
+x = tf.ones((2, 6))
+
+attr_read_layer = AttrReadLayer()
+out1 = attr_read_layer(x)
+assert out1.shape == (2, 5)
+assert out1.dtype == tf.float32
+
+dict_key_layer = DictKeyLayer()
+out2 = dict_key_layer(x)
+assert out2.shape == (2, 5)
+assert out2.dtype == tf.float32
+
+opaque_index_layer = OpaqueIndexLayer(int("1"))
+out3 = opaque_index_layer(x)
+assert out3.shape == (2, 5)
+assert out3.dtype == tf.float32
+
+oob_index_layer = OobIndexLayer()
+out4 = oob_index_layer(x)
+assert out4.shape == (2, 5)
+assert out4.dtype == tf.float32
+
+negative_oob_index_layer = NegativeOobIndexLayer()
+out5 = negative_oob_index_layer(x)
+assert out5.shape == (2, 5)
+assert out5.dtype == tf.float32
+
+nested_cfg_layer = NestedCfgLayer()
+out8 = nested_cfg_layer(x)
+assert out8.shape == (2, 5)
+assert out8.dtype == tf.float32
+
+direct_nested_cfg_layer = DirectNestedCfgLayer()
+out9 = direct_nested_cfg_layer(x)
+assert out9.shape == (2, 5)
+assert out9.dtype == tf.float32


### PR DESCRIPTION
Closes wala/ML#725.

Fixtures for the untested arms of the `build` `input_shape` resolution helpers, plus the requested reachability determination for the `SSAGetInstruction`/`SSAPutInstruction` shapes. The determination method was empirical (per-arm JaCoCo over the new fixtures and then the whole suite) backed by a front-end survey of where the translator emits field instructions.

## Fixtures (`tf2_test_build_stored_attr.py`, 7 Tests)

Every targeted stored value derives from an `input_shape` subscript, whose result has an empty points-to set, so resolution is forced through the helper chain rather than the constant-propagation path (a first draft stored plain constants and never reached the helpers; JaCoCo caught it).

- **Attribute Read**: a same-body holder attribute exercises the non-numeric-string classification (the `NumberFormatException` rejection); the depth-one chase then degrades the weight's leading dimension.
- **Numeric-String Key**: a dict subscript keyed `"2"` exercises the string-index parse success and the shape-vector rejection.
- **Opaque Index**: a runtime int index exercises the unresolved-constant sentinel guard.
- **Out-of-Bounds Index**, positive and negative: runtime-guarded `try`/`except IndexError` subscripts exercise both sides of the bounds check, and the unresolvable first write makes the attribute unresolvable.
- **Nested Config Class**, stored and direct: a class declared in the method body carries class-declaration field-puts in the scanned body; the fixtures pin that the write scans skip them rather than misattributing them.

With these, `resolveShapeVectorElementDim` is fully covered suite-wide. The conflicting-writes and conflicting-receivers rejections turned out to be already covered by existing tests (the issue's line data predates the wala/ML#717 helpers); a conflicting-receivers fixture through an inherited `build` is not currently constructible, since user-subclass `build` does not dispatch (wala/ML#118).

## Reachability Determination (Arms Removed)

The three remaining uncovered arms are unreachable, and are removed with comments citing the argument:

- The front end emits `SSAPutInstruction` only for module, function-binding, and class-declaration member writes, whose receiver is the script or class object: it can never be `self` (the `resolveStoredAttributeDimInClass` arm) nor a chased local (the `resolveLocalObjectAttributeDim` arm). A `self`/holder attribute write is always a `PythonPropertyWrite`.
- The front end emits `SSAGetInstruction` only for the inherited-member propagation of class declarations, whose temporaries never surface as chased stored values, so the `resolveStoredAttributeDim` read arm reduces to `PythonPropertyRead`.

The whole suite is green with the arms removed, and the nested-class fixtures keep the skip behavior pinned should the front end's emission profile ever change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
