### PR TITLE
Render query keys legibly in the engine dump (wala/ML#753).

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
@@ -164,27 +164,17 @@ public class WorklistTypeResolverTest {
   }
 
   /**
-   * The wala/ML#756 perturbation seed parses defensively: an unparsable value disables the knob
-   * instead of aborting the analysis.
+   * The wala/ML#756 perturbation knob end to end: the seed parses defensively (an unparsable value
+   * disables the knob instead of aborting the analysis), and a perturbed engine converges cycles to
+   * the same values as the unperturbed one, exercising the shuffle's enqueue and re-enqueue arms.
+   * One method rather than one per property scenario: the suite runs test methods in parallel and
+   * the knob is a shared system property, so split methods race on it.
    */
   @Test
-  public void testShuffleSeedParsesDefensively() {
-    System.setProperty("ariadne.typeResolution.shuffleCycles", "bogus");
-    try {
-      assertNull(WorklistTypeResolver.parseCycleShuffleSeed());
-      System.setProperty("ariadne.typeResolution.shuffleCycles", "42");
-      assertEquals(Long.valueOf(42), WorklistTypeResolver.parseCycleShuffleSeed());
-    } finally {
-      System.clearProperty("ariadne.typeResolution.shuffleCycles");
-    }
-  }
-
-  /**
-   * The perturbed engine converges cycles to the same values as the unperturbed one; the seeded run
-   * also exercises the shuffle's enqueue and re-enqueue arms.
-   */
-  @Test
-  public void testShuffledCycleConverges() {
+  public void testShuffleSeedKnob() {
+    assertNull(WorklistTypeResolver.parseCycleShuffleSeed(null));
+    assertNull(WorklistTypeResolver.parseCycleShuffleSeed("bogus"));
+    assertEquals(Long.valueOf(42), WorklistTypeResolver.parseCycleShuffleSeed("42"));
     System.setProperty("ariadne.typeResolution.shuffleCycles", "11");
     try {
       testCanonicalizationRetractsStaleCollapse();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -413,9 +413,25 @@ final class WorklistTypeResolver {
     }
   }
 
+  /**
+   * Renders a key or value for the diagnostic dump. The interesting record components of a query
+   * key (the value number and the exactness mode) trail its node's rendering, whose nested calling
+   * contexts exceed any reasonable truncation length, so they are hoisted in front of the truncated
+   * remainder; without this, every dumped query reads as an anonymous node prefix (wala/ML#753's
+   * localization sessions).
+   *
+   * @param o The key or value to render.
+   * @return The rendering.
+   */
   private static String brief(Object o) {
     String s = String.valueOf(o);
-    return s.length() > 160 ? s.substring(0, 160) : s;
+    int vnAt = s.lastIndexOf("valueNumber=");
+    String prefix = "";
+    if (vnAt >= 0) {
+      int end = s.indexOf(']', vnAt);
+      prefix = "{" + (end > vnAt ? s.substring(vnAt, end) : s.substring(vnAt)) + "} ";
+    }
+    return prefix + (s.length() > 400 ? s.substring(0, 400) : s);
   }
 
   private void iterate() {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -239,6 +239,18 @@ final class WorklistTypeResolver {
   static Long parseCycleShuffleSeed() {
     String seed = System.getProperty("ariadne.typeResolution.shuffleCycles");
     if (seed == null) seed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
+    return parseCycleShuffleSeed(seed);
+  }
+
+  /**
+   * Parsing core of {@link #parseCycleShuffleSeed()}, taking the setting value directly so the
+   * defensive behavior is testable without owning the shared system property (the suite runs test
+   * methods in parallel).
+   *
+   * @param seed The configured value, or {@code null} when unset.
+   * @return The seed, or {@code null} when unset or unparsable (logged).
+   */
+  static Long parseCycleShuffleSeed(String seed) {
     if (seed == null) return null;
     try {
       return Long.valueOf(seed);


### PR DESCRIPTION
Diagnostics increment from the wala/ML#753 substrate provenance experiment.

The dump's query keys rendered as anonymous node prefixes: the value number and exactness mode trail the node's rendering, whose nested calling contexts exceed any truncation length. They are now hoisted in front, which is what let the experiment identify the demanded value numbers on the encoder-loop chain. The second commit deflakes the shuffle-knob unit pins: the suite runs test methods in parallel and the knob is a shared system property, so the split property-scenario methods raced on it; the parsing core now takes the setting value directly.

The experiment's finding is posted on wala/ML#753: the points-to substrate is context-precise at the witness value (the library and vendored-copy transformer chains see strictly their own contexts' members), so the substrate-contamination hypothesis is refuted and the multiplicity is confined to the per-context walk chain.

Advances wala/ML#753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
