### PR TITLE
Pin non-tensor slice-constructor and iterator objects empty (wala/ML#732)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorOrigins.java
@@ -146,17 +146,13 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
    * The wala/ML#726 consumer contract on the vendored {@code deep_recommenders} Cora subject (the
    * Hybridize-Functions-Refactoring#774 methods), anchored in-repo so the consumer's re-measure is
    * corroboration rather than the gate. The nested helpers ({@code _sample_mask}, {@code
-   * _get_labels}) and {@code encode_labels} satisfy the contract cleanly: every tensor-typed local
-   * reads exactly {@code {NUMPY}} (an origin-keyed consumer declines them as convertible data
-   * preparation) and every tensor-typed parameter reads {@code {PARAMETER}}; {@code
-   * encode_labels}'s enumerate over its string-list attribute stopped surfacing a spurious unknown
-   * tensor once an unresolved iterable became ⊥ on every axis (wala/ML#730). {@code build_graph}
-   * captures the remaining deviations, all type-level over-typing of semantically non-tensor values
-   * rather than origin defects (wala/ML#731): two {@code slice(None, None, None)} constructor
-   * objects reading the cross-caller TensorFlow union through the shared slice builtin, and the
-   * evidence-free enumerate iterator object. Its subscripts classify {@code {NUMPY}} through the
-   * wala/ML#731 receiver delegation, and no def carries {@code PARAMETER}, since only user code
-   * bodies seed the hybridization-frame origin.
+   * _get_labels}), {@code encode_labels}, and {@code build_graph} all satisfy the contract: every
+   * tensor-typed local reads exactly {@code {NUMPY}} (an origin-keyed consumer declines all four as
+   * convertible data preparation) and every tensor-typed parameter reads {@code {PARAMETER}}.
+   * Reaching this took the whole wala/ML#728&ndash;wala/ML#732 arc: an unresolved enumerate
+   * iterable became ⊥ on every axis (wala/ML#730), the hybridization-frame origin became
+   * user-code-only and slices classify through their receiver (wala/ML#731), and the non-tensor
+   * slice-constructor and iterator objects pin empty via {@code drops} (wala/ML#732).
    *
    * <p>Assertions are per-method censuses (how many locals read each origin set) rather than
    * per-value-number, so front-end numbering drift does not break the anchor.
@@ -196,15 +192,7 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
 
     MethodOrigins buildGraph = methodOrigins.get(".Cora.build_graph.do(");
     assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(buildGraph.parameters()));
-    assertEquals(
-        Map.of(
-            EnumSet.of(TensorOrigin.NUMPY),
-            6L,
-            EnumSet.noneOf(TensorOrigin.class),
-            1L,
-            EnumSet.of(TensorOrigin.TENSORFLOW),
-            2L),
-        census(buildGraph.locals()));
+    assertEquals(Map.of(EnumSet.of(TensorOrigin.NUMPY), 6L), census(buildGraph.locals()));
   }
 
   /**
@@ -227,7 +215,9 @@ public class TestTensorOrigins extends TestPythonMLCallGraphShape {
 
     MethodOrigins f = methodOrigins.get(".f.do(");
     assertEquals(Map.of(EnumSet.of(TensorOrigin.PARAMETER), 1L), census(f.parameters()));
-    assertEquals(Map.of(EnumSet.of(TensorOrigin.NUMPY), 2L), census(f.locals()));
+    // One numpy-only local: the comprehension def. The enumerate result itself is an iterator
+    // object, pinned non-tensor since wala/ML#732.
+    assertEquals(Map.of(EnumSet.of(TensorOrigin.NUMPY), 1L), census(f.locals()));
 
     for (String fragment : List.of(".g.do(", ".h.do(")) {
       MethodOrigins contrast = methodOrigins.get(fragment);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1945,6 +1945,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
+   *     <p>The local count excludes the {@code enumerate(targets)} iterator object, pinned
+   *     non-tensor since wala/ML#732; the element and its TensorFlow uses stay typed.
    */
   @Test
   public void testTuckerTargetConvert()
@@ -1962,7 +1964,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "TuckERLoader.target_convert",
         "tucker_proj",
         1,
-        7,
+        6,
         Map.of(
             3,
             Set.of(
@@ -2537,6 +2539,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
+   *     <p>The local count excludes the two all-constant slice-constructor objects under the
+   *     multi-dim subscript, pinned non-tensor since wala/ML#732; the subscript result stays typed.
    */
   @Test
   public void testMusicTransformerPositionEmbedding()
@@ -2551,7 +2555,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "DynamicPositionEmbedding.call",
         "musictx_proj",
         1,
-        6,
+        4,
         Map.of(3, Set.of(TensorType.of(FLOAT_32, 2, 50, 64))));
   }
 
@@ -11454,6 +11458,8 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
+   *     <p>The local count excludes the two all-constant slice-constructor objects under the {@code
+   *     [:, :-1]} subscripts, pinned non-tensor since wala/ML#732.
    */
   @Test
   public void testMusicTransformerPrepareTrainData()
@@ -11464,7 +11470,7 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         "MusicTransformer.__prepare_train_data",
         "musictransformer_proj",
         2,
-        7,
+        5,
         Map.of(
             2,
             Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1168,6 +1168,28 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
+   * Returns whether the given invoke is a slice <em>constructor</em>: it resolves to the {@code
+   * slice} builtin and every argument is a compile-time constant (the {@code slice(None, None,
+   * None)} form that subscripts like {@code x[:, 0]} compile to). The subscript-application form
+   * never matches, since its first argument is the sliced tensor. See wala/ML#732.
+   *
+   * @param node The {@link CGNode} containing the invoke.
+   * @param invoke The invoke instruction to test.
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @return {@code true} iff the invoke constructs a slice object from constants.
+   */
+  private static boolean isConstantSliceConstructor(
+      CGNode node, SSAAbstractInvokeInstruction invoke, PropagationCallGraphBuilder builder) {
+    SymbolTable st = node.getIR().getSymbolTable();
+    for (int i = 1; i < invoke.getNumberOfUses(); i++)
+      if (!st.isConstant(invoke.getUse(i))) return false;
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite()))
+      if (callee.getMethod().getReference().getDeclaringClass().equals(PythonTypes.SLICE_BUILTIN))
+        return true;
+    return false;
+  }
+
+  /**
    * Returns whether the given invoke resolves to the {@code enumerate} builtin. The declared target
    * is a generic trampoline ({@code LCodeBody}), so resolution goes through {@code
    * getPossibleTargets}, matching {@code isEnumerateFirstFieldRead}.
@@ -1373,6 +1395,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       for (PointsToSetVariable v : dataflow) {
         if (isEnumerateFirstFieldRead(v, builder)) drops.add(v);
       }
+      // Semantically non-tensor iteration machinery pins to empty-and-fixed too (wala/ML#732):
+      // an all-constant-bounds slice constructor (`slice(None, None, None)` under `x[:, 0]`) is a
+      // runtime slice object, and an enumerate result is an iterator object whose element typing
+      // the element generators serve; both otherwise read cross-caller tensor state through
+      // shared builtin frames and count as tensor defs downstream. The subscript-application form
+      // is untouched: its first argument is a tensor receiver, not a constant.
+      for (PointsToSetVariable v : dataflow) {
+        if (!(v.getPointerKey() instanceof LocalPointerKey)) continue;
+        LocalPointerKey lpk = (LocalPointerKey) v.getPointerKey();
+        if (lpk.getNode().getDU() == null || lpk.getNode().getIR() == null) continue;
+        SSAInstruction def = lpk.getNode().getDU().getDef(lpk.getValueNumber());
+        if (!(def instanceof SSAAbstractInvokeInstruction)) continue;
+        SSAAbstractInvokeInstruction invoke = (SSAAbstractInvokeInstruction) def;
+        if (isEnumerateCall(lpk.getNode(), invoke, builder)
+            || isConstantSliceConstructor(lpk.getNode(), invoke, builder)) drops.add(v);
+      }
+
       LOGGER.fine(() -> "wala/ML#409 drops (enumerate-first-field): " + drops.size());
       for (PointsToSetVariable d : drops)
         LOGGER.fine(() -> "  drop: " + describe(d.getPointerKey()));


### PR DESCRIPTION
Closes wala/ML#732.

Applies the wala/ML#409 recipe to the two semantically non-tensor value classes the wala/ML#731 residue identified: an all-constant-bounds slice constructor (`slice(None, None, None)` under subscripts like `x[:, 0]`) is a runtime slice object, and an `enumerate` result is an iterator object whose element typing the element generators serve. Both otherwise read cross-caller tensor state through shared builtin frames and count as tensor defs downstream. Their destinations are detected structurally (the subscript-application form never matches, since its first argument is the sliced tensor rather than a constant) and pinned empty-and-fixed via `drops`.

With this, the vendored Cora anchor reaches the full decline contract: all four Hybridize-Functions-Refactoring#774 data-preparation methods read exactly `{NUMPY}` on every tensor-typed local, closing the wala/ML#728 through wala/ML#732 arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
