### PR TITLE
Make an unresolved enumerate iterable bottom on every axis (wala/ML#730)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -146,15 +146,14 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
    * The wala/ML#726 consumer contract on the vendored {@code deep_recommenders} Cora subject (the
    * Hybridize-Functions-Refactoring#774 methods), anchored in-repo so the consumer's re-measure is
    * corroboration rather than the gate. The nested helpers ({@code _sample_mask}, {@code
-   * _get_labels}) satisfy the contract cleanly: every tensor-typed local reads exactly {@code
-   * {NUMPY}} (an origin-keyed consumer declines them as convertible data preparation) and every
-   * tensor-typed parameter reads {@code {PARAMETER}}. The other two capture observed deviations:
-   * {@code encode_labels}'s enumerate-element read leaks the TensorFlow default through its
-   * unresolved container (TODO: <a href="https://github.com/wala/ML/issues/728">wala/ML#728</a>),
-   * and {@code build_graph} additionally carries the elementwise no-evidence default on its
-   * unmodeled scipy operators plus {@code PARAMETER} provenance in its operator products, the
-   * confirmed wala/ML#726 semantics; its enumerate product reads the evidence-free empty set now
-   * that the iteration filter blocks the parameter constant (wala/ML#729).
+   * _get_labels}) and {@code encode_labels} satisfy the contract cleanly: every tensor-typed local
+   * reads exactly {@code {NUMPY}} (an origin-keyed consumer declines them as convertible data
+   * preparation) and every tensor-typed parameter reads {@code {PARAMETER}}; {@code
+   * encode_labels}'s enumerate over its string-list attribute stopped surfacing a spurious unknown
+   * tensor once an unresolved iterable became ⊥ on every axis (wala/ML#730). {@code build_graph}
+   * captures the remaining deviations: {@code PARAMETER} provenance in its operator products (the
+   * confirmed wala/ML#726 semantics) alongside the elementwise no-evidence default on its unmodeled
+   * scipy operators, plus one evidence-free local from its enumerate chain (wala/ML#729).
    *
    * <p>Assertions are per-method censuses (how many locals read each origin set) rather than
    * per-value-number, so front-end numbering drift does not break the anchor.
@@ -190,9 +189,7 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
 
     MethodOrigins encodeLabels = methodOrigins.get(".Cora.encode_labels.do(");
     assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(encodeLabels.parameters()));
-    assertEquals(
-        Map.of(EnumSet.of(TensorOrigin.NUMPY), 2L, EnumSet.of(TensorOrigin.TENSORFLOW), 1L),
-        census(encodeLabels.locals()));
+    assertEquals(Map.of(EnumSet.of(TensorOrigin.NUMPY), 2L), census(encodeLabels.locals()));
 
     MethodOrigins buildGraph = methodOrigins.get(".Cora.build_graph.do(");
     assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(buildGraph.parameters()));
@@ -201,8 +198,6 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
             EnumSet.of(TensorOrigin.NUMPY),
             4L,
             EnumSet.noneOf(TensorOrigin.class),
-            1L,
-            EnumSet.of(TensorOrigin.TENSORFLOW),
             1L,
             EnumSet.of(TensorOrigin.TENSORFLOW, TensorOrigin.PARAMETER),
             4L),

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -3515,13 +3515,14 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    *
    * <p>The tracked tensor variables are {@code inputs} (concrete {@code (2, 5) int32}), the
    * embedding output (concrete {@code (2, 5, 8)} float32 with {@code Embedding} modeled,
-   * wala/ML#676), the convolution intermediate (⊤ on both axes &mdash; {@code Conv1D}/{@code
-   * GlobalAvgPool1D} remain unmodeled), and the softmax {@code Dense} head's output (vn=72, {@code
-   * float32} dtype but ⊤ shape &mdash; {@code DenseCall} hard-codes {@code float32} but loses the
-   * shape through the chained-layer body, <a
-   * href="https://github.com/wala/ML/issues/358">wala/ML#358</a>/<a
-   * href="https://github.com/wala/ML/issues/530">wala/ML#530</a>). These residual-⊤ body locals are
-   * pre-existing shape gaps, not new findings, and are downstream of the (exact) input signature.
+   * wala/ML#676), and the softmax {@code Dense} head's output ({@code float32} dtype but ⊤ shape
+   * &mdash; {@code DenseCall} hard-codes {@code float32} but loses the shape through the
+   * chained-layer body, <a href="https://github.com/wala/ML/issues/358">wala/ML#358</a>/<a
+   * href="https://github.com/wala/ML/issues/530">wala/ML#530</a>). The convolution intermediate is
+   * ⊥: {@code Conv1D}/{@code GlobalAvgPool1D} remain unmodeled, and its former both-axes-⊤ rode the
+   * spurious unknown-tensor composition of the enumerate over the unresolved {@code kernel_sizes}
+   * list, which wala/ML#730 removed. These residual body locals are pre-existing modeling gaps, not
+   * new findings, and are downstream of the (exact) input signature.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -3542,7 +3543,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "TextCNN.call",
         "textcnn_proj",
         1,
