### PR TITLE
Don't type a loop-carried `list` concatenation as a tensor (wala/ML#750)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -4966,6 +4966,26 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * Companion to {@link #testListConcatNotTensor()} for the {@code tuple} arm of the wala/ML#750
+   * fix. {@code _divide_note_tuple} accumulates a loop-carried {@code tuple} with {@code
+   * result_tuple += (on, off)}. Like the list case, the {@code +} binop is gated by operand tensor
+   * evidence, and the loop-carried {@code tuple}'s allocation is reached only through its points-to
+   * set. A {@code tuple} concatenation is not a tensor op, so the accumulator's {@code tuple}
+   * allocation must not count as tensor evidence and {@code _divide_note_tuple} must have no tensor
+   * variables.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error.
+   */
+  @Test
+  public void testTupleConcatNotTensor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf750_list_concat.py", "_divide_note_tuple", 0, 0);
+  }
+
+  /**
    * Regression test for <a href="https://github.com/wala/ML/issues/653">wala/ML#653</a>: Python
    * list repetition ({@code [0] * 3}) is not a tensor. The {@code *} binop has a {@code list}
    * operand and an {@code int} operand, so it is list repetition (producing a list), not tensor

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -1614,10 +1614,23 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
             Set.of(TENSOR_1_2_FLOAT32, TENSOR_2_2_FLOAT32)));
   }
 
+  /**
+   * {@code add(a, b)} is called only as {@code add(list, list)} where {@code list = [tf.ones([1,
+   * 2]), tf.ones([2, 2])]}, so {@code a} and {@code b} are Python lists. {@code a + b} is therefore
+   * list concatenation, not a tensor add, so {@code add} has no tensor variables. Before
+   * wala/ML#750 the {@code list} operands' allocations were counted as tensor evidence and {@code a
+   * + b} was falsely typed as a tensor (the local count was 1); the concatenation is now correctly
+   * not a tensor.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error.
+   */
   @Test
   public void testTensorList2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_tensor_list2.py", "add", 0, 1);
+    test("tf2_test_tensor_list2.py", "add", 0, 0);
   }
 
   @Test
@@ -4627,19 +4640,22 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
    * {@code (256, 784)} dtype {@code float32} (verified by Python assert statements in {@code
    * autoencoder.py}).
    *
-   * <p>Expected tensor variable count: 4. Rule-based would be 6 (1 parameter + 5 intermediate ops
-   * {@code encoder(x)} result, {@code decoder(...) = reconstructed_image}, {@code mean_square(...)
-   * = loss}, {@code trainable_variables}, {@code gradients}), dropping to 4 if list-of-tensors
-   * values don't register. After wala/ML#430's {@code Gradient} generator, {@code gradients} now
-   * registers as one fresh tensor variable; combined with the previously-registered tensors the
-   * count reaches 4 — matching the rule-based-minus-{@code trainable_variables} ceiling. (Pre-#430
-   * the count was 1, so the master baseline of 3 had been deliberately preserved as a regression
-   * canary; that role is now superseded by reaching the rule-based ceiling.)
+   * <p>Expected local tensor variable count: 5, the tensor-producing values {@code encoder(x)}
+   * result, {@code decoder(...) = reconstructed_image}, {@code mean_square(...) = loss}, {@code
+   * gradients} (a fresh tensor variable since wala/ML#430's {@code Gradient} generator), and the
+   * returned {@code loss} alias. The count dropped from 6 to 5 with wala/ML#750: {@code
+   * trainable_variables = list(weights.values()) + list(biases.values())} is a Python list
+   * concatenation, not a tensor, so it no longer falsely registers as a tensor variable.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error.
    */
   @Test
   public void testAutoencoder3()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("autoencoder.py", "run_optimization", 1, 6, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
+    test("autoencoder.py", "run_optimization", 1, 5, Map.of(2, Set.of(TENSOR_256_784_FLOAT32)));
   }
 
   /**
@@ -4919,6 +4935,34 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   public void testSliceOpaqueIter()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_slice_opaque_iter.py", "consume", 0, 0);
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/wala/ML/issues/750">wala/ML#750</a>: a Python
+   * list concatenation accumulated in a loop ({@code result_array += [on, off]}) is not a tensor.
+   * The pattern is vendored from {@code MusicTransformer-tensorflow2.0}'s {@code
+   * midi_processor/processor.py} {@code _divide_note}, where {@code on}/{@code off} are plain
+   * {@code SplitNote} objects and {@code result_array} is a list. The concatenation's {@code +}
+   * binop lands in {@link
+   * com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine#getDataflowSources}'s {@code
+   * SSABinaryOpInstruction} branch, so it is gated by operand tensor evidence. The loop-carried
+   * {@code result_array} is a phi over the initial {@code []} allocation and the previous
+   * concatenation, so its {@code list} allocation is reached only through its points-to set, not
+   * its own def. Before the fix, the points-to-set tensor-evidence check counted that {@code list}
+   * allocation as evidence, so the binop dispatched to {@code ElementWiseOperation} and typed the
+   * result as a tensor; that type then fed back through the loop into {@code result_array}, a
+   * self-reinforcing false tensor with a {@code TENSORFLOW} origin. {@code _divide_note} must have
+   * no tensor variables.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error.
+   */
+  @Test
+  public void testListConcatNotTensor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf750_list_concat.py", "_divide_note", 0, 0);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -797,7 +797,20 @@ public class TensorGeneratorFactory {
     PointsToSetVariable operandSrc = getPointsToSetVariable(pk, builder);
     if (operandSrc != null && tryGetGenerator(operandSrc, builder, visited) != null) return true;
     for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(pk)) {
-      if (!(ik instanceof ConstantKey)) return true;
+      if (ik instanceof ConstantKey) continue;
+      // A Python `list`/`tuple` allocation in the operand's PTS is not tensor evidence: a `+` binop
+      // over it is list/tuple concatenation and a `*` is repetition, neither a tensor op. The
+      // structural check above only catches an operand whose own def is the allocating `new`; a
+      // loop-carried container (a phi over the accumulator and the previous concatenation result)
+      // reaches its allocation only through its PTS, so without this a `result_array += [...]`
+      // accumulator is misread as a tensor, and the concatenation's result feeds back through the
+      // loop into a self-reinforcing tensor type. Mirrors the structural exclusion so both the
+      // direct and PTS-reached container operands gate identically. wala/ML#750.
+      if (ik instanceof AllocationSiteInNode) {
+        TypeReference allocated = ((AllocationSiteInNode) ik).getSite().getDeclaredType();
+        if (allocated.equals(PythonTypes.list) || allocated.equals(PythonTypes.tuple)) continue;
+      }
+      return true;
     }
     return false;
   }

