### PR TITLE
Project constant slice bounds onto `int` exactly

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -14089,6 +14089,55 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Degradation arms of the candidate-bound enumeration (wala/ML#710): a combination count past the
+   * cap, a zero step candidate, a non-numeric constant candidate, more candidates on a single bound
+   * than the cap, and a non-constant bound in each of the three positions all keep the sound ⊤
+   * fallback rather than asserting any particular slicing.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeSliceAmbiguousDegrade()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_slice_ambiguous2.py",
+        "top",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Precision arms of the candidate-bound enumeration (wala/ML#710): a propagated {@code None}
+   * alongside a numeric candidate unions both slicings ({@code (4, 5, 1)} and {@code (4, 5)}), and
+   * numerically equal {@code int} and {@code float} candidates deduplicate to one slicing ({@code
+   * (5,)}).
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeSliceAmbiguousPrecise()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_slice_ambiguous2.py",
+        "precise",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                TensorType.of(FLOAT_32, 4, 5, 1),
+                TensorType.of(FLOAT_32, 4, 5),
+                TensorType.of(FLOAT_32, 5))));
+  }
+
+  /**
    * Tier-5 generator (wala/ML#449): {@code tf.math.top_k(input, k)}. Returns a {@code (values,
    * indices)} 2-tuple. The dedicated {@link com.ibm.wala.cast.python.ml.client.TopK} generator
    * implements {@link com.ibm.wala.cast.python.ml.client.TupleElementProvider} with per-index dtype

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -85,6 +85,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -4703,7 +4704,8 @@ public abstract class TensorGenerator {
    * @param st The node's symbol table.
    * @param invoke The slice-builtin invoke.
    * @param useIndex The use index of the bound ({@code 2}=lower, {@code 3}=upper, {@code 4}=step).
-   * @return The candidate values, or {@code null} when the bound does not resolve to constants.
+   * @return The candidate values, or {@code null} when the bound does not resolve to constants with
+   *     exact {@code int} projections.
    */
   private static List<Integer> sliceBoundCandidates(
       PropagationCallGraphBuilder builder,
@@ -4722,18 +4724,35 @@ public abstract class TensorGenerator {
     if (pk == null || builder.getPropagationSystem().isImplicit(pk)) return null;
     OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
     if (pts == null || pts.isEmpty()) return null;
-    List<Integer> candidates = new ArrayList<>();
+    Set<Integer> candidates = new LinkedHashSet<>();
     for (InstanceKey ik : pts) {
       if (!(ik instanceof ConstantKey)) return null;
       Object value = ((ConstantKey<?>) ik).getValue();
       Integer candidate;
       if (value == null) candidate = null; // Propagated None: the Python default.
-      else if (value instanceof Number) candidate = ((Number) value).intValue();
-      else return null;
-      if (!candidates.contains(candidate)) candidates.add(candidate);
+      else if (value instanceof Number) {
+        candidate = intProjectionOrNull((Number) value);
+        if (candidate == null) return null;
+      } else return null;
+      candidates.add(candidate);
       if (candidates.size() > SLICE_CANDIDATE_COMBINATION_CAP) return null;
     }
-    return candidates;
+    return new ArrayList<>(candidates);
+  }
+
+  /**
+   * Projects a constant {@link Number} onto an {@code int} exactly. A value outside the {@code int}
+   * range or with a fractional part has no exact projection; truncating it would assert a bound or
+   * index the runtime value violates.
+   *
+   * @param value The constant numeric value to project.
+   * @return The exact {@code int} projection, or {@code null} when none exists.
+   */
+  private static Integer intProjectionOrNull(Number value) {
+    double doubleValue = value.doubleValue();
+    long longValue = value.longValue();
+    if (doubleValue != longValue || longValue != (int) longValue) return null;
+    return (int) longValue;
   }
 
   /**
@@ -4777,7 +4796,10 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, CGNode node, SymbolTable st, int vn) {
     if (vn <= 0) return null;
     if (st.isNullConstant(vn)) return null; // Explicit None.
-    if (st.isNumberConstant(vn)) return ((Number) st.getConstantValue(vn)).intValue();
+    if (st.isNumberConstant(vn)) {
+      Integer projection = intProjectionOrNull((Number) st.getConstantValue(vn));
+      return projection == null ? UNRESOLVED_BOUND : projection;
+    }
 
     // Constant-fold a unary minus of a resolvable operand.
     SSAInstruction def = node.getDU() != null ? node.getDU().getDef(vn) : null;
@@ -4801,8 +4823,9 @@ public abstract class TensorGenerator {
         continue;
       }
       if (!(value instanceof Number)) return UNRESOLVED_BOUND;
-      int intValue = ((Number) value).intValue();
-      if (found != null && found != intValue) return UNRESOLVED_BOUND; // Ambiguous.
+      Integer intValue = intProjectionOrNull((Number) value);
+      if (intValue == null) return UNRESOLVED_BOUND; // No exact int projection.
+      if (found != null && !found.equals(intValue)) return UNRESOLVED_BOUND; // Ambiguous.
       found = intValue;
     }
     // A points-to set holding both None and a numeric constant is ambiguous; collapsing it to

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_ambiguous2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_slice_ambiguous2.py
@@ -1,0 +1,170 @@
+import tensorflow as tf
+
+
+def top(v):
+    pass
+
+
+def precise(v):
+    pass
+
+
+def get_shape(t):
+    return t.shape.as_list()
+
+
+def blowup(t, f1, f2, f3, f4):
+    lo = 0 if f1 else 1 if f2 else 2
+    hi = 1 if f3 else 2 if f4 else 3
+    return tf.reshape(tf.ones((4,)), get_shape(t)[lo:hi])
+
+
+def zero_step(t, flag):
+    s = 0 if flag else 2
+    return tf.reshape(tf.ones((4,)), get_shape(t)[::s])
+
+
+def string_bound(t, flag):
+    u = "x" if flag else 2
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:u])
+
+
+def many(t, f1, f2, f3, f4, f5, f6, f7, f8):
+    u = (
+        1
+        if f1
+        else (
+            2
+            if f2
+            else (
+                3
+                if f3
+                else 4 if f4 else 5 if f5 else 6 if f6 else 7 if f7 else 8 if f8 else 9
+            )
+        )
+    )
+    return tf.reshape(tf.ones((4,)), get_shape(t)[:u])
+
+
+def nonconst_lower(t):
+    u = len(get_shape(t))
+    return tf.reshape(tf.ones((1,)), get_shape(t)[u:])
+
+
+def nonconst_upper(t):
+    u = len(get_shape(t))
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:u])
+
+
+def nonconst_step(t):
+    u = len(get_shape(t))
+    return tf.reshape(tf.ones((4,)), get_shape(t)[::u])
+
+
+def huge(t, flag):
+    u = 2 if flag else 4294967298
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:u])
+
+
+def huge_literal(t):
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:4294967298])
+
+
+def mixed_nonconst(t, flag):
+    u = 2 if flag else t
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:u])
+
+
+def none_or_two(t, flag):
+    u = None if flag else 2
+    return tf.reshape(tf.ones((20,)), get_shape(t)[:u])
+
+
+def dup(t, flag):
+    u = 2 if flag else 2.0
+    return tf.reshape(tf.ones((5,)), get_shape(t)[1:u])
+
+
+# Coverage companions of tf2_test_shape_slice_ambiguous.py (wala/ML#710). Each function
+# exercises one arm of the candidate-bound enumeration; the asserts document the Python
+# runtime truth for the taken branch.
+t = tf.ones((4, 5, 1))
+
+# The candidate combinations (3 lowers x 3 uppers) exceed the enumeration cap: the
+# analysis reports an unknown (top) shape.
+a = blowup(t, True, False, True, False)
+assert a.shape == (4,)
+assert a.dtype == tf.float32
+top(a)
+
+# A zero step candidate is an invalid slicing: the analysis reports an unknown shape.
+b = zero_step(t, False)
+assert b.shape == (4, 1)
+assert b.dtype == tf.float32
+top(b)
+
+# A non-numeric constant candidate cannot be a slice bound: the analysis reports an
+# unknown shape.
+c = string_bound(t, False)
+assert c.shape == (4, 5)
+assert c.dtype == tf.float32
+top(c)
+
+# Nine candidates on a single bound exceed the per-bound cap: the analysis reports an
+# unknown shape.
+d = many(t, True, False, False, False, False, False, False, False)
+assert d.shape == (4,)
+assert d.dtype == tf.float32
+top(d)
+
+# A non-constant bound (in each of the three positions) defeats the enumeration: the
+# analysis reports an unknown shape.
+e = nonconst_lower(t)
+assert e.shape == ()
+assert e.dtype == tf.float32
+top(e)
+
+g = nonconst_upper(t)
+assert g.shape == (4, 5, 1)
+assert g.dtype == tf.float32
+top(g)
+
+h = nonconst_step(t)
+assert h.shape == (4,)
+assert h.dtype == tf.float32
+top(h)
+
+# A candidate bound outside the int range has no exact projection; truncating it would
+# assert a slicing the runtime value violates, so the analysis reports an unknown shape.
+i = huge(t, True)
+assert i.shape == (4, 5)
+assert i.dtype == tf.float32
+top(i)
+
+# The same for a literal out-of-range bound (which at runtime just clamps).
+j = huge_literal(t)
+assert j.shape == (4, 5, 1)
+assert j.dtype == tf.float32
+top(j)
+
+# A non-constant value alongside a constant candidate defeats the enumeration: the
+# analysis reports an unknown shape.
+k = mixed_nonconst(t, True)
+assert k.shape == (4, 5)
+assert k.dtype == tf.float32
+top(k)
+
+# A propagated None alongside a numeric candidate unions both slicings: (4, 5, 1) under
+# [:None] and (4, 5) under [:2].
+p = none_or_two(t, False)
+assert p.shape == (4, 5)
+assert p.dtype == tf.float32
+precise(p)
+
+# Numerically equal int and float candidates fold to one slicing, (5,) under [1:2]: the
+# front end folds the float literal onto the int, so a single candidate reaches the
+# analysis.
+q = dup(t, True)
+assert q.shape == (5,)
+assert q.dtype == tf.float32
+precise(q)


### PR DESCRIPTION
Follow-up to #605: its `codecov/patch` failure flagged 14 uncovered lines in the candidate-bound enumeration, and chasing them surfaced a soundness defect. Both bound-projection sites (`sliceBoundCandidates` and `constantIntValueOrSentinel`, the latter also serving subscript and shape-vector-element resolution) projected constant `Number`s with `intValue()`, which silently truncates values outside the `int` range: a bound of `4294967298` truncated to `2` and asserted a slicing the runtime value violates.

**The Fix**

`intProjectionOrNull` projects a constant `Number` onto an `int` only when the projection is exact, rejecting out-of-range and fractional values; a rejected bound degrades to the sound unresolved (⊤) fallback. With exact projection, distinct constant keys can no longer collide on one candidate (a probe showed the front end already folds `2.0` onto `Long 2`), so the duplicate-check branch was dead; a `LinkedHashSet` replaces it.

**Coverage**

`tf2_test_shape_slice_ambiguous2.py` (runtime-verified) exercises each enumeration arm: the combination cap, the per-bound candidate cap, a zero-step candidate, a non-numeric constant candidate, out-of-range candidate and literal bounds, a mixed constant/non-constant bound, a non-constant bound in each of the three positions, a propagated `None` unioning with a numeric candidate, and the int/float fold. `testShapeSliceAmbiguousDegrade` pins the ⊤ arms and `testShapeSliceAmbiguousPrecise` the precise ones. The remaining uncovered branches are defensive guards fixtures cannot reach: `pk == null` (the heap model always returns a key for a local), `pts == null` (the pointer analysis returns an empty set, not `null`), and the fractional-`double` projection arm (the front end folds float literals).

Refs wala/ML#710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
