### PR TITLE
Triage the wala/ML#370 shape-annotation worklist by cause (wala/ML#735)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestShapeAnnotationTriage.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestShapeAnnotationTriage.java
@@ -1,0 +1,66 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine.ShapeAnnotationCandidate;
+import com.ibm.wala.cast.python.ml.client.TensorGenerator.ShapeUnresolutionCause;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/**
+ * Regression guards for the wala/ML#370 shape-annotation triage (<a
+ * href="https://github.com/wala/ML/issues/735">wala/ML#735</a>): {@link
+ * PythonTensorAnalysisEngine#getShapeAnnotationCandidates()} classifies each allocator whose shape
+ * argument did not resolve as content-dependent (a genuine annotation candidate) or a recoverable
+ * precision gap, so the "candidate for a wala/ML#370 shape annotation" suggestion no longer fires
+ * for statically-recoverable shapes.
+ */
+public class TestShapeAnnotationTriage extends TestPythonMLCallGraphShape {
+
+  private Map<ShapeUnresolutionCause, Long> triage(String file)
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    PythonTensorAnalysisEngine engine = makeEngine(emptyList(), file);
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    builder.makeCallGraph(builder.getOptions());
+    engine.performAnalysis(builder);
+    List<ShapeAnnotationCandidate> candidates = engine.getShapeAnnotationCandidates();
+    return candidates.stream()
+        .collect(Collectors.groupingBy(ShapeAnnotationCandidate::cause, Collectors.counting()));
+  }
+
+  /**
+   * The content-dependent allocator ({@code tf.zeros(np.load(...).shape)}) is a wala/ML#370
+   * annotation candidate, while the modeled-op allocator ({@code
+   * tf.zeros(tf.transpose(...).shape)}) is a recoverable precision gap rather than an annotation
+   * candidate.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeAnnotationTriage()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    Map<ShapeUnresolutionCause, Long> byCause = triage("tf2_test_shape_annotation_triage.py");
+    // The tf.zeros(np.load(...).shape) allocator is a genuine content-dependent wala/ML#370
+    // candidate; the tf.zeros(tf.transpose(...).shape) allocator, whose shape roots in a modeled
+    // op, is a recoverable precision gap and not a candidate.
+    assertEquals(
+        "tf.zeros(np.load(...).shape) is a content-dependent wala/ML#370 candidate.",
+        1L,
+        (long) byCause.getOrDefault(ShapeUnresolutionCause.CONTENT_DEPENDENT, 0L));
+    assertEquals(
+        "tf.zeros(tf.transpose(...).shape) is a recoverable precision gap, not a candidate.",
+        1L,
+        (long) byCause.getOrDefault(ShapeUnresolutionCause.RECOVERABLE_GAP, 0L));
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Fill.java
@@ -150,17 +150,29 @@ public class Fill extends Constant {
         this.isKeywordArgumentPresent(builder, Parameters.DIMS.getName())
             || this.getNumberOfPossiblePositionalArguments(builder).stream()
                 .anyMatch(n -> n >= Parameters.DIMS.getIndex() + 1);
+    if (!dimsSupplied) {
+      LOGGER.fine(
+          () ->
+              SIGNATURE
+                  + " reached without its mandatory dims argument for source: "
+                  + describe(source)
+                  + " (malformed call?); returning ⊤.");
+      return null;
+    }
+    // Triage the ⊤ so the wala/ML#370 worklist stays honest (wala/ML#735): the `dims` argument is
+    // this allocator's shape parameter.
+    ShapeUnresolutionCause cause =
+        this.classifyUnresolvedShapeArgument(
+            builder, Parameters.DIMS.getIndex(), Parameters.DIMS.getName());
+    recordShapeAnnotationCandidate(builder, source == null ? null : source.getPointerKey(), cause);
     LOGGER.fine(
-        dimsSupplied
-            ? "Could not resolve the dims argument of "
+        () ->
+            "Could not resolve the dims argument of "
                 + SIGNATURE
                 + " for source: "
                 + describe(source)
-                + "; returning ⊤. Candidate for a wala/ML#370 shape annotation."
-            : SIGNATURE
-                + " reached without its mandatory dims argument for source: "
-                + describe(source)
-                + " (malformed call?); returning ⊤.");
+                + "; returning ⊤. "
+                + shapeAnnotationTriageMessage(cause));
     return null;
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1647,7 +1647,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                     + tt.getOutState(fed));
 
       recordDepthLimitedResults(tt, builder.getClassHierarchy());
-      recordShapeAnnotationCandidates(tt, builder);
+      recordShapeAnnotationCandidates(builder);
 
       return tt;
     } finally {
@@ -1866,14 +1866,15 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * accumulate the raw {@code (source, cause)} pairs during the run (see {@link
    * TensorGenerator#recordShapeAnnotationCandidate}); this reads them before {@link
    * TensorGenerator#clearCaches} drops them, dedups per pointer key (a memoized shape read may
-   * record a source more than once), keeps the strongest classification per key, and intersects
-   * with the final ⊤-shape set so a value another path later resolved is not reported.
+   * record a source more than once), and keeps the strongest classification per key. Every recorded
+   * key is an allocator whose shape did not resolve at its ⊤ floor; the floor is taken as the
+   * signal rather than intersected with the solved ⊤ set, since a manually anchored allocator's
+   * synthetic-return key is absent from the analysis's seeded pointer keys and intersecting would
+   * drop exactly those.
    *
-   * @param tt The solved tensor-type analysis.
    * @param builder The builder whose per-run generator records to read.
    */
