### PR TITLE
Map the mixed-vector reshape `-1` placeholder to the symbolic dimension (wala/ML#741)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -12952,6 +12952,35 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Pins <a href="https://github.com/wala/ML/issues/741">wala/ML#741</a>: a reshape target mixing
+   * an {@code Unresolved} leading element with the literal {@code -1} placeholder surfaces the
+   * placeholder as the symbolic unknown-size dimension rather than a fixed size of {@code -1}, so
+   * the follow-on broadcast against a fully concrete operand composes instead of flooring to ⊤ on
+   * the impossible {@code -1} extent. The markers dominate the concrete sides in the broadcast
+   * join, so the sum carries the reshape's {@code (Unresolved, ?, 8)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testReshapeMixedPlaceholder()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_mixed_placeholder.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(UnresolvedDim.INSTANCE, new SymbolicDim("?"), new NumericDim(8))))));
+  }
+
+  /**
    * Regression guard for {@code tf.reshape(x, tf.shape(y))} shape inference. Runtime answer is
    * {@code (2, 3)} of {@code float32}. Post wala/ML#538's graceful-degradation fix in {@link
    * com.ibm.wala.cast.python.ml.client.Reshape} (mirroring {@link

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NdarrayReshape.java
@@ -114,22 +114,20 @@ public class NdarrayReshape extends TensorGenerator {
       long productKnown = 1;
       boolean canInfer = true;
 
+      // Scan the whole member so a mixed vector's `-1` placeholder is always detected and mapped;
+      // breaking early let the raw `-1` escape as a fixed size (wala/ML#741, mirroring `Reshape`).
       for (int i = 0; i < shape.size(); i++) {
         Dimension<?> dim = shape.get(i);
         if (dim instanceof NumericDim) {
           int val = ((NumericDim) dim).value();
           if (val == -1) {
-            if (unknownIndex != -1) {
-              canInfer = false;
-              break;
-            }
-            unknownIndex = i;
+            if (unknownIndex != -1) canInfer = false;
+            else unknownIndex = i;
           } else {
             productKnown *= val;
           }
         } else {
-          canInfer = false;
-          break;
+          canInfer = false; // Non-numeric dimension; keep scanning for placeholders.
         }
       }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -137,22 +137,22 @@ public class Reshape extends TensorGenerator {
         long productKnown = 1;
         boolean canInfer = true;
 
+        // Scan the whole member: breaking out early on a non-numeric dimension skipped the
+        // `-1`-placeholder detection for mixed vectors (e.g. an unresolved leading fold alongside
+        // a literal `-1`), letting the raw `-1` escape as a fixed size into downstream broadcast
+        // and compatibility checks (wala/ML#741).
         for (int i = 0; i < shape.size(); i++) {
           Dimension<?> dim = shape.get(i);
           if (dim instanceof NumericDim) {
             int val = ((NumericDim) dim).value();
             if (val == -1) {
-              if (unknownIndex != -1) {
-                canInfer = false; // More than one -1
-                break;
-              }
-              unknownIndex = i;
+              if (unknownIndex != -1) canInfer = false; // More than one -1
+              else unknownIndex = i;
             } else {
               productKnown *= val;
             }
           } else {
-            canInfer = false; // Non-numeric dimension
-            break;
+            canInfer = false; // Non-numeric dimension; keep scanning for placeholders.
           }
         }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/util/TensorShapeUtil.java
@@ -6,6 +6,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
 import java.util.List;
 
@@ -21,11 +22,13 @@ public class TensorShapeUtil {
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
       // Either side missing (out of rank), a raw-null placeholder, a ragged dim, a dynamic dim,
-      // or an unresolved dim is treated as broadcast-compatible—we lack the precision to reason
-      // about the actual extent, so be permissive. https://github.com/wala/ML/issues/544
-      // introduced `RaggedDim`; https://github.com/wala/ML/issues/545 introduced `DynamicDim` for
-      // the runtime-`None` case (batch/placeholder/Keras `None`); wala/ML#721 introduced
-      // `UnresolvedDim` for the fixed-but-uncomputed case. All join the same permissive branch.
+      // an unresolved dim, or a symbolic dim is treated as broadcast-compatible—we lack the
+      // precision to reason about the actual extent, so be permissive.
+      // https://github.com/wala/ML/issues/544 introduced `RaggedDim`;
+      // https://github.com/wala/ML/issues/545 introduced `DynamicDim` for the runtime-`None` case
+      // (batch/placeholder/Keras `None`); wala/ML#721 introduced `UnresolvedDim` for the
+      // fixed-but-uncomputed case; wala/ML#741 added `SymbolicDim` (the unknown-size placeholder,
+      // e.g. an uninferable reshape `-1`). All join the same permissive branch.
       if (xDim == null
           || yDim == null
           || xDim instanceof RaggedDim
@@ -33,7 +36,9 @@ public class TensorShapeUtil {
           || xDim instanceof DynamicDim
           || yDim instanceof DynamicDim
           || xDim instanceof UnresolvedDim
-          || yDim instanceof UnresolvedDim) {
+          || yDim instanceof UnresolvedDim
+          || xDim instanceof SymbolicDim
+          || yDim instanceof SymbolicDim) {
         continue;
       }
 
@@ -60,19 +65,22 @@ public class TensorShapeUtil {
       Dimension<?> xDim = i < (maxRank - xRank) ? null : xShape.get(i - (maxRank - xRank));
       Dimension<?> yDim = i < (maxRank - yRank) ? null : yShape.get(i - (maxRank - yRank));
 
-      // Propagate raggedness, dynamic-ness, or unresolvedness when either side carries them—
-      // broadcasting against anything (including a compatible-rank counterpart) preserves the
-      // wider unknown semantics. https://github.com/wala/ML/issues/544 introduced `RaggedDim`;
-      // https://github.com/wala/ML/issues/545 introduced `DynamicDim`; wala/ML#721 introduced
-      // `UnresolvedDim`. When two markers meet on the same axis, the wider unknown dominates:
-      // ragged (varies per row) over dynamic (runtime `None`) over unresolved (fixed but
-      // uncomputed).
+      // Propagate raggedness, dynamic-ness, unresolvedness, or symbolic-ness when either side
+      // carries them—broadcasting against anything (including a compatible-rank counterpart)
+      // preserves the wider unknown semantics. https://github.com/wala/ML/issues/544 introduced
+      // `RaggedDim`; https://github.com/wala/ML/issues/545 introduced `DynamicDim`; wala/ML#721
+      // introduced `UnresolvedDim`; wala/ML#741 added `SymbolicDim`. When two markers meet on the
+      // same axis, the wider unknown dominates: ragged (varies per row) over dynamic (runtime
+      // `None`) over unresolved (fixed but uncomputed) over symbolic (unknown size with no
+      // provenance claim).
       if (xDim instanceof RaggedDim) ret.add(xDim);
       else if (yDim instanceof RaggedDim) ret.add(yDim);
       else if (xDim instanceof DynamicDim) ret.add(xDim);
       else if (yDim instanceof DynamicDim) ret.add(yDim);
       else if (xDim instanceof UnresolvedDim) ret.add(xDim);
       else if (yDim instanceof UnresolvedDim) ret.add(yDim);
+      else if (xDim instanceof SymbolicDim) ret.add(xDim);
+      else if (yDim instanceof SymbolicDim) ret.add(yDim);
       else if (xDim == null) ret.add(yDim);
       else if (yDim == null) ret.add(xDim);
       else if (xDim instanceof NumericDim && yDim instanceof NumericDim) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_mixed_placeholder.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_mixed_placeholder.py
@@ -1,0 +1,29 @@
+import os
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# Mixed reshape target (wala/ML#741): an `Unresolved` leading element (an
+# environment-read size the analysis cannot compute, per the wala/ML#721
+# criterion) alongside the literal `-1` placeholder. The placeholder must
+# surface as the symbolic unknown-size dimension, not as a fixed size of -1:
+# the follow-on addition broadcasts the reshaped tensor against a fully
+# concrete one, which a raw -1 "size" would wrongly reject.
+n = int(os.environ.get("ARIADNE_TEST_N", "2"))
+
+x = tf.ones((n, 3, 8))
+
+batch = tf.shape(x)[0]
+
+y = tf.reshape(x, [batch, -1, 8])
+w = tf.ones((2, 3, 8))
+z = y + w
+
+assert z.shape == (2, 3, 8)
+assert z.dtype == tf.float32
+
+consume(z)


### PR DESCRIPTION
Closes wala/ML#741: the raw `-1` reshape placeholder no longer escapes as a fixed `NumericDim(-1)`.

Two halves:

- `Reshape.getShapeResult`'s refinement scan broke out of a member on the first non-numeric dimension, so a mixed target vector (an unresolved leading fold alongside a literal `-1`) exited before the placeholder was recorded and passed through unrefined; the scan now covers the whole member, so the existing mapping (inference when the input size folds, `SymbolicDim("?")` otherwise) applies. `NdarrayReshape` had the same early exit and gets the same repair.
- `TensorShapeUtil` treats `SymbolicDim` like the other unknown-size markers: permissive in `areBroadcastable`, and joining `getBroadcastedShapes` below `UnresolvedDim` in the dominance order, since the bare `?` makes no provenance claim.

The witness is the vendored gpt-2 decoder (wala/ML#739): `DecoderLayer.call`'s first residual add pairs the concrete `(2, 3, 8)` against `merge_heads`'s `(Unresolved, -1, 8)` reshape, and the impossible `-1` extent floored the whole add to ⊤ through the all-pairs-non-broadcastable degrade (wala/ML#583); with the repair the pair composes. `testReshapeMixedPlaceholder` pins the fixture-scale form: an environment-read leading size (per the wala/ML#721 criterion) alongside the literal `-1`, whose sum against a concrete operand now carries `(Unresolved, ?, 8)` of float32.

The `tf.slice` `size` path is untouched: its `-1` ("all remaining") is consumed from the shared list-field walk before any reshape refinement, and `testSliceRemaining` still pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmWVYtFE9fw4A6xFhFo8cq
