### PR TITLE
Seed the hybridization-frame origin on user-code parameters only (wala/ML#731)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -151,9 +151,12 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
    * preparation) and every tensor-typed parameter reads {@code {PARAMETER}}; {@code
    * encode_labels}'s enumerate over its string-list attribute stopped surfacing a spurious unknown
    * tensor once an unresolved iterable became ⊥ on every axis (wala/ML#730). {@code build_graph}
-   * captures the remaining deviations: {@code PARAMETER} provenance in its operator products (the
-   * confirmed wala/ML#726 semantics) alongside the elementwise no-evidence default on its unmodeled
-   * scipy operators, plus one evidence-free local from its enumerate chain (wala/ML#729).
+   * captures the remaining deviations, all type-level over-typing of semantically non-tensor values
+   * rather than origin defects (wala/ML#731): two {@code slice(None, None, None)} constructor
+   * objects reading the cross-caller TensorFlow union through the shared slice builtin, and the
+   * evidence-free enumerate iterator object. Its subscripts classify {@code {NUMPY}} through the
+   * wala/ML#731 receiver delegation, and no def carries {@code PARAMETER}, since only user code
+   * bodies seed the hybridization-frame origin.
    *
    * <p>Assertions are per-method censuses (how many locals read each origin set) rather than
    * per-value-number, so front-end numbering drift does not break the anchor.
@@ -196,11 +199,11 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
     assertEquals(
         Map.of(
             EnumSet.of(TensorOrigin.NUMPY),
-            4L,
+            6L,
             EnumSet.noneOf(TensorOrigin.class),
             1L,
-            EnumSet.of(TensorOrigin.TENSORFLOW, TensorOrigin.PARAMETER),
-            4L),
+            EnumSet.of(TensorOrigin.TENSORFLOW),
+            2L),
         census(buildGraph.locals()));
   }
 
@@ -231,6 +234,34 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
       assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(contrast.parameters()));
       assertEquals(Map.of(), census(contrast.locals()));
     }
+  }
+
+  /** Temporary probe for wala/ML#731: dump build_graph's typed locals with their defs. */
+  @Test
+  public void observeBuildGraphDefs() throws ClassHierarchyException, CancelException, IOException {
+    List<File> pathFiles =
+        List.of(new File(TestTensorOrigins.class.getResource("/tr_proj").getPath()));
+    PythonTensorAnalysisEngine engine =
+        makeEngine(
+            pathFiles,
+            "tr_proj/deep_recommenders/__init__.py",
+            "tr_proj/deep_recommenders/datasets/__init__.py",
+            "tr_proj/deep_recommenders/datasets/cora.py",
+            "tr_proj/tf2_test_cora_origins.py");
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+    TensorTypeAnalysis analysis = engine.performAnalysis(builder);
+    analysis.forEach(
+        pt -> {
+          if (!(pt.fst instanceof LocalPointerKey)) return;
+          LocalPointerKey k = (LocalPointerKey) pt.fst;
+          if (!k.getNode().getMethod().getSignature().contains(".Cora.build_graph.do(")) return;
+          SSAInstruction def =
+              k.getNode().getDU() == null ? null : k.getNode().getDU().getDef(k.getValueNumber());
+          System.err.println(
+              "BG vn=" + k.getValueNumber() + " origins=" + pt.snd.getOrigins() + " def=" + def);
+        });
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -13,6 +13,7 @@ import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
+import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.lsp.AnalysisError;
 import com.ibm.wala.cast.python.client.PythonAnalysisEngine;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
@@ -1376,17 +1377,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       for (PointsToSetVariable d : drops)
         LOGGER.fine(() -> "  drop: " + describe(d.getPointerKey()));
 
-      // Parameter destinations get the hybridization-frame origin and a barrier against
+      // User-code parameter destinations get the hybridization-frame origin and a barrier against
       // caller-side origin inflow (wala/ML#726): under `tf.function` tracing a tensor parameter is
       // a symbolic tensor regardless of the library that produced its eager feeds, so its
       // provenance is first-class rather than inherited. Types still flow into parameters; only
-      // provenance stops at the boundary. Seeding every parameter unconditionally is safe:
+      // provenance stops at the boundary. Seeding every user parameter unconditionally is safe:
       // non-tensor parameters never surface, since the solution iterator filters empty-state
-      // variables.
+      // variables. Only user code bodies (AstMethods) are hybridization frames, so synthetic
+      // parameters (builtin summaries, XML API summaries, trampolines) neither seed nor barrier:
+      // seeding them exported the parameter constant through shared builtin frames onto every
+      // caller's derived values (the slice builtin under `edges[:, 0]` was the wala/ML#731
+      // witness), and values crossing pass-through API summaries lost their true provenance.
       Set<PointsToSetVariable> parameters = HashSetFactory.make();
       for (PointsToSetVariable v : dataflow)
         if (v.getPointerKey() instanceof LocalPointerKey
-            && ((LocalPointerKey) v.getPointerKey()).isParameter()) parameters.add(v);
+            && ((LocalPointerKey) v.getPointerKey()).isParameter()
+            && ((LocalPointerKey) v.getPointerKey()).getNode().getMethod() instanceof AstMethod)
+          parameters.add(v);
       LOGGER.fine(() -> "wala/ML#726 parameter destinations: " + parameters.size());
       for (PointsToSetVariable p : parameters)
         initOrigins.put(p, EnumSet.of(TensorOrigin.PARAMETER));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