-  private void recordShapeAnnotationCandidates(
-      TensorTypeAnalysis tt, PropagationCallGraphBuilder builder) {
+  private void recordShapeAnnotationCandidates(PropagationCallGraphBuilder builder) {
     shapeAnnotationCandidates.clear();
 
     // Keep the strongest classification per source key: a content-dependent finding for any read of

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -81,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -379,6 +380,24 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       LocalPointerKey pointerKey, CGNode node, int valueNumber, int callStringLength) {}
 
   private final List<DepthLimitedResult> depthLimitedResults = new ArrayList<>();
+
+  /**
+   * An allocator whose shape argument did not resolve, with the classified reason (wala/ML#735).
+   * The reason triages the wala/ML#370 annotation worklist: {@link
+   * TensorGenerator.ShapeUnresolutionCause#CONTENT_DEPENDENT} is a genuine annotation candidate
+   * (the shape depends on runtime content), while {@link
+   * TensorGenerator.ShapeUnresolutionCause#RECOVERABLE_GAP} is an analyzer precision gap that a
+   * #370 annotation would wrongly paper over.
+   *
+   * @param pointerKey The pointer key of the allocator's ⊤-shape result (a synthetic {@code do()}
+   *     {@code ReturnValueKey} for a manually anchored allocator, or a local for a caller-site
+   *     one).
+   * @param cause The classified reason the shape argument did not resolve.
+   */
+  public record ShapeAnnotationCandidate(
+      PointerKey pointerKey, TensorGenerator.ShapeUnresolutionCause cause) {}
+
+  private final List<ShapeAnnotationCandidate> shapeAnnotationCandidates = new ArrayList<>();
 
   /**
    * Identifies the dataflow sources for tensor analysis.
@@ -1628,6 +1647,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                     + tt.getOutState(fed));
 
       recordDepthLimitedResults(tt, builder.getClassHierarchy());
+      recordShapeAnnotationCandidates(tt, builder);
 
       return tt;
     } finally {
@@ -1788,6 +1808,19 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   }
 
   /**
+   * Returns the triaged wala/ML#370 shape-annotation worklist from the most recent {@link
+   * #performAnalysis} run (wala/ML#735): each allocator whose shape argument did not resolve, with
+   * the classified reason. A consumer filters to {@link
+   * TensorGenerator.ShapeUnresolutionCause#CONTENT_DEPENDENT} for the genuine annotation
+   * candidates.
+   *
+   * @return The shape-annotation triage records; empty when no allocator shape went unresolved.
+   */
+  public List<ShapeAnnotationCandidate> getShapeAnnotationCandidates() {
+    return shapeAnnotationCandidates;
+  }
+
+  /**
    * Records the ⊤ values whose nodes sit at a call-string context saturated to {@code
    * targetedCfaDepth}, the wala/ML#601 depth-too-short signal. Scans the solved analysis for ⊤
    * tensor variables at local pointer keys, keeps those whose node is routed through the targeted
@@ -1825,6 +1858,59 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                   + " the targeted CFA depth of "
                   + targetedCfaDepth
                   + "; a deeper depth may resolve them. See wala/ML#601.");
+  }
+
+  /**
+   * Records the triaged wala/ML#370 shape-annotation worklist (wala/ML#735): the allocators whose
+   * shape argument did not resolve, classified content-dependent vs recoverable-gap. The generators
+   * accumulate the raw {@code (source, cause)} pairs during the run (see {@link
+   * TensorGenerator#recordShapeAnnotationCandidate}); this reads them before {@link
+   * TensorGenerator#clearCaches} drops them, dedups per pointer key (a memoized shape read may
+   * record a source more than once), keeps the strongest classification per key, and intersects
+   * with the final ⊤-shape set so a value another path later resolved is not reported.
+   *
+   * @param tt The solved tensor-type analysis.
+   * @param builder The builder whose per-run generator records to read.
+   */
+  private void recordShapeAnnotationCandidates(
+      TensorTypeAnalysis tt, PropagationCallGraphBuilder builder) {
+    shapeAnnotationCandidates.clear();
+
+    // Keep the strongest classification per source key: a content-dependent finding for any read of
+    // a source overrides a recoverable or undetermined finding for the same source. The generators
+    // record only at their ⊤ floor, so every recorded key is an allocator whose shape did not
+    // resolve; a manually anchored allocator's synthetic-return key is absent from the analysis's
+    // seeded pointer keys, so intersecting with the solved ⊤ set would drop exactly those, and the
+    // recorded floor is taken as the signal instead.
+    Map<PointerKey, TensorGenerator.ShapeUnresolutionCause> byKey = new HashMap<>();
+    for (Pair<PointerKey, TensorGenerator.ShapeUnresolutionCause> record :
+        TensorGenerator.getShapeAnnotationCandidates(builder)) {
+      PointerKey key = record.fst;
+      byKey.merge(
+          key,
+          record.snd,
+          (a, b) ->
+              a == TensorGenerator.ShapeUnresolutionCause.CONTENT_DEPENDENT
+                      || b == TensorGenerator.ShapeUnresolutionCause.CONTENT_DEPENDENT
+                  ? TensorGenerator.ShapeUnresolutionCause.CONTENT_DEPENDENT
+                  : a == TensorGenerator.ShapeUnresolutionCause.RECOVERABLE_GAP ? a : b);
+    }
+
+    byKey.forEach(
+        (key, cause) -> shapeAnnotationCandidates.add(new ShapeAnnotationCandidate(key, cause)));
+
+    long contentDependent =
+        shapeAnnotationCandidates.stream()
+            .filter(c -> c.cause() == TensorGenerator.ShapeUnresolutionCause.CONTENT_DEPENDENT)
+            .count();
+    if (contentDependent > 0)
+      LOGGER.fine(
+          () ->
+              contentDependent
+                  + " content-dependent allocator shape(s) are wala/ML#370 annotation candidates; "
+                  + (shapeAnnotationCandidates.size() - contentDependent)
+                  + " unresolved allocator shape(s) are recoverable/undetermined precision gaps"
+                  + " (wala/ML#735).");
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -276,6 +276,69 @@ public abstract class TensorGenerator {
       BUILD_CONTRACT_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
 
   /**
+   * Why an allocator's shape argument did not resolve, triaging the wala/ML#370 annotation worklist
+   * (wala/ML#735). The "candidate for a wala/ML#370 shape annotation" suggestion is honest only for
+   * {@link #CONTENT_DEPENDENT}: #370 recovers shapes that depend on runtime content (file loaders,
+   * unmodeled user-function returns), which no static reasoning can derive. A shape whose value is
+   * present in the program but currently missed is a {@link #RECOVERABLE_GAP} &mdash; an analyzer
+   * precision fix, not an annotation request.
+   */
+  public enum ShapeUnresolutionCause {
+    /**
+     * The shape argument roots in a genuinely opaque source (a content-dependent file loader or an
+     * unmodeled user-function return): a true wala/ML#370 annotation candidate.
+     */
+    CONTENT_DEPENDENT,
+    /**
+     * The shape argument roots in an internal computation whose shape is statically present but the
+     * analyzer currently misses (a modeled op whose shape did not resolve, a consumer-constrained
+     * tensor): a precision gap, not a wala/ML#370 candidate.
+     */
+    RECOVERABLE_GAP,
+    /** The argument's provenance could not be classified either way. */
+    UNDETERMINED
+  }
+
+  /**
+   * The shape-annotation triage records accumulated during an analysis, per builder (wala/ML#735).
+   * An allocator whose shape argument does not resolve appends its source's pointer key and the
+   * classified {@link ShapeUnresolutionCause} here; the engine reads the list at the end of the run
+   * (before {@link #clearCaches}) to expose the triaged wala/ML#370 worklist. Recorded eagerly at
+   * the (memoized) shape read, so the same source may appear once; the engine dedups and intersects
+   * with the final ⊤-shape set.
+   */
+  private static final Map<
+          PropagationCallGraphBuilder, List<Pair<PointerKey, ShapeUnresolutionCause>>>
+      SHAPE_ANNOTATION_CANDIDATES = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
+   * Records a shape-annotation triage entry for the given builder (wala/ML#735).
+   *
+   * @param builder The builder whose analysis produced the unresolved allocator shape.
+   * @param source The pointer key of the allocator's result, or {@code null} for a manual anchor.
+   * @param cause The classified reason the shape argument did not resolve.
+   */
+  static void recordShapeAnnotationCandidate(
+      PropagationCallGraphBuilder builder, PointerKey source, ShapeUnresolutionCause cause) {
+    if (source == null) return;
+    SHAPE_ANNOTATION_CANDIDATES
+        .computeIfAbsent(builder, b -> Collections.synchronizedList(new java.util.ArrayList<>()))
+        .add(Pair.make(source, cause));
+  }
+
+  /**
+   * Returns the shape-annotation triage records accumulated for the given builder (wala/ML#735).
+   *
+   * @param builder The builder whose records to read.
+   * @return The recorded {@code (source, cause)} pairs; empty when none were recorded.
+   */
+  static List<Pair<PointerKey, ShapeUnresolutionCause>> getShapeAnnotationCandidates(
+      PropagationCallGraphBuilder builder) {
+    List<Pair<PointerKey, ShapeUnresolutionCause>> ret = SHAPE_ANNOTATION_CANDIDATES.get(builder);
+    return ret == null ? Collections.emptyList() : ret;
+  }
+
+  /**
    * Drops the shape/dtype caches for the given builder. Intended to be called at the end of an
    * analysis to release cache memory deterministically, rather than waiting for the builder to be
    * garbage-collected. Safe to call more than once.
@@ -289,6 +352,7 @@ public abstract class TensorGenerator {
   public static void clearCaches(PropagationCallGraphBuilder builder) {
     STORED_ATTRIBUTE_CACHE.remove(builder);
     BUILD_CONTRACT_CACHE.remove(builder);
+    SHAPE_ANNOTATION_CANDIDATES.remove(builder);
   }
 
   /** The source of the tensor, represented by a points-to set variable. */
@@ -5175,6 +5239,342 @@ public abstract class TensorGenerator {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Callee declaring-class name fragments of the content-dependent loaders wala/ML#370 enumerates:
+   * their result's shape is whatever was on disk or in the input, so no static reasoning recovers
+   * it. Matched as substrings of the invoke target's declaring-class name (wala/ML#735).
+   */
+  private static final String[] CONTENT_DEPENDENT_LOADER_FRAGMENTS = {
+    "numpy/load",
+    "numpy/loadtxt",
+    "numpy/genfromtxt",
+    "numpy/fromfile",
+    "read_csv",
+    "read_parquet",
+    "read_json",
+    "read_pickle",
+    "read_table",
+    "io/read_file",
+    "io/decode",
+    "read_file",
+    "parse_tensor",
+    "pickle/load",
+    "json/load",
+    "loads"
+  };
+
+  /**
+   * The triage clause for an unresolved-allocator-shape diagnostic, phrased by cause (wala/ML#735):
+   * a wala/ML#370 annotation suggestion only for a content-dependent shape, a precision-gap note
+   * for a statically-recoverable one, and a neutral undetermined clause otherwise.
+   *
+   * @param cause The classified reason the shape argument did not resolve.
+   * @return The human-readable triage clause.
+   */
+  protected static String shapeAnnotationTriageMessage(ShapeUnresolutionCause cause) {
+    switch (cause) {
+      case CONTENT_DEPENDENT:
+        return "Content-dependent source; candidate for a wala/ML#370 shape annotation.";
+      case RECOVERABLE_GAP:
+        return "Statically recoverable but currently missed; an analyzer precision gap, not a"
+            + " wala/ML#370 annotation candidate.";
+      default:
+        return "Cause undetermined; not classified as a wala/ML#370 annotation candidate.";
+    }
+  }
+
+  /**
+   * Classifies why this allocator's shape argument did not resolve, to triage the wala/ML#370
+   * annotation worklist (wala/ML#735). The "candidate for a wala/ML#370 shape annotation"
+   * suggestion is honest only when the shape roots in a genuinely opaque source; a shape whose
+   * value is present in the program but currently missed is a precision gap, not an annotation
+   * request.
+   *
+   * <p>The shape argument reaches an allocator's ⊤ floor only with an empty points-to set and after
+   * the {@code .shape}-recovery path failed, so the argument is a runtime-computed value (a shape
+   * vector, a loader result, an unmodeled call). This peels a shape-vector argument to its root
+   * tensor and classifies that root: a root that dispatches to a modeled generator is a {@link
+   * ShapeUnresolutionCause#RECOVERABLE_GAP} (an internal op whose shape the analyzer missed), a
+   * root produced by a content-dependent loader or an unmodeled user function is {@link
+   * ShapeUnresolutionCause#CONTENT_DEPENDENT}, and anything else is {@link
+   * ShapeUnresolutionCause#UNDETERMINED}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param shapeParamPos The positional index of the shape parameter.
+   * @param shapeParamName The keyword name of the shape parameter, or {@code null}.
+   * @return The classified cause; never {@code null}.
+   */
+  protected ShapeUnresolutionCause classifyUnresolvedShapeArgument(
+      PropagationCallGraphBuilder builder, int shapeParamPos, String shapeParamName) {
+    // Source-anchored with a direct invoke (a binary-op or caller-site source): the shape argument
+    // is in this frame.
+    PythonInvokeInstruction call = this.getInvokeInstruction();
+    if (call != null && this.getNode().getIR() != null && this.getNode().getDU() != null) {
+      int argVn;
+      try {
+        argVn = this.getArgumentValueNumber(builder, shapeParamPos, shapeParamName, true);
+      } catch (IllegalStateException e) {
+        argVn = -1;
+      }
+      if (argVn > 0) return this.classifyShapeArgumentInFrame(builder, this.getNode(), argVn);
+      return ShapeUnresolutionCause.UNDETERMINED;
+    }
+
+    // Manual / synthetic-do() anchor (the common allocator case, e.g. the `tf.zeros.do()` result):
+    // the shape argument is written at each caller's call site, not in the synthetic node's frame,
+    // so classify it per caller and keep the strongest finding (wala/ML#735; the manual-anchor
+    // argument path mirrors wala/ML#718's caller-aware resolution).
+    ShapeUnresolutionCause best = ShapeUnresolutionCause.UNDETERMINED;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)
+          || caller.getIR() == null
+          || caller.getDU() == null) continue;
+      PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = -1;
+      if (shapeParamName != null) argVn = pyCall.getUse(shapeParamName);
+      if (argVn == -1 && shapeParamPos >= 0) {
+        int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+        if (shapeParamPos < numPosParams) argVn = pyCall.getUse(shapeParamPos + 1);
+      }
+      if (argVn <= 0) continue;
+      best = strongerCause(best, this.classifyShapeArgumentInFrame(builder, caller, argVn));
+      if (best == ShapeUnresolutionCause.CONTENT_DEPENDENT) break;
+    }
+    return best;
+  }
+
+  /**
+   * Classifies a shape argument resolved to {@code argVn} in {@code node}'s frame (wala/ML#735):
+   * peels a shape-vector argument to its root tensor and classifies that root.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The {@link CGNode} whose IR defines {@code argVn}.
+   * @param argVn The shape-argument value number.
+   * @return The classified cause.
+   */
+  private ShapeUnresolutionCause classifyShapeArgumentInFrame(
+      PropagationCallGraphBuilder builder, CGNode node, int argVn) {
+    if (argVn <= 0 || node.getIR() == null || node.getDU() == null)
+      return ShapeUnresolutionCause.UNDETERMINED;
+    int rootVn = this.peelShapeVectorRoot(builder, node, argVn, HashSetFactory.make());
+    return this.classifyRootValue(builder, node, rootVn);
+  }
+
+  /**
+   * Returns the stronger of two classifications under the dominance order {@link
+   * ShapeUnresolutionCause#CONTENT_DEPENDENT} &gt; {@link ShapeUnresolutionCause#RECOVERABLE_GAP}
+   * &gt; {@link ShapeUnresolutionCause#UNDETERMINED} (wala/ML#735): a content-dependent finding at
+   * any caller makes the source a genuine wala/ML#370 candidate.
+   *
+   * @param a One cause.
+   * @param b The other cause.
+   * @return The dominant cause.
+   */
+  private static ShapeUnresolutionCause strongerCause(
+      ShapeUnresolutionCause a, ShapeUnresolutionCause b) {
+    if (a == ShapeUnresolutionCause.CONTENT_DEPENDENT
+        || b == ShapeUnresolutionCause.CONTENT_DEPENDENT)
+      return ShapeUnresolutionCause.CONTENT_DEPENDENT;
+    if (a == ShapeUnresolutionCause.RECOVERABLE_GAP || b == ShapeUnresolutionCause.RECOVERABLE_GAP)
+      return ShapeUnresolutionCause.RECOVERABLE_GAP;
+    return ShapeUnresolutionCause.UNDETERMINED;
+  }
+
+  /**
+   * Peels a shape-vector argument ({@code t.shape}, {@code t.shape.as_list()}, a slice of one) to
+   * the value number of its root tensor {@code t}, so the classification reasons about the tensor
+   * whose shape the vector reports rather than the vector itself (wala/ML#735). Returns {@code vn}
+   * unchanged when it is not a shape-vector chain.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The shape-argument value number.
+   * @param visited The value numbers already peeled, guarding cyclic def-use chains.
+   * @return The root tensor's value number, or {@code vn} when it is not a shape vector.
+   */
+  private int peelShapeVectorRoot(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<Integer> visited) {
+    if (vn <= 0 || !visited.add(vn) || node.getDU() == null || node.getIR() == null) return vn;
+    SSAInstruction def = node.getDU().getDef(vn);
+    SymbolTable st = node.getIR().getSymbolTable();
+    if (def instanceof PythonPropertyRead) {
+      int memberVn = ((PythonPropertyRead) def).getMemberRef();
+      if (st.isStringConstant(memberVn) && "shape".equals(st.getStringValue(memberVn)))
+        return this.peelShapeVectorRoot(
+            builder, node, ((PythonPropertyRead) def).getObjectRef(), visited);
+      return vn;
+    }
+    if (def instanceof PythonInvokeInstruction) {
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) def;
+      if (invoke.getNumberOfUses() < 1) return vn;
+      SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
+      if (funcDef instanceof PythonPropertyRead) {
+        int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
+        if (st.isStringConstant(memberVn) && "as_list".equals(st.getStringValue(memberVn)))
+          return this.peelShapeVectorRoot(
+              builder, node, ((PythonPropertyRead) funcDef).getObjectRef(), visited);
+      }
+      if (dispatchesToSliceBuiltin(builder, node, invoke) && invoke.getNumberOfUses() >= 2)
+        return this.peelShapeVectorRoot(builder, node, invoke.getUse(1), visited);
+      if (dispatchesToTfShape(builder, node, invoke) && invoke.getNumberOfUses() >= 2)
+        return this.peelShapeVectorRoot(builder, node, invoke.getUse(1), visited);
+    }
+    return vn;
+  }
+
+  /**
+   * Classifies a shape argument's root value as content-dependent, a recoverable gap, or
+   * undetermined (wala/ML#735).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The {@link CGNode} whose IR defines {@code rootVn}.
+   * @param rootVn The root value number.
+   * @return The classified cause.
+   */
+  private ShapeUnresolutionCause classifyRootValue(
+      PropagationCallGraphBuilder builder, CGNode node, int rootVn) {
+    if (rootVn <= 0) return ShapeUnresolutionCause.UNDETERMINED;
+    SSAInstruction def = node.getDU().getDef(rootVn);
+
+    // A recognized content-dependent loader: the shape is whatever was on disk / in the input.
+    if (def instanceof SSAAbstractInvokeInstruction
+        && this.dispatchesToContentDependentLoader(
+            builder, node, (SSAAbstractInvokeInstruction) def))
+      return ShapeUnresolutionCause.CONTENT_DEPENDENT;
+
+    // A root that dispatches to a modeled generator is an internal computation whose shape the
+    // analyzer missed: a precision gap, recoverable in principle from the op's semantics.
+    if (this.rootDispatchesToModeledGenerator(builder, node, rootVn))
+      return ShapeUnresolutionCause.RECOVERABLE_GAP;
+
+    // An unmodeled user-function return (a script function that resolved to no generator) is the
+    // other wala/ML#370 category: the analyzer has no contract for its shape.
+    if (def instanceof SSAAbstractInvokeInstruction
+        && this.dispatchesToUnmodeledUserFunction(
+            builder, node, (SSAAbstractInvokeInstruction) def))
+      return ShapeUnresolutionCause.CONTENT_DEPENDENT;
+
+    return ShapeUnresolutionCause.UNDETERMINED;
+  }
+
+  /**
+   * Returns whether every resolved target of the invoke is one of the content-dependent loaders
+   * wala/ML#370 enumerates (wala/ML#735).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @param node The calling {@link CGNode}.
+   * @param invoke The invoke instruction to test.
+   * @return {@code true} iff a resolved target is a recognized content-dependent loader.
+   */
+  private boolean dispatchesToContentDependentLoader(
+      PropagationCallGraphBuilder builder, CGNode node, SSAAbstractInvokeInstruction invoke) {
+    Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+    if (targets != null)
+      for (CGNode target : targets) {
+        String name = target.getMethod().getDeclaringClass().getReference().getName().toString();
+        for (String fragment : CONTENT_DEPENDENT_LOADER_FRAGMENTS)
+          if (name.contains(fragment)) return true;
+      }
+    // A content-dependent loader is often entirely unmodeled, so the call graph resolves no
+    // target and the declaring-class check above sees nothing. Fall back to the invoked
+    // function's member name (`np.loadtxt`, `pd.read_csv`, `tf.io.read_file`): a property read
+    // whose member matches a recognized loader (wala/ML#735).
+    if (invoke instanceof PythonInvokeInstruction && node.getDU() != null && node.getIR() != null) {
+      SSAInstruction funcDef = node.getDU().getDef(invoke.getUse(0));
+      if (funcDef instanceof PythonPropertyRead) {
+        SymbolTable st = node.getIR().getSymbolTable();
+        int memberVn = ((PythonPropertyRead) funcDef).getMemberRef();
+        if (st.isStringConstant(memberVn)
+            && isContentDependentLoaderMember(st.getStringValue(memberVn))) return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the given invoked-function member name is one of the content-dependent loaders
+   * wala/ML#370 enumerates (wala/ML#735). Kept specific so a benign member (e.g. {@code
+   * model.load_weights}) does not match: the bare {@code load}/{@code loads} names are the {@code
+   * numpy}/{@code pickle}/{@code json} loaders.
+   *
+   * @param member The member name read off the call's receiver.
+   * @return {@code true} for a recognized loader member.
+   */
+  private static boolean isContentDependentLoaderMember(String member) {
+    switch (member) {
+      case "load":
+      case "loads":
+      case "loadtxt":
+      case "genfromtxt":
+      case "fromfile":
+      case "read_csv":
+      case "read_parquet":
+      case "read_json":
+      case "read_pickle":
+      case "read_table":
+      case "read_file":
+      case "decode_csv":
+      case "decode_image":
+      case "decode_jpeg":
+      case "decode_png":
+      case "parse_tensor":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Returns whether the root value dispatches to a modeled {@link TensorGenerator} &mdash; i.e. it
+   * is produced by an op the analyzer models, so its shape is recoverable in principle even when
+   * the current analysis missed it (wala/ML#735).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param node The {@link CGNode} whose IR defines {@code rootVn}.
+   * @param rootVn The root value number.
+   * @return {@code true} iff the root's points-to producer resolves to a generator.
+   */
+  private boolean rootDispatchesToModeledGenerator(
+      PropagationCallGraphBuilder builder, CGNode node, int rootVn) {
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, rootVn);
+    if (builder.getPropagationSystem().isImplicit(pk)) return false;
+    PointsToSetVariable var = builder.getPropagationSystem().findOrCreatePointsToSet(pk);
+    if (var == null) return false;
+    try {
+      TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
+      return generator != null && !this.isSameOperation(generator);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether every resolved target of the invoke is an unmodeled user-defined function: a
+   * script-level function (not a synthetic op summary) that dispatched to no generator, the
+   * wala/ML#370 "unmodeled user-function return" category (wala/ML#735).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @param node The calling {@link CGNode}.
+   * @param invoke The invoke instruction to test.
+   * @return {@code true} iff a resolved target is an unmodeled script function.
+   */
+  private boolean dispatchesToUnmodeledUserFunction(
+      PropagationCallGraphBuilder builder, CGNode node, SSAAbstractInvokeInstruction invoke) {
+    Set<CGNode> targets = builder.getCallGraph().getPossibleTargets(node, invoke.getCallSite());
+    if (targets == null || targets.isEmpty()) return false;
+    boolean sawScriptFunction = false;
+    for (CGNode target : targets) {
+      String name = target.getMethod().getDeclaringClass().getReference().getName().toString();
+      // A synthetic op summary (`Ltensorflow/...`, `Lnumpy/...`) is modeled, not a user function;
+      // its unresolved shape is a modeling gap the loader/generator arms already ruled on.
+      if (name.startsWith("Lscript ") || name.contains("/script ")) sawScriptFunction = true;
+      else return false;
+    }
+    return sawScriptFunction;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -119,14 +119,20 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
       return fromShapeAttribute;
     }
 
-    // Emit a discoverable marker so the ⊤ here is distinguishable from a "true" ⊤ elsewhere: this
-    // is exactly the set of sites where a user-supplied shape annotation would help. The set is
-    // grep-able as the wala/ML#370 annotation worklist without aborting the rest of the analysis
+    // Triage the ⊤ so the wala/ML#370 worklist stays honest: suggest an annotation only for a
+    // genuinely content-dependent shape, and mark a statically-recoverable-but-missed shape as a
+    // precision gap instead (wala/ML#735). The set stays grep-able and the analysis does not abort
     // (which is what throwing here did, wala/ML#604).
+    ShapeUnresolutionCause cause =
+        this.classifyUnresolvedShapeArgument(
+            builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+    recordShapeAnnotationCandidate(builder, source == null ? null : source.getPointerKey(), cause);
     LOGGER.fine(
-        "Unresolved allocator shape for source: "
-            + describe(source)
-            + "; returning ⊤ (unknown shape). Candidate for a wala/ML#370 shape annotation.");
+        () ->
+            "Unresolved allocator shape for source: "
+                + describe(source)
+                + "; returning ⊤ (unknown shape). "
+                + shapeAnnotationTriageMessage(cause));
     return null;
   }
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_annotation_triage.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_annotation_triage.py
@@ -1,0 +1,21 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# Content-dependent: the shape flows from an opaque file loader. A genuine wala/ML#370 candidate.
+# Analyzed statically (the loaded file need not exist), like the vendored dataset fixtures.
+loaded = np.load("data.npy")
+a = tf.zeros(loaded.shape)
+consume(a)
+
+# Recoverable gap: the shape flows from a modeled op (transpose) whose shape the analyzer missed
+# for a non-content reason (a runtime-computed perm), not from an opaque source.
+x = tf.ones((2, 3, 4))
+perm = tf.random.shuffle(tf.range(3))
+t = tf.transpose(x, perm)
+b = tf.zeros(t.shape)
+consume(b)


### PR DESCRIPTION
Closes wala/ML#735: the "candidate for a wala/ML#370 shape annotation" suggestion no longer fires for statically-recoverable shapes.

An allocator whose shape argument does not resolve is now classified before the ⊤ floor's diagnostic. wala/ML#370 recovers shapes that depend on runtime content (file loaders, unmodeled user-function returns), which no static reasoning can derive; a shape whose value is present in the program but currently missed is an analyzer precision gap, and suggesting an annotation for it mis-triages a fixable gap as an annotation request. The classifier peels a shape-vector argument (`t.shape`, `.as_list()`, a slice) to its root tensor and reads the root: a root that dispatches to a modeled generator is a recoverable gap, a root produced by a recognized content-dependent loader or an unmodeled user function is content-dependent, and anything else is undetermined. A realistic allocator (`tf.zeros(...)`) is anchored at the synthetic `do()` return, so the shape argument lives at the call site rather than in the synthetic frame; the classifier walks the callers and reads the argument in each caller's frame, keeping the strongest finding.

The `TensorTypeAllocator` and `Fill` diagnostics phrase the wala/ML#370 suggestion only for a content-dependent shape and mark a recoverable one as a precision gap. A structured `getShapeAnnotationCandidates()` engine signal (mirroring the wala/ML#601 `DepthLimitedResult` pattern) exposes the triaged worklist for consumers, filtered to the content-dependent cause for the genuine candidates.

`testShapeAnnotationTriage` pins the two cases against one fixture: `tf.zeros(np.load(...).shape)` classifies content-dependent, and `tf.zeros(tf.transpose(...).shape)` (a modeled-op root whose shape the analyzer missed) classifies as a recoverable gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmWVYtFE9fw4A6xFhFo8cq
