### PR TITLE
Filter the parameter origin at iteration-product destinations (wala/ML#729)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -152,8 +152,9 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
    * {@code encode_labels}'s enumerate-element read leaks the TensorFlow default through its
    * unresolved container (TODO: <a href="https://github.com/wala/ML/issues/728">wala/ML#728</a>),
    * and {@code build_graph} additionally carries the elementwise no-evidence default on its
-   * unmodeled scipy operators plus {@code PARAMETER} provenance from {@code enumerate(nodes)}, the
-   * confirmed wala/ML#726 semantics for parameter-derived defs.
+   * unmodeled scipy operators plus {@code PARAMETER} provenance in its operator products, the
+   * confirmed wala/ML#726 semantics; its enumerate product reads the evidence-free empty set now
+   * that the iteration filter blocks the parameter constant (wala/ML#729).
    *
    * <p>Assertions are per-method censuses (how many locals read each origin set) rather than
    * per-value-number, so front-end numbering drift does not break the anchor.
@@ -199,13 +200,42 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
         Map.of(
             EnumSet.of(TensorOrigin.NUMPY),
             4L,
-            EnumSet.of(TensorOrigin.PARAMETER),
+            EnumSet.noneOf(TensorOrigin.class),
             1L,
             EnumSet.of(TensorOrigin.TENSORFLOW),
             1L,
             EnumSet.of(TensorOrigin.TENSORFLOW, TensorOrigin.PARAMETER),
             4L),
         census(buildGraph.locals()));
+  }
+
+  /**
+   * The wala/ML#729 pin: a def derived by {@code enumerate}-iterating a numpy-fed tensor parameter
+   * reads numpy-only origins. Iterating a symbolic tensor raises under {@code tf.function} tracing,
+   * so an iteration product is an eager-only value of the fed data: the PA aliases it with its
+   * iterable, and without the iteration-product filter the parameter constant crossed onto it (the
+   * pre-fix reading was {@code {NUMPY, PARAMETER}}). The parameter itself keeps its {@code
+   * {PARAMETER}} seed, and the {@code map}/{@code for}-loop contrast functions carry no
+   * tensor-typed locals at all.
+   *
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test file cannot be read.
+   */
+  @Test
+  public void testEnumerateOrigin() throws ClassHierarchyException, CancelException, IOException {
+    Map<String, MethodOrigins> methodOrigins =
+        getMethodOrigins("tf2_test_enumerate_origin.py", ".f.do(", ".g.do(", ".h.do(");
+
+    MethodOrigins f = methodOrigins.get(".f.do(");
+    assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(f.parameters()));
+    assertEquals(Map.of(EnumSet.of(TensorOrigin.NUMPY), 2L), census(f.locals()));
+
+    for (String fragment : List.of(".g.do(", ".h.do(")) {
+      MethodOrigins contrast = methodOrigins.get(fragment);
+      assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(contrast.parameters()));
+      assertEquals(Map.of(), census(contrast.locals()));
+    }
   }
 
   /**
@@ -247,7 +277,38 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
       throws ClassHierarchyException, CancelException, IOException {
     List<File> pathFiles =
         List.of(new File(TestTensorOrigins.class.getResource("/" + pythonPath).getPath()));
-    PythonTensorAnalysisEngine engine = makeEngine(pathFiles, projectFilenames);
+    return getMethodOrigins(makeEngine(pathFiles, projectFilenames), methodFragments);
+  }
+
+  /**
+   * Single-file variant of {@link #getMethodOrigins(String, String[], String...)}.
+   *
+   * @param filename The Python test file to analyze.
+   * @param methodFragments The signature fragments naming the methods under test.
+   * @return The observed origins, keyed by fragment.
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test file cannot be read.
+   */
+  private Map<String, MethodOrigins> getMethodOrigins(String filename, String... methodFragments)
+      throws ClassHierarchyException, CancelException, IOException {
+    return getMethodOrigins(makeEngine(emptyList(), filename), methodFragments);
+  }
+
+  /**
+   * Core of the {@code getMethodOrigins} variants: builds the call graph, runs the analysis, and
+   * collects the per-method origins.
+   *
+   * @param engine The analysis engine over the files under test.
+   * @param methodFragments The signature fragments naming the methods under test.
+   * @return The observed origins, keyed by fragment.
+   * @throws ClassHierarchyException If the class hierarchy cannot be built.
+   * @throws CancelException If the analysis is canceled.
+   * @throws IOException If the test files cannot be read.
+   */
+  private Map<String, MethodOrigins> getMethodOrigins(
+      PythonTensorAnalysisEngine engine, String... methodFragments)
+      throws ClassHierarchyException, CancelException, IOException {
     PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
 
     CallGraph CG = builder.makeCallGraph(builder.getOptions());

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -258,6 +258,51 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
     }
   }
 
