### PR TITLE
Name the wala/ML#756 shuffle-seed settings with constants.

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolverTest.java
@@ -175,11 +175,11 @@ public class WorklistTypeResolverTest {
     assertNull(WorklistTypeResolver.parseCycleShuffleSeed(null));
     assertNull(WorklistTypeResolver.parseCycleShuffleSeed("bogus"));
     assertEquals(Long.valueOf(42), WorklistTypeResolver.parseCycleShuffleSeed("42"));
-    System.setProperty("ariadne.typeResolution.shuffleCycles", "11");
+    System.setProperty(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY, "11");
     try {
       testCanonicalizationRetractsStaleCollapse();
     } finally {
-      System.clearProperty("ariadne.typeResolution.shuffleCycles");
+      System.clearProperty(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY);
     }
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/WorklistOrderInvarianceTest.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.test;
 
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures;
 import com.ibm.wala.cast.python.ml.test.tensorflow.v2.TestCorpusFixtures;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
@@ -62,11 +63,11 @@ public class WorklistOrderInvarianceTest {
   @Test
   public void testCycleOrderInvariance()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    System.setProperty("ariadne.typeResolution.shuffleCycles", "11");
+    System.setProperty(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY, "11");
     try {
       new TestCorpusFixtures().runNlpgnnFullGeneration();
     } finally {
-      System.clearProperty("ariadne.typeResolution.shuffleCycles");
+      System.clearProperty(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY);
     }
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -305,6 +305,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   /** A "fake" function name in the summaries that indicates that an API produces a new tensor. */
   public static final String TENSOR_GENERATOR_SYNTHETIC_FUNCTION_NAME = "read_data";
 
+  /**
+   * System property naming the wala/ML#756 order-perturbation seed: a {@code long} that seeds a
+   * deterministic shuffle of the demand-root order and the worklist engine's cycle-internal orders.
+   * The {@link #SHUFFLE_CYCLES_VARIABLE} environment variable is its fallback.
+   */
+  public static final String SHUFFLE_CYCLES_PROPERTY = "ariadne.typeResolution.shuffleCycles";
+
+  /** Environment-variable fallback of {@link #SHUFFLE_CYCLES_PROPERTY}. */
+  public static final String SHUFFLE_CYCLES_VARIABLE = "ARIADNE_SHUFFLE_CYCLES";
+
   private static final Logger LOGGER = Logger.getLogger(PythonTensorAnalysisEngine.class.getName());
 
   private static final MethodReference conv2d =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -237,8 +237,8 @@ final class WorklistTypeResolver {
    *     not parse as a {@code long}.
    */
   static Long parseCycleShuffleSeed() {
-    String seed = System.getProperty("ariadne.typeResolution.shuffleCycles");
-    if (seed == null) seed = System.getenv("ARIADNE_SHUFFLE_CYCLES");
+    String seed = System.getProperty(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY);
+    if (seed == null) seed = System.getenv(PythonTensorAnalysisEngine.SHUFFLE_CYCLES_VARIABLE);
     return parseCycleShuffleSeed(seed);
   }
 


### PR DESCRIPTION
Review follow-up on the wala/ML#756 knob: the `ariadne.typeResolution.shuffleCycles` property and its `ARIADNE_SHUFFLE_CYCLES` environment fallback were string literals at every consumption and test site; they are now `PythonTensorAnalysisEngine.SHUFFLE_CYCLES_PROPERTY`/`SHUFFLE_CYCLES_VARIABLE` (public, since the order-invariance test lives outside the `client` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX