### PR TITLE
Feed the dtype of a pure-⊤ seed from its operand's dataflow state (wala/ML#736)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -2241,10 +2241,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code "BFH"} term and {@code DenseLayer3dProj.call}'s of the rank-4 {@code "BFND"} term, and
    * the refined parameter states transport through the call boundary into this helper. Every proven
    * axis stays {@link UnresolvedDim} in vivo, since {@code w}'s extents are config-derived; the
-   * rank-3 unknown-dtype member is the {@code DenseLayer3d}-path input that resolves no dtype
-   * (wala/ML#736). The {@code w} parameter keeps rank 3 and {@code float32} (its chain is
-   * layer-local) but no numeric dimensions, since the {@code build}-computed head sizes also derive
-   * from the config.
+   * union is dtype-homogeneous {@code float32} since the dtype feed (wala/ML#736) replaced the
+   * attention path's pure-⊤ seeds. The {@code w} parameter keeps rank 3 and {@code float32} (its
+   * chain is layer-local) but no numeric dimensions, since the {@code build}-computed head sizes
+   * also derive from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -2264,9 +2264,6 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(
             2,
             Set.of(
-                new TensorType(
-                    UNKNOWN,
-                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
                 new TensorType(
                     FLOAT_32,
                     asList(
@@ -2310,6 +2307,50 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
                 new TensorType(
                     FLOAT_32,
                     asList(new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))))));
+  }
+
+  /**
+   * In-vivo anchor for wala/ML#736 at its measurement point: the vendored NLPGNN {@code
+   * DenseLayer3d.call}'s {@code input_tensor}, formerly carrying an {@code unknown}-dtype member
+   * alongside its {@code float32} ones (the heterogeneous union the issue reported). The dtype feed
+   * replaces pure-⊤ generator seeds with synthetic edges from their dtype-source operands, so the
+   * attention path's element-wise and pass-through results take the converged {@code float32}
+   * instead of seeding {@code unknown}, and the union is dtype-homogeneous in every context. The
+   * {@code (8, 100)}/{@code (8, 10)} leading pairs are the entry contracts (wala/ML#717); the ranks
+   * are the einsum operand refinement's (wala/ML#704).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNlpgnnFullDense3dInput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        NLPGNN_FULL_PROJECT_FILES,
+        "nlpgnn/layers/dense.py",
+        "DenseLayer3d.call",
+        "nlpgnn_full_proj",
+        1,
+        9,
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(FLOAT_32, asList(new NumericDim(8), UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new NumericDim(8), new NumericDim(100), UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new NumericDim(8), new NumericDim(10), UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new NumericDim(8), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -308,6 +308,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> reshapeNodes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -491,6 +492,44 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             @Override
             public String toString() {
               return "refine shape against einsum operand constraint " + this.constraint;
+            }
+          }
+
+          /**
+           * A transfer function for the synthetic dtype-feed edge from a generator's dtype-source
+           * operand to its result (wala/ML#736): the result variable, whose generator seed would
+           * have been a single unknown-dtype member (its PTS-based dtype walk failed), instead
+           * takes each operand member's dtype as an unknown-shape member. Feeding from converged
+           * dataflow state is what the PTS-based walk cannot do; an operand member whose dtype is
+           * itself unknown reproduces the suppressed seed, so the feed never loses information.
+           */
+          final class DtypeFeedOp extends UnaryOperator<TensorVariable> {
+            @Override
+            public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+              if (lhs == null || rhs == null || rhs.state == null) return NOT_CHANGED;
+              boolean changed = false;
+              if (lhs.state == null) lhs.state = HashSetFactory.make();
+              for (TensorType t : rhs.state)
+                changed |= lhs.state.add(new TensorType(t.getDType(), null));
+              // The fed result is a TensorFlow op's product regardless of what produced the
+              // operand (wala/ML#724).
+              if (!rhs.state.isEmpty()) changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
+              return changed ? CHANGED : NOT_CHANGED;
+            }
+
+            @Override
+            public int hashCode() {
+              return 0x736FEED0; // arbitrary constant; all instances are equal
+            }
+
+            @Override
+            public boolean equals(Object o) {
+              return o instanceof DtypeFeedOp;
+            }
+
+            @Override
+            public String toString() {
+              return "feed dtypes from the einsum dtype-source operand";
             }
           }
 