+  /**
+   * A transfer function for iteration-product destinations (wala/ML#729): tensor types flow through
+   * unchanged and non-parameter origin evidence flows with them, but {@link TensorOrigin#PARAMETER}
+   * is filtered from the inflow. Iterating a symbolic tensor raises under {@code tf.function}
+   * tracing (the iteration protocol is Python-level, not a traceable op), so a value iterated out
+   * of a parameter is an eager-only product of the fed data: its provenance comes from its own
+   * seed's creator walk, which reaches the caller-side producer, and the PA's aliasing of iteration
+   * results with their iterables must not pull the parameter constant across.
+   */
+  static final class ParameterOriginFilterOp extends UnaryOperator<TensorVariable> {
+    static final ParameterOriginFilterOp INSTANCE = new ParameterOriginFilterOp();
+
+    private ParameterOriginFilterOp() {}
+
+    @Override
+    public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+      if (lhs == null || rhs == null) return NOT_CHANGED;
+      boolean changed = false;
+      if (rhs.state != null) {
+        if (lhs.state == null) {
+          lhs.state = HashSetFactory.make(rhs.state);
+          changed = true;
+        } else changed |= lhs.state.addAll(rhs.state);
+      }
+      for (TensorOrigin origin : rhs.origins)
+        if (origin != TensorOrigin.PARAMETER) changed |= lhs.origins.add(origin);
+      return changed ? CHANGED : NOT_CHANGED;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x729F117E; // arbitrary constant; this is a singleton
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof ParameterOriginFilterOp;
+    }
+
+    @Override
+    public String toString() {
+      return "propagate tensor types, filter the parameter origin (iteration product)";
+    }
+  }
+
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, TensorType> reshapeNodes,
@@ -266,6 +311,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> iterationProducts,
       Map<PointerKey, AnalysisError> errorLog) {
     return new IKilldallFramework<PointsToSetVariable, TensorVariable>() {
 
@@ -555,6 +601,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return new ConvOp(3, node);
             } else if (parameters.contains(node)) {
               return ParameterBarrierOp.INSTANCE;
+            } else if (iterationProducts.contains(node)) {
+              return ParameterOriginFilterOp.INSTANCE;
             } else {
               return nodeOp;
             }
@@ -574,6 +622,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return new SetShapeOp(set_shapes.get(dst));
             } else if (parameters.contains(dst)) {
               return ParameterBarrierOp.INSTANCE;
+            } else if (iterationProducts.contains(dst)) {
+              return ParameterOriginFilterOp.INSTANCE;
             } else {
               return nodeOp;
             }
