### PR TITLE
Key trampoline code bodies on the call's positional/keyword split (wala/ML#740).

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12482,6 +12482,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
         Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
   }
 
+  /**
+   * Test two call sites of the same method with equal total arity but different positional/keyword
+   * splits. The trampoline cache must not collide them; see <a
+   * href="https://github.com/wala/ML/issues/740">wala/ML#740</a>. The parameter {@code x} receives
+   * a tensor positionally at one call site and by keyword at the other, so its type must be the
+   * union of both.
+   */
+  @Test
+  public void testTrampolineSplit() throws ClassHierarchyException, CancelException, IOException {
+    test(
+        "tf2_test_trampoline_split.py",
+        "C.f",
+        1,
+        1,
+        Map.of(3, Set.of(TENSOR_1_2_FLOAT32, TENSOR_1_3_FLOAT32)));
+  }
+
   @Test
   public void testStaticMethod4() throws ClassHierarchyException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_trampoline_split.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_trampoline_split.py
@@ -1,0 +1,23 @@
+# Test https://github.com/wala/ML/issues/740. Two call sites of the same
+# method with equal total arity but different positional/keyword splits.
+import tensorflow as tf
+
+
+class C:
+
+    def f(self, x, training=True):
+        assert isinstance(x, tf.Tensor)
+
+
+c = C()
+
+a = tf.ones([1, 2])
+assert a.shape == (1, 2)
+assert a.dtype == tf.float32
+
+b = tf.ones([1, 3])
+assert b.shape == (1, 3)
+assert b.dtype == tf.float32
+
+c.f(a, False)
+c.f(training=False, x=b)

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestCalls.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestCalls.java
@@ -109,11 +109,12 @@ public class TestCalls extends TestJythonCallGraphShape {
               "script calls5.py",
               new String[] {
                 "script calls5.py/Foo",
-                "$script calls5.py/Foo/foo:trampoline3",
+                "$script calls5.py/Foo/foo:trampoline1$a$b",
                 "script calls5.py/bad"
               }),
           new GraphAssertion(
-              "$script calls5.py/Foo/foo:trampoline3", new String[] {"script calls5.py/Foo/foo"}),
+              "$script calls5.py/Foo/foo:trampoline1$a$b",
+              new String[] {"script calls5.py/Foo/foo"}),
           new GraphAssertion("script calls5.py/Foo/foo", new String[] {"script calls5.py/id"}));
 
   @Test
@@ -130,11 +131,11 @@ public class TestCalls extends TestJythonCallGraphShape {
               "script calls6.py",
               new String[] {
                 "script calls6.py/Foo",
-                "$script calls6.py/Foo/foo:trampoline3",
+                "$script calls6.py/Foo/foo:trampoline2$b",
                 "script calls6.py/bad"
               }),
           new GraphAssertion(
-              "$script calls6.py/Foo/foo:trampoline3", new String[] {"script calls6.py/Foo/foo"}),
+              "$script calls6.py/Foo/foo:trampoline2$b", new String[] {"script calls6.py/Foo/foo"}),
           new GraphAssertion("script calls6.py/Foo/foo", new String[] {"script calls6.py/id"}));
 
   @Test

--- a/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestLambda.java
+++ b/com.ibm.wala.cast.python.test/source/com/ibm/wala/cast/python/test/TestLambda.java
@@ -19,12 +19,12 @@ public class TestLambda extends TestJythonCallGraphShape {
               "script lambda1.py",
               new String[] {
                 "script lambda1.py/Foo",
-                "$script lambda1.py/Foo/foo:trampoline3",
+                "$script lambda1.py/Foo/foo:trampoline2$b",
                 "script lambda1.py/lambda1",
                 "script lambda1.py/lambda2"
               }),
           new GraphAssertion(
-              "$script lambda1.py/Foo/foo:trampoline3",
+              "$script lambda1.py/Foo/foo:trampoline2$b",
               new String[] {"script lambda1.py/Foo/foo"}));
 
   @Test
