### PR TITLE
Cover the einsum operand-refinement arms (wala/ML#704 follow-up)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13448,6 +13448,107 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Three-term einsum operand refinement (wala/ML#704): the first operand binds {@code h} dynamic
+   * ({@code keras.Input}'s {@code None}) and {@code n} to 3, the second operand's known {@code h =
+   * 6} refines the dynamic binding, and the unresolved third operand's {@code "nq"} term proves
+   * rank 2 with the shared {@code n = 3} and an {@link UnresolvedDim} {@code q}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumOperandRefinement()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_operand_refinement.py",
+        "project",
+        3,
+        4,
+        Map.of(
+            2,
+            Set.of(new TensorType(FLOAT_32, asList(new NumericDim(3), UnresolvedDim.INSTANCE))),
+            3,
+            Set.of(TENSOR_NONE_3_FLOAT32),
+            4,
+            Set.of(TensorType.of(FLOAT_32, 2, 6))));
+  }
+
+  /**
+   * A multi-shape einsum operand is constrained too (wala/ML#704): the guard-φ argument carries
+   * both {@code keras.Input} members, and each fills its non-numeric leading axis from the
+   * constraint's known {@code n = 3} while keeping its own trailing size.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumOperandRefinement2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_operand_refinement.py",
+        "fill",
+        2,
+        3,
+        Map.of(
+            2,
+            Set.of(TensorType.of(FLOAT_32, 3, 5), TensorType.of(FLOAT_32, 3, 7)),
+            3,
+            Set.of(TensorType.of(FLOAT_32, 3, 2))));
+  }
+
+  /**
+   * An unresolved einsum operand whose term carries an ellipsis proves no rank (wala/ML#704), so
+   * the equation constrains nothing about it and the parameter keeps its unknown shape: the sound
+   * bail.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumOperandRefinement3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_operand_refinement.py",
+        "blur",
+        2,
+        3,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32), 3, Set.of(TensorType.of(FLOAT_32, 3, 5))));
+  }
+
+  /**
+   * Two einsum call sites prove disagreeing constraints for the same operand (wala/ML#704) — rank 2
+   * with a trailing 3 versus rank 3 with a trailing 5 — so neither is asserted and the parameter
+   * keeps its unknown shape: the conflicting refinement drops.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumOperandRefinement4()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_operand_refinement.py",
+        "choose",
+        3,
+        5,
+        Map.of(
+            2,
+            Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32),
+            3,
+            Set.of(TensorType.of(FLOAT_32, 3, 4)),
+            4,
+            Set.of(TensorType.of(FLOAT_32, 5, 6))));
+  }
+
+  /**
    * Operand-order companion of {@link #testDense3dEinsum()} (wala/ML#704): the weight, whose
    * contracted dim is dynamic, comes first in the equation ({@code "HND,BFH->BFND"}), so the
    * input's statically-known occurrence of the shared {@code H} label arrives second and refines

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_operand_refinement.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_operand_refinement.py
@@ -1,0 +1,112 @@
+import tensorflow as tf
+
+
+def get_shape_list(tensor):
+    return tensor.shape.as_list()
+
+
+# A reshape whose target is a shape-vector slice with an opaque bound
+# (wala/ML#711): the analysis cannot resolve `k`, so the result's shape is
+# unknown while its dtype survives.
+def opaque(t, k):
+    return tf.reshape(t, get_shape_list(t)[0:k])
+
+
+# The three-term binding order (wala/ML#704): the first operand binds `h`
+# dynamic (keras.Input's None) and `n` to 3; the second operand's known
+# `h = 6` refines the dynamic binding; the unresolved third operand's term
+# proves rank 2 with `n = 3` shared and `q` unconstrained.
+def project(x, inp, w):
+    return tf.einsum("hn,fh,nq->fq", inp, w, x)
+
+
+# A multi-shape operand (the guard-phi below) is constrained too: each
+# incoming member of the proven rank fills its non-numeric axes from the
+# constraint's known ones (`n = 3` from the resolved second operand).
+def fill(x, w):
+    return tf.einsum("nq,nf->qf", x, w)
+
+
+# An unresolved operand whose term carries an ellipsis proves no rank, so
+# the equation constrains nothing about it: the sound bail.
+def blur(x, w):
+    return tf.einsum("...i,ij->...j", x, w)
+
+
+# Two call sites prove disagreeing constraints (rank 2 with a trailing 3
+# versus rank 3 with a trailing 5) for the same operand, so neither is
+# asserted: the conflicting refinement drops.
+def choose(x, a, b, flag):
+    if flag:
+        return tf.einsum("ij,jk->ik", x, a)
+    return tf.einsum("ijk,kl->ijl", x, b)
+
+
+def f(a):
+    pass
+
+
+def g(a):
+    pass
+
+
+def h(a):
+    pass
+
+
+def k(a):
+    pass
+
+
+def dead(flag, x):
+    # This branch is dead at runtime (the runtime rejects each call), but the
+    # analysis still explores it: a resolved operand whose rank contradicts
+    # its term, a shared label with two unequal known sizes, and a call site
+    # with fewer positional tensors than the equation's terms each prove no
+    # constraint, so the unresolved operand keeps its unknown shape.
+    if flag:
+        t = tf.ones((2, 3, 4))
+        u = tf.ones((2, 3))
+        v = tf.ones((4, 5))
+        f(tf.einsum("ij,jk->ik", t, x))  # Rank 3 against a rank-2 term.
+        f(tf.einsum("ij,ik,jl->kl", u, v, x))  # Shared `i` is 2 and 4.
+        f(tf.einsum("ij,jk->ik", x))  # A single positional tensor.
+
+
+x0 = tf.ones((3, 5))
+x = opaque(x0, x0.shape.ndims)
+
+inp = tf.keras.Input(shape=(3,))
+w = tf.ones((2, 6))
+r1 = project(x, inp, w)
+assert r1.shape == (2, 5)
+assert r1.dtype == tf.float32
+f(r1)
+
+phi = (
+    tf.keras.Input(shape=(5,))
+    if len(get_shape_list(x0)) == 2
+    else tf.keras.Input(shape=(7,))
+)
+w2 = tf.ones((3, 2))
+r2 = fill(phi, w2)
+assert r2.shape == (5, 2)
+assert r2.dtype == tf.float32
+g(r2)
+
+y0 = tf.ones((2, 3))
+y = opaque(y0, y0.shape.ndims)
+w3 = tf.ones((3, 5))
+r3 = blur(y, w3)
+assert r3.shape == (2, 5)
+assert r3.dtype == tf.float32
+h(r3)
+
+z0 = tf.ones((2, 3))
+z = opaque(z0, z0.shape.ndims)
+r4 = choose(z, tf.ones((3, 4)), tf.ones((5, 6)), True)
+assert r4.shape == (2, 4)
+assert r4.dtype == tf.float32
+k(r4)
+
+dead(False, x)


### PR DESCRIPTION
Covers the einsum operand-refinement arms Codecov flagged on ponder-lab/ML#612 (toward wala/ML#704). One fixture exercises each previously-unforced path:

- `project` (three terms): the shared `h` label binds dynamic from `keras.Input` and refines to the second operand's known `6` (the binding-order arms of `bindLabelOccurrence` via the constraint path), while the unresolved third operand recovers `(3, ?)`.
- `fill`: a multi-shape (guard-φ) operand is constrained too; each member of the proven rank fills its non-numeric leading axis from the known `n = 3`, keeping its own trailing size.
- `blur`: an unresolved operand whose term carries an ellipsis proves no rank, so nothing is asserted about it (the sound bail).
- `choose`: two call sites prove disagreeing constraints for the same operand (rank 2 versus rank 3), so the conflicting refinement drops on the engine side.
- `dead`: the runtime-rejected forms via the analysis-only dead-branch idiom (ponder-lab/ML#608): a resolved operand whose rank contradicts its term, a shared label with two unequal known sizes, and a call site with a single positional tensor.

Not fixture-forceable, left uncovered: `RefineShapeOp`'s solver-plumbing `equals`/`toString`, the null-endpoint guard, the non-`PythonInvokeInstruction` caller arm, and `bindLabelOccurrence`'s raw-`null`-then-known refinement (a raw `null` binding requires an einsum-composed operand shape; no fixture-producible input carries one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U
