### PR TITLE
Cover the einsum ellipsis and diagonal degradation arms

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13117,6 +13117,113 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Malformed and unsatisfiable einsum equations (wala/ML#705): a stray or truncated dot, a second
+   * ellipsis in one term, a non-letter label, a malformed output term, a repeated output label, a
+   * label/rank mismatch, non-broadcastable batch axes, broadcast axes with no output ellipsis, and
+   * the empty equation all compose no shape, keeping the sound ⊤ fallback with a precise dtype.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumMalformed()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_malformed.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * Ellipsis identity with leading letters ({@code "i...j->i...j"}, wala/ML#705): labels before the
+   * ellipsis bind leading axes and labels after it bind trailing ones.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumEllipsisLeadingLetter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_mixed.py", "f", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 4))));
+  }
+
+  /**
+   * Implicit mode with an ellipsis ({@code "i...j"}, wala/ML#705): the broadcast group precedes the
+   * once-occurring labels, composing {@code (3, 2, 4)} from a {@code (2, 3, 4)} input.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumImplicitEllipsis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_mixed.py", "g", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_32, 3, 2, 4))));
+  }
+
+  /**
+   * The mirror of {@link #testEinsumBatchBroadcast()} (wala/ML#705): the size-1 axis sits in the
+   * second input's ellipsis group, so the {@code (5,)} and {@code (2, 1)} groups still broadcast to
+   * {@code (2, 5)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumBatchBroadcastReversed()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_mixed.py",
+        "h",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 5, 3, 2))));
+  }
+
+  /**
+   * A statically-unknown batch axis ({@code keras.Input}'s {@code None}) refines against a known
+   * one (wala/ML#705): the runtime requires the unknown to be 1 or equal, so the known non-1 size
+   * wins in either input order.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumSymbolicBatchRefined()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_einsum_mixed.py", "k", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_32, 2))));
+  }
+
+  /**
+   * Two statically-unknown batch axes (wala/ML#705): the broadcast keeps the rank but not the size,
+   * composing a rank-1 shape whose axis stays dynamic.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumSymbolicBatchPair()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_mixed.py",
+        "m",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE)))));
+  }
+
+  /**
    * Shape-vector provenance (wala/ML#703): {@code tf.reshape(x, t.shape.as_list()[-2:])} resolves
    * to the source tensor's trailing sub-shape. The shape argument's points-to set is empty (the
    * {@code shape} member, {@code as_list}, and the slice are unmodeled in the heap), so {@code

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_malformed.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_malformed.py
@@ -1,0 +1,39 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def dead(flag):
+    # This branch is dead at runtime (the equations below are rejected by the
+    # runtime), but the analysis still types each call: every malformed or
+    # unsatisfiable equation composes no shape, so each result is an unknown
+    # (top) shape with a precise float32 dtype.
+    if flag:
+        t = tf.ones((2, 3))
+        u = tf.ones((3, 2))
+        v = tf.ones((2, 4))
+        w = tf.ones((3, 4))
+        f(tf.einsum("i.j", t))  # A dot outside an ellipsis in an input term.
+        f(tf.einsum("ij.", t))  # An ellipsis truncated at the term end.
+        f(tf.einsum("i..jk", t))  # A two-dot run that never completes an ellipsis.
+        f(tf.einsum("...i...j", t))  # A second ellipsis within one term.
+        f(tf.einsum("i1", t))  # A non-letter label.
+        f(tf.einsum("ij->i.j", t))  # A malformed output term.
+        f(tf.einsum("ij,jk->ii", t, u))  # A repeated output label.
+        f(tf.einsum("ijk", t))  # More labels than the input's rank.
+        f(tf.einsum("...ijk", t))  # Ellipsis letters exceeding the rank.
+        f(tf.einsum("...i,...i->...i", v, w))  # Batch axes that don't broadcast.
+        f(tf.einsum("...i,...i->i", v, v))  # Broadcast axes but no output ellipsis.
+
+
+dead(False)
+
+# An empty equation is runtime-valid on a scalar (an identity), but the parser
+# treats it as unresolvable, so the analysis reports an unknown shape.
+r = tf.einsum("", tf.constant(3.0))
+assert r.shape == ()
+assert r.dtype == tf.float32
+assert float(r) == 3.0
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_mixed.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_mixed.py
@@ -1,0 +1,80 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def h(a):
+    pass
+
+
+def k(a):
+    pass
+
+
+def m(a):
+    pass
+
+
+# Ellipsis forms beyond the leading-batch idiom (wala/ML#705). Labels before an
+# ellipsis bind leading axes; labels after it bind trailing ones.
+t = tf.ones((2, 3, 4))
+r1 = tf.einsum("i...j->i...j", t)
+assert r1.shape == (2, 3, 4)
+assert r1.dtype == tf.float32
+f(r1)
+
+# Implicit mode with an ellipsis: the broadcast group precedes the
+# once-occurring labels, so "i...j" composes (3, 2, 4).
+r2 = tf.einsum("i...j", t)
+assert r2.shape == (3, 2, 4)
+assert r2.dtype == tf.float32
+g(r2)
+
+# The mirror of tf2_test_einsum_batch.py's broadcast: the size-1 axis sits in
+# the second input's group, so the (5,) and (2, 1) groups broadcast to (2, 5).
+a = tf.ones((5, 3, 4))
+b = tf.ones((2, 1, 4, 2))
+r3 = tf.einsum("...ij,...jk->...ik", a, b)
+assert r3.shape == (2, 5, 3, 2)
+assert r3.dtype == tf.float32
+h(r3)
+
+# A statically-unknown batch axis (keras.Input's None) refines against a known
+# one: the runtime requires the unknown to be 1 or equal, so the known non-1
+# size wins in either input order.
+c = tf.ones((2, 4))
+inp = tf.keras.Input(shape=(4,))
+r4 = tf.einsum("...i,...i->...", c, inp)
+assert r4.shape == (2,)
+assert r4.dtype == tf.float32
+k(r4)
+
+r5 = tf.einsum("...i,...i->...", inp, c)
+assert r5.shape == (2,)
+assert r5.dtype == tf.float32
+k(r5)
+
+# Two statically-unknown batch axes stay unknown in size but keep the rank.
+r6 = tf.einsum("...i,...i->...", inp, inp)
+assert r6.shape == (None,)
+assert r6.dtype == tf.float32
+m(r6)
+
+# A known size-1 axis yields the other side of the broadcast, so against an
+# unknown axis the result stays unknown, in either input order.
+one = tf.ones((1, 4))
+r7 = tf.einsum("...i,...i->...", one, inp)
+assert r7.shape == (None,)
+assert r7.dtype == tf.float32
+m(r7)
+
+r8 = tf.einsum("...i,...i->...", inp, one)
+assert r8.shape == (None,)
+assert r8.dtype == tf.float32
+m(r8)


### PR DESCRIPTION
Follow-up to #607: its `codecov/patch` failure flagged 23 uncovered lines, mostly the malformed-equation rejections and several broadcast-merge arms.

**Malformed Equations**

The runtime rejects these forms, so `tf2_test_einsum_malformed.py` reaches them through analysis-only dead branches: a stray or truncated dot, a two-dot run, a second ellipsis in one term, a non-letter label, a malformed output term, a repeated output label, label/rank mismatches with and without an ellipsis, non-broadcastable known batch axes, and broadcast axes with no output ellipsis. The runtime-valid empty equation rides along live. All pin the sound ⊤ fallback with a precise dtype.

**Live Merge Arms**

`tf2_test_einsum_mixed.py` exercises letters before an ellipsis (`"i...j->i...j"`), implicit mode with an ellipsis (`"i...j"`), the mirrored batch broadcast (the size-1 axis in the second input's group), and `mergeBroadcastGroups`' refinement rules with a `keras.Input` dynamic batch axis: known non-1 against dynamic (either order), size-1 against dynamic (either order), and the dynamic pair. A first attempt used `tf.reshape(..., (-1, 4))` for the unknown axis, but the `Reshape` generator folds the `-1` when the source element count is known, which is why the fixtures use `keras.Input` instead.

Refs wala/ML#705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
