### PR TITLE
Root the shape-vector provenance walk at parameters

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -13570,6 +13570,53 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
   }
 
   /**
+   * The real BERT/ALBERT {@code get_shape_list} vendored verbatim from NLPGNN's {@code
+   * nlpgnn/tools.py} (wala/ML#706): unlike {@link #testShapeHelperSliceVar()}'s simplified
+   * single-return helper, it patches {@code None} entries after the {@code as_list()} read
+   * (subscript writes on the returned list), returns on two paths, and takes default parameters.
+   * The def-use walk follows the helper invoke to its {@code .shape.as_list()} chain; the source
+   * tensor's static {@code (4, 5, 6)} has no {@code None} axes, so the unpatched chain is the
+   * runtime value and the {@code [-k:]} slice is the precise {@code (5, 6)}.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeHelperFull()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_shape_helper_full.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_5_6_FLOAT32)));
+  }
+
+  /**
+   * Parameter-rooted shape-vector provenance (wala/ML#706): the BERT matrix-reshape round trip
+   * ({@code reshape_to_matrix}/{@code reshape_from_matrix}, vendored from NLPGNN's {@code
+   * nlpgnn/tools.py}). {@code reshape_from_matrix}'s reshape target is {@code orig_dims + [width]},
+   * where {@code orig_dims} slices the {@code orig_shape_list} <em>parameter</em> — the def-use
+   * walk roots at a parameter and maps it back to the corresponding argument at the caller's invoke
+   * (the {@code get_shape_list(t)} chain), continuing in the caller's frame. The reshape resolves
+   * to the precise runtime {@code (4, 5, 6)}; the {@code (20, 6)} member is the rank-2 early-return
+   * arm's path-insensitive phantom (runtime skips it since {@code len(input_shape) == 3}), its
+   * {@code -1} target folded against the input's element count.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testShapeHelperParam()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_shape_helper_param.py",
+        "f",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 20, 6), TENSOR_4_5_6_FLOAT32)));
+  }
+
+  /**
    * {@code np.prod} over a shape-derived list (wala/ML#707): {@code [np.prod(get_shape(t)[-2:])]}
    * folds the product of the static trailing dimensions ({@code 5 * 6}) into the reshape target, so
    * the result is the precise {@code (30,)}. Mirrors NLPGNN's {@code einsum_via_matmul} ({@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4348,6 +4348,13 @@ public abstract class TensorGenerator {
    *   <li>{@code v[a:b]} — an invoke of the {@code slice} builtin with constant (or {@code None})
    *       bounds and a unit step; recurses on the receiver and takes the corresponding sub-list of
    *       each shape, with Python negative-index semantics.
+   *   <li>{@code helper(...)} — an invoke of a user function (the BERT/ALBERT {@code
+   *       get_shape_list} pattern); recurses on each resolvable callee's returned values and unions
+   *       (wala/ML#706).
+   *   <li>a parameter — maps back to the corresponding argument at each caller's invoke and
+   *       continues in the caller's frame, unioning the callers (wala/ML#706).
+   *   <li>{@code a + b} — the concatenation of two shape vectors, either operand possibly a literal
+   *       list of resolvable elements (wala/ML#708).
    * </ul>
    *
    * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
@@ -4379,13 +4386,13 @@ public abstract class TensorGenerator {
 
   /**
    * Core of {@link #getShapeResultOfShapeVector(PropagationCallGraphBuilder, CGNode, int)}
-   * threading the set of callee nodes already on the walk, guarding recursive helpers
-   * (wala/ML#706).
+   * threading the set of nodes already on the walk — callees entered through helper returns and
+   * callers entered through parameter arguments — guarding recursive chains (wala/ML#706).
    *
    * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
    * @param node The {@link CGNode} whose IR defines {@code vn}.
    * @param vn The value number to resolve.
-   * @param visited The callee nodes already on the walk.
+   * @param visited The nodes already on the walk.
    * @return The resolution result; see the wrapper.
    */
   private ShapeResult getShapeResultOfShapeVector(
@@ -4456,6 +4463,57 @@ public abstract class TensorGenerator {
         }
       }
       return combined == null ? ShapeResult.unknown() : new ShapeResult(combined, callerUnknown);