@@ -705,6 +744,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               PointsToSetVariable src, PointsToSetVariable dst) {
             if (drops.contains(dst)) {
               return DropOp.INSTANCE;
+            } else if (dtypeFeeds.getOrDefault(dst, Collections.emptySet()).contains(src)) {
+              return new DtypeFeedOp();
             } else if (set_shapes.containsKey(dst)) {
               return new SetShapeOp(set_shapes.get(dst));
             } else if (refinements.containsKey(dst)) {
@@ -773,6 +814,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param set_shapes Destinations pinned by an {@code x.set_shape(s)} assertion (wala/ML#509).
    * @param refinements Einsum-operand destinations refined against the shape the einsum equation
    *     proves for them (wala/ML#704); incoming members are refined, never discarded.
+   * @param dtypeFeeds Einsum-result destinations fed their dtype from the dtype-source operand's
+   *     dataflow state over a synthetic edge (wala/ML#736), keyed to the feeding sources; each
+   *     replaces a suppressed unknown-dtype generator seed.
    * @param conv2ds Destinations of 2D convolutions, rank-checked by {@code ConvOp}.
    * @param conv3ds Destinations of 3D convolutions, rank-checked by {@code ConvOp}.
    * @param drops Destinations pinned to empty-and-fixed (wala/ML#409).
@@ -790,6 +834,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -802,6 +847,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             reshapeTypes,
             set_shapes,
             refinements,
+            dtypeFeeds,
             conv2ds,
             conv3ds,
             drops,
@@ -810,6 +856,36 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             errorLog));
     this.init = init;
     this.initOrigins = initOrigins;
+  }
+
+  /**
+   * Restores suppressed seeds on fed destinations whose dtype feed delivered no state
+   * (wala/ML#736). A dtype feed replaces a pure-⊤ seed profitably only when some operand state
+   * arrives; when none ever does, the destination would otherwise lose its tensor identity entirely
+   * (the seed at least asserted an unknown tensor). Destinations whose feed delivered members are
+   * left alone. Callers re-run {@link #solve} afterward so the restored members propagate.
+   *
+   * @param seeds The suppressed seeds, keyed by their fed destination.
+   * @param origins The suppressed origin seeds, keyed the same way.
+   * @return Whether any destination was restored.
+   */
+  public boolean restoreUnfedSeeds(
+      Map<PointsToSetVariable, Set<TensorType>> seeds,
+      Map<PointsToSetVariable, Set<TensorOrigin>> origins) {
+    boolean changed = false;
+    for (Map.Entry<PointsToSetVariable, Set<TensorType>> entry : seeds.entrySet()) {
+      TensorVariable out = getOut(entry.getKey());
+      if (out == null || (out.state != null && !out.state.isEmpty())) continue;
+      if (out.state == null) out.state = HashSetFactory.make();
+      boolean restored = out.state.addAll(entry.getValue());
+      Set<TensorOrigin> seedOrigins = origins.get(entry.getKey());
+      if (seedOrigins != null) restored |= out.origins.addAll(seedOrigins);
+      if (restored) {
+        changedVariable(out);
+        changed = true;
+      }
+    }
+    return changed;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -26,6 +26,7 @@ import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -582,6 +583,27 @@ public class ElementWiseOperation extends TensorGenerator {
     // identification across the chain even though every step is demonstrably a tensor producer.
     if (xDTypes == null || xDTypes.isEmpty()) return EnumSet.of(DType.UNKNOWN);
     return xDTypes;
+  }
+
+  /**
+   * The dtype-determining operands are both sides of the element-wise operation, resolved in this
+   * generator's own frame: the runtime requires the operand dtypes to agree (scalar-literal
+   * promotion aside), so either operand's converged dataflow dtype determines the result when the
+   * PTS-based walk fails (wala/ML#736).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The pointer keys of the resolvable operands; empty when neither value number resolves.
+   */
+  @Override
+  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
+    Set<PointerKey> ret = new LinkedHashSet<>();
+    CGNode node = this.getNode();
+    int xVn = this.getXArgumentValueNumber(builder);
+    int yVn = this.getYArgumentValueNumber(builder);
+    for (int vn : new int[] {xVn, yVn})
+      if (vn > 0)
+        ret.add(builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn));
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -2,12 +2,18 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -126,6 +132,34 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     Set<DType> dtypes = dtypesOfArg(builder, getInputParameterPosition(), getInputParameterName());
     return dtypes == null || dtypes.isEmpty() ? EnumSet.of(DType.UNKNOWN) : dtypes;
+  }
+
+  /**
+   * The dtype-determining operand is the input argument, located caller-side: the source is the
+   * synthetic summary's return value, so each caller's invoke supplies its own operand value number
+   * in that caller's frame (wala/ML#736).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The caller-side pointer keys of the input argument, one per caller invoke that passes
+   *     it positionally; empty when none does or the input position is undefined.
+   */
+  @Override
+  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
+    int position = getInputParameterPosition();
+    if (position == UNDEFINED_PARAMETER_POSITION) return Collections.emptySet();
+    Set<PointerKey> ret = new LinkedHashSet<>();
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) callerInvoke.snd;
+      if (invoke.getNumberOfPositionalParameters() < position + 2) continue;
+      ret.add(
+          builder
+              .getPointerAnalysis()
+              .getHeapModel()
+              .getPointerKeyForLocal(callerInvoke.fst, invoke.getUse(position + 1)));
+    }
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -21,6 +21,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.TrampolineReceiverContextSelector;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.analysis.TensorVariable;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -1449,6 +1450,48 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         LOGGER.fine(
             () -> "  refine: " + describe(r.getKey().getPointerKey()) + " -> " + r.getValue());
 
