### PR TITLE
Divert cross-generator 1-arg reads through the engine's memo layer (wala/ML#365).

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetChooseFromDatasetsGenerator.java
@@ -110,7 +110,8 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
                     try {
                       TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                       if (generator != null) {
-                        ret.addAll(generator.getDTypes(builder));
+                        Set<DType> generatorDTypes = memoizedDTypes(builder, generator);
+                        if (generatorDTypes != null) ret.addAll(generatorDTypes);
                       }
                     } catch (IllegalArgumentException e) {
                       // Ignore.
@@ -162,8 +163,8 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
                   try {
                     TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                     if (generator != null) {
-                      Set<DType> preciseTypes = generator.getDTypes(builder);
-                      if (!preciseTypes.isEmpty()) {
+                      Set<DType> preciseTypes = memoizedDTypes(builder, generator);
+                      if (preciseTypes != null && !preciseTypes.isEmpty()) {
                         ret.addAll(preciseTypes);
                         preciseTypesFound = true;
                       }
@@ -235,8 +236,7 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
                     try {
                       TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                       if (generator != null) {
-                        Set<List<Dimension<?>>> generatorShapes = generator.getShapes(builder);
-                        if (generatorShapes != null) ret.addAll(generatorShapes);
+                        ret.addAll(memoizedShapeResult(builder, generator).members());
                       }
                     } catch (IllegalArgumentException e) {
                       // Ignore.
@@ -288,8 +288,9 @@ public class DatasetChooseFromDatasetsGenerator extends DatasetGenerator {
                   try {
                     TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                     if (generator != null) {
-                      Set<List<Dimension<?>>> preciseTypes = generator.getShapes(builder);
-                      if (preciseTypes != null && !preciseTypes.isEmpty()) {
+                      Set<List<Dimension<?>>> preciseTypes =
+                          memoizedShapeResult(builder, generator).members();
+                      if (!preciseTypes.isEmpty()) {
                         ret.addAll(preciseTypes);
                         preciseTypesFound = true;
                       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetElementGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetElementGenerator.java
@@ -66,7 +66,9 @@ public class DatasetElementGenerator extends TensorGenerator implements Delegati
   @Override
   public Set<List<Dimension<?>>> getShapes(PropagationCallGraphBuilder builder) {
     if (underlying != null) {
-      return underlying.getShapes(builder);
+      // Diverted through the engine's memo layer (wala/ML#365): a direct 1-arg call recurses
+      // outside the engine and breaks order-dependently on cyclic chains (wala/ML#753).
+      return memoizedShapeResult(builder, underlying).toLegacy();
     }
     return super.getShapes(builder);
   }
@@ -79,7 +81,8 @@ public class DatasetElementGenerator extends TensorGenerator implements Delegati
   @Override
   public Set<DType> getDTypes(PropagationCallGraphBuilder builder) {
     if (underlying != null) {
-      return underlying.getDTypes(builder);
+      // Diverted like the shape counterpart (wala/ML#365).
+      return memoizedDTypes(builder, underlying);
     }
     return super.getDTypes(builder);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetFromTensorSlicesGenerator.java
@@ -246,7 +246,9 @@ public class DatasetFromTensorSlicesGenerator extends DatasetGenerator
                     PointsToSetVariable svar =
                         builder.getPropagationSystem().findOrCreatePointsToSet(spk);
                     try {
-                      fieldShapes = new SliceBuiltinOperation(svar).getShapes(builder);
+                      // Diverted through the engine's memo layer (wala/ML#365).
+                      fieldShapes =
+                          memoizedShapeResult(builder, new SliceBuiltinOperation(svar)).toLegacy();
                     } catch (IllegalArgumentException e) {
                       // leave as null
                     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetSampleFromDatasetsGenerator.java
@@ -111,7 +111,8 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
                     try {
                       TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                       if (generator != null) {
-                        ret.addAll(generator.getDTypes(builder));
+                        Set<DType> generatorDTypes = memoizedDTypes(builder, generator);
+                        if (generatorDTypes != null) ret.addAll(generatorDTypes);
                       }
                     } catch (IllegalArgumentException e) {
                       // Ignore.
@@ -163,8 +164,8 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
                   try {
                     TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                     if (generator != null) {
-                      Set<DType> preciseTypes = generator.getDTypes(builder);
-                      if (!preciseTypes.isEmpty()) {
+                      Set<DType> preciseTypes = memoizedDTypes(builder, generator);
+                      if (preciseTypes != null && !preciseTypes.isEmpty()) {
                         ret.addAll(preciseTypes);
                         preciseTypesFound = true;
                       }
@@ -236,8 +237,7 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
                     try {
                       TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                       if (generator != null) {
-                        Set<List<Dimension<?>>> generatorShapes = generator.getShapes(builder);
-                        if (generatorShapes != null) ret.addAll(generatorShapes);
+                        ret.addAll(memoizedShapeResult(builder, generator).members());
                       }
                     } catch (IllegalArgumentException e) {
                       // Ignore.
@@ -289,8 +289,9 @@ public class DatasetSampleFromDatasetsGenerator extends DatasetGenerator {
                   try {
                     TensorGenerator generator = TensorGeneratorFactory.getGenerator(var, builder);
                     if (generator != null) {
-                      Set<List<Dimension<?>>> preciseTypes = generator.getShapes(builder);
-                      if (preciseTypes != null && !preciseTypes.isEmpty()) {
+                      Set<List<Dimension<?>>> preciseTypes =
+                          memoizedShapeResult(builder, generator).members();
+                      if (!preciseTypes.isEmpty()) {
                         ret.addAll(preciseTypes);
                         preciseTypesFound = true;
                       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -270,9 +270,13 @@ public class DenseCall extends TensorGenerator {
                   + ".");
 
       if (generator != null) {
-        Set<List<Dimension<?>>> generatorShapes = generator.getShapes(builder);
+        // Divert through the engine's memo layer (wala/ML#365): a direct 1-arg call recurses
+        // outside the engine, so a cyclic chain breaks at the wala/ML#599 thread-local guard with
+        // an evaluation-order-dependent null instead of converging (wala/ML#753). The resolvable
+        // members stand; an unknown remainder drops, as the legacy null-filtered call did.
+        ShapeResult generatorShapes = memoizedShapeResult(builder, generator);
         LOGGER.fine(() -> "Found input shapes: " + generatorShapes + ".");
-        if (generatorShapes != null) ret.addAll(generatorShapes);
+        ret.addAll(generatorShapes.members());
       } else {
         LOGGER.fine(
             () ->

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ModelCall.java
@@ -91,11 +91,14 @@ public class ModelCall extends TensorGenerator {
 
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Diverted through the engine's memo layer (wala/ML#365): a direct 1-arg call recurses
+    // outside the engine, so cyclic model graphs break at thread-local guards with
+    // evaluation-order-dependent nulls instead of converging (wala/ML#753). The resolvable
+    // members stand; an unknown remainder drops, as the legacy null filter did.
     Set<List<Dimension<?>>> outputShapes =
         this.getOutputGenerators(builder).stream()
-            .map(g -> g.getShapes(builder))
-            .filter(shapes -> shapes != null)
-            .flatMap(Collection::stream)
+            .map(g -> memoizedShapeResult(builder, g))
+            .flatMap(result -> result.members().stream())
             .collect(Collectors.toSet());
 
     // Extract shapes from the inputs passed to __call__.
@@ -274,9 +277,13 @@ public class ModelCall extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    // Diverted like the shape counterpart (wala/ML#365); a null (⊤) dtype result contributes
+    // nothing here, as before.
     Set<DType> outputDTypes =
         this.getOutputGenerators(builder).stream()
-            .flatMap(g -> g.getDTypes(builder).stream())
+            .map(g -> memoizedDTypes(builder, g))
+            .filter(dTypes -> dTypes != null)
+            .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 
     if (outputDTypes.isEmpty()) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1720,6 +1720,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       Set<TensorType> tensorTypes = generator.getTensorTypes(builder);
       LOGGER.fine(() -> "Found tensor types: " + tensorTypes + ".");
 
+      if (tensorTypes != null && tensorTypes.stream().anyMatch(t -> t.getDims() == null))
+        LOGGER.fine(
+            () ->
+                "NULLDIMS-SEED generator="
+                    + generator.getClass().getSimpleName()
+                    + " source="
+                    + describe(source));
+
       return tensorTypes;
     } catch (IllegalArgumentException e) {
       LOGGER.log(


### PR DESCRIPTION
Second increment of the wala/ML#753 arc, from the localization the wala/ML#756 knob enabled.

## What It Does

The engine's wala/ML#365 diversion covered the 3-arg recursive layer; direct cross-generator `getShapes(builder)`/`getDTypes(builder)` calls (the tracked wala/ML#365 residual) still recursed outside it, breaking cyclic chains at ad-hoc guards (e.g. the wala/ML#599 thread-local) with evaluation-order-dependent nulls. The eleven call sites in `DenseCall`, `ModelCall`, and the dataset generators now read memoized, edge-recorded results. A companion FINE log names any seed that composes a null-dims (shape-⊤) member, which is the exact composition that decides the wala/ML#753 flip; it localized the witness to the encoder-loop block outputs (`DenseCall`/`ElementWiseOperation` in `Transformer.call`, the attention internals) in minutes.

## What It Does Not Do

The witness itself still flips under shuffle seeds 11 and 3: the remaining order-sensitivity sits in the fallback-on-empty arm gates (a transfer consults its caller-union fallback only when the primary delegation path is interim-empty, and the fallback's union spans the saturated-context callers, importing an unrelated `GraphSAGE.call` ⊤ into the transformer's argument union). Making those gates canonical, or keying the caller union by receiver (the wala/ML#570/wala/ML#742 coupling), is the follow-on design round; the sharpened diagnosis is posted on wala/ML#753.

Advances wala/ML#753 and wala/ML#365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
