### PR TITLE
Compose type feeds per operation kind (wala/ML#682)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -12,12 +12,15 @@ package com.ibm.wala.cast.python.ml.analysis;
 
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.lsp.AnalysisError;
+import com.ibm.wala.cast.python.ml.client.TensorGenerator;
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.CompoundDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
+import com.ibm.wala.cast.python.ml.util.TensorShapeUtil;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.cast.util.SourceBuffer;
 import com.ibm.wala.dataflow.graph.AbstractMeetOperator;
@@ -40,6 +43,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, TensorVariable>
@@ -303,17 +308,31 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
     }
   }
 
+  /**
+   * A type feed installed on a destination (wala/ML#736, wala/ML#682): the composition kind, the
+   * feeding operand variables in operand order, and the dtype the suppressed seed had resolved
+   * (kept when known, since the operands' dataflow dtype can be weaker than what the generator
+   * proved).
+   *
+   * @param kind The composition kind.
+   * @param operands The feeding operand variables, in operand order.
+   * @param seedDType The suppressed seed's dtype; {@link DType#UNKNOWN} when it had none.
+   */
+  public record FeedPlan(
+      TensorGenerator.TypeFeedKind kind, List<PointsToSetVariable> operands, DType seedDType) {}
+
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, TensorType> reshapeNodes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
-      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds,
+      Map<PointsToSetVariable, FeedPlan> typeFeeds,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
       Set<PointsToSetVariable> iterationProducts,