+      // A generator whose dtype walk fails seeds an unknown-dtype member that no later evidence
+      // can remove, although the dtype-source operand's dtype often exists in dataflow state the
+      // PTS-based walk cannot see (wala/ML#736; the wala/ML#661/wala/ML#570 substrate). Replace
+      // such a pure-⊤ seed with a synthetic dataflow edge from each dtype-source operand the
+      // generator declares: the result then takes the operand's converged dtypes, and the
+      // unknown-dtype member is never born.
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds = HashMapFactory.make();
+      Map<PointsToSetVariable, Set<TensorType>> suppressedSeeds = HashMapFactory.make();
+      Map<PointsToSetVariable, Set<TensorOrigin>> suppressedOrigins = HashMapFactory.make();
+      for (PointsToSetVariable src : sources) {
+        Set<TensorType> types = init.get(src);
+        if (types == null || types.size() != 1) continue;
+        TensorType only = types.iterator().next();
+        if (only.getDims() != null || only.getDType() != DType.UNKNOWN) continue;
+        TensorGenerator generator;
+        try {
+          generator = getGenerator(src, builder);
+        } catch (IllegalArgumentException e) {
+          continue;
+        }
+        Set<PointsToSetVariable> feedSources = HashSetFactory.make();
+        for (PointerKey operandKey : generator.getDTypeFeedSourceKeys(builder)) {
+          if (builder.getPropagationSystem().isImplicit(operandKey)) continue;
+          PointsToSetVariable operand =
+              builder.getPropagationSystem().findOrCreatePointsToSet(operandKey);
+          if (operand.equals(src)) continue; // A self-loop feeds nothing.
+          if (!dataflow.containsNode(operand)) dataflow.addNode(operand);
+          if (!dataflow.hasEdge(operand, src)) dataflow.addEdge(operand, src);
+          feedSources.add(operand);
+        }
+        if (feedSources.isEmpty()) continue; // No located operand: keep the seed.
+        dtypeFeeds.put(src, feedSources);
+        suppressedSeeds.put(src, types);
+        Set<TensorOrigin> origins = initOrigins.get(src);
+        if (origins != null) suppressedOrigins.put(src, origins);
+        init.remove(src);
+        initOrigins.remove(src);
+      }
+      LOGGER.fine(() -> "wala/ML#736 dtype feeds: " + dtypeFeeds.size());
+      for (PointsToSetVariable fed : dtypeFeeds.keySet())
+        LOGGER.fine(() -> "  feed: " + describe(fed.getPointerKey()));
+
       Map<PointsToSetVariable, TensorType> shapeOps = HashMapFactory.make();
       shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
 
