### PR TITLE
Dump the tensor analysis lazily at FINE in the test helper

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorflow2Model.java
@@ -16834,7 +16834,10 @@ public class TestTensorflow2Model extends TestPythonMLCallGraphShape {
     }
 
     TensorTypeAnalysis analysis = engine.performAnalysis(builder);
-    LOGGER.info("Tensor analysis: " + analysis);
+    // A lazy FINE supplier: the whole-lattice dump is a multi-hundred-MB string on the
+    // whole-project fixtures, and an eager INFO concatenation builds it even when the CI logging
+    // config discards the message (the release runner's heap exhaustion).
+    LOGGER.fine(() -> "Tensor analysis: " + analysis);
 
     Map<PointerKey, AnalysisError> errors = engine.getErrors();
 


### PR DESCRIPTION
Closes wala/ML#754.

The 0.52.37 Cut release run failed with `OutOfMemoryError` in `TensorTypeAnalysis.toString`: the test helper's `LOGGER.info("Tensor analysis: " + analysis)` concatenates eagerly, so the whole-lattice dump builds even when the forwarded `logging.ci.properties` discards the message, and the wala/ML#706 member growth pushed it past the runner's heap on the whole-project fixtures. A lazy `FINE` supplier never builds the string under the CI config, matching the diagnostic-logging convention and the `CALL_GRAPH_DUMP_NODE_LIMIT` skip precedent at the same call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199rmW7UZxVPVuXRVPc8bPF
