### PR TITLE
Expose starred (unpacked) positional arguments on `PythonInvokeInstruction` (wala/ML#751)

### DIFF
--- a/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
+++ b/com.ibm.wala.cast.python.jython3/source/com/ibm/wala/cast/python/parser/PythonParser.java
@@ -797,7 +797,23 @@ public abstract class PythonParser<T> extends AbstractParser implements Translat
           new CAstNode[arg0.getInternalArgs().size() + arg0.getInternalKeywords().size() + 1];
       args[i++] = Ast.makeNode(CAstNode.EMPTY);
       for (expr e : arg0.getInternalArgs()) {
-        args[i++] = notePosition(e.accept(this), e);
+        CAstNode argNode = notePosition(e.accept(this), e);
+        if (e instanceof Starred) {
+          // Wrap a starred (unpacked) positional argument (`*rest`) so the CAst-to-IR translator
+          // can tell it apart from an ordinary positional and degrade positional-to-parameter
+          // alignment past it. Without this the star is erased (visitStarred returns the inner
+          // value unchanged), leaving the unpack indistinguishable from one ordinary argument. The
+          // wrapper mirrors the keyword ARRAY_LITERAL form but carries the starred marker in place
+          // of a keyword name. See wala/ML#751.
+          argNode =
+              notePosition(
+                  Ast.makeNode(
+                      CAstNode.ARRAY_LITERAL,
+                      Ast.makeConstant(PythonCAstToIRTranslator.STARRED_ARGUMENT_MARKER),
+                      argNode),
+                  e);
+        }
+        args[i++] = argNode;
       }
       for (keyword k : arg0.getInternalKeywords()) {
         args[i++] =

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestStarArgAlignment.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestStarArgAlignment.java
@@ -1,0 +1,154 @@
+package com.ibm.wala.cast.python.ml.test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ssa.SSAInstruction;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Tests that a starred (unpacked) positional call argument (e.g. the {@code *rest} in {@code f(a,
+ * *rest, b)}) is recorded on the {@link PythonInvokeInstruction} so a positional-alignment consumer
+ * can degrade past it rather than mis-align every argument after the unpack. See <a
+ * href="https://github.com/wala/ML/issues/751">wala/ML#751</a>.
+ */
+public class TestStarArgAlignment extends TestPythonMLCallGraphShape {
+
+  /**
+   * The {@code combine(tf.constant(...), *rest, i)} call in {@code tf751_star_align.py} has three
+   * syntactic positional arguments after the callable: the tensor, the {@code *rest} unpack, and
+   * the trailing {@code i}. The invoke therefore carries four positional slots (the callable plus
+   * those three), and slot 2 (the {@code *rest}) is the sole starred slot. Before wala/ML#751 the
+   * unpack was indistinguishable from an ordinary argument.
+   *
+   * @throws Exception On analysis error.
+   */
+  @Test
+  public void testStarredSlotRecorded() throws Exception {
+    PythonTensorAnalysisEngine engine =
+        (PythonTensorAnalysisEngine) makeEngine("tf751_star_align.py");
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+
+    List<PythonInvokeInstruction> starredCalls = new ArrayList<>();
+    for (CGNode node : CG) {
+      if (!node.getMethod().getSignature().contains(".driver.")) continue;
+      if (node.getIR() == null) continue;
+      for (SSAInstruction inst : node.getIR().getInstructions())
+        if (inst instanceof PythonInvokeInstruction) {
+          PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+          if (call.getStarredPositions().length > 0) starredCalls.add(call);
+        }
+    }
+
+    assertEquals(
+        "Exactly one call in `driver` unpacks a starred argument.", 1, starredCalls.size());
+    PythonInvokeInstruction combineCall = starredCalls.get(0);
+    assertEquals(
+        "The `combine(tensor, *rest, i)` call has four positional slots.",
+        4,
+        combineCall.getNumberOfPositionalParameters());
+    assertArrayEquals(
+        "The `*rest` unpack is the sole starred slot, at index 2.",
+        new int[] {2},
+        combineCall.getStarredPositions());
+    assertEquals(
+        "The first starred slot bounds where positional alignment becomes unreliable.",
+        2,
+        combineCall.firstStarredPosition());
+    assertTrue(combineCall.isPositionalSlotStarred(2));
+  }
+
+  /**
+   * An ordinary call with no unpack records no starred slots, so the marker does not fire
+   * spuriously and existing positional alignment is unaffected.
+   *
+   * @throws Exception On analysis error.
+   */
+  @Test
+  public void testNoStarredSlotOnOrdinaryCall() throws Exception {
+    PythonTensorAnalysisEngine engine =
+        (PythonTensorAnalysisEngine) makeEngine("tf751_star_align.py");
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    assertNotNull(CG);
+
+    boolean sawOrdinaryCall = false;
+    for (CGNode node : CG) {
+      if (node.getIR() == null) continue;
+      for (SSAInstruction inst : node.getIR().getInstructions())
+        if (inst instanceof PythonInvokeInstruction) {
+          PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+          // `combine`'s body calls `tf.reduce_sum(a)`, an ordinary unstarred call.
+          if (node.getMethod().getSignature().contains(".combine.")) {
+            sawOrdinaryCall = true;
+            assertEquals(
+                "An ordinary call records no starred slots.", 0, call.getStarredPositions().length);
+            assertEquals(-1, call.firstStarredPosition());
+          }
+        }
+    }
+    assertTrue("The reproduction must exercise `combine`'s ordinary calls.", sawOrdinaryCall);
+  }
+
+  /**
+   * Captured gap for the argument-<em>binding</em> half of wala/ML#751. Exposing the starred slot
+   * (above) lets a consumer distrust the alignment, but the analysis still binds the arguments
+   * themselves incorrectly: in {@code combine(tf.constant(...), *rest, i)} the whole {@code rest}
+   * sequence floods {@code combine}'s first covered parameter {@code b} instead of spreading across
+   * {@code b} and {@code c}, and the trailing {@code i} never reaches {@code scale}. This is the
+   * behavior the maintainer's points-to dump on wala/ML#751 records. Fixing it requires degrading
+   * the actual-to-formal binding past a starred slot in <em>both</em> the trampoline forwarding and
+   * the direct function-call dispatch (a plain function call like {@code combine} does not go
+   * through the trampoline), so it is tracked separately from the marker exposure.
+   *
+   * <p>This test pins the current (incorrect) binding so it becomes a positive regression guard
+   * once the binding degrades: {@code combine}'s {@code b} parameter (vn=3) currently points to the
+   * {@code rest} list. When the binding is fixed, {@code b} will instead be unbound (empty
+   * points-to set) because an unpack of statically-unknown length cannot be aligned to a specific
+   * parameter.
+   *
+   * <p>TODO(<a href="https://github.com/wala/ML/issues/751">wala/ML#751</a>): flip this assertion
+   * to expect an empty points-to set for {@code b} once the binding degrades past the unpack.
+   *
+   * @throws Exception On analysis error.
+   */
+  @Test
+  public void testBindingFloodsFirstParameterPastUnpackCapturedGap() throws Exception {
+    PythonTensorAnalysisEngine engine =
+        (PythonTensorAnalysisEngine) makeEngine("tf751_star_align.py");
+    PythonSSAPropagationCallGraphBuilder builder = engine.defaultCallGraphBuilder();
+    CallGraph CG = builder.makeCallGraph(builder.getOptions());
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+
+    boolean checkedCombine = false;
+    for (CGNode node : CG) {
+      if (!node.getMethod().getSignature().contains(".combine.")) continue;
+      if (node.getIR() == null) continue;
+      // combine.do()'s parameters are (callable, a, b, c, scale); `b` is vn=3.
+      int b = node.getIR().getSymbolTable().getParameter(2);
+      PointerKey bKey = pa.getHeapModel().getPointerKeyForLocal(node, b);
+      assertFalse(
+          "Captured gap for wala/ML#751: the `*rest` unpack floods `combine`'s `b` parameter"
+              + " instead of leaving it unbound. Flip to expect an empty points-to set when the"
+              + " actual-to-formal binding degrades past a starred slot.",
+          pa.getPointsToSet(bKey).isEmpty());
+      checkedCombine = true;
+    }
+    assertTrue("The reproduction must reach `combine`.", checkedCombine);
+  }
+}

--- a/com.ibm.wala.cast.python.test/data/tf751_star_align.py
+++ b/com.ibm.wala.cast.python.test/data/tf751_star_align.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def combine(a, b, c, scale=1):
+    return tf.reduce_sum(a) * scale
+
+
+def driver(rest):
+    for i in range(3):
+        combine(tf.constant([1.0, 2.0]), *rest, i)
+
+
+driver([tf.constant([3.0, 4.0]), tf.constant([5.0, 6.0])])

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -86,6 +86,17 @@ public class PythonCAstToIRTranslator extends AstTranslator {
 
   private static final Logger LOGGER = Logger.getLogger(PythonCAstToIRTranslator.class.getName());
 
+  /**
+   * Marker stored as the name of the {@code ARRAY_LITERAL} wrapper the parser emits for a starred
+   * (unpacked) positional call argument (e.g. {@code *rest} in {@code f(a, *rest, b)}). A starred
+   * argument reuses the same {@code ARRAY_LITERAL} form as a keyword argument but carries this
+   * marker in place of a keyword name, so {@link #doCall} can route it to a positional slot rather
+   * than a keyword and record the slot as starred. The value is not a valid Python identifier, so
+   * it cannot collide with a real keyword name. See <a
+   * href="https://github.com/wala/ML/issues/751">wala/ML#751</a>.
+   */
+  public static final String STARRED_ARGUMENT_MARKER = "*starred*";
+
   private final Map<CAstType, TypeName> walaTypeNames = HashMapFactory.make();
 
   /**
@@ -1006,14 +1017,25 @@ public class PythonCAstToIRTranslator extends AstTranslator {
     List<Position> keypos = new ArrayList<Position>();
     List<Integer> posp = new ArrayList<Integer>();
     List<Pair<String, Integer>> keyp = new ArrayList<Pair<String, Integer>>();
+    List<Integer> starred = new ArrayList<Integer>();
     posp.add(receiver);
     pospos.add(context.getSourceMap().getPosition(call.getChild(0)));
     for (int i = 2; i < call.getChildCount(); i++) {
       CAstNode cl = call.getChild(i);
       if (cl.getKind() == CAstNode.ARRAY_LITERAL) {
-        keyp.add(
-            Pair.make(String.valueOf(cl.getChild(0).getValue()), context.getValue(cl.getChild(1))));
-        keypos.add(context.getSourceMap().getPosition(cl));
+        String tag = String.valueOf(cl.getChild(0).getValue());
+        if (STARRED_ARGUMENT_MARKER.equals(tag)) {
+          // A starred (unpacked) positional argument, `*rest`. The parser wraps it in the same
+          // ARRAY_LITERAL form as a keyword but tags it with the marker; route it to a positional
+          // slot and record that slot so downstream positional-to-parameter alignment can degrade
+          // past an unpack of statically-unknown length (wala/ML#751).
+          starred.add(posp.size());
+          posp.add(context.getValue(cl.getChild(1)));
+          pospos.add(context.getSourceMap().getPosition(cl));
+        } else {
+          keyp.add(Pair.make(tag, context.getValue(cl.getChild(1))));
+          keypos.add(context.getSourceMap().getPosition(cl));
+        }
       } else {
         posp.add(context.getValue(cl));
         pospos.add(context.getSourceMap().getPosition(cl));
@@ -1029,6 +1051,11 @@ public class PythonCAstToIRTranslator extends AstTranslator {
       hack[i] = posp.get(i);
     }
 
+    int[] starredArr = new int[starred.size()];
+    for (int i = 0; i < starredArr.length; i++) {
+      starredArr[i] = starred.get(i);
+    }
+
     int pos = context.cfg().getCurrentInstruction();
     CallSiteReference site = new DynamicCallSiteReference(PythonTypes.CodeBody, pos);
 
@@ -1036,7 +1063,13 @@ public class PythonCAstToIRTranslator extends AstTranslator {
         .cfg()
         .addInstruction(
             new PythonInvokeInstruction(
-                pos, result, exception, site, hack, keyp.toArray(new Pair[keyp.size()])));
+                pos,
+                result,
+                exception,
+                site,
+                hack,
+                keyp.toArray(new Pair[keyp.size()]),
+                starredArr));
 
     pospos.addAll(keypos);
     context.cfg().noteOperands(pos, pospos.toArray(new Position[pospos.size()]));

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ssa/PythonInvokeInstruction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ssa/PythonInvokeInstruction.java
@@ -28,6 +28,16 @@ public class PythonInvokeInstruction extends SSAAbstractInvokeInstruction {
   private final int[] positionalParams;
   private final Pair<String, Integer>[] keywordParams;
 
+  /**
+   * Indices into {@link #positionalParams} whose call-site argument was a starred (unpacked)
+   * expression (e.g. the {@code *rest} in {@code f(a, *rest, b)}). A starred slot collapses an
+   * unpacked sequence of statically-unknown length into a single positional slot, so a consumer
+   * that aligns positional slots to callee parameters by index cannot trust the alignment of any
+   * slot at or after a starred one. Empty for calls with no unpack (the common case). See <a
+   * href="https://github.com/wala/ML/issues/751">wala/ML#751</a>.
+   */
+  private final int[] starredPositions;
+
   public PythonInvokeInstruction(
       int iindex,
       int result,
@@ -35,11 +45,25 @@ public class PythonInvokeInstruction extends SSAAbstractInvokeInstruction {
       CallSiteReference site,
       int[] positionalParams,
       Pair<String, Integer>[] keywordParams) {
+    this(iindex, result, exception, site, positionalParams, keywordParams, EMPTY_STARRED);
+  }
+
+  public PythonInvokeInstruction(
+      int iindex,
+      int result,
+      int exception,
+      CallSiteReference site,
+      int[] positionalParams,
+      Pair<String, Integer>[] keywordParams,
+      int[] starredPositions) {
     super(iindex, exception, site);
     this.positionalParams = positionalParams;
     this.keywordParams = keywordParams;
+    this.starredPositions = starredPositions;
     this.result = result;
   }
+
+  private static final int[] EMPTY_STARRED = new int[0];
 
   @Override
   public int getNumberOfPositionalParameters() {
@@ -48,6 +72,39 @@ public class PythonInvokeInstruction extends SSAAbstractInvokeInstruction {
 
   public int getNumberOfKeywordParameters() {
     return keywordParams.length;
+  }
+
+  /**
+   * The positional-slot indices whose call-site argument was a starred (unpacked) expression.
+   *
+   * @return the starred positional-slot indices, empty if the call has no unpack.
+   */
+  public int[] getStarredPositions() {
+    return starredPositions;
+  }
+
+  /**
+   * Whether the given positional slot's call-site argument was a starred (unpacked) expression.
+   *
+   * @param slot The positional-slot index to test.
+   * @return {@code true} iff the slot was a starred argument.
+   */
+  public boolean isPositionalSlotStarred(int slot) {
+    for (int s : starredPositions) if (s == slot) return true;
+    return false;
+  }
+
+  /**
+   * The smallest starred positional-slot index, at or after which positional-to-parameter alignment
+   * is unreliable (an unpack of statically-unknown length precedes those slots). See <a
+   * href="https://github.com/wala/ML/issues/751">wala/ML#751</a>.
+   *
+   * @return the first starred slot index, or {@code -1} if the call has no unpack.
+   */
+  public int firstStarredPosition() {
+    int min = -1;
+    for (int s : starredPositions) if (min == -1 || s < min) min = s;
+    return min;
   }
 
   public int getNumberOfTotalParameters() {
@@ -118,7 +175,7 @@ public class PythonInvokeInstruction extends SSAAbstractInvokeInstruction {
       }
     }
 
-    return new PythonInvokeInstruction(iIndex(), nr, ne, site, newpos, newkey);
+    return new PythonInvokeInstruction(iIndex(), nr, ne, site, newpos, newkey, starredPositions);
   }
 
   @Override


### PR DESCRIPTION
Advances wala/ML#751: a starred (unpacked) positional call argument is now recorded on `PythonInvokeInstruction`, so a positional-alignment consumer can distrust the alignment of every slot at or after an unpack instead of reading a starred slot as one ordinary argument.

## The Gap

`f(a, *rest, b)` lowers each syntactic positional argument, including the `*rest` unpack, to a single positional slot of the invoke. Nothing distinguished a starred slot from a plain one, so a consumer aligning invoke slots to callee parameters by index read the single `rest` slot as covering exactly one parameter and mis-attributed every argument after it. The star was erased at the parser: `visitStarred` returned the inner value unchanged (a literal `// FIXME`), so by the time the CAst existed the unpack was byte-identical to an ordinary `VAR`.

## The Change

The parser wraps a starred positional argument in the same `ARRAY_LITERAL` form it already uses for a keyword argument, tagged with a marker in place of a keyword name (the marker is not a valid Python identifier, so it cannot collide with one). `doCall` routes a marker-tagged slot to a positional slot rather than a keyword and records the slot index as starred. `PythonInvokeInstruction` carries the starred slot indices, exposed through `getStarredPositions`, `isPositionalSlotStarred`, and `firstStarredPosition`, and preserved across `copyForSSA`. Calls with no unpack record nothing, so existing positional and keyword handling is unchanged.

`testStarredSlotRecorded` and `testNoStarredSlotOnOrdinaryCall` pin the marker on the `combine(tf.constant(...), *rest, i)` reproduction and confirm it does not fire on ordinary calls.

## Remaining Work (Captured)

Exposing the marker lets a consumer distrust the alignment, but the analysis still binds the arguments themselves incorrectly: the unpacked sequence floods the first covered parameter and later arguments are dropped, as the maintainer's points-to dump on wala/ML#751 records. Degrading the actual-to-formal binding past a starred slot is a separate change spanning both the trampoline forwarding and the direct function-call dispatch (a plain function call does not go through the trampoline), and is tracked by `testBindingFloodsFirstParameterPastUnpackCapturedGap`, a captured-gap guard that flips to a positive regression check when the binding degrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