@@ -1547,6 +1590,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               shapeOps,
               setCalls,
               refinements,
+              dtypeFeeds,
               conv2ds,
               conv3ds,
               drops,
@@ -1555,6 +1599,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               errorLog);
 
       tt.solve(new NullProgressMonitor());
+
+      // A dtype feed that never delivered any operand state left its destination stateless,
+      // although the suppressed seed at least asserted an unknown tensor; restore those seeds
+      // and continue the (monotone) fixpoint so the restored members propagate (wala/ML#736).
+      if (tt.restoreUnfedSeeds(suppressedSeeds, suppressedOrigins))
+        tt.solve(new NullProgressMonitor());
 
       recordDepthLimitedResults(tt, builder.getClassHierarchy());
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3472,6 +3472,24 @@ public abstract class TensorGenerator {
     return resolved;
   }
 
+  /**
+   * Locates the dataflow variables that determine this generator's result dtype when its own dtype
+   * walk fails. A pure-⊤ seed (unknown shape and dtype) cannot be improved by later evidence,
+   * although the dtype-source operand's dtype often exists in {@code TensorTypeAnalysis} dataflow
+   * state that PTS-based resolution cannot see (wala/ML#736, the wala/ML#661/wala/ML#570
+   * substrate); the engine replaces such a seed with a synthetic dataflow edge from each of these
+   * variables, so the result takes the operand's converged dtypes and the unknown-dtype member is
+   * never born. Overridden by generators whose result dtype is determined by an operand; the
+   * default declares none.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The pointer keys of the dtype-determining operands; empty when this generator has none
+   *     or they cannot be located.
+   */
+  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
+    return Collections.emptySet();
+  }
+
   protected PythonInvokeInstruction getInvokeInstruction() {
     if (this.source == null) {
       return null;


### PR DESCRIPTION
Closes wala/ML#736.

A generator whose dtype walk fails seeds a single unknown-dtype member that no later evidence can remove, although the dtype-source operand's dtype often exists in `TensorTypeAnalysis` dataflow state the PTS-based walk cannot see (the wala/ML#661/wala/ML#570 substrate). The engine now replaces such a pure-⊤ seed with a synthetic dataflow edge from each dtype-source operand the generator declares, so the result takes the operand's converged dtypes and the unknown-dtype member is never born: seeds consuming dataflow state, narrowly. Three pieces:

- `TensorGenerator.getDTypeFeedSourceKeys` (empty default), overridden by `PassThroughUnaryTensorGenerator` (the input argument, caller-side, covering the einsum/softmax/dropout family) and `ElementWiseOperation` (both operands, own-frame); the runtime requires the fed operands' dtypes to agree with the result's.
- A `DtypeFeedOp` edge transfer that lifts each operand member's dtype into an unknown-shape member; an unknown-dtype operand member reproduces the suppressed seed, so the feed never loses information.
- A post-fixpoint reconciliation, `restoreUnfedSeeds`: a feed that never delivered any operand state would otherwise leave its destination stateless (losing the tensor identity the seed asserted), so such seeds are restored and the monotone fixpoint continues.

On the vendored NLPGNN, 287 feeds fire and the issue's observable resolves: `DenseLayer3d.call`'s `input_tensor` is dtype-homogeneous `float32` in every calling context, where the wala/ML#704 reopen measured no resolved dtype and the pre-fix state kept an `unknown`-dtype twin. The twin was born in the attention path's element-wise scale/mask results, not the einsums, whose seeds already carried `float32`.

## Coverage

`testNlpgnnFullDense3dInput` pins the issue's measurement point in the vendored suite: the six-member all-`float32` union across every context. `testNlpgnnFullEinsumViaMatmul` loses its last `unknown`-dtype member and is updated. The seven fixtures that exercise unfed destinations (the gpt-2 and autoencoder families among them) pass unchanged through the reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U