+    }
+
+    // A shape-vector parameter (e.g. `orig_shape_list` of NLPGNN's `reshape_from_matrix`, fed
+    // `get_shape_list(input_tensor)` by its callers): map the parameter back to the corresponding
+    // argument at each caller's invoke and continue the walk in the caller's frame (wala/ML#706).
+    // The parameter unions all callers; a caller whose argument cannot be mapped (keyword-passed
+    // or defaulted) or walked marks the unknown remainder while the resolvable callers' members
+    // still stand (wala/ML#718).
+    if (def == null && !st.isConstant(vn)) {
+      int paramPos = Integer.MIN_VALUE;
+      for (int i = 0; i < node.getIR().getNumberOfParameters(); i++)
+        if (node.getIR().getParameter(i) == vn) {
+          paramPos = node.getMethod().isStatic() ? i : i - 1;
+          break;
+        }
+      if (paramPos >= 0) {
+        LOGGER.fine(
+            () ->
+                "getShapesOfShapeVector: resolving parameter vn "
+                    + vn
+                    + " of "
+                    + describe(node)
+                    + " via its callers.");
+        boolean callerUnknown = false;
+        Set<List<Dimension<?>>> combined = null;
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+            getCallerInvokes(builder, node)) {
+          CGNode caller = callerInvoke.fst;
+          int argVn = -1;
+          if (callerInvoke.snd instanceof PythonInvokeInstruction) {
+            PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+            int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+            if (paramPos < numPosParams) argVn = pyCall.getUse(paramPos + 1);
+          }
+          if (argVn <= 0 || !visited.add(caller)) {
+            callerUnknown = true; // Unmappable argument, or the walk is already in this caller.
+            continue;
+          }
+          try {
+            ShapeResult shapes = this.getShapeResultOfShapeVector(builder, caller, argVn, visited);
+            if (shapes.hasUnknown() || shapes.isBottom()) callerUnknown = true;
+            if (!shapes.members().isEmpty()) {
+              if (combined == null) combined = HashSetFactory.make();
+              combined.addAll(shapes.members());
+            }
+          } finally {
+            visited.remove(caller);
+          }
+        }
+        return combined == null ? ShapeResult.unknown() : new ShapeResult(combined, callerUnknown);
+      }
     }
 
     if (def instanceof PythonPropertyRead) {
@@ -5161,12 +5219,13 @@ public abstract class TensorGenerator {
 
   /**
    * Core of {@link #isShapeVectorChain(PropagationCallGraphBuilder, CGNode, int)} threading the set
-   * of callee nodes already on the walk, guarding recursive helpers (wala/ML#706).
+   * of nodes already on the walk — callees entered through helper returns and callers entered
+   * through parameter arguments — guarding recursive chains (wala/ML#706).
    *
    * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves helper calls.
    * @param node The {@link CGNode} whose IR defines {@code vn}.
    * @param vn The value number to test.
-   * @param visited The callee nodes already on the walk.
+   * @param visited The nodes already on the walk.
    * @return {@code true} iff the def-use chain matches a shape-vector form.
    */
   private static boolean isShapeVectorChain(
@@ -5178,6 +5237,35 @@ public abstract class TensorGenerator {
     if (def instanceof PythonPropertyRead) {
       int memberVn = ((PythonPropertyRead) def).getMemberRef();
       return st.isStringConstant(memberVn) && "shape".equals(st.getStringValue(memberVn));
+    }
+
+    // A parameter chains iff some caller's corresponding argument chains (wala/ML#706); the
+    // resolve-side walk unions the callers and marks the unmappable ones as the unknown
+    // remainder.
+    if (def == null && !st.isConstant(vn)) {
+      int paramPos = Integer.MIN_VALUE;
+      for (int i = 0; i < node.getIR().getNumberOfParameters(); i++)
+        if (node.getIR().getParameter(i) == vn) {
+          paramPos = node.getMethod().isStatic() ? i : i - 1;
+          break;
+        }
+      if (paramPos >= 0)
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+            getCallerInvokes(builder, node)) {
+          CGNode caller = callerInvoke.fst;
+          if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+          PythonInvokeInstruction pyCall = (PythonInvokeInstruction) callerInvoke.snd;
+          int numPosParams = pyCall.getNumberOfPositionalParameters() - 1;
+          if (paramPos >= numPosParams) continue;
+          int argVn = pyCall.getUse(paramPos + 1);
+          if (argVn <= 0 || !visited.add(caller)) continue;
+          try {
+            if (isShapeVectorChain(builder, caller, argVn, visited)) return true;
+          } finally {
+            visited.remove(caller);
+          }
+        }
+      return false;
     }
 
     if (def instanceof PythonInvokeInstruction) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_full.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_full.py
@@ -1,0 +1,57 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def assert_rank(tensor, expected_rank, name=None):
+    excepted_rank_dict = {}
+    if isinstance(expected_rank, int):
+        excepted_rank_dict[expected_rank] = True
+    else:
+        for x in expected_rank:
+            excepted_rank_dict[x] = True
+    actual_rank = tensor.shape.ndims
+    if actual_rank not in excepted_rank_dict:
+        raise (
+            "For tensor {} , the actual rank {} is not equal"
+            "to expected rank {}".format(name, actual_rank, str(expected_rank))
+        )
+
+
+def get_shape_list(tensor, expected_rank=None, name=None):
+    if expected_rank is not None:
+        assert_rank(tensor, expected_rank, name)
+
+    shape = tensor.shape.as_list()
+
+    non_static_indexes = []
+    for index, dim in enumerate(shape):
+        if dim is None:
+            non_static_indexes.append(index)
+
+    if not non_static_indexes:
+        return shape
+
+    dyn_shape = tf.shape(tensor)
+    for index in non_static_indexes:
+        shape[index] = dyn_shape[index]
+    return shape
+
+
+# The real BERT/ALBERT `get_shape_list` vendored verbatim from NLPGNN's
+# `nlpgnn/tools.py` (wala/ML#706): unlike the simplified single-return helper
+# of `tf2_test_shape_helper_slice.py`, it patches `None` entries after the
+# `as_list()` read (subscript writes on the returned list), has two `return
+# shape` statements, and takes default parameters. The def-use walk must still
+# follow the helper invoke to the `.shape.as_list()` chain rooted at the
+# `tensor` parameter.
+t = tf.ones((4, 5, 6))
+x = tf.ones((30,))
+k = 2
+r = tf.reshape(x, get_shape_list(t)[-k:])
+assert isinstance(r, tf.Tensor)
+assert r.shape == (5, 6)
+assert r.dtype == tf.float32
+f(r)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_param.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_shape_helper_param.py
@@ -1,0 +1,56 @@
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+def get_shape_list(tensor, expected_rank=None, name=None):
+    shape = tensor.shape.as_list()
+
+    non_static_indexes = []
+    for index, dim in enumerate(shape):
+        if dim is None:
+            non_static_indexes.append(index)
+
+    if not non_static_indexes:
+        return shape
+
+    dyn_shape = tf.shape(tensor)
+    for index in non_static_indexes:
+        shape[index] = dyn_shape[index]
+    return shape
+
+
+def reshape_to_matrix(tensor):
+    if len(tensor.shape) == 0:
+        return tensor
+    dim = tensor.shape[-1]
+    tensor_2d = tf.reshape(tensor, [-1, dim])
+    return tensor_2d
+
+
+def reshape_from_matrix(output_tensor, orig_shape_list):
+    if len(orig_shape_list) == 2:
+        return output_tensor
+    output_shape = get_shape_list(output_tensor)
+    orig_dims = orig_shape_list[0:-1]
+    width = output_shape[-1]
+    return tf.reshape(output_tensor, orig_dims + [width])
+
+
+# The BERT matrix-reshape round trip vendored from NLPGNN's `nlpgnn/tools.py`
+# (wala/ML#706): `reshape_from_matrix`'s reshape target is `orig_dims +
+# [width]`, where `orig_dims` slices the `orig_shape_list` PARAMETER — the
+# def-use walk roots at a parameter and must map it back to the corresponding
+# argument at each caller's invoke (here the `get_shape_list(t)` chain) and
+# continue in the caller's frame.
+t = tf.ones((4, 5, 6))
+input_shape = get_shape_list(t)
+m = reshape_to_matrix(t)
+assert m.shape == (20, 6)
+r = reshape_from_matrix(m, input_shape)
+assert isinstance(r, tf.Tensor)
+assert r.shape == (4, 5, 6)
+assert r.dtype == tf.float32
+f(r)


### PR DESCRIPTION
Closes wala/ML#706.

## The Gap

The wala/ML#703 provenance walk resolves `.shape`/`as_list()`/slice/concat chains, and it already follows a helper invoke into its callees' returns (the `get_shape_list` descent; the verbatim two-return, `None`-patching helper resolves in vitro). What still collapsed to ⊤ was a chain rooted at a *parameter*: NLPGNN's `reshape_from_matrix` builds its reshape target as `orig_shape_list[0:-1] + [width]`, and `orig_shape_list` is a parameter that every caller feeds `get_shape_list(input_tensor)`. The walk had no arm for parameter roots (only the Keras `build` special case), so the concat's left operand resolved 0 members in every one of the whole-project run's 750 walk activations and the reshape reported ⊤. That reshape is each BERT `Transformer` block's output, so `Transformer.call`'s `input_tensor` carried a shape-⊤ `? of float32` member in every calling context, which is what the reopen's evaluator run measured downstream.

## The Fix

`TensorGenerator.getShapeResultOfShapeVector` gets the parameter arm the issue's "What Is Needed" section describes: when the walk reaches a parameter root, it maps the parameter back to the corresponding positional argument at each caller's invoke and continues the walk in the caller's frame. Callers union; a caller whose argument cannot be mapped (keyword-passed or defaulted arguments, non-Python invokes) or whose walk fails marks the unknown remainder while the resolvable callers' members stand, per the wala/ML#718 partial-result contract. The on-walk node set that already guards the callee descent now also guards the caller ascent, cutting call cycles in both directions. The structural companion `isShapeVectorChain` gets the matching arm (a parameter chains iff some caller's corresponding argument chains).

## Effect on the Vendored Subject

On `nlpgnn_full_proj`, the `reshape_from_matrix` concat's left operand goes from 0 resolved members in every walk activation to 2-5 members in each, and the shape-⊤ member disappears from `Transformer.call`'s `input_tensor`, leaving ranked members whose leading (batch, sequence) dimensions are the entry scripts' concrete contracts. The dimensions that remain `Unresolved` are the config-derived hidden sizes (wala/ML#721); the sibling einsum-extent recovery is wala/ML#734.

One caveat: the in-vivo anchor sits on the BERT encoder loop, whose cyclic demand chain settles at evaluation-order-dependent fixpoints, so the ⊤ member's elimination is real but not JVM-order-stable and is not pinned by a suite assertion; wala/ML#753 tracks that engine-side multiplicity with the bisect evidence.

## New Guards

- `testShapeHelperParam`: the in-vitro BERT matrix-reshape round trip (`reshape_to_matrix`/`reshape_from_matrix` vendored verbatim); the parameter-rooted reshape target resolves to the precise runtime `(4, 5, 6)`. Fails without the fix (the union carries a `? of float32` member).
- `testShapeHelperFull`: the real two-return, `None`-patching `get_shape_list` vendored verbatim from `nlpgnn/tools.py`, pinning the existing callee-return descent on the unsimplified helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199rmW7UZxVPVuXRVPc8bPF