--- a/com.ibm.wala.cast.python.test/data/tf750_list_concat.py
+++ b/com.ibm.wala.cast.python.test/data/tf750_list_concat.py
@@ -1,0 +1,29 @@
+import tensorflow as tf
+
+
+class SplitNote:
+    def __init__(self, type, time, value, velocity):
+        self.type = type
+        self.time = time
+        self.value = value
+        self.velocity = velocity
+
+
+def _divide_note(notes):
+    result_array = []
+    for note in notes:
+        on = SplitNote("note_on", note.start, note.pitch, note.velocity)
+        off = SplitNote("note_off", note.end, note.pitch, None)
+        result_array += [on, off]
+    return result_array
+
+
+def encode_midi(notes):
+    return _divide_note(notes)
+
+
+def consume(x):
+    return x
+
+
+consume(encode_midi([]))

--- a/com.ibm.wala.cast.python.test/data/tf750_list_concat.py
+++ b/com.ibm.wala.cast.python.test/data/tf750_list_concat.py
@@ -1,6 +1,3 @@
-import tensorflow as tf
-
-
 class SplitNote:
     def __init__(self, type, time, value, velocity):
         self.type = type
@@ -18,8 +15,21 @@ def _divide_note(notes):
     return result_array
 
 
+def _divide_note_tuple(notes):
+    result_tuple = ()
+    for note in notes:
+        on = SplitNote("note_on", note.start, note.pitch, note.velocity)
+        off = SplitNote("note_off", note.end, note.pitch, None)
+        result_tuple += (on, off)
+    return result_tuple
+
+
 def encode_midi(notes):
     return _divide_note(notes)
+
+
+def encode_midi_tuple(notes):
+    return _divide_note_tuple(notes)
 
 
 def consume(x):
@@ -27,3 +37,4 @@ def consume(x):
 
 
 consume(encode_midi([]))
+consume(encode_midi_tuple([]))


### PR DESCRIPTION
Closes wala/ML#750: a Python list concatenation accumulated in a loop is no longer mis-typed as a tensor, so a barren pure-Python function no longer acquires a `TENSORFLOW`-origin tensor definition.

## Root Cause

`getDataflowSources` seeds every `SSABinaryOpInstruction` result as a candidate tensor source, and `TensorGeneratorFactory` gates the `ElementWiseOperation` dispatch on operand tensor evidence (wala/ML#451): the binop is only element-wise if an operand is itself a tensor. Tensor evidence is checked structurally (an operand whose own def is a `list`/`tuple` allocation is not a tensor, wala/ML#653) and by points-to-set content (any non-`ConstantKey` instance key counts).

In `result_array += [on, off]`, the accumulator `result_array` is a phi over the initial `[]` allocation and the previous concatenation, so its `list` allocation is reached only through its points-to set, not its own def. The structural exclusion therefore missed it, and the points-to-set check counted the `list` allocation as tensor evidence. The binop dispatched to `ElementWiseOperation` and typed the concatenation result as a tensor; that type fed back through the loop into `result_array`, a self-reinforcing false tensor. A consumer's provenance check then read the barren function as performing a tensor computation.

## Fix

The points-to-set tensor-evidence check now skips `list`/`tuple` allocations, mirroring the structural exclusion so a container operand gates identically whether its allocation is reached through its own def or its points-to set. A concatenation over lists has no tensor evidence, so it is not typed as a tensor. An operand whose points-to set contains an actual tensor still counts, so legitimate tensor binops are unaffected.

## Validation

`testListConcatNotTensor` vendors the pattern from `MusicTransformer-tensorflow2.0`'s `midi_processor/processor.py` `_divide_note` and asserts it has no tensor variables; it fails before the fix (two false tensor locals) and passes after. The vendored slice reproduces the same SSA binop the report isolates, and the fix removes the false tensor there and on the standalone `processor.py`.

## The `notes` Parameter Is Also Cleared

The report also observes `_divide_note`'s `notes` parameter mis-typed as a tensor. That false type is a downstream effect of the same cascade: verified against the standalone `processor.py`, `notes` types as an unknown-shape tensor before the fix and carries no tensor type after it, so breaking the self-reinforcing concatenation type clears the parameter too. No residual false tensor remains in the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
