### PR TITLE
Drop the stale einsum reference from the dtype-feed transfer description (wala/ML#736 follow-up)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -529,7 +529,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
             @Override
             public String toString() {
-              return "feed dtypes from the einsum dtype-source operand";
+              return "feed dtypes from the dtype-source operand";
             }
           }
 


### PR DESCRIPTION
The `DtypeFeedOp` debug description still named einsum from the mechanism's first draft; the op serves every generator that declares dtype-feed sources (ponder-lab/ML#615).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U