### PR TITLE
Treat a shape-vector element as a scalar elementwise co-operand (wala/ML#723)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3640,7 +3640,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * body mirrors {@code crf_unary_score} from {@code kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py}, a
    * real-world linear-chain CRF function exercised for tensor-type inference coverage. Its {@code
    * tf.reshape} with runtime-derived dimensions ({@code tf.shape(inputs)[0]}) previously crashed
-   * the analysis (wala/ML#567).
+   * the analysis (wala/ML#567). The local count includes the {@code tf.range(...) * shape-element}
+   * offset chain, whose rank-0 co-operands preserve the range results' shapes through the
+   * elementwise scalar rule (wala/ML#723).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -3654,7 +3656,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_unary_score",
         3,
-        20,
+        22,
         Map.of(
             2, Set.of(TENSOR_2_3_INT32),
             3, Set.of(TENSOR_2_INT32),
@@ -3666,10 +3668,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * types. Function body mirrors {@code crf_binary_score} from {@code
    * kyzhouhzau/NLPGNN/nlpgnn/metrics/crf.py} for tensor-type inference coverage.
    *
-   * <p>The local count captures one {@code tf.shape}-scalar arithmetic intermediate at ⊥; its
-   * gather-fixture siblings recovered with the {@code tf.range} remodel, but this one did not, and
-   * its cause is unidentified—TODO: <a
-   * href="https://github.com/wala/ML/issues/723">wala/ML#723</a>.
+   * <p>The local count includes the flat-index arithmetic ({@code start_tag_indices * num_tags +
+   * end_tag_indices}), typed exactly {@code (2, 2) int32}: a {@code tf.shape} element is a rank-0
+   * tensor, so the elementwise scalar-co-operand rule preserves the tensor operand's shape through
+   * the nested product (wala/ML#723).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -3683,7 +3685,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "tf2_test_crf.py",
         "crf_binary_score",
         3,
-        13,
+        14,
         Map.of(
             2, Set.of(TENSOR_2_3_INT32),
             3, Set.of(TENSOR_2_INT32),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -249,7 +249,7 @@ public class ElementWiseOperation extends TensorGenerator {
     LOGGER.fine(
         () ->
             "EWO record broadcast for source "
-                + describe(this.source)
+                + describe(this.getSource())
                 + ": xVn "
                 + xVn
                 + " shapes "
@@ -492,7 +492,7 @@ public class ElementWiseOperation extends TensorGenerator {
     // the resolved side's shapes. Covers a tf.shape-element co-operand, a rank-0 tensor at
     // runtime (wala/ML#723). Manual anchors resolve arguments caller-side and keep their own
     // scalar rule, so this applies to source-anchored instances only.
-    if (this.source != null && xShapes.isEmpty() != yShapes.isEmpty()) {
+    if (this.getSource() != null && xShapes.isEmpty() != yShapes.isEmpty()) {
       Set<List<Dimension<?>>> resolved = xShapes.isEmpty() ? yShapes : xShapes;
       int opaqueVn = xShapes.isEmpty() ? xVn : yVn;
       if (resolved.stream().anyMatch(dims -> !dims.isEmpty())

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -246,6 +246,19 @@ public class ElementWiseOperation extends TensorGenerator {
 
     boolean xHas = xShapes != null && !xShapes.isEmpty();
     boolean yHas = yShapes != null && !yShapes.isEmpty();
+    LOGGER.fine(
+        () ->
+            "EWO record broadcast for source "
+                + describe(this.source)
+                + ": xVn "
+                + xVn
+                + " shapes "
+                + xShapes
+                + ", yVn "
+                + yVn
+                + " shapes "
+                + yShapes
+                + ".");
     if (xHas != yHas) {
       Set<List<Dimension<?>>> resolved = xHas ? xShapes : yShapes;
       int opaqueVn = xHas ? yVn : xVn;
@@ -373,6 +386,17 @@ public class ElementWiseOperation extends TensorGenerator {
           && isScalarExpression(builder, node, def.getUse(1));
     if (def instanceof SSAUnaryOpInstruction)
       return isScalarExpression(builder, node, def.getUse(0));
+    // A shape-vector element (e.g. `tf.shape(x)[k]`) is a rank-0 int32 tensor: structurally
+    // scalar for broadcast purposes even though it is a runtime tensor, so a broadcast against it
+    // preserves the tensor operand's shape. Only the singular element qualifies; a shape-vector
+    // slice is rank-1 and must not classify as scalar. See wala/ML#723.
+    if (def instanceof PythonPropertyRead) {
+      Dimension<?> element =
+          this.resolveShapeVectorElementDim(builder, node, node.getIR().getSymbolTable(), vn);
+      LOGGER.fine(
+          () -> "Shape-vector element check for operand vn " + vn + " resolved: " + element + ".");
+      if (element != null) return true;
+    }
     if (def instanceof PythonInvokeInstruction) {
       SSAInstruction funcDef = node.getDU().getDef(def.getUse(0));
       if (funcDef instanceof PythonPropertyRead) {
@@ -462,6 +486,18 @@ public class ElementWiseOperation extends TensorGenerator {
     Set<List<Dimension<?>>> yShapes = this.getOperandShapes(builder, yVn);
     LOGGER.fine(() -> "EWO.getDefaultShapes yShapes: " + yShapes);
     if (yShapes == null) return null;
+
+    // One-sided broadcast, mirroring the wala/ML#718 record rule at this layer, which the
+    // nested-operand resolution routes through: a statically opaque scalar co-operand preserves
+    // the resolved side's shapes. Covers a tf.shape-element co-operand, a rank-0 tensor at
+    // runtime (wala/ML#723). Manual anchors resolve arguments caller-side and keep their own
+    // scalar rule, so this applies to source-anchored instances only.
+    if (this.source != null && xShapes.isEmpty() != yShapes.isEmpty()) {
+      Set<List<Dimension<?>>> resolved = xShapes.isEmpty() ? yShapes : xShapes;
+      int opaqueVn = xShapes.isEmpty() ? xVn : yVn;
+      if (resolved.stream().anyMatch(dims -> !dims.isEmpty())
+          && this.isScalarExpression(builder, opaqueVn)) return resolved;
+    }
 
     // wala/ML#462: when the operands carry per-context shape unions (e.g., `y_true ∈ {[256],
     // [10000]}` for train vs. test), the cartesian product surfaces cross-context pairs (e.g.,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -798,7 +798,7 @@ public abstract class TensorGenerator {
    * @return The subscripted {@link Dimension}, or {@code null} when the value isn't a
    *     constant-indexed subscript of a resolvable shape vector or the index is out of range.
    */
-  private Dimension<?> resolveShapeVectorElementDim(
+  Dimension<?> resolveShapeVectorElementDim(
       PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     if (vn <= 0) return null;
     SSAInstruction def = node.getDU().getDef(vn);


### PR DESCRIPTION
Closes wala/ML#723.

The issue's fabrication itself was fixed by the `tf.range` remodel (#587); this lands the narrowed residue, the one CRF-fixture intermediate still at ⊥.

## Diagnosis

`crf_binary_score`'s flat-index arithmetic (`start_tag_indices * num_tags + end_tag_indices`) fell to ⊥ through two interacting gaps:

1. The elementwise scalar-expression recognizer (wala/ML#718) did not classify a `tf.shape` element (`tf.shape(x)[k]`), which is a rank-0 int32 tensor: a broadcast against it preserves the tensor operand's shape.
2. The one-sided scalar rule existed only on the record path, and the nested product is never seeded as a source: it resolves only as the outer sum's operand, and that read routes through the legacy layer (the record path's operand read fails on the unregistered `tf.slice` producer), which had no scalar rule. The empty co-operand made the legacy broadcast produce no pairs, and ⊥ cascaded outward.

## Fix

- `isScalarExpression` classifies a resolvable shape-vector element as structurally scalar. Singular elements only: a shape-vector slice is rank-1 and must not classify (`derivesFromShapeVector` was deliberately not reused for this reason).
- The legacy `getDefaultShapes` gains the record path's one-sided scalar rule, guarded to source-anchored instances, since manual anchors resolve arguments caller-side (the wala/ML#718 value-number trap).
- FINE diagnostics on the record broadcast and the shape-element classification, which located the routing.

## Captures

`testCrfBinaryScore` recovers its intermediate at the exact runtime `(2, 2) int32` (count 13 to 14, TODO removed); `testCrfUnaryScore` recovers its two `tf.range(...) * shape-element` offset products at sound `Unresolved` dimensions (count 20 to 22); `testGatherElementsAlongRow` and the remaining CRF pins are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
