### PR TITLE
Add a cycle-order perturbation knob and post-fixpoint canonicalization (wala/ML#756).

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
@@ -105,4 +105,91 @@ public class WorklistTypeResolverTest {
 
     assertEquals(ShapeResult.unknown(), result);
   }
+
+  /**
+   * The wala/ML#753 join-history class in vitro: a transfer that collapsed to the unknown-marked
+   * element because it consumed an interim (still-bottom) cycle read joins the mark permanently,
+   * even though its recomputation against the settled value is precise. The post-fixpoint
+   * canonicalization must replace the marked value with the precise recomputation.
+   */
+  @Test
+  public void testCanonicalizationRetractsStaleCollapse() {
+    WorklistTypeResolver engine = WorklistTypeResolver.install(null);
+
+    ShapeResult scalar = ShapeResult.of(Set.of(List.of()));
+    List<Supplier<Object>> transfers = new ArrayList<>();
+    // STALE_C collapses to ⊤ while its partner is interim and is precise once it settles.
+    transfers.add(
+        () -> {
+          ShapeResult d = (ShapeResult) engine.read("STALE_D", transfers.get(1), true);
+          return d.members().isEmpty() ? ShapeResult.unknown() : d;
+        });
+    // STALE_D reads its partner (recording the cycle) but has its own external base.
+    transfers.add(
+        () -> {
+          engine.read("STALE_C", transfers.get(0), true);
+          return scalar;
+        });
+
+    assertEquals(scalar, engine.demand("STALE_D", transfers.get(1), true));
+    assertEquals(scalar, engine.demand("STALE_C", transfers.get(0), true));
+  }
+
+  /**
+   * The canonicalization recomputes with the settled state, and a non-monotone transfer may then
+   * yield ⊥ where the iteration had settled a real value; the replacement must keep the settled
+   * value, since the evidence that the value is a tensor stands and the pure-cycle promotion's ⊤
+   * would otherwise be reclassified as "not a tensor."
+   */
+  @Test
+  public void testCanonicalizationKeepsSettledOverBottom() {
+    WorklistTypeResolver engine = WorklistTypeResolver.install(null);
+
+    ShapeResult scalar = ShapeResult.of(Set.of(List.of()));
+    int[] evaluations = {0};
+    List<Supplier<Object>> transfers = new ArrayList<>();
+    // GUARD_G contributes its base only on the first evaluation and ⊥ afterwards.
+    transfers.add(
+        () -> {
+          engine.read("GUARD_H", transfers.get(1), true);
+          return evaluations[0]++ == 0 ? scalar : ShapeResult.bottom();
+        });
+    transfers.add(
+        () -> {
+          engine.read("GUARD_G", transfers.get(0), true);
+          return ShapeResult.bottom();
+        });
+
+    assertEquals(scalar, engine.demand("GUARD_G", transfers.get(0), true));
+  }
+
+  /**
+   * The wala/ML#756 perturbation seed parses defensively: an unparsable value disables the knob
+   * instead of aborting the analysis.
+   */
+  @Test
+  public void testShuffleSeedParsesDefensively() {
+    System.setProperty("ariadne.typeResolution.shuffleCycles", "bogus");
+    try {
+      assertNull(WorklistTypeResolver.parseCycleShuffleSeed());
+      System.setProperty("ariadne.typeResolution.shuffleCycles", "42");
+      assertEquals(Long.valueOf(42), WorklistTypeResolver.parseCycleShuffleSeed());
+    } finally {
+      System.clearProperty("ariadne.typeResolution.shuffleCycles");
+    }
+  }
+
+  /**
+   * The perturbed engine converges cycles to the same values as the unperturbed one; the seeded run
+   * also exercises the shuffle's enqueue and re-enqueue arms.
+   */
+  @Test
+  public void testShuffledCycleConverges() {
+    System.setProperty("ariadne.typeResolution.shuffleCycles", "11");
+    try {
+      testCanonicalizationRetractsStaleCollapse();
+    } finally {
+      System.clearProperty("ariadne.typeResolution.shuffleCycles");
+    }
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
@@ -41,4 +41,32 @@ public class WorklistOrderInvarianceTest {
       System.clearProperty("ariadne.typeResolution.reverseSeeds");
     }
   }
+
+  /**
+   * Runs the NLPGNN generation analysis under a cycle-order shuffle seed; the run must satisfy the
+   * same assertions as the unperturbed one (wala/ML#756). Reversed seeds permute only the demand
+   * roots, and provably do not exercise the cycle-internal iteration orders (worklist polls,
+   * dependent re-enqueues) whose identity-hash-seeded variation lets settled states differ with JVM
+   * run history; the {@code ariadne.typeResolution.shuffleCycles} knob perturbs all of them
+   * deterministically. Seed 11 is the recorded wala/ML#753 reproducer: it flips the BERT
+   * encoder-loop {@code Transformer.call} anchor, whose exact-set pin therefore stays out of the
+   * suite until that issue is fixed; the generation anchor asserted here is stable under every seed
+   * tried and guards the invariance property for the acyclic region and the canonicalized cycle
+   * residue.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testCycleOrderInvariance()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    System.setProperty("ariadne.typeResolution.shuffleCycles", "11");
+    try {
+      new TestCorpusFixtures().runNlpgnnFullGeneration();
+    } finally {
+      System.clearProperty("ariadne.typeResolution.shuffleCycles");
+    }
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -85,6 +85,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1370,6 +1371,15 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       List<PointsToSetVariable> ordered = new ArrayList<>(sources);
       if (Boolean.getBoolean("ariadne.typeResolution.reverseSeeds")
           || "true".equals(System.getenv("ARIADNE_REVERSE_SEEDS"))) Collections.reverse(ordered);
+
+      // The wala/ML#756 perturbation knob also permutes the demand roots: reversal alone leaves
+      // most of the root order's multiplicity unexercised (the source set's iteration order is
+      // identity-hash-seeded, so a JVM rerun is an arbitrary permutation, not a reversal), and the
+      // root order decides where the evaluation first enters each dependency cycle.
+      String shuffleSeed = System.getProperty("ariadne.typeResolution.shuffleCycles");
+      if (shuffleSeed == null) shuffleSeed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
+      if (shuffleSeed != null)
+        Collections.shuffle(ordered, new Random(Long.parseLong(shuffleSeed)));
       for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
 
       // Second pass: a seed materialized early in the first pass predates the constraints

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1376,10 +1376,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       // most of the root order's multiplicity unexercised (the source set's iteration order is
       // identity-hash-seeded, so a JVM rerun is an arbitrary permutation, not a reversal), and the
       // root order decides where the evaluation first enters each dependency cycle.
-      String shuffleSeed = System.getProperty("ariadne.typeResolution.shuffleCycles");
-      if (shuffleSeed == null) shuffleSeed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
-      if (shuffleSeed != null)
-        Collections.shuffle(ordered, new Random(Long.parseLong(shuffleSeed)));
+      Long shuffleSeed = WorklistTypeResolver.parseCycleShuffleSeed();
+      if (shuffleSeed != null) Collections.shuffle(ordered, new Random(shuffleSeed));
       for (PointsToSetVariable v : ordered) init.put(v, getTensorTypes(v, builder));
 
       // Second pass: a seed materialized early in the first pass predates the constraints

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -11,6 +11,7 @@ import java.util.Deque;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Supplier;
@@ -88,6 +89,18 @@ final class WorklistTypeResolver {
   private final Deque<Object> worklist = new ArrayDeque<>();
   private final Set<Object> enqueued = HashSetFactory.make();
   private final Map<Object, Integer> evaluationCounts = HashMapFactory.make();
+
+  /**
+   * The cycle-order perturbation source (wala/ML#756), or {@code null} when the knob is off. The
+   * hybrid inline scheduling fixes the acyclic region's evaluation order, so the only order the
+   * engine does not determine is the one the worklist and the dependent re-enqueues impose on
+   * cycle-affected keys; that order is identity-hash-seeded and varies with JVM run history, which
+   * is exactly what an order-invariance test cannot rerun on demand. Seeding this source (the
+   * {@code ariadne.typeResolution.shuffleCycles} system property or the {@code
+   * ARIADNE_SHUFFLE_CYCLES} environment variable, holding a {@code long} seed) perturbs both orders
+   * deterministically, mirroring the reverse-seeds property for demand roots.
+   */
+  private final Random cycleShuffle = createCycleShuffle();
 
   /** The stack of currently-evaluating queries; reads record edges against the top. */
   private final Deque<Object> evaluating = new ArrayDeque<>();
@@ -212,8 +225,43 @@ final class WorklistTypeResolver {
     return shapeKind ? ShapeResult.bottom() : EnumSet.noneOf(DType.class);
   }
 
+  /**
+   * Creates the cycle-order perturbation source from the {@code
+   * ariadne.typeResolution.shuffleCycles} system property or the {@code ARIADNE_SHUFFLE_CYCLES}
+   * environment variable (wala/ML#756).
+   *
+   * @return A {@link Random} seeded with the configured {@code long}, or {@code null} when neither
+   *     setting is present.
+   */
+  private static Random createCycleShuffle() {
+    String seed = System.getProperty("ariadne.typeResolution.shuffleCycles");
+    if (seed == null) seed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
+    if (seed == null) return null;
+    return new Random(Long.parseLong(seed));
+  }
+
   private void enqueue(Object key) {
-    if (this.enqueued.add(key)) this.worklist.add(key);
+    if (!this.enqueued.add(key)) return;
+    // Perturbation point 1 of the wala/ML#756 knob: enqueueing at a random end permutes the poll
+    // order among the keys concurrently on the worklist, which are exactly the cycle-affected keys.
+    if (this.cycleShuffle != null && !this.worklist.isEmpty() && this.cycleShuffle.nextBoolean())
+      this.worklist.addFirst(key);
+    else this.worklist.add(key);
+  }
+
+  /**
+   * Orders a changed query's dependents for re-enqueueing: iteration order as-is normally, a seeded
+   * shuffle under the wala/ML#756 perturbation knob (point 2: the relative order in which a grown
+   * value's readers join the worklist).
+   *
+   * @param dependents The dependents to order.
+   * @return The re-enqueue order.
+   */
+  private Iterable<Object> orderDependentsForReEnqueue(Set<Object> dependents) {
+    if (this.cycleShuffle == null || dependents.size() < 2) return dependents;
+    List<Object> shuffled = new ArrayList<>(dependents);
+    Collections.shuffle(shuffled, this.cycleShuffle);
+    return shuffled;
   }
 
   /** Runs the fixpoint: chaotic iteration, then SCC promotion, repeating until neither moves. */
@@ -303,7 +351,9 @@ final class WorklistTypeResolver {
     joined = this.widen(key, joined);
     if (!joined.equals(old)) {
       this.state.put(key, joined);
-      for (Object dependent : this.dependents.getOrDefault(key, Collections.emptySet()))
+      for (Object dependent :
+          this.orderDependentsForReEnqueue(
+              this.dependents.getOrDefault(key, Collections.emptySet())))
         // An on-stack reader consumes this fresh value as its own evaluation completes (the
         // read returns after this update), so re-enqueueing it would only repeat the same
         // transfer; every first inline evaluation would otherwise schedule its whole reader
@@ -372,8 +422,9 @@ final class WorklistTypeResolver {
         if (!bottomShapes) continue;
         if (value == null && !(this.transfers.containsKey(key))) continue;
         this.state.put(key, ShapeResult.unknown());
-        for (Object dependent : this.dependents.getOrDefault(key, Collections.emptySet()))
-          this.enqueue(dependent);
+        for (Object dependent :
+            this.orderDependentsForReEnqueue(
+                this.dependents.getOrDefault(key, Collections.emptySet()))) this.enqueue(dependent);
         any = true;
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -228,18 +228,35 @@ final class WorklistTypeResolver {
   }
 
   /**
-   * Creates the cycle-order perturbation source from the {@code
-   * ariadne.typeResolution.shuffleCycles} system property or the {@code ARIADNE_SHUFFLE_CYCLES}
-   * environment variable (wala/ML#756).
+   * Parses the wala/ML#756 perturbation seed from the {@code ariadne.typeResolution.shuffleCycles}
+   * system property or the {@code ARIADNE_SHUFFLE_CYCLES} environment variable. An unparsable value
+   * disables the perturbation with a logged warning rather than aborting the analysis: the knob is
+   * diagnostic, so misconfiguration should be visible but harmless.
    *
-   * @return A {@link Random} seeded with the configured {@code long}, or {@code null} when neither
-   *     setting is present.
+   * @return The configured seed, or {@code null} when neither setting is present or the value does
+   *     not parse as a {@code long}.
    */
-  private static Random createCycleShuffle() {
+  static Long parseCycleShuffleSeed() {
     String seed = System.getProperty("ariadne.typeResolution.shuffleCycles");
     if (seed == null) seed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
     if (seed == null) return null;
-    return new Random(Long.parseLong(seed));
+    try {
+      return Long.valueOf(seed);
+    } catch (NumberFormatException e) {
+      LOGGER.warning("Ignoring the unparsable cycle-shuffle seed: " + seed + ".");
+      return null;
+    }
+  }
+
+  /**
+   * Creates the cycle-order perturbation source (wala/ML#756).
+   *
+   * @return A {@link Random} seeded per {@link #parseCycleShuffleSeed}, or {@code null} when the
+   *     knob is off.
+   */
+  private static Random createCycleShuffle() {
+    Long seed = parseCycleShuffleSeed();
+    return seed == null ? null : new Random(seed);
   }
 
   private void enqueue(Object key) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -92,13 +92,15 @@ final class WorklistTypeResolver {
 
   /**
    * The cycle-order perturbation source (wala/ML#756), or {@code null} when the knob is off. The
-   * hybrid inline scheduling fixes the acyclic region's evaluation order, so the only order the
-   * engine does not determine is the one the worklist and the dependent re-enqueues impose on
-   * cycle-affected keys; that order is identity-hash-seeded and varies with JVM run history, which
-   * is exactly what an order-invariance test cannot rerun on demand. Seeding this source (the
-   * {@code ariadne.typeResolution.shuffleCycles} system property or the {@code
-   * ARIADNE_SHUFFLE_CYCLES} environment variable, holding a {@code long} seed) perturbs both orders
-   * deterministically, mirroring the reverse-seeds property for demand roots.
+   * hybrid inline scheduling fixes the acyclic region's evaluation order, so the orders the engine
+   * does not determine are the ones the worklist and the dependent re-enqueues impose on
+   * cycle-affected keys; both are identity-hash-seeded and vary with JVM run history, which is
+   * exactly what an order-invariance test cannot rerun on demand. Seeding this source (the {@code
+   * ariadne.typeResolution.shuffleCycles} system property or the {@code ARIADNE_SHUFFLE_CYCLES}
+   * environment variable, holding a {@code long} seed) perturbs both orders deterministically; the
+   * same setting also shuffles the demand-root order in {@link
+   * PythonTensorAnalysisEngine#performAnalysis}, the third undetermined order and the one whose
+   * reversal alone the reverse-seeds property exercises.
    */
   private final Random cycleShuffle = createCycleShuffle();
 
@@ -275,8 +277,104 @@ final class WorklistTypeResolver {
       this.iterate();
       promoted = this.cycleSeen && this.promotePureCycles();
     } while (promoted);
+    if (this.cycleSeen) this.canonicalize();
     this.cycleSeen = false;
     this.dumpFiltered();
+  }
+
+  /**
+   * Recomputes cycle-affected queries once against the settled state, replacing their values
+   * (wala/ML#753, wala/ML#748). The iteration to the fixpoint joins every recomputation into the
+   * state, so join history rides into the settled values: a transfer that consumed an on-stack
+   * interim read collapses to the unknown-marked element, {@link ShapeResult#union} disjoins the
+   * mark permanently, and interim per-axis folds survive alongside their converged refinements.
+   * Which artifacts persist depends on the order the cycle iterated in, so the settled states are
+   * order-dependent exactly on cycle-affected keys. One post-fixpoint recomputation per key against
+   * the settled (no longer interim) values, replacing instead of joining, makes each canonical
+   * value a function of its dependencies' final values rather than of the join history.
+   *
+   * <p>The sweep runs over the SCC condensation in reverse-topological order (the Tarjan emission
+   * order), so every recomputation reads dependencies that are already canonical; a key is
+   * recomputed only if it sits in a cyclic SCC (where join history can originate) or reads a key
+   * whose canonical value changed (where it can propagate). Within a cyclic SCC the replacements
+   * are computed jointly against the settled state before any is written back (a Jacobi step), so
+   * intra-SCC recomputation order cannot influence the result. Two guards keep the replacement
+   * semantics sound: a transfer that throws keeps the settled value, and a recomputation may not
+   * degrade a non-bottom settled value to ⊥ &mdash; the settled evidence that the value is a tensor
+   * stands, and the pure-cycle promotion's unknown-marked elements (whose baseless transfers
+   * recompute to ⊥) must not be reclassified as "not a tensor."
+   */
+  private void canonicalize() {
+    int replaced = 0;
+    Set<Object> changed = HashSetFactory.make();
+    for (List<Object> scc : this.tarjan()) {
+      boolean cyclic =
+          scc.size() > 1
+              || this.reads.getOrDefault(scc.get(0), Collections.emptySet()).contains(scc.get(0));
+      List<Object> targets = new ArrayList<>();
+      for (Object key : scc)
+        if (cyclic
+            || !Collections.disjoint(this.reads.getOrDefault(key, Collections.emptySet()), changed))
+          targets.add(key);
+      if (targets.isEmpty()) continue;
+      Map<Object, Object> replacements = HashMapFactory.make();
+      for (Object key : targets) replacements.put(key, this.recomputeSettled(key));
+      for (Map.Entry<Object, Object> replacement : replacements.entrySet()) {
+        Object key = replacement.getKey();
+        Object value = replacement.getValue();
+        Object settled = this.state.get(key);
+        if (value == null || value.equals(settled)) continue;
+        if (isBottomValue(value) && !isBottomValue(settled)) continue;
+        this.state.put(key, value);
+        changed.add(key);
+        replaced++;
+      }
+    }
+    if (replaced > 0) {
+      int count = replaced;
+      LOGGER.fine(() -> "Canonicalization replaced " + count + " settled values.");
+    }
+  }
+
+  /**
+   * Recomputes a query's transfer once against the settled state for {@link #canonicalize}.
+   *
+   * @param key The query to recompute.
+   * @return The recomputed (widened) value, or the settled value when the transfer is unknown or
+   *     throws.
+   */
+  private Object recomputeSettled(Object key) {
+    Supplier<Object> transfer = this.transfers.get(key);
+    if (transfer == null) return this.state.get(key);
+    Object result;
+    this.evaluating.push(key);
+    this.inStack.add(key);
+    try {
+      result = transfer.get();
+    } catch (IllegalArgumentException e) {
+      LOGGER.log(
+          Level.FINE, e, () -> "Canonicalization IAE for " + key + "; keeping the settled value.");
+      return this.state.get(key);
+    } finally {
+      this.evaluating.pop();
+      this.inStack.remove(key);
+    }
+    if (result == null) result = this.shapeKinds.get(key) ? ShapeResult.unknown() : NULL_DTYPE;
+    return this.widen(key, result);
+  }
+
+  /**
+   * Decides whether a state value is the ⊥ of its kind.
+   *
+   * @param value The state value, {@code null} meaning the iteration bottom.
+   * @return {@code true} iff the value reads as "not a tensor."
+   */
+  private static boolean isBottomValue(Object value) {
+    if (value == null) return true;
+    if (value == NULL_DTYPE) return false;
+    if (value instanceof ShapeResult) return ((ShapeResult) value).isBottom();
+    if (value instanceof Set) return ((Set<?>) value).isEmpty();
+    return false;
   }
 
   /**


### PR DESCRIPTION
Entry step and first fix increment of the wala/ML#753 + wala/ML#748 fixpoint-monotonicity arc.

## Perturbation Knob (wala/ML#756)

`ariadne.typeResolution.shuffleCycles=<seed>` (or `ARIADNE_SHUFFLE_CYCLES`) seeds a deterministic shuffle of the three evaluation orders the analysis does not itself determine: the worklist poll order, the dependent re-enqueue order, and the demand-root order. The reverse-seeds property permutes only the roots, and only by reversal, which is why `WorklistOrderInvarianceTest` stayed green while wala/ML#753 flaked with JVM run history. Seed 11 deterministically reproduces the wala/ML#753 flip in a fresh JVM with no test pairing: the BERT encoder-loop `Transformer.call` `input_tensor` union gains its shape-⊤ member, 3/3 across JVMs. `WorklistOrderInvarianceTest` now also reruns the NLPGNN generation analysis under that seed.

## Post-Fixpoint Canonicalization (wala/ML#753, wala/ML#748)

The iteration to the fixpoint joins every recomputation into the state, so join history rides into the settled values: a transfer that consumed an interim read collapses to the unknown-marked element, `ShapeResult.union` disjoins the mark permanently, and interim per-axis folds survive alongside their converged refinements. After `solve()` stabilizes, the engine now recomputes cycle-affected queries once, in reverse-topological order over the SCC condensation (Jacobi within an SCC), replacing values instead of joining, so each canonical value is a function of its dependencies' final values rather than of the join history. A transfer that throws keeps the settled value, and a recomputation may not degrade a non-bottom settled value to ⊥, preserving the pure-cycle promotion's sound ⊤ for baseless loops.

## What Stays Open

The canonicalization covers the interim-artifact class but not the wala/ML#753 witness itself: the stuck pure-⊤ cycle fixpoint is transfer-consistent, so recomputation against settled values re-derives it, and the diagnosis (posted on wala/ML#753) locates the flip in the seed-composition layer. The `Transformer.call` exact-set pin therefore stays out of the suite, and the escape has to happen at the collapse/composition arms. Opened as a draft for that scope call: the landed pieces are complete and suite-green, but the arc's headline witness needs the follow-on design round.

Closes wala/ML#756. Advances wala/ML#753 and wala/ML#748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
