### PR TITLE
Run the whole-project fixture analyses in a parallel CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,7 +64,16 @@ jobs:
         mvn package -B -q -DskipTests
         mvn install:install-file -Dfile=target/com.ibm.wala.cast.lsp-0.0.1-SNAPSHOT.jar -DgroupId="com.ibm.wala" -DartifactId="com.ibm.wala.cast.lsp" -Dversion="0.0.1" -Dpackaging="jar" -DgeneratePom=true -B
         popd
+    # The whole-project fixture analyses (the `WholeProjectFixtures` category) run in the parallel
+    # `whole-project-fixtures` job on PR/branch/queue runs, pulling the wall clock back to the
+    # pre-context-broadening band (wala/ML#755). Tag pushes run the FULL suite here instead: the
+    # deploy gate below sits in this job, and a release must never deploy while its long-pole
+    # tests run unconsumed in a sibling job.
     - name: Build with Maven
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco -DexcludedGroups=com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures
+    - name: Build with Maven (full suite, tag push)
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco
     # Guard against `run.sh`'s JAR path drifting behind the project version (wala/ML#525): verify
     # its glob resolves to exactly one fat JAR carrying the driver's `Main-Class` manifest entry.
@@ -127,6 +136,54 @@ jobs:
         path: com.ibm.wala.cast.python.ml/target/com.ibm.wala.cast.python.ml-*-fat.jar
         if-no-files-found: error
         retention-days: 1
+  # The suite's long pole (the whole-project corpus analyses, ~4-6 of the ~12 minutes) runs beside
+  # the rest of the suite instead of after it (wala/ML#755). Tag pushes skip this job: the `build`
+  # job runs the full suite there so the deploy gate consumes every test itself.
+  whole-project-fixtures:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out wala/ML sources
+      uses: actions/checkout@v7
+      with:
+        submodules: 'recursive'
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install Python dependencies
+      run: pip install -r requirements.txt
+    - name: Install Jython3
+      run: |
+        pushd jython3
+        ant
+        pushd dist
+        mvn install:install-file -Dfile=./jython-dev.jar -DgroupId="org.python" -DartifactId="jython3" -Dversion="0.0.2" -Dpackaging="jar" -DgeneratePom=true -B
+        popd
+        popd
+      shell: bash
+    - name: Install IDE
+      run: |
+        pushd IDE/com.ibm.wala.cast.lsp
+        mvn package -B -q -DskipTests
+        mvn install:install-file -Dfile=target/com.ibm.wala.cast.lsp-0.0.1-SNAPSHOT.jar -DgroupId="com.ibm.wala" -DartifactId="com.ibm.wala.cast.lsp" -Dversion="0.0.1" -Dpackaging="jar" -DgeneratePom=true -B
+        popd
+    - name: Run whole-project fixture tests
+      run: mvn -Dlogging.config.file=./logging.ci.properties verify -B -Pjacoco -Dgroups=com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures -DfailIfNoTests=false
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v7
+      with:
+        token: $CODECOV_TOKEN
+        slug: ponder-lab/ML
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # Attach the fat-classifier JAR to the GitHub Release on semver tag-push, so standalone-driver
   # users (`java -jar`) can fetch it without the `read:packages` PAT that GitHub Packages requires.
   # A separate job scopes the elevated `contents: write` permission to release tag-pushes only;

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/DiagnosticLoggingVolumeTest.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.test;
 
 import static org.junit.Assert.assertTrue;
 
+import com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures;
 import com.ibm.wala.cast.python.ml.test.tensorflow.v2.TestCorpusFixtures;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Diagnostic-logging volume guard (<a
@@ -18,6 +20,7 @@ import org.junit.Test;
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
+@Category(WholeProjectFixtures.class)
 public class DiagnosticLoggingVolumeTest {
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
@@ -1,10 +1,12 @@
 package com.ibm.wala.cast.python.ml.test;
 
+import com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures;
 import com.ibm.wala.cast.python.ml.test.tensorflow.v2.TestCorpusFixtures;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Order-independence guard for the worklist engine (wala/ML#365): the whole-project NLPGNN
@@ -16,6 +18,7 @@ import org.junit.Test;
  *
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
+@Category(WholeProjectFixtures.class)
 public class WorklistOrderInvarianceTest {
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/categories/WholeProjectFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/categories/WholeProjectFixtures.java
@@ -1,0 +1,8 @@
+package com.ibm.wala.cast.python.ml.test.categories;
+
+/**
+ * JUnit category marking tests that analyze a whole vendored project (the suite's long pole), so CI
+ * can run them in a job parallel to the rest of the suite (wala/ML#755). Annotate the test class
+ * with {@code @Category(WholeProjectFixtures.class)}.
+ */
+public interface WholeProjectFixtures {}

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -10,6 +10,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.UNKNOWN;
 import static java.util.Arrays.asList;
 
+import com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
@@ -21,6 +22,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Whole-project corpus-fixture tests (the vendored NLPGNN, gpt-2, MusicTransformer, BiLSTM, and
@@ -29,6 +31,7 @@ import org.junit.Test;
  * parallel-split candidate), and their loop-carried expectations are sensitive to JVM test ordering
  * (wala/ML#753). The assertions are verbatim.
  */
+@Category(WholeProjectFixtures.class)
 public class TestCorpusFixtures extends AbstractTensorTest {
 
   /**


### PR DESCRIPTION
Closes wala/ML#755.

The `WholeProjectFixtures` JUnit category marks the suite's long pole: `TestCorpusFixtures` (the vendored NLPGNN/gpt-2/MusicTransformer/BiLSTM/TextCNN analyses), `DiagnosticLoggingVolumeTest`, and `WorklistOrderInvarianceTest` (both rerun the NLPGNN generation analysis). On PR, branch, and queue runs, the `build` job excludes the category and the new `whole-project-fixtures` job runs it in parallel; both upload coverage and Codecov merges the flags. Tag pushes keep the full suite in `build`, since the deploy gate lives there and a release must consume every test in the gating job. Locally the partition is exact: 19 category tests plus 1,095 remaining, summing to the module's 1,114.

One follow-up needs repo admin: adding `whole-project-fixtures` to the ruleset's required status checks (currently `build` + the two `Analyze` checks), so the parallel job gates the merge queue rather than merely reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199rmW7UZxVPVuXRVPc8bPF
