### PR TITLE
Assert the depth-too-short signal reports only genuine ⊤ values

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestDepthLimitedSignal.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestDepthLimitedSignal.java
@@ -5,12 +5,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
+import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
 import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine.DepthLimitedResult;
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 
 /**
@@ -29,14 +38,37 @@ import org.junit.Test;
  */
 public class TestDepthLimitedSignal extends TestPythonMLCallGraphShape {
 
-  private List<DepthLimitedResult> depthLimitedResults(int targetedCfaDepth)
+  /**
+   * The depth-limited signal from an analysis, paired with the pointer keys of every ⊤-shape value
+   * the same analysis produced. The paired ⊤ set lets a test check that the signal reports only
+   * genuine ⊤ values (not concrete values that merely share a saturated context), the property the
+   * {@code hasTopShape} filter enforces.
+   *
+   * @param results The reported depth-limited ⊤ values.
+   * @param topKeys The local pointer keys of all ⊤-shape values in the analysis.
+   */
+  private record Signal(List<DepthLimitedResult> results, Set<LocalPointerKey> topKeys) {}
+
+  private Signal analyze(int targetedCfaDepth)
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     PythonTensorAnalysisEngine engine =
         makeEngine(targetedCfaDepth, emptyList(), "neural_network.py");
     PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
     builder.makeCallGraph(builder.getOptions());
-    engine.performAnalysis(builder);
-    return engine.getDepthLimitedResults();
+    TensorTypeAnalysis analysis = engine.performAnalysis(builder);
+
+    Set<LocalPointerKey> topKeys = new HashSet<>();
+    for (Iterator<Pair<PointerKey, TensorVariable>> it = analysis.iterator(); it.hasNext(); ) {
+      Pair<PointerKey, TensorVariable> pair = it.next();
+      if (pair.fst instanceof LocalPointerKey && hasTopShape(pair.snd))
+        topKeys.add((LocalPointerKey) pair.fst);
+    }
+    return new Signal(engine.getDepthLimitedResults(), topKeys);
+  }
+
+  private static boolean hasTopShape(TensorVariable variable) {
+    for (TensorType type : variable.getTypes()) if (type.getDims() == null) return true;
+    return false;
   }
 
   /**
@@ -51,13 +83,14 @@ public class TestDepthLimitedSignal extends TestPythonMLCallGraphShape {
   @Test
   public void testEmptyAtDepthZero()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    assertEquals(List.of(), depthLimitedResults(0));
+    assertEquals(List.of(), analyze(0).results());
   }
 
   /**
    * At the default depth the accuracy-path framework ops resolve to ⊤ at a saturated call string,
-   * so the signal is non-empty; every reported value carries a ⊤ shape, sits at a node routed
-   * through the targeted selector, and has a call string of exactly the configured depth.
+   * so the signal is non-empty; every reported value carries a genuine ⊤ shape (not a concrete
+   * value sharing the saturated context), sits at a node routed through the targeted selector, and
+   * has a call string of exactly the configured depth.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -67,12 +100,16 @@ public class TestDepthLimitedSignal extends TestPythonMLCallGraphShape {
   @Test
   public void testFiresAtDefaultDepth()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    List<DepthLimitedResult> results =
-        depthLimitedResults(PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH);
-    assertTrue("Expected a depth-too-short signal at the default depth", results.size() > 0);
-    for (DepthLimitedResult result : results) {
+    Signal signal = analyze(PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH);
+    assertTrue(
+        "Expected a depth-too-short signal at the default depth", signal.results().size() > 0);
+    for (DepthLimitedResult result : signal.results()) {
       assertEquals(
           PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH, result.callStringLength());
+      assertTrue(
+          "Every reported value should be a genuine ⊤ shape",
+          signal.topKeys().contains(result.pointerKey()));
+      assertEquals(result.pointerKey().getValueNumber(), result.valueNumber());
       assertTrue(
           "Every reported node should be in the framework subgraph",
           result
@@ -88,7 +125,9 @@ public class TestDepthLimitedSignal extends TestPythonMLCallGraphShape {
   /**
    * By the model-forward depth every targeted call string reaches the call-graph root within the
    * budget, so the signal is empty: the subject's fixed point, past which the remaining ⊤ values
-   * are genuine unknowns rather than merged-context artifacts.
+   * are genuine unknowns rather than merged-context artifacts. The analysis still holds ⊤ values in
+   * the targeted subgraph at this depth (they are simply unsaturated), so the emptiness confirms
+   * the saturation filter, not an absence of ⊤.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -98,7 +137,10 @@ public class TestDepthLimitedSignal extends TestPythonMLCallGraphShape {
   @Test
   public void testEmptyAtFixedPoint()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    assertEquals(
-        List.of(), depthLimitedResults(PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH));
+    Signal signal = analyze(PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH);
+    assertEquals(List.of(), signal.results());
+    assertTrue(
+        "The fixed-point analysis should still hold ⊤ values (now unsaturated)",
+        signal.topKeys().size() > 0);
   }
 }


### PR DESCRIPTION
Follow-up to #610 (wala/ML#601). The depth-too-short signal's positive test checked that each reported value sits at a saturated framework context, but not that its shape is genuinely ⊤. That left a hole: the analysis holds concrete-valued framework values at saturated contexts too (24 of them on `neural_network.py` at the default depth, e.g. `reduce_mean` = `(256, 784)`), so a regression dropping the `hasTopShape` filter would report those concretes and the test would still pass.

**The Change**

`testFiresAtDefaultDepth` now cross-checks each reported pointer key against the analysis's set of ⊤ values (a new `Signal` pair of the results and the ⊤ keys), so a reported concrete fails the test. `testEmptyAtFixedPoint` additionally asserts the fixed-point analysis still holds ⊤ values in the targeted subgraph, confirming the emptiness comes from the saturation filter rather than an absence of ⊤. Verified by mutation: removing the `hasTopShape` filter now fails `testFiresAtDefaultDepth` on the ⊤-membership assertion.

Refs wala/ML#601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zz8VGsQyEUEH1Avux95w6
