### PR TITLE
Refine `tf.einsum` operand shapes against the equation (wala/ML#704)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2235,10 +2235,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code (8, 100, U, U)}/{@code (8, 10, U, U)} members are the {@code DenseLayer3dProj} contexts'
    * inputs (the attention's return value): the worklist engine converges the loop-carried union
    * from its non-cyclic base and all four proj contexts carry them (wala/ML#365 Phase 3 resolved
-   * the fourth, the wala/ML#718 residual under the retired round-based resolution). The remaining
-   * pure-⊤/shape-⊤ members come from the guard-φ phantom and non-entry contexts. The {@code w}
-   * parameter keeps rank 3 and {@code float32} (its chain is layer-local) but no numeric
-   * dimensions, since the {@code build}-computed head sizes also derive from the config.
+   * the fourth, the wala/ML#718 residual under the retired round-based resolution). The formerly
+   * shape-⊤ members carry equation-proven ranks since the einsum-operand refinement (wala/ML#704):
+   * {@code DenseLayer3d.call}'s {@code use_einsum} arm makes its input an operand of the rank-3
+   * {@code "BFH"} term and {@code DenseLayer3dProj.call}'s of the rank-4 {@code "BFND"} term, and
+   * the refined parameter states transport through the call boundary into this helper. Every proven
+   * axis stays {@link UnresolvedDim} in vivo, since {@code w}'s extents are config-derived; the
+   * rank-3 unknown-dtype member is the {@code DenseLayer3d}-path input that resolves no dtype
+   * (wala/ML#736). The {@code w} parameter keeps rank 3 and {@code float32} (its chain is
+   * layer-local) but no numeric dimensions, since the {@code build}-computed head sizes also derive
+   * from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2258,8 +2264,16 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2,
             Set.of(
-                TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE,
-                TENSOR_UNKNOWN_SHAPE_FLOAT32,
+                new TensorType(
+                    UNKNOWN,
+                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE)),
                 new TensorType(FLOAT_32, asList(new NumericDim(8), UnresolvedDim.INSTANCE)),
                 new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
                 new TensorType(
@@ -2296,6 +2310,57 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                 new TensorType(
                     FLOAT_32,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+  }
+
+  /**
+   * In-vivo anchor for the wala/ML#704 einsum-operand refinement at its reopen measurement point:
+   * the vendored NLPGNN {@code DenseLayer3dProj.call}'s {@code input_tensor}, formerly {@code ? of
+   * float32} (shape ⊤) in every context. The {@code use_einsum} arm's {@code
+   * einsum("BFND,NDH->BFH", input_tensor, w)} proves the input rank 4; the shared {@code N}/{@code
+   * D} extents stay {@link UnresolvedDim} in vivo because {@code w}'s dimensions are config-derived
+   * (contrast {@link #testDense3dProj()}, where the weight's static extents transfer). The {@code
+   * (8, 100, U, U)}/{@code (8, 10, U, U)} members arrive already rank-4 from the entry contracts
+   * (wala/ML#717) and pass through the refinement with their concrete leading dims intact.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNlpgnnFullDenseProjInput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        NLPGNN_FULL_PROJECT_FILES,
+        "nlpgnn/layers/dense.py",
+        "DenseLayer3dProj.call",
+        "nlpgnn_full_proj",
+        1,
+        8,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        new NumericDim(8),
+                        new NumericDim(100),
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        new NumericDim(8),
+                        new NumericDim(10),
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE)))));
   }
 
   /**
@@ -13348,6 +13413,38 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 4, 3, 5))));
+  }
+
+  /**
+   * NLPGNN's {@code DenseLayer3dProj} (wala/ML#704): the input arrives with an unresolvable shape
+   * (the wala/ML#711 opaque-bound reshape), but {@code einsum("BFND,NDH->BFH", input_tensor, w)}
+   * proves the input is rank 4, and the shared {@code N}/{@code D} labels take their extents from
+   * the reshaped weight's statically-known {@code (3, 5, 6)}. The {@code B}/{@code F} axes carry no
+   * {@code None} evidence, so they are {@code Unresolved} (wala/ML#721), not {@code Dynamic}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testDense3dProj()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dense3d_proj.py",
+        "DenseLayer3dProj.call",
+        1,
+        4,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        UnresolvedDim.INSTANCE,
+                        UnresolvedDim.INSTANCE,
+                        new NumericDim(3),
+                        new NumericDim(5))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -307,6 +307,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, TensorType> reshapeNodes,
       Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -404,6 +405,92 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             @Override
             public String toString() {
               return "set shape to " + setShapeTo;
+            }
+          }
+
+          /**
+           * A transfer function for einsum-operand destinations (wala/ML#704): each incoming tensor
+           * type is refined against the shape the einsum equation proves for the operand. An
+           * unknown-rank (⊤-shape) member takes the proven shape outright, keeping its dtype and
+           * layout; a member of the proven rank fills each non-numeric axis from the constraint's
+           * known one. A member that contradicts the constraint (a different rank) passes through
+           * unchanged: such a value fails at the einsum call at runtime, and the analysis reports
+           * what flows rather than fabricating agreement. Unlike {@code SetShapeOp} this is a
+           * monotone per-member refinement, not a pin: predecessors keep contributing, and concrete
+           * incoming state is never discarded.
+           *
+           * <p>Origin handling matches the transfer this op displaces on its destination: a
+           * parameter destination blocks origin inflow ({@code ParameterBarrierOp}, wala/ML#726),
+           * an iteration-product destination filters {@link TensorOrigin#PARAMETER} ({@code
+           * ParameterOriginFilterOp}, wala/ML#729), and any other destination unions origins as the
+           * plain transfer does.
+           */
+          final class RefineShapeOp extends UnaryOperator<TensorVariable> {
+            private final List<Dimension<?>> constraint;
+            private final PointsToSetVariable destination;
+
+            public RefineShapeOp(List<Dimension<?>> constraint, PointsToSetVariable destination) {
+              this.constraint = constraint;
+              this.destination = destination;
+            }
+
+            @Override
+            public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+              if (lhs == null || rhs == null) return NOT_CHANGED;
+              boolean changed = false;
+              if (rhs.state != null) {
+                if (lhs.state == null) lhs.state = HashSetFactory.make();
+                for (TensorType t : rhs.state) changed |= lhs.state.add(this.refine(t));
+              }
+              if (!parameters.contains(this.destination)) {
+                for (TensorOrigin origin : rhs.origins)
+                  if (origin != TensorOrigin.PARAMETER
+                      || !iterationProducts.contains(this.destination))
+                    changed |= lhs.origins.add(origin);
+              }
+              return changed ? CHANGED : NOT_CHANGED;
+            }
+
+            /**
+             * Refines one incoming member against the proven operand shape.
+             *
+             * @param t The incoming tensor type.
+             * @return The refined type: the proven shape (with {@code t}'s dtype and layout) when
+             *     {@code t}'s rank is unknown, {@code t} with each non-numeric axis filled from the
+             *     constraint's known one when the ranks agree, and {@code t} itself otherwise.
+             */
+            private TensorType refine(TensorType t) {
+              List<Dimension<?>> dims = t.getDims();
+              if (dims == null) return TensorType.of(t.getDType(), this.constraint, t.layout());
+              if (dims.size() != this.constraint.size()) return t;
+              List<Dimension<?>> merged = new ArrayList<>(dims.size());
+              boolean refined = false;
+              for (int i = 0; i < dims.size(); i++) {
+                Dimension<?> have = dims.get(i);
+                Dimension<?> want = this.constraint.get(i);
+                if (!(have instanceof NumericDim) && want instanceof NumericDim) {
+                  merged.add(want);
+                  refined = true;
+                } else merged.add(have);
+              }
+              return refined ? TensorType.of(t.getDType(), merged, t.layout()) : t;
+            }
+
+            @Override
+            public int hashCode() {
+              return this.constraint.hashCode() * 31 + this.destination.hashCode();
+            }
+
+            @Override
+            public boolean equals(Object o) {
+              return o instanceof RefineShapeOp
+                  && this.constraint.equals(((RefineShapeOp) o).constraint)
+                  && this.destination.equals(((RefineShapeOp) o).destination);
+            }
+
+            @Override
+            public String toString() {
+              return "refine shape against einsum operand constraint " + this.constraint;
             }
           }
 
@@ -620,6 +707,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return DropOp.INSTANCE;
             } else if (set_shapes.containsKey(dst)) {
               return new SetShapeOp(set_shapes.get(dst));
+            } else if (refinements.containsKey(dst)) {
+              return new RefineShapeOp(refinements.get(dst), dst);
             } else if (parameters.contains(dst)) {
               return ParameterBarrierOp.INSTANCE;
             } else if (iterationProducts.contains(dst)) {
@@ -682,6 +771,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    *     same edges as the types.
    * @param reshapeTypes Destinations pinned by an explicit reshape target shape.
    * @param set_shapes Destinations pinned by an {@code x.set_shape(s)} assertion (wala/ML#509).
+   * @param refinements Einsum-operand destinations refined against the shape the einsum equation
+   *     proves for them (wala/ML#704); incoming members are refined, never discarded.
    * @param conv2ds Destinations of 2D convolutions, rank-checked by {@code ConvOp}.
    * @param conv3ds Destinations of 3D convolutions, rank-checked by {@code ConvOp}.
    * @param drops Destinations pinned to empty-and-fixed (wala/ML#409).
@@ -698,6 +789,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
       Map<PointsToSetVariable, TensorType> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -709,6 +801,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             G,
             reshapeTypes,
             set_shapes,
+            refinements,
             conv2ds,
             conv3ds,
             drops,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -1,22 +1,33 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Logger;
 
 /**
  * Generator for {@code tf.einsum(equation, *inputs, **kwargs)}. Parses the equation string (e.g.
@@ -50,6 +61,8 @@ import java.util.TreeMap;
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class Einsum extends PassThroughUnaryTensorGenerator {
+
+  private static final Logger LOGGER = Logger.getLogger(Einsum.class.getName());
 
   /**
    * Parameter positions and keyword names for {@code tf.einsum(equation, *inputs, **kwargs)}.
@@ -291,21 +304,7 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
         if (ELLIPSIS.equals(label)) continue;
         // Letters before the ellipsis bind leading axes; letters after it bind trailing ones.
         Dimension<?> dim = shape.get(ellipsis >= 0 && d > ellipsis ? d - 1 + groupRank : d);
-        if (!labelToDim.containsKey(label)) labelToDim.put(label, dim);
-        else {
-          Dimension<?> previous = labelToDim.get(label);
-          // A shared label names the same dimension, and einsum requires the sizes equal at
-          // runtime, so a statically-known occurrence refines an unknown or dynamic one
-          // (wala/ML#704: the contracted hidden dim is known on the input but dynamic on the
-          // reshaped weight). Two known occurrences that disagree mean the constraint isn't
-          // satisfiable, so fall back to ⊤.
-          boolean previousKnown = previous instanceof NumericDim;
-          boolean dimKnown = dim instanceof NumericDim;
-          if (previousKnown && dimKnown) {
-            if (!previous.equals(dim)) return null;
-          } else if (dimKnown) labelToDim.put(label, dim);
-          else if (!previousKnown && previous == null && dim != null) labelToDim.put(label, dim);
-        }
+        if (!bindLabelOccurrence(labelToDim, label, dim)) return null;
       }
 
       if (ellipsis >= 0) {
@@ -327,6 +326,130 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
     // runtime rejects it), so no shape is inferred.
     if (!broadcast.isEmpty() && !parsed.output().contains(ELLIPSIS)) return null;
     return output;
+  }
+
+  /**
+   * Binds one occurrence of a subscript label to the dimension it names. A shared label names the
+   * same dimension, and einsum requires the sizes equal at runtime, so a statically-known
+   * occurrence refines an unknown or dynamic one (wala/ML#704: the contracted hidden dim is known
+   * on the input but dynamic on the reshaped weight). Two known occurrences that disagree mean the
+   * constraint isn't satisfiable.
+   *
+   * @param labelToDim The bindings accumulated so far; updated in place.
+   * @param label The subscript label.
+   * @param dim The dimension this occurrence names; may be {@code null} (known rank, unknown size).
+   * @return {@code false} iff this occurrence conflicts with a known binding (two unequal known
+   *     sizes).
+   */
+  private static boolean bindLabelOccurrence(
+      Map<String, Dimension<?>> labelToDim, String label, Dimension<?> dim) {
+    if (!labelToDim.containsKey(label)) {
+      labelToDim.put(label, dim);
+      return true;
+    }
+    Dimension<?> previous = labelToDim.get(label);
+    boolean previousKnown = previous instanceof NumericDim;
+    boolean dimKnown = dim instanceof NumericDim;
+    if (previousKnown && dimKnown) return previous.equals(dim);
+    if (dimKnown) labelToDim.put(label, dim);
+    else if (!previousKnown && previous == null && dim != null) labelToDim.put(label, dim);
+    return true;
+  }
+
+  /**
+   * Derives, for each tensor operand whose own shape does not resolve, the shape the equation
+   * proves for it: the operand's term fixes its rank (when the term carries no ellipsis), and each
+   * label shared with an operand whose shape is statically known fixes that axis's extent, since
+   * einsum requires same-label sizes equal at runtime (wala/ML#704). An axis the equation leaves
+   * unconstrained carries {@link UnresolvedDim}: its size is a fixed runtime value the analysis
+   * could not compute, with no {@code None} evidence (wala/ML#721); an axis bound to another
+   * operand's {@link DynamicDim} or {@link TensorType.RaggedDim} keeps that evidence.
+   *
+   * <p>The einsum source is the synthetic summary's return value, so the operands live caller-side:
+   * each caller's invoke supplies its own operand value numbers, resolved in that caller's frame
+   * (the {@code getArgumentShapesViaCallers} walk). Operand shapes are read in exact mode
+   * (wala/ML#716): a label binding asserts an equality on another operand, so a partially resolved
+   * shape set is not proof.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return A map from each caller-side operand's {@link PointerKey} to the shape the equation
+   *     proves for it; empty when the equation does not resolve, every operand resolves on its own,
+   *     or a resolved operand contradicts the equation. An operand whose call sites prove
+   *     disagreeing constraints is omitted.
+   */
+  public Map<PointerKey, List<Dimension<?>>> getOperandShapeConstraints(
+      PropagationCallGraphBuilder builder) {
+    String equation = this.getEquation(builder);
+    LOGGER.fine(() -> "getOperandShapeConstraints: equation=" + equation);
+    if (equation == null) return Collections.emptyMap();
+
+    ParsedEquation parsed = parseEquation(equation);
+    if (parsed == null) return Collections.emptyMap();
+    int inputCount = parsed.inputs().size();
+
+    Map<PointerKey, List<Dimension<?>>> ret = new LinkedHashMap<>();
+    Set<PointerKey> conflicting = new HashSet<>();
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) callerInvoke.snd;
+      // The *inputs varargs are spread positionally after the equation (input i sits at
+      // positional index i + 1, i.e., use i + 2); a call site with fewer positional arguments
+      // than the equation's terms is left alone.
+      if (invoke.getNumberOfPositionalParameters() < inputCount + 2) continue;
+
+      List<Set<List<Dimension<?>>>> operandShapes = new ArrayList<>(inputCount);
+      for (int i = 0; i < inputCount; i++) {
+        int argVn = invoke.getUse(Parameters.INPUTS.getIndex() + i + 1);
+        Set<List<Dimension<?>>> shapes = this.getShapes(builder, caller, argVn, true);
+        final int index = i;
+        LOGGER.fine(() -> "getOperandShapeConstraints: input " + index + " shapes=" + shapes);
+        operandShapes.add(shapes);
+      }
+
+      // Bind the labels of the operands whose own shape resolves to a single known form. A
+      // resolved operand whose rank contradicts its term means the call fails at runtime; so
+      // does a shared label with two unequal known sizes. No constraint is proven either way.
+      Map<String, Dimension<?>> labelToDim = new HashMap<>();
+      boolean contradicted = false;
+      for (int i = 0; i < inputCount && !contradicted; i++) {
+        Set<List<Dimension<?>>> shapes = operandShapes.get(i);
+        if (shapes == null || shapes.size() != 1) continue;
+        List<String> labels = parsed.inputs().get(i);
+        if (labels.contains(ELLIPSIS)) continue;
+        List<Dimension<?>> shape = shapes.iterator().next();
+        if (shape.size() != labels.size()) contradicted = true;
+        for (int d = 0; d < labels.size() && !contradicted; d++)
+          contradicted = !bindLabelOccurrence(labelToDim, labels.get(d), shape.get(d));
+      }
+      if (contradicted) continue;
+
+      for (int i = 0; i < inputCount; i++) {
+        Set<List<Dimension<?>>> shapes = operandShapes.get(i);
+        if (shapes != null && shapes.size() == 1)
+          continue; // Resolves on its own; nothing to prove.
+        List<String> labels = parsed.inputs().get(i);
+        if (labels.contains(ELLIPSIS)) continue; // The term does not fix the operand's rank.
+        List<Dimension<?>> constraint = new ArrayList<>(labels.size());
+        for (String label : labels) {
+          Dimension<?> dim = labelToDim.get(label);
+          constraint.add(
+              dim instanceof NumericDim || dim instanceof DynamicDim || dim instanceof RaggedDim
+                  ? dim
+                  : UnresolvedDim.INSTANCE);
+        }
+        PointerKey operandKey =
+            builder
+                .getPointerAnalysis()
+                .getHeapModel()
+                .getPointerKeyForLocal(caller, invoke.getUse(Parameters.INPUTS.getIndex() + i + 1));
+        List<Dimension<?>> previous = ret.putIfAbsent(operandKey, constraint);
+        if (previous != null && !previous.equals(constraint)) conflicting.add(operandKey);
+      }
+    }
+    ret.keySet().removeAll(conflicting);
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1417,6 +1417,38 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         setCalls.put(src, onlyType);
       }
 
+      // An einsum call site with a constant equation constrains each tensor operand: the
+      // operand's term fixes its rank, and shared labels take their extents from operands whose
+      // shapes are statically known (wala/ML#704). Refine — rather than pin — the operand
+      // destinations, so unknown-shape members recover the proven axes while concrete members
+      // pass through untouched. An operand whose call sites prove disagreeing constraints is
+      // left alone.
+      Map<PointsToSetVariable, List<Dimension<?>>> refinements = HashMapFactory.make();
+      Set<PointsToSetVariable> conflictingRefinements = HashSetFactory.make();
+      for (PointsToSetVariable src : sources) {
+        TensorGenerator generator;
+        try {
+          generator = getGenerator(src, builder);
+        } catch (IllegalArgumentException e) {
+          continue;
+        }
+        if (!(generator instanceof Einsum)) continue;
+        for (Map.Entry<PointerKey, List<Dimension<?>>> entry :
+            ((Einsum) generator).getOperandShapeConstraints(builder).entrySet()) {
+          if (builder.getPropagationSystem().isImplicit(entry.getKey())) continue;
+          PointsToSetVariable operand =
+              builder.getPropagationSystem().findOrCreatePointsToSet(entry.getKey());
+          List<Dimension<?>> previous = refinements.putIfAbsent(operand, entry.getValue());
+          if (previous != null && !previous.equals(entry.getValue()))
+            conflictingRefinements.add(operand);
+        }
+      }
+      refinements.keySet().removeAll(conflictingRefinements);
+      LOGGER.fine(() -> "wala/ML#704 einsum operand refinements: " + refinements.size());
+      for (Map.Entry<PointsToSetVariable, List<Dimension<?>>> r : refinements.entrySet())
+        LOGGER.fine(
+            () -> "  refine: " + describe(r.getKey().getPointerKey()) + " -> " + r.getValue());
+
       Map<PointsToSetVariable, TensorType> shapeOps = HashMapFactory.make();
       shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
 
@@ -1514,6 +1546,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               initOrigins,
               shapeOps,
               setCalls,
+              refinements,
               conv2ds,
               conv3ds,
               drops,

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_proj.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dense3d_proj.py
@@ -1,0 +1,56 @@
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+# A reshape whose target is a shape-vector slice with an opaque bound
+# (wala/ML#711): the analysis cannot resolve `k`, so the result's shape is
+# unknown while its dtype survives — the in-vivo arrival state of the
+# encoder inputs.
+def opaque(t, k):
+    return tf.reshape(t, get_shape_list(t)[0:k])
+
+
+# NLPGNN's DenseLayer3dProj (wala/ML#704) in miniature: the input arrives
+# with an unresolvable shape, but the explicit einsum equation proves the
+# input is rank 4, and its N/D axes share their labels with the reshaped
+# weight, whose extents are statically known.
+class DenseLayer3dProj(tf.keras.layers.Layer):
+    def __init__(self, num_attention_heads, head_size, hidden_size, **kwargs):
+        super(DenseLayer3dProj, self).__init__(**kwargs)
+        self.num_attention_heads = num_attention_heads
+        self.head_size = head_size
+        self.hidden_size = hidden_size
+
+    def build(self, input_shape):
+        self.w = self.add_weight(
+            name="kernel",
+            shape=[self.hidden_size, self.num_attention_heads * self.head_size],
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, input_tensor):
+        w = tf.reshape(
+            self.w, [self.num_attention_heads, self.head_size, self.hidden_size]
+        )
+        return tf.einsum("BFND,NDH->BFH", input_tensor, w)
+
+
+layer = DenseLayer3dProj(3, 5, 6)
+x0 = tf.ones((2, 4, 3, 5))
+x = opaque(x0, x0.shape.ndims)
+out = layer(x)
+
+assert x.shape == (2, 4, 3, 5)
+assert x.dtype == tf.float32
+assert out.shape == (2, 4, 6)
+assert out.dtype == tf.float32
+
+consume(out)


### PR DESCRIPTION
Advances wala/ML#704 (now the parent of its remaining dtype axis, wala/ML#736): this PR delivers the operand-side shape axis. The related, more general partial-output composition is standalone as wala/ML#737.

An einsum call site with a constant equation constrains each tensor operand, not just its output: the operand's term fixes its rank (when it carries no ellipsis), and a label shared with an operand whose shape is statically known fixes that axis's extent, since the runtime requires same-label sizes equal. `Einsum.getOperandShapeConstraints` derives those proven shapes caller-side (the einsum source is the synthetic summary's return value, so the operands live in each caller's frame), and a new `RefineShapeOp` edge transfer in `TensorTypeAnalysis` refines the operand destination's incoming members against them: an unknown-rank member takes the proven shape outright, keeping its dtype and layout; a member of the proven rank fills its non-numeric axes from the constraint's known ones; anything that contradicts the constraint passes through untouched. Unconstrained axes carry `Unresolved` per the wala/ML#721 criterion, and a `Dynamic` or `Ragged` binding keeps its evidence.

This resolves the reopen's `DenseLayer3dProj.call` residual: the input, formerly `float32` with shape ⊤, recovers rank 4, with the shared `N`/`D` extents wherever the weight's dimensions are static. The dtype-side `DenseLayer3d` residual is split to wala/ML#736.

## Coverage

`testDense3dProj` pins the reduced form: an opaque-shape input recovers the weight's static `N`/`D` extents with `Unresolved` leading axes. `testNlpgnnFullDenseProjInput` pins the reopen's in-vivo measurement point: `DenseLayer3dProj.call`'s `input_tensor` carries rank-4 members in every context, the `N`/`D` extents `Unresolved` by necessity since the vendored weight's dimensions are config-derived. `testNlpgnnFullEinsumViaMatmul`'s formerly shape-⊤ members now carry the equation-proven ranks transported through the call boundary, and its capture-observed expectation is updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U