+      AtomicReference<Function<PointsToSetVariable, TensorVariable>> outAccessor,
       Map<PointerKey, AnalysisError> errorLog) {
     return new IKilldallFramework<PointsToSetVariable, TensorVariable>() {
 
@@ -496,40 +515,107 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
           }
 
           /**
-           * A transfer function for the synthetic dtype-feed edge from a generator's dtype-source
-           * operand to its result (wala/ML#736): the result variable, whose generator seed would
-           * have been a single unknown-dtype member (its PTS-based dtype walk failed), instead
-           * takes each operand member's dtype as an unknown-shape member. Feeding from converged
-           * dataflow state is what the PTS-based walk cannot do; an operand member whose dtype is
-           * itself unknown reproduces the suppressed seed, so the feed never loses information.
+           * A transfer function for the synthetic type-feed edge from a generator's operand to its
+           * result (wala/ML#736, wala/ML#682): the result variable, whose generator seed did not
+           * resolve its shape (and possibly not its dtype), instead composes members from the
+           * operands' converged dataflow state, which the PTS-based walks cannot see. Composition
+           * follows the plan's kind: {@code DTYPE_ONLY} lifts each operand member's dtype as an
+           * unknown-shape member; {@code PASS_THROUGH} forwards each member unchanged; {@code
+           * BROADCAST} pairs each incoming member with the other operand's current members and
+           * broadcasts their shapes (a pair whose shapes don't broadcast statically degrades to an
+           * unknown shape, and no member composes until both operands carry state, so the result is
+           * order-independent). A seed dtype the generator had proven wins over the operand
+           * members' dtype, which can be weaker.
            */
-          final class DtypeFeedOp extends UnaryOperator<TensorVariable> {
+          final class TypeFeedOp extends UnaryOperator<TensorVariable> {
+            private final FeedPlan plan;
+            private final PointsToSetVariable source;
+
+            public TypeFeedOp(FeedPlan plan, PointsToSetVariable source) {
+              this.plan = plan;
+              this.source = source;
+            }
+
             @Override
             public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
-              if (lhs == null || rhs == null || rhs.state == null) return NOT_CHANGED;
+              if (lhs == null || rhs == null || rhs.state == null || rhs.state.isEmpty())
+                return NOT_CHANGED;
               boolean changed = false;
               if (lhs.state == null) lhs.state = HashSetFactory.make();
-              for (TensorType t : rhs.state)
-                changed |= lhs.state.add(new TensorType(t.getDType(), null));
+              switch (this.plan.kind()) {
+                case DTYPE_ONLY:
+                  for (TensorType t : rhs.state)
+                    changed |= lhs.state.add(new TensorType(this.pickDType(t), null));
+                  break;
+                case PASS_THROUGH:
+                  for (TensorType t : rhs.state)
+                    changed |=
+                        lhs.state.add(TensorType.of(this.pickDType(t), t.getDims(), t.layout()));
+                  break;
+                case BROADCAST:
+                  PointsToSetVariable other =
+                      this.plan.operands().get(0).equals(this.source)
+                          ? this.plan.operands().get(1)
+                          : this.plan.operands().get(0);
+                  TensorVariable otherOut = outAccessor.get().apply(other);
+                  if (otherOut == null || otherOut.state == null) return NOT_CHANGED;
+                  for (TensorType t : rhs.state)
+                    for (TensorType u : otherOut.state)
+                      changed |= lhs.state.add(this.broadcastMembers(t, u));
+                  break;
+              }
               // The fed result is a TensorFlow op's product regardless of what produced the
               // operand (wala/ML#724).
-              if (!rhs.state.isEmpty()) changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
+              if (changed) changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
               return changed ? CHANGED : NOT_CHANGED;
+            }
+
+            /**
+             * Broadcasts one member pair: the shapes broadcast right-aligned when both are known
+             * and compatible, and degrade to unknown otherwise (an unmarked non-numeric dimension
+             * or statically incompatible sizes).
+             *
+             * @param t The incoming operand's member.
+             * @param u The other operand's member.
+             * @return The composed member.
+             */
+            private TensorType broadcastMembers(TensorType t, TensorType u) {
+              DType dtype = this.pickDType(t.getDType() != DType.UNKNOWN ? t : u);
+              if (t.getDims() == null || u.getDims() == null) return new TensorType(dtype, null);
+              try {
+                return new TensorType(
+                    dtype, TensorShapeUtil.getBroadcastedShapes(t.getDims(), u.getDims()));
+              } catch (IllegalArgumentException e) {
+                return new TensorType(dtype, null);
+              }
+            }
+
+            /**
+             * Picks the composed member's dtype: the suppressed seed's when the generator had
+             * proven one, else the operand member's.
+             *
+             * @param t The operand member.
+             * @return The dtype for the composed member.
+             */
+            private DType pickDType(TensorType t) {
+              return this.plan.seedDType() != DType.UNKNOWN ? this.plan.seedDType() : t.getDType();
             }
 
             @Override
             public int hashCode() {
-              return 0x736FEED0; // arbitrary constant; all instances are equal
+              return this.plan.hashCode() * 31 + this.source.hashCode();
             }
 
             @Override
             public boolean equals(Object o) {
-              return o instanceof DtypeFeedOp;
+              return o instanceof TypeFeedOp
+                  && this.plan.equals(((TypeFeedOp) o).plan)
+                  && this.source.equals(((TypeFeedOp) o).source);
             }
 
             @Override
             public String toString() {
-              return "feed dtypes from the dtype-source operand";
+              return "feed " + this.plan.kind() + " types from the operand's dataflow state";
             }
           }
 
@@ -744,8 +830,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               PointsToSetVariable src, PointsToSetVariable dst) {
             if (drops.contains(dst)) {
               return DropOp.INSTANCE;
-            } else if (dtypeFeeds.getOrDefault(dst, Collections.emptySet()).contains(src)) {
-              return new DtypeFeedOp();
+            } else if (typeFeeds.containsKey(dst) && typeFeeds.get(dst).operands().contains(src)) {
+              return new TypeFeedOp(typeFeeds.get(dst), src);
             } else if (set_shapes.containsKey(dst)) {
               return new SetShapeOp(set_shapes.get(dst));
             } else if (refinements.containsKey(dst)) {
@@ -814,9 +900,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param set_shapes Destinations pinned by an {@code x.set_shape(s)} assertion (wala/ML#509).
    * @param refinements Einsum-operand destinations refined against the shape the einsum equation
    *     proves for them (wala/ML#704); incoming members are refined, never discarded.
-   * @param dtypeFeeds Einsum-result destinations fed their dtype from the dtype-source operand's
-   *     dataflow state over a synthetic edge (wala/ML#736), keyed to the feeding sources; each
-   *     replaces a suppressed unknown-dtype generator seed.
+   * @param typeFeeds Destinations fed from their operands' dataflow state over synthetic edges
+   *     (wala/ML#736, wala/ML#682), keyed to the composition plan; each replaces a suppressed
+   *     unresolved-shape generator seed.
    * @param conv2ds Destinations of 2D convolutions, rank-checked by {@code ConvOp}.
    * @param conv3ds Destinations of 3D convolutions, rank-checked by {@code ConvOp}.
    * @param drops Destinations pinned to empty-and-fixed (wala/ML#409).
@@ -834,28 +920,83 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
-      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds,
+      Map<PointsToSetVariable, FeedPlan> typeFeeds,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
       Set<PointsToSetVariable> iterationProducts,
       Map<PointerKey, AnalysisError> errorLog) {
+    this(
+        G,
+        init,
+        initOrigins,
+        reshapeTypes,
+        set_shapes,
+        refinements,
+        typeFeeds,
+        conv2ds,
+        conv3ds,
+        drops,
+        parameters,
+        iterationProducts,
+        errorLog,
+        new AtomicReference<>());
+  }
+
+  /**
+   * Chained core constructor: the accessor holder must exist before the (static) problem is
+   * created, since the broadcast feed's transfer reads the other operand's solver state through it,
+   * and can only be bound to {@link #getOut} once construction completes.
+   *
+   * @param outAccessor The pre-created holder the transfer functions capture.
+   */
+  // The method reference escapes `this` by design: the holder is only dereferenced when the
+  // solver evaluates a broadcast feed inside solve(), long after construction completes.
+  @SuppressWarnings("this-escape")
+  private TensorTypeAnalysis(
+      Graph<PointsToSetVariable> G,
+      Map<PointsToSetVariable, Set<TensorType>> init,
+      Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
+      Map<PointsToSetVariable, TensorType> reshapeTypes,
+      Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, List<Dimension<?>>> refinements,
+      Map<PointsToSetVariable, FeedPlan> typeFeeds,
+      Set<PointsToSetVariable> conv2ds,
+      Set<PointsToSetVariable> conv3ds,
+      Set<PointsToSetVariable> drops,
+      Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> iterationProducts,
+      Map<PointerKey, AnalysisError> errorLog,
+      AtomicReference<Function<PointsToSetVariable, TensorVariable>> outAccessor) {
     super(
         createProblem(
             G,
             reshapeTypes,
             set_shapes,
             refinements,
-            dtypeFeeds,
+            typeFeeds,
             conv2ds,
             conv3ds,
             drops,
             parameters,
             iterationProducts,
+            outAccessor,
             errorLog));
+    outAccessor.set(this::getOut);
     this.init = init;
     this.initOrigins = initOrigins;
+  }
+
+  /**
+   * Read-only view of a variable's solved state, for post-solve diagnostics.
+   *
+   * @param variable The flow-graph variable.
+   * @return The solved state, or {@code null} when the variable is unknown to the solver.
+   */
+  public Set<TensorType> getOutState(PointsToSetVariable variable) {
+    TensorVariable out = getOut(variable);
+    return out == null ? null : out.state;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/BooleanMask.java
@@ -108,4 +108,17 @@ public class BooleanMask extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Diag.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Diag.java
@@ -85,4 +85,17 @@ public class Diag extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DiagPart.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DiagPart.java
@@ -84,4 +84,17 @@ public class DiagPart extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -520,4 +520,17 @@ public class Einsum extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -26,7 +26,6 @@ import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -586,24 +585,38 @@ public class ElementWiseOperation extends TensorGenerator {
   }
 
   /**
-   * The dtype-determining operands are both sides of the element-wise operation, resolved in this
-   * generator's own frame: the runtime requires the operand dtypes to agree (scalar-literal
-   * promotion aside), so either operand's converged dataflow dtype determines the result when the
-   * PTS-based walk fails (wala/ML#736).
+   * The type-determining operands are both sides of the element-wise operation, resolved in this
+   * generator's own frame (wala/ML#736): the result's member types compose as the pairwise
+   * broadcast of the operands' converged dataflow members (wala/ML#682). A scalar-constant operand
+   * broadcasts as the identity, so the other operand's members pass through unchanged; two scalar
+   * constants declare no feed.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The pointer keys of the resolvable operands; empty when neither value number resolves.
+   * @return The broadcast feed over both operands, the pass-through feed over the tensor operand
+   *     when the other is a scalar constant, or {@code null} when neither operand resolves.
    */
   @Override
-  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
-    Set<PointerKey> ret = new LinkedHashSet<>();
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
     CGNode node = this.getNode();
     int xVn = this.getXArgumentValueNumber(builder);
     int yVn = this.getYArgumentValueNumber(builder);
-    for (int vn : new int[] {xVn, yVn})
-      if (vn > 0)
-        ret.add(builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn));
-    return ret;
+    if (node.getIR() == null) return null;
+    SymbolTable st = node.getIR().getSymbolTable();
+    boolean xScalar = xVn <= 0 || st.isConstant(xVn);
+    boolean yScalar = yVn <= 0 || st.isConstant(yVn);
+    if (xScalar && yScalar) return null;
+    if (xScalar || yScalar) {
+      int tensorVn = xScalar ? yVn : xVn;
+      return new TypeFeed(
+          TypeFeedKind.PASS_THROUGH,
+          List.of(
+              builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, tensorVn)));
+    }
+    return new TypeFeed(
+        TypeFeedKind.BROADCAST,
+        List.of(
+            builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, xVn),
+            builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, yVn)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EmbeddingLookup.java
@@ -82,4 +82,17 @@ public class EmbeddingLookup extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExpandDims.java
@@ -145,4 +145,17 @@ public class ExpandDims extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ExtractPatches.java
@@ -196,4 +196,17 @@ public class ExtractPatches extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GatherNd.java
@@ -90,4 +90,17 @@ public class GatherNd extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatrixTranspose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/MatrixTranspose.java
@@ -90,4 +90,17 @@ public class MatrixTranspose extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PassThroughUnaryTensorGenerator.java
@@ -11,7 +11,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -135,18 +135,36 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
   }
 
   /**
-   * The dtype-determining operand is the input argument, located caller-side: the source is the
+   * The type-determining operand is the input argument, located caller-side: the source is the
    * synthetic summary's return value, so each caller's invoke supplies its own operand value number
-   * in that caller's frame (wala/ML#736).
+   * in that caller's frame (wala/ML#736). This family's base shape composition forwards the input's
+   * shapes unchanged, so the feed is {@link TypeFeedKind#PASS_THROUGH}; a subclass that overrides
+   * the shape composition (its result shape differs from its input's) must override this to {@link
+   * #getTypeFeed(PropagationCallGraphBuilder, TypeFeedKind)} with {@link TypeFeedKind#DTYPE_ONLY}
+   * (wala/ML#682).
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The caller-side pointer keys of the input argument, one per caller invoke that passes
-   *     it positionally; empty when none does or the input position is undefined.
+   * @return The pass-through feed over the caller-side input keys, or {@code null} when none is
+   *     located or the input position is undefined.
    */
   @Override
-  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.PASS_THROUGH);
+  }
+
+  /**
+   * Kind-parameterized core of {@link #getTypeFeed(PropagationCallGraphBuilder)}, for the
+   * shape-transforming subclasses that keep the operand walk but demote the feed to {@link
+   * TypeFeedKind#DTYPE_ONLY} (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param kind The composition kind to declare.
+   * @return The feed over the caller-side input keys, or {@code null} when none is located or the
+   *     input position is undefined.
+   */
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder, TypeFeedKind kind) {
     int position = getInputParameterPosition();
-    if (position == UNDEFINED_PARAMETER_POSITION) return Collections.emptySet();
+    if (position == UNDEFINED_PARAMETER_POSITION) return null;
     Set<PointerKey> ret = new LinkedHashSet<>();
     for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
         getCallerInvokes(builder, this.getNode())) {
@@ -159,7 +177,7 @@ public abstract class PassThroughUnaryTensorGenerator extends TensorGenerator {
               .getHeapModel()
               .getPointerKeyForLocal(callerInvoke.fst, invoke.getUse(position + 1)));
     }
-    return ret;
+    return ret.isEmpty() ? null : new TypeFeed(kind, new ArrayList<>(ret));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1450,19 +1450,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         LOGGER.fine(
             () -> "  refine: " + describe(r.getKey().getPointerKey()) + " -> " + r.getValue());
 
-      // A generator whose dtype walk fails seeds an unknown-dtype member that no later evidence
-      // can remove, although the dtype-source operand's dtype often exists in dataflow state the
-      // PTS-based walk cannot see (wala/ML#736; the wala/ML#661/wala/ML#570 substrate). Replace
-      // such a pure-⊤ seed with a synthetic dataflow edge from each dtype-source operand the
-      // generator declares: the result then takes the operand's converged dtypes, and the
-      // unknown-dtype member is never born.
-      Map<PointsToSetVariable, Set<PointsToSetVariable>> dtypeFeeds = HashMapFactory.make();
+      // A generator whose shape walk fails seeds an unresolved-shape member that no later
+      // evidence can remove, although the operands' types often exist in dataflow state the
+      // PTS-based walks cannot see (wala/ML#736, wala/ML#682; the wala/ML#661/wala/ML#570
+      // substrate). Replace such a seed with synthetic dataflow edges from the operands the
+      // generator declares: the result composes from the operands' converged members per the
+      // feed's kind, and the unresolved seed member is never born.
+      Map<PointsToSetVariable, TensorTypeAnalysis.FeedPlan> typeFeeds = HashMapFactory.make();
       Map<PointsToSetVariable, Set<TensorType>> suppressedSeeds = HashMapFactory.make();
       Map<PointsToSetVariable, Set<TensorOrigin>> suppressedOrigins = HashMapFactory.make();
       for (PointsToSetVariable src : sources) {
         Set<TensorType> types = init.get(src);
         if (types == null || types.size() != 1) continue;
         TensorType only = types.iterator().next();
+        // Only a pure-⊤ seed is replaced: suppressing a seed whose dtype the generator proved
+        // couples into the engine-side pin computations that read seeded state (the vendored
+        // Conv1d and gather probes are the witnesses), so the known-dtype widening stays with
+        // wala/ML#682's residual.
         if (only.getDims() != null || only.getDType() != DType.UNKNOWN) continue;
         TensorGenerator generator;
         try {
@@ -1470,27 +1474,37 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         } catch (IllegalArgumentException e) {
           continue;
         }
-        Set<PointsToSetVariable> feedSources = HashSetFactory.make();
-        for (PointerKey operandKey : generator.getDTypeFeedSourceKeys(builder)) {
+        TensorGenerator.TypeFeed feed = generator.getTypeFeed(builder);
+        if (feed == null) continue;
+        List<PointsToSetVariable> feedSources = new ArrayList<>();
+        for (PointerKey operandKey : feed.operands()) {
           if (builder.getPropagationSystem().isImplicit(operandKey)) continue;
           PointsToSetVariable operand =
               builder.getPropagationSystem().findOrCreatePointsToSet(operandKey);
           if (operand.equals(src)) continue; // A self-loop feeds nothing.
-          if (!dataflow.containsNode(operand)) dataflow.addNode(operand);
-          if (!dataflow.hasEdge(operand, src)) dataflow.addEdge(operand, src);
           feedSources.add(operand);
         }
-        if (feedSources.isEmpty()) continue; // No located operand: keep the seed.
-        dtypeFeeds.put(src, feedSources);
+        // A broadcast composes pairs, so it needs both operands; the other kinds need at least
+        // one located operand. Otherwise keep the seed.
+        if (feedSources.isEmpty()
+            || (feed.kind() == TensorGenerator.TypeFeedKind.BROADCAST && feedSources.size() != 2))
+          continue;
+        for (PointsToSetVariable operand : feedSources) {
+          if (!dataflow.containsNode(operand)) dataflow.addNode(operand);
+          if (!dataflow.hasEdge(operand, src)) dataflow.addEdge(operand, src);
+        }
+        typeFeeds.put(
+            src, new TensorTypeAnalysis.FeedPlan(feed.kind(), feedSources, only.getDType()));
         suppressedSeeds.put(src, types);
         Set<TensorOrigin> origins = initOrigins.get(src);
         if (origins != null) suppressedOrigins.put(src, origins);
         init.remove(src);
         initOrigins.remove(src);
       }
-      LOGGER.fine(() -> "wala/ML#736 dtype feeds: " + dtypeFeeds.size());
-      for (PointsToSetVariable fed : dtypeFeeds.keySet())
-        LOGGER.fine(() -> "  feed: " + describe(fed.getPointerKey()));
+      LOGGER.fine(() -> "wala/ML#736 type feeds: " + typeFeeds.size());
+      for (Map.Entry<PointsToSetVariable, TensorTypeAnalysis.FeedPlan> f : typeFeeds.entrySet())
+        LOGGER.fine(
+            () -> "  feed " + f.getValue().kind() + ": " + describe(f.getKey().getPointerKey()));
 
       Map<PointsToSetVariable, TensorType> shapeOps = HashMapFactory.make();
       shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
@@ -1590,7 +1604,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               shapeOps,
               setCalls,
               refinements,
-              dtypeFeeds,
+              typeFeeds,
               conv2ds,
               conv3ds,
               drops,
@@ -1605,6 +1619,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       // and continue the (monotone) fixpoint so the restored members propagate (wala/ML#736).
       if (tt.restoreUnfedSeeds(suppressedSeeds, suppressedOrigins))
         tt.solve(new NullProgressMonitor());
+      for (PointsToSetVariable fed : typeFeeds.keySet())
+        LOGGER.fine(
+            () ->
+                "post-feed state for "
+                    + describe(fed.getPointerKey())
+                    + ": "
+                    + tt.getOutState(fed));
 
       recordDepthLimitedResults(tt, builder.getClassHierarchy());
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SequenceMask.java
@@ -116,4 +116,17 @@ public class SequenceMask extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Slice.java
@@ -174,4 +174,17 @@ public class Slice extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Split.java
@@ -169,4 +169,17 @@ public class Split extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Squeeze.java
@@ -206,4 +206,17 @@ public class Squeeze extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3472,22 +3472,43 @@ public abstract class TensorGenerator {
     return resolved;
   }
 
+  /** How a type feed composes the fed members from its operand state (wala/ML#736, wala/ML#682). */
+  public enum TypeFeedKind {
+    /** Each operand member's dtype is lifted as an unknown-shape member. */
+    DTYPE_ONLY,
+
+    /** Each operand member forwards unchanged (the operation preserves its input's type). */
+    PASS_THROUGH,
+
+    /** The two operands' member shapes broadcast pairwise (element-wise semantics). */
+    BROADCAST
+  }
+
   /**
-   * Locates the dataflow variables that determine this generator's result dtype when its own dtype
-   * walk fails. A pure-⊤ seed (unknown shape and dtype) cannot be improved by later evidence,
-   * although the dtype-source operand's dtype often exists in {@code TensorTypeAnalysis} dataflow
-   * state that PTS-based resolution cannot see (wala/ML#736, the wala/ML#661/wala/ML#570
-   * substrate); the engine replaces such a seed with a synthetic dataflow edge from each of these
-   * variables, so the result takes the operand's converged dtypes and the unknown-dtype member is
-   * never born. Overridden by generators whose result dtype is determined by an operand; the
-   * default declares none.
+   * A type-feed declaration (wala/ML#736, wala/ML#682): how the result composes from its operands
+   * and where the operands live.
+   *
+   * @param kind The composition kind.
+   * @param operands The operand pointer keys, in operand order; {@link TypeFeedKind#BROADCAST}
+   *     requires exactly two.
+   */
+  public record TypeFeed(TypeFeedKind kind, List<PointerKey> operands) {}
+
+  /**
+   * Declares the type feed that can replace this generator's unresolved seed. An unknown-shape seed
+   * cannot be improved by later evidence, although the operands' types often exist in {@code
+   * TensorTypeAnalysis} dataflow state that PTS-based resolution cannot see (wala/ML#736,
+   * wala/ML#682; the wala/ML#661/wala/ML#570 substrate); the engine replaces such a seed with a
+   * synthetic dataflow edge from each declared operand, composing the result per the feed's kind,
+   * so the unresolved seed member is never born. Overridden by generators whose result type is
+   * determined by their operands; the default declares none.
    *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The pointer keys of the dtype-determining operands; empty when this generator has none
-   *     or they cannot be located.
+   * @return The type feed, or {@code null} when this generator declares none or its operands cannot
+   *     be located.
    */
-  protected Set<PointerKey> getDTypeFeedSourceKeys(PropagationCallGraphBuilder builder) {
-    return Collections.emptySet();
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return null;
   }
 
   protected PythonInvokeInstruction getInvokeInstruction() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tensordot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tensordot.java
@@ -110,4 +110,17 @@ public class Tensordot extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Tile.java
@@ -164,4 +164,17 @@ public class Tile extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Trace.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Trace.java
@@ -75,4 +75,17 @@ public class Trace extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
@@ -193,4 +193,17 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
     // Exactly one distinct candidate is the resolved permutation; zero or several is ⊤.
     return candidates.size() == 1 ? candidates.iterator().next() : null;
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/UnsortedSegmentReduction.java
@@ -161,4 +161,17 @@ public class UnsortedSegmentReduction extends PassThroughUnaryTensorGenerator {
   protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }
+
+  /**
+   * This generator transforms its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side input keys, or {@code null} when none is
+   *     located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
 }


### PR DESCRIPTION
Advances wala/ML#682: the type-feed transfer (ponder-lab/ML#615) generalizes from dtype-only lifting to op-aware composition, the mechanism the issue's shape axis needs.

A feed now declares its composition kind (`TypeFeedKind`): `PASS_THROUGH` forwards each operand member unchanged, the sound default for the pass-through-unary family, whose base shape logic is the identity; `BROADCAST` pairs an element-wise destination's incoming members with the other operand's current members through a post-construction solver accessor and broadcasts their shapes (a scalar-constant operand degrades to the exact pass-through of the tensor side); `DTYPE_ONLY` remains for the 18 pass-through-unary subclasses the audit found to transform their input's shape (einsum, transpose, squeeze, tile, and kin), where forwarding operand shapes would overclaim. A dtype the generator had proven survives composition over weaker operand dtypes.

Two scope boundaries, measured and documented in code:
- The feed criterion stays pure-⊤ seeds. Widening it to known-dtype unknown-shape seeds, which the gpt-2 member needs, breaks the engine-side pin computations that read seeded state; the vendored `Conv1d` and gather probes are the witnesses, and the widening continues under wala/ML#682.
- The gpt-2 decoder chain itself is unchanged: its sublayer outputs pass through genuinely shape-transforming ops whose generator-side operand walks still fail, so the concrete shape cannot yet reach the residual adds' broadcast.

The suite is behavior-identical (the current fixtures' pure-⊤ operand chains still compose unknown shapes), so this PR carries the machinery and its soundness audit without expectation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsESiZwqVVnF8KSUgWu65U