@@ -60,6 +61,36 @@ public class SliceBuiltinOperation extends TensorGenerator {
 
   public SliceBuiltinOperation(CGNode node) {
     super(node);
+  }
+
+  /**
+   * Returns the origin of the slice result by classifying its receiver (wala/ML#731): slicing
+   * preserves the producing library under the runtime-type rule (wala/ML#724), since an ndarray
+   * slice is an ndarray and a {@code Tensor} slice a {@code Tensor}. A receiver that does not
+   * resolve keeps the TensorFlow default, preserving the pre-wala/ML#724 reading.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The origin of the slice result.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    CallSiteView view = findCallSite(builder);
+    if (view == null) return super.getOrigins(builder);
+    PointerKey pk =
+        builder
+            .getPointerAnalysis()
+            .getHeapModel()
+            .getPointerKeyForLocal(view.callerNode(), view.receiverVn);
+    if (builder.getPropagationSystem().isImplicit(pk)) return super.getOrigins(builder);
+    PointsToSetVariable receiver = builder.getPropagationSystem().findOrCreatePointsToSet(pk);
+    if (receiver == null) return super.getOrigins(builder);
+    TensorGenerator generator;
+    try {
+      generator = TensorGeneratorFactory.getGenerator(receiver, builder);
+    } catch (IllegalArgumentException e) {
+      return super.getOrigins(builder);
+    }
+    return generator == null ? super.getOrigins(builder) : generator.getOrigins(builder);
   }
 
   @Override


### PR DESCRIPTION
Closes wala/ML#731.

## Design Answer

The issue's options resolve to a refined (c): the origin abstraction stands, and the `f(x): return x + 1` recovery is untouched (its pins are unchanged), but the anchor's counting was not the abstraction's cost. Probing the `build_graph` defs showed the `{PARAMETER}` carriers were not operator products over the parameter at all: the constant arrived through the shared slice-builtin frame, whose parameters the wala/ML#726 barrier seeded like user parameters. Options (a) and (b) remain rejected for the reasons the issue gives.

## Fixes

- **Hybridization Frames Are User Code Only**: the `PARAMETER` seed and barrier now apply to `AstMethod` parameters only. Synthetic parameters (builtin summaries, XML API summaries, trampolines) neither seed nor barrier: seeding them exported the parameter constant through shared builtin frames onto every caller's derived values, and the barrier made values crossing pass-through API summaries lose their true provenance (the edge accepted at wala/ML#726 time, now closed).
- **Slice Results Classify Through Their Receiver**: `SliceBuiltinOperation.getOrigins` delegates to the receiver's producing generator (an ndarray slice is an ndarray, a `Tensor` slice a `Tensor`, per the wala/ML#724 runtime-type rule), with the TensorFlow default only when the receiver does not resolve.

## Anchor Movement

`build_graph`'s census goes from four `{TENSORFLOW, PARAMETER}` defs to none: its subscripts read `{NUMPY}` and no def carries `PARAMETER`. The remaining three census entries are type-level over-typing of semantically non-tensor values (two `slice(None, None, None)` constructor objects and the enumerate iterator object), split out as wala/ML#732 since they are census/typing residue, not origin defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