-        4,
+        3,
         Map.of(3, Set.of(TENSOR_2_5_INT32)));
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EnumerateGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EnumerateGenerator.java
@@ -50,6 +50,10 @@ public class EnumerateGenerator extends TensorGenerator implements DelegatingTen
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // An unresolved iterable is ⊥ on every axis, matching getTensorTypes' convention above: a ⊤
+    // here composed a spurious unknown-tensor member (and, with it, an origin seed) for values
+    // like an enumerate over a string list, which are not tensors at all (wala/ML#730).
+    if (underlying == null) return Collections.emptySet();
     return null;
   }
 
@@ -65,6 +69,8 @@ public class EnumerateGenerator extends TensorGenerator implements DelegatingTen
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    // See getDefaultShapes: ⊥ must pair on both axes (wala/ML#730).
+    if (underlying == null) return Collections.emptySet();
     return EnumSet.of(DType.UNKNOWN);
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorElementGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorElementGenerator.java
@@ -35,7 +35,12 @@ public class TensorElementGenerator extends TensorGenerator implements Delegatin
 
   @Override
   public String toString() {
-    return "TensorElementGenerator(" + containerGenerator + ")";
+    return "TensorElementGenerator("
+        + containerGenerator
+        + (containerGenerator == null
+            ? ""
+            : " [" + containerGenerator.getClass().getSimpleName() + "]")
+        + ")";
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2799,7 +2799,11 @@ public abstract class TensorGenerator {
   protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
     if (this instanceof DelegatingTensorGenerator) {
       TensorGenerator underlying = ((DelegatingTensorGenerator) this).getUnderlying();
-      if (underlying != null && underlying != this) return underlying.getOrigins(builder);
+      if (underlying == null || underlying == this)
+        // The value this generator delegates to never resolved, so there is no producer to
+        // classify: no origin evidence, not the TensorFlow default (wala/ML#730).
+        return EnumSet.noneOf(TensorOrigin.class);
+      return underlying.getOrigins(builder);
     }
     return EnumSet.of(TensorOrigin.TENSORFLOW);
   }


### PR DESCRIPTION
Closes wala/ML#730. Closes wala/ML#728.

The two issues are one defect observed through two lenses (the consumer's instrumented def and the in-repo Cora anchor's census): an `enumerate` over an iterable the analysis cannot resolve surfaced a spurious unknown tensor carrying a `TENSORFLOW` origin.

## Mechanism

Dataflow-predecessor tracing on the anchor pinned the seed, not propagation: `EnumerateGenerator` over an unresolved iterable (a null underlying, e.g. `enumerate(self._cora_classes)` where the attribute is a list of string literals) returned ⊥ for whole-value types but ⊤ shapes and `UNKNOWN` dtypes from its default arms, violating the lattice rule that ⊥ must pair on both axes; the base machinery composed those into a spurious `{? of unknown}` member, which in turn made the origins seeding run, and the origin delegation for a null underlying fell through to the base `TENSORFLOW` default. The issue's field-type-union candidate is not the mechanism.

## Fix

- An unresolved iterable is ⊥ on every axis in `EnumerateGenerator` (`getDefaultShapes`/`getDefaultDTypes` now match `getTensorTypes`' documented convention).
- A `DelegatingTensorGenerator` with no resolved underlying contributes no origin evidence instead of the TensorFlow default.

## Captures

- The Cora anchor's `encode_labels` now satisfies the numpy-only decline contract (`{NUMPY}` locals, `{PARAMETER}` parameter), and `build_graph` loses its standalone `{TENSORFLOW}` enumerate leak, leaving its operator products and the scipy no-evidence default as the documented residue.
- `testTextcnnCall`'s local count drops by one: the convolution intermediate's former both-axes-⊤ rode the spurious composition of `enumerate(self.kernel_sizes)`; it is honestly ⊥ until `Conv1D`/`GlobalAvgPool1D` gain modeling (the Javadoc records this alongside the pre-existing wala/ML#358/wala/ML#530 gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