@@ -638,6 +688,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param parameters Parameter destinations, whose types flow normally but whose origins are
    *     pinned to their {@link TensorOrigin#PARAMETER} seed by blocking caller-side origin inflow
    *     (wala/ML#726).
+   * @param iterationProducts Iteration-product destinations, whose types flow normally but whose
+   *     origin inflow drops {@link TensorOrigin#PARAMETER} (wala/ML#729).
    * @param errorLog The sink for shape-mismatch diagnostics.
    */
   public TensorTypeAnalysis(
@@ -650,9 +702,19 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> iterationProducts,
       Map<PointerKey, AnalysisError> errorLog) {
     super(
-        createProblem(G, reshapeTypes, set_shapes, conv2ds, conv3ds, drops, parameters, errorLog));
+        createProblem(
+            G,
+            reshapeTypes,
+            set_shapes,
+            conv2ds,
+            conv3ds,
+            drops,
+            parameters,
+            iterationProducts,
+            errorLog));
     this.init = init;
     this.initOrigins = initOrigins;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1167,6 +1167,27 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
+   * Returns whether the given invoke resolves to the {@code enumerate} builtin. The declared target
+   * is a generic trampoline ({@code LCodeBody}), so resolution goes through {@code
+   * getPossibleTargets}, matching {@code isEnumerateFirstFieldRead}.
+   *
+   * @param node The {@link CGNode} containing the invoke.
+   * @param invoke The invoke instruction to test.
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @return {@code true} iff a resolved callee is the {@code enumerate} builtin.
+   */
+  private static boolean isEnumerateCall(
+      CGNode node, SSAAbstractInvokeInstruction invoke, PropagationCallGraphBuilder builder) {
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite()))
+      if (callee
+          .getMethod()
+          .getReference()
+          .getDeclaringClass()
+          .equals(PythonTypes.ENUMERATE_BUILTIN)) return true;
+    return false;
+  }
+
+  /**
    * Reports whether {@code v}'s defining instruction is the first-field read of the tuple yielded
    * by Python's {@code enumerate} builtin &mdash; i.e., the {@code step} slot in {@code for step, x
    * in enumerate(iterable)}. Such variables are integer indices, not tensors, even though the
@@ -1370,6 +1391,34 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       for (PointsToSetVariable p : parameters)
         initOrigins.put(p, EnumSet.of(TensorOrigin.PARAMETER));
 
+      // Iteration products do not inherit the hybridization-frame origin (wala/ML#729): iterating
+      // a symbolic tensor raises under tf.function tracing, so a value iterated out of a parameter
+      // is an eager-only product of the fed data, whose provenance comes from its own seed's
+      // creator walk. The PA aliases iteration results with their iterables, so without a filter
+      // the parameter constant crosses onto the products. Collected here are the aliased
+      // destinations: enumerate results, each-element reads, and their tuple-field unwraps.
+      Set<PointsToSetVariable> iterationProducts = HashSetFactory.make();
+      for (PointsToSetVariable v : dataflow) {
+        if (!(v.getPointerKey() instanceof LocalPointerKey)) continue;
+        LocalPointerKey lpk = (LocalPointerKey) v.getPointerKey();
+        if (lpk.getNode().getDU() == null || lpk.getNode().getIR() == null) continue;
+        SSAInstruction def = lpk.getNode().getDU().getDef(lpk.getValueNumber());
+        if (def instanceof EachElementGetInstruction) {
+          iterationProducts.add(v);
+          continue;
+        }
+        if (def instanceof PythonPropertyRead) {
+          SSAInstruction objDef =
+              lpk.getNode().getDU().getDef(((PythonPropertyRead) def).getObjectRef());
+          if (objDef instanceof EachElementGetInstruction) iterationProducts.add(v);
+          continue;
+        }
+        if (def instanceof SSAAbstractInvokeInstruction
+            && isEnumerateCall(lpk.getNode(), (SSAAbstractInvokeInstruction) def, builder))
+          iterationProducts.add(v);
+      }
+      LOGGER.fine(() -> "wala/ML#729 iteration-product destinations: " + iterationProducts.size());
+
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
               dataflow,
@@ -1381,6 +1430,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               conv3ds,
               drops,
               parameters,
+              iterationProducts,
               errorLog);
 
       tt.solve(new NullProgressMonitor());

--- a/com.ibm.wala.cast.python.test/data/tf2_test_enumerate_origin.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_enumerate_origin.py
@@ -1,0 +1,33 @@
+# Reproducer for wala/ML#729: a def derived by enumerate-iterating a numpy-fed tensor parameter
+# must read numpy-only origins, like the map/for-loop contrast cases, since Python iteration is
+# not a traceable TensorFlow operation (enumerate over a symbolic tensor raises under tracing).
+import numpy as np
+
+
+def f(nodes):
+    return {int(j): i for i, j in enumerate(nodes)}
+
+
+def g(nodes):
+    return list(map(int, nodes))
+
+
+def h(nodes):
+    total = 0
+    for n in nodes:
+        total += int(n)
+    return total
+
+
+def consume_f(x):
+    pass
+
+
+a = np.array([1, 2, 3])
+fa = f(a)
+assert fa == {1: 0, 2: 1, 3: 2}
+ga = g(a)
+assert ga == [1, 2, 3]
+ha = h(a)
+assert ha == 6
+consume_f(a)


### PR DESCRIPTION
Closes wala/ML#729.

## Design Answer

The issue's open question (should a numpy-fed parameter's `enumerate`-derived elements carry `PARAMETER` or `NUMPY`) resolves to: neither the parameter mask nor a blanket answer, but the fed data's own provenance. Iterating a symbolic tensor raises under `tf.function` tracing (`enumerate` and the iteration protocol are Python-level, not traceable ops), so an iteration product is an eager-only value of whatever was fed; classification follows the runtime-type rule through the seed's creator walk, which reaches the caller-side producer (`np.array` in the repro, hence `{NUMPY}`; a `tf.constant` feed would classify `TENSORFLOW`, keeping the rule sound).

## Mechanism and Fix

The leak channel was PA aliasing, not seeding: the seed already classified the repro's derived def `{NUMPY}` through the creator walk, but the PA aliases iteration results with their iterables, so the parameter's `{PARAMETER}` flowed in on top (`{NUMPY, PARAMETER}` observed). A `ParameterOriginFilterOp` transfer now serves iteration-product destinations (`enumerate` results, each-element reads, and their tuple-field unwraps, collected like the `drops` and parameter destinations): tensor types and non-parameter origin evidence flow through unchanged; only the `PARAMETER` constant is dropped from the inflow.

## Pins

`tf2_test_enumerate_origin.py` pins the repro (`{int(j): i for i, j in enumerate(nodes)}` fed `np.array([1, 2, 3])` reads `{NUMPY}`) and the `map`/`for`-loop contrast cases (no tensor-typed locals, parameters keep `{PARAMETER}`). On the Cora anchor, `build_graph`'s enumerate product now reads the evidence-free empty set instead of `{PARAMETER}`; its operator products keep `PARAMETER` per the confirmed wala/ML#726 semantics, and `encode_labels` is unchanged (its blocker is wala/ML#728's unresolved-container leak, a different channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