@@ -41,12 +41,13 @@ public class TestLambda extends TestJythonCallGraphShape {
               "script lambda2.py",
               new String[] {
                 "script lambda2.py/Foo",
-                "$script lambda2.py/Foo/foo:trampoline3",
+                "$script lambda2.py/Foo/foo:trampoline2$b",
                 "script lambda2.py/lambda2",
                 "script lambda2.py/lambda3"
               }),
           new GraphAssertion(
-              "$script lambda2.py/Foo/foo:trampoline3", new String[] {"script lambda2.py/Foo/foo"}),
+              "$script lambda2.py/Foo/foo:trampoline2$b",
+              new String[] {"script lambda2.py/Foo/foo"}),
           new GraphAssertion(
               "script lambda2.py/lambda2", new String[] {"script lambda2.py/lambda1"}),
           new GraphAssertion(
@@ -64,9 +65,10 @@ public class TestLambda extends TestJythonCallGraphShape {
           new GraphAssertion(ROOT, new String[] {"script lambda3.py"}),
           new GraphAssertion(
               "script lambda3.py",
-              new String[] {"script lambda3.py/Foo", "$script lambda3.py/Foo/foo:trampoline3"}),
+              new String[] {"script lambda3.py/Foo", "$script lambda3.py/Foo/foo:trampoline1$a$b"}),
           new GraphAssertion(
-              "$script lambda3.py/Foo/foo:trampoline3", new String[] {"script lambda3.py/Foo/foo"}),
+              "$script lambda3.py/Foo/foo:trampoline1$a$b",
+              new String[] {"script lambda3.py/Foo/foo"}),
           new GraphAssertion(
               "script lambda3.py/Foo/foo", new String[] {"script lambda3.py/lambda3"}),
           new GraphAssertion(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonMethodTrampolineTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonMethodTrampolineTargetSelector.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ipa.callgraph;
 
 import static com.ibm.wala.cast.python.types.PythonTypes.TRAMPOLINE_METHOD_NAME;
+import static java.util.stream.Collectors.joining;
 
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummarizedFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonSummary;
@@ -15,15 +16,30 @@ import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.collections.HashMapFactory;
-import com.ibm.wala.util.collections.Pair;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 public abstract class PythonMethodTrampolineTargetSelector<T> implements MethodTargetSelector {
 
+  /**
+   * Identifies a trampoline code body by the receiver and the calling layout it was generated for.
+   * A body's instructions depend on the call's positional/keyword split and on the keyword names,
+   * not just the total argument count; keying on the total collides call sites with equal total
+   * arity but different splits (<a href="https://github.com/wala/ML/issues/740">wala/ML#740</a>).
+   * Keyword names are a set because binding is by name in both the caller-to-trampoline and
+   * trampoline-to-method directions, making bodies insensitive to keyword order.
+   *
+   * @param receiver The {@link IClass} being dispatched on.
+   * @param positionalParameterCount The call's number of positional parameters.
+   * @param keywordNames The call's keyword argument names.
+   */
+  protected record TrampolineKey(
+      IClass receiver, int positionalParameterCount, Set<String> keywordNames) {}
+
   protected final MethodTargetSelector base;
 
-  protected final Map<Pair<IClass, Integer>, IMethod> codeBodies = HashMapFactory.make();
+  protected final Map<TrampolineKey, IMethod> codeBodies = HashMapFactory.make();
 
   public PythonMethodTrampolineTargetSelector(MethodTargetSelector base) {
     this.base = base;
@@ -40,14 +56,13 @@ public abstract class PythonMethodTrampolineTargetSelector<T> implements MethodT
       if (this.shouldProcess(caller, site, receiver)) {
         PythonInvokeInstruction call = this.getCall(caller, site);
         if (call == null) return null;
-        Pair<IClass, Integer> key = this.makeKey(receiver, call);
+        TrampolineKey key = this.makeKey(receiver, call);
 
         if (!codeBodies.containsKey(key)) {
           MethodReference tr =
               MethodReference.findOrCreate(
                   receiver.getReference(),
-                  Atom.findOrCreateUnicodeAtom(
-                      TRAMPOLINE_METHOD_NAME + call.getNumberOfTotalParameters()),
+                  Atom.findOrCreateUnicodeAtom(this.getTrampolineName(call)),
                   AstMethodReference.fnDesc);
           PythonSummary x = new PythonSummary(tr, call.getNumberOfTotalParameters());
           int v = call.getNumberOfTotalParameters() + 1;
@@ -82,14 +97,33 @@ public abstract class PythonMethodTrampolineTargetSelector<T> implements MethodT
   }
 
   /**
-   * Returns a unique {@link Pair} for the given {@link Receiver} and {@link
-   * PythonInvokeInstruction}.
+   * Returns the {@link TrampolineKey} identifying the trampoline code body for the given receiver
+   * and the given call's positional/keyword layout.
    *
-   * @return A unique {@link Pair} for the given {@link Receiver} and {@link
-   *     PythonInvokeInstruction}.
+   * @param receiver The {@link IClass} being dispatched on.
+   * @param call The {@link PythonInvokeInstruction} whose layout the trampoline is generated for.
+   * @return The {@link TrampolineKey} identifying the trampoline code body for the given receiver
+   *     and the given call's positional/keyword layout.
    */
-  private Pair<IClass, Integer> makeKey(IClass receiver, PythonInvokeInstruction call) {
-    return Pair.make(receiver, call.getNumberOfTotalParameters());
+  private TrampolineKey makeKey(IClass receiver, PythonInvokeInstruction call) {
+    return new TrampolineKey(
+        receiver, call.getNumberOfPositionalParameters(), Set.copyOf(call.getKeywords()));
+  }
+
+  /**
+   * Returns the name of the trampoline method for the given call's positional/keyword layout.
+   * Distinct layouts must yield distinct names; otherwise, {@link MethodReference#findOrCreate}
+   * canonicalizes distinct code bodies onto one reference (<a
+   * href="https://github.com/wala/ML/issues/740">wala/ML#740</a>). Keyword names are sorted so call
+   * sites differing only in keyword order share a name, matching {@link TrampolineKey}.
+   *
+   * @param call The {@link PythonInvokeInstruction} whose layout the trampoline is generated for.
+   * @return The name of the trampoline method for the given call's positional/keyword layout.
+   */
+  private String getTrampolineName(PythonInvokeInstruction call) {
+    return TRAMPOLINE_METHOD_NAME
+        + call.getNumberOfPositionalParameters()
+        + call.getKeywords().stream().sorted().map(k -> "$" + k).collect(joining());
   }
 
   /**


### PR DESCRIPTION
`PythonMethodTrampolineTargetSelector` cached trampoline code bodies keyed on the sum of a call's positional and keyword arguments, so two call sites of the same method with equal total arity but different positional/keyword splits shared one body whose layout was fixed by whichever site was processed first. The colliding site then misbinds: an argument passed by keyword can land in a different parameter or drop its dataflow entirely, since its keyword has no named slot in the stale body.

Changes:
- Key `codeBodies` on a `TrampolineKey` record of the receiver, the positional parameter count, and the keyword-name set. The names form a set because binding is by name in both the caller-to-trampoline and trampoline-to-method directions, so keyword order cannot change a body's semantics.
- Encode the split in the trampoline `MethodReference` name (`trampoline<positional>` plus the sorted keyword names) so distinct bodies get distinct references. Positional-only calls keep their previous names.
- Add `tf2_test_trampoline_split.py` and `testTrampolineSplit`, in which the same method receives a tensor positionally at one call site and by keyword at another with equal total arity. Before the fix, the tensor passed as `x=` binds into `training`, yielding two tensor parameters instead of one.
- Update the expected trampoline names in `testCalls5`, `testCalls6`, and `testLambda1` through `testLambda3`, whose fixtures call with keywords.

Closes wala/ML#740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmWVYtFE9fw4A6xFhFo8cq
