### PR TITLE
Resolve the matmul result dtype from either operand (wala/ML#677)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -5760,14 +5760,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * vocab dimension is concrete ({@code (?, ?, 10)}). Receiver-keyed trampoline contexts
    * (wala/ML#679) removed the spurious {@code (?, ?, 4)} constructor-collapse member, but the
    * flat-logits matmul member that carried the embedding dimension ({@code (?, 8)} float32)
-   * degrades to {@code ? of float32} in decoder-stack propagation. The union is the
-   * order-independent fixed point (wala/ML#674): identical across runs and across suite/single-test
-   * modes. Analyzed statically here, like the consumer's vendoring; it runs in the perf-eval with
-   * its tfrecord/data setup.
+   * degrades to {@code ? of float32} in decoder-stack propagation. The runtime-true logits form
+   * carries {@code float32} through the matmul operands' dtype-equality constraint (wala/ML#677):
+   * {@code OutputLayer.call}'s live arm multiplies by {@code self.layer_weights}, whose {@code
+   * add_weight} allocation types {@code float32}, and the reshape passes it through. The {@code
+   * unknown}-dtype twin is the same φ's other arm, a path-insensitive phantom: the {@code
+   * self.porj_weights} site (a subject-side typo, never assigned, dead at runtime) resolves neither
+   * operand, its first being the decoder-stack output whose producer walk wala/ML#680 tracks. The
+   * union is the order-independent fixed point (wala/ML#674): identical across runs and across
+   * suite/single-test modes. Analyzed statically here, like the consumer's vendoring; it runs in
+   * the perf-eval with its tfrecord/data setup.
    *
    * <p>TODO: Expect the float32 member's concrete shape back once <a
    * href="https://github.com/wala/ML/issues/682">wala/ML#682</a> recovers concrete shapes through
-   * the decoder stack under receiver-keyed contexts.
+   * the decoder stack under receiver-keyed contexts, and the phantom arm's dtype once <a
+   * href="https://github.com/wala/ML/issues/680">wala/ML#680</a> resolves the loop-carried producer
+   * cycle.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -5791,6 +5799,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE))),
             4,
             Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))),
                 new TensorType(
                     UNKNOWN,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))),
@@ -11566,6 +11577,11 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * runtime-true vocab member {@code (?, ?, 10)}, but the previously concrete {@code (2, 3, 8)
    * float32} member degrades to {@code ? of float32} in decoder-stack propagation ({@link
    * #testCollectionProbeVendoredEmbedding()} still recovers it concretely at the embedding output).
+   * The vocab member appears twice, once per {@code OutputLayer.call} matmul arm (wala/ML#677): the
+   * live {@code self.layer_weights} arm carries {@code float32} through the operands'
+   * dtype-equality constraint, and the dead {@code self.porj_weights} arm (a subject-side typo,
+   * never assigned) resolves neither operand, so its phantom keeps the {@code unknown} dtype
+   * wala/ML#680 tracks.
    *
    * <p>TODO: Expect the float32 member's concrete shape back once <a
    * href="https://github.com/wala/ML/issues/682">wala/ML#682</a> recovers concrete shapes through
@@ -11597,6 +11613,9 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             2,
             Set.of(
                 TENSOR_UNKNOWN_SHAPE_FLOAT32,
+                new TensorType(
+                    FLOAT_32,
+                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))),
                 new TensorType(
                     UNKNOWN,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))))));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatMul.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatMul.java
@@ -79,9 +79,25 @@ public class MatMul extends TensorGenerator {
     return this.getDefaultShapeResult(builder);
   }
 
+  /**
+   * Resolves the result dtype from either operand: the runtime requires {@code a} and {@code b} to
+   * agree on dtype, so a resolved second operand proves the result dtype when the first operand's
+   * walk does not (wala/ML#677; the equality constraint mirrors the einsum operand refinement,
+   * wala/ML#704). The gpt-2 witness is {@code tf.matmul(h_flat, self.layer_weights)}: {@code
+   * h_flat} flattens the decoder-stack output, whose producer walk does not resolve, while the
+   * weight types {@code float32}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtypes of the first operand when any resolves beyond ⊤, else the second operand's,
+   *     else {@code UNKNOWN}.
+   */
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     Set<DType> aDTypes = dtypesOfArg(builder, 0, "a");
+    if (aDTypes != null && !aDTypes.isEmpty() && !aDTypes.equals(EnumSet.of(DType.UNKNOWN)))
+      return aDTypes;
+    Set<DType> bDTypes = dtypesOfArg(builder, 1, "b");
+    if (bDTypes != null && !bDTypes.isEmpty()) return bDTypes;
     return aDTypes == null || aDTypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : aDTypes;
   }
 


### PR DESCRIPTION
Closes wala/ML#677.

The runtime requires the matmul operands to agree on dtype, so a resolved second operand proves the result dtype when the first operand's walk does not (the equality-constraint rationale of wala/ML#704's operand refinement). `MatMul.getDefaultDTypes` previously read only operand `a` and floored to `UNKNOWN` when its producer walk failed; it now falls back to operand `b`. On the vendored gpt-2 that is exactly the issue's chain: in `OutputLayer.call`'s `tf.matmul(h_flat, self.layer_weights)`, `a` flattens the decoder-stack output (whose walk wala/ML#680 tracks), while `b` resolves to the `float32` `add_weight` allocation, so the runtime-true rank-3 logits form now carries `float32`, the issue's expected outcome.

The remaining `unknown`-dtype twin at the same rank is outside this issue's case: it is the path-insensitive phantom of `OutputLayer.call`'s other arm, which reads `self.porj_weights`, a subject-side typo that is never assigned (dead at runtime), so neither operand resolves and its dtype stays with wala/ML#680's loop-carried producer cycle.

## Coverage

`testGpt2GetLossVendored` and `testCollectionProbeVendoredForward` pin the full observed unions: the live arm's `(?, ?, 10)` member flips to `float32`, the phantom arm's `unknown` twin stays and is documented with its wala/ML#680 TODO. No distilled fixture: a live matmul whose first operand resolves no dtype requires the vendored producer cycle, and the two anchors exercise both fallback arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U
