### PR TITLE
Repair the decoder-stack operand walks one link deeper (wala/ML#739)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -13,6 +13,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
@@ -380,6 +381,23 @@ public class ElementWiseOperation extends TensorGenerator {
     if (vn <= 0) return false;
     if (node.getDU() == null || node.getIR() == null) return false;
     if (node.getIR().getSymbolTable().isConstant(vn)) return true;
+
+    // A value whose every points-to member is a numeric constant is a runtime scalar whatever its
+    // syntactic form — e.g. a scalar-defaulted parameter like the vendored LayerNormalization's
+    // `epsilon=1e-6`, bound to the default's constant by the call trampoline (wala/ML#739).
+    PointerKey scalarPk =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    OrdinalSet<InstanceKey> scalarPts = builder.getPointerAnalysis().getPointsToSet(scalarPk);
+    if (scalarPts != null && !scalarPts.isEmpty()) {
+      boolean allNumericConstants = true;
+      for (InstanceKey ik : scalarPts)
+        if (!(ik instanceof ConstantKey) || !(((ConstantKey<?>) ik).getValue() instanceof Number)) {
+          allNumericConstants = false;
+          break;
+        }
+      if (allNumericConstants) return true;
+    }
+
     SSAInstruction def = node.getDU().getDef(vn);
     if (def instanceof SSABinaryOpInstruction)
       return isScalarExpression(builder, node, def.getUse(0))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Loggables.java
@@ -103,6 +103,14 @@ final class Loggables {
   }
 
   private static String signature(CGNode node) {
-    return node == null ? "null" : node.getMethod().getSignature();
+    // The context tag is the context's identity hash: bounded and recursion-free (unlike the
+    // context's own toString, wala/ML#697), and stable within a run, so log lines for the same
+    // node in different receiver-keyed contexts are distinguishable (wala/ML#739).
+    return node == null
+        ? "null"
+        : node.getMethod().getSignature()
+            + " [ctx#"
+            + Integer.toHexString(System.identityHashCode(node.getContext()))
+            + "]";
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Reshape.java
@@ -212,10 +212,23 @@ public class Reshape extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
-    // Infer shape from 'tensor' argument.
+    // Infer shape from the 'tensor' argument: its points-to union first, then the per-context
+    // caller walk. A caller-side operator-produced argument (e.g. the matmul-plus-bias feeding the
+    // vendored Conv1d's output reshape) has no allocation site, so it is invisible to the
+    // argument's points-to set and resolves only through the caller's value-number read
+    // (wala/ML#739).
     OrdinalSet<InstanceKey> tensorPts =
         this.getArgumentPointsToSet(
             builder, this.getValueParameterPosition(), this.getValueParameterName());
+    if (tensorPts != null && !tensorPts.isEmpty()) {
+      Set<List<Dimension<?>>> fromValue = this.getShapesOfValue(builder, tensorPts);
+      if (fromValue != null && !fromValue.isEmpty()) return fromValue;
+    }
+    ShapeResult viaCallers =
+        this.getArgumentShapeResultViaCallers(
+            builder, this.getValueParameterPosition(), this.getValueParameterName());
+    // The default mode's contract is the resolvable subset (wala/ML#716).
+    if (!viaCallers.members().isEmpty()) return viaCallers.members();
     return this.getShapesOfValue(builder, tensorPts);
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -97,6 +97,7 @@ import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * An abstract generator for {@link TensorType}s.
@@ -3906,8 +3907,16 @@ public abstract class TensorGenerator {
     // Synthetic/manual node: walk the call-graph callers to find the argument's value number.
     boolean callerUnknown = false;
     Set<List<Dimension<?>>> combined = null;
-    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
-        getCallerInvokes(builder, this.getNode())) {
+    List<Pair<CGNode, SSAAbstractInvokeInstruction>> callerInvokes =
+        getCallerInvokes(builder, this.getNode());
+    LOGGER.fine(
+        () ->
+            "getShapeResultFromShapeVectorArgument: caller walk for "
+                + describe(this.getNode())
+                + " found "
+                + callerInvokes.size()
+                + " caller invoke(s).");
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke : callerInvokes) {
       CGNode caller = callerInvoke.fst;
       if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
       PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
@@ -4163,9 +4172,27 @@ public abstract class TensorGenerator {
         && ((SSABinaryOpInstruction) def).getOperator() == IBinaryOpInstruction.Operator.ADD) {
       ShapeResult left =
           this.shapeResultOfShapeVectorOrLiteralList(builder, node, def.getUse(0), visited);
+      LOGGER.fine(
+          () ->
+              "Shape-vector concat in "
+                  + describe(node)
+                  + ": left operand vn "
+                  + def.getUse(0)
+                  + " resolved "
+                  + left.members().size()
+                  + " member(s).");
       if (left.members().isEmpty()) return ShapeResult.unknown();
       ShapeResult right =
           this.shapeResultOfShapeVectorOrLiteralList(builder, node, def.getUse(1), visited);
+      LOGGER.fine(
+          () ->
+              "Shape-vector concat in "
+                  + describe(node)
+                  + ": right operand vn "
+                  + def.getUse(1)
+                  + " resolved "
+                  + right.members().size()
+                  + " member(s).");
       if (right.members().isEmpty()) return ShapeResult.unknown();
       Set<List<Dimension<?>>> concatenated = HashSetFactory.make();
       for (List<Dimension<?>> l : left.members())
@@ -4255,7 +4282,24 @@ public abstract class TensorGenerator {
       if (index == null) continue;
       byIndex.put(index, elementDims(builder, node, st, writtenVal));
     }
-    if (byIndex.isEmpty() || byIndex.containsValue(null)) return ShapeResult.unknown();
+    if (byIndex.isEmpty() || byIndex.containsValue(null)) {
+      final TreeMap<Integer, Set<Dimension<?>>> resolved = byIndex;
+      LOGGER.fine(
+          () ->
+              "Literal-list walk for vn "
+                  + vn
+                  + " in "
+                  + describe(node)
+                  + " failed; unresolved element indices: "
+                  + resolved.entrySet().stream()
+                      .filter(e -> e.getValue() == null)
+                      .map(Map.Entry::getKey)
+                      .collect(Collectors.toList())
+                  + " of "
+                  + resolved.keySet()
+                  + ".");
+      return ShapeResult.unknown();
+    }
     // The indices must be contiguous from 0 or the element order can't be reconstructed.
     if (byIndex.firstKey() != 0 || byIndex.lastKey() != byIndex.size() - 1)
       return ShapeResult.unknown();
@@ -5741,6 +5785,26 @@ public abstract class TensorGenerator {
       return new ExpandDims(node);
     } else if (type.equals(TensorFlowTypes.CLIP_BY_VALUE.getDeclaringClass())) {
       return new ClipByValue(node);
+    } else if (type.equals(TensorFlowTypes.RSQRT.getDeclaringClass())) {
+      // The elementwise-math family below closes wala/ML#739's dispatch-table gap for producer
+      // delegation: each op was factory-dispatchable but unregistered here, so a generic Tensor
+      // allocation from its synthetic body dead-ended the walk (the vendored LayerNormalization's
+      // rsqrt/square chain is the witness).
+      return new Rsqrt(node);
+    } else if (type.equals(TensorFlowTypes.SQUARE.getDeclaringClass())) {
+      return new Square(node);
+    } else if (type.equals(TensorFlowTypes.SQRT.getDeclaringClass())) {
+      return new Sqrt(node);
+    } else if (type.equals(TensorFlowTypes.SIN.getDeclaringClass())) {
+      return new Sin(node);
+    } else if (type.equals(TensorFlowTypes.COS.getDeclaringClass())) {
+      return new Cos(node);
+    } else if (type.equals(TensorFlowTypes.EXP.getDeclaringClass())) {
+      return new Exp(node);
+    } else if (type.equals(TensorFlowTypes.TILE.getDeclaringClass())) {
+      return new Tile(node);
+    } else if (type.equals(TensorFlowTypes.EMBEDDING_LOOKUP.getDeclaringClass())) {
+      return new EmbeddingLookup(node);
     } else if (type.equals(CONSTANT.getDeclaringClass())) {
       return new TensorGenerator(node) {
         @Override


### PR DESCRIPTION
Advances wala/ML#739: the operand walks now carry the concrete member through the attention arm to both residual adds, and the remaining blocker is isolated and filed.

- The reshape tensor-argument read falls back to the per-caller value-number walk when the argument's points-to union yields nothing: the vendored `Conv1d`'s output reshape reads its `outputs` argument, a caller-side matmul-plus-bias operator result with no allocation site, which the points-to set structurally cannot represent.
- The elementwise-math family (`rsqrt`, `square`, `sqrt`, `sin`, `cos`, `exp`, `tile`, `embedding_lookup`) joins the manual-generator registry, closing the factory-vs-manual dispatch-table gap for producer delegation. On the witness this raised the resolved shape-vector concat contexts from 2 to 18: the `LayerNormalization` chain's `rsqrt`/`square` delegations previously dead-ended on their generic `Tensor` allocations.
- The element-wise scalar-operand rule accepts points-to evidence: a value whose every member is a numeric constant is a runtime scalar whatever its syntactic form. The intended beneficiary is a scalar-defaulted parameter like `LayerNormalization.call`'s `epsilon=1e-6`, which currently has an empty points-to set because parameter defaults never materialize in the pointer analysis; that root cause is filed as wala/ML#743 and blocks the rest of the chain (`variance + epsilon` floors ⊥, taking the layer result and the second residual operand with it).
- The context-free log renderers tag nodes with the context's identity hash (bounded and recursion-free, unlike the context's own rendering per wala/ML#697), and the previously silent shape-vector concat and literal-list walks log their per-operand outcomes; the receiver-keyed diagnosis in this arc was not reconstructible without either.

The suite is behavior-identical (the witness pins still hold, since the chain's final link waits on wala/ML#743).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmWVYtFE9fw4A6xFhFo8cq
