### PR TITLE
Add the post-settlement replay diagnostic for order-dependent fixpoints

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -315,6 +315,17 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   /** Environment-variable fallback of {@link #SHUFFLE_CYCLES_PROPERTY}. */
   public static final String SHUFFLE_CYCLES_VARIABLE = "ARIADNE_SHUFFLE_CYCLES";
 
+  /**
+   * System property naming the wala/ML#753 post-settlement replay filter: comma-separated
+   * key-string substrings selecting the settled pure-⊤ shape queries whose transfers re-run
+   * read-only against the settled state, logging each aggregation's per-member results. The {@link
+   * #REPLAY_FILTER_VARIABLE} environment variable is its fallback.
+   */
+  public static final String REPLAY_FILTER_PROPERTY = "ariadne.typeResolution.replayFilter";
+
+  /** Environment-variable fallback of {@link #REPLAY_FILTER_PROPERTY}. */
+  public static final String REPLAY_FILTER_VARIABLE = "ARIADNE_REPLAY_FILTER";
+
   private static final Logger LOGGER = Logger.getLogger(PythonTensorAnalysisEngine.class.getName());
 
   private static final MethodReference conv2d =
@@ -1666,6 +1677,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
 
       recordDepthLimitedResults(tt, builder.getClassHierarchy());
       recordShapeAnnotationCandidates(builder);
+
+      // The wala/ML#753 replay diagnostic runs last, when every demanded query has settled, so
+      // its recomputations read only final values and cannot perturb the evaluation order under
+      // measurement.
+      String replayFilter = System.getProperty(REPLAY_FILTER_PROPERTY);
+      if (replayFilter == null) replayFilter = System.getenv(REPLAY_FILTER_VARIABLE);
+      if (replayFilter != null) {
+        WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
+        if (engine != null) engine.replaySettled(replayFilter);
+      }
 
       return tt;
     } finally {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1959,6 +1959,21 @@ public abstract class TensorGenerator {
             // default mode keeps the resolvable subset (wala/ML#716, wala/ML#718).
             if (argShapes.hasUnknown() && exact) callerUnknown = true;
             combinedRet.addAll(argShapes.members());
+            WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
+            if (activeEngine != null && activeEngine.isReplaying()) {
+              int arg = argVn;
+              LOGGER.fine(
+                  () ->
+                      "REPLAY caller arg v"
+                          + arg
+                          + " in "
+                          + describe(caller)
+                          + " => members="
+                          + argShapes.members()
+                          + ", unknown="
+                          + argShapes.hasUnknown()
+                          + ".");
+            }
           }
         }
         if (!combinedRet.isEmpty()) return new ShapeResult(combinedRet, callerUnknown);
@@ -2737,6 +2752,8 @@ public abstract class TensorGenerator {
     boolean hasUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
+    boolean replay = activeEngine != null && activeEngine.isReplaying();
 
     for (InstanceKey valueIK : valuePointsToSet)
       if (valueIK instanceof ConstantKey) ret.add(emptyList()); // Scalar value.
@@ -2821,6 +2838,16 @@ public abstract class TensorGenerator {
                       + fromTensor.members().size()
                       + " unk="
                       + fromTensor.hasUnknown());
+          if (replay)
+            LOGGER.fine(
+                () ->
+                    "REPLAY member "
+                        + describe(asin)
+                        + " => members="
+                        + fromTensor.members()
+                        + ", unknown="
+                        + fromTensor.hasUnknown()
+                        + ".");
           // An empty result means no producer resolved for this member, not a scalar.
           if (fromTensor.hasUnknown() || fromTensor.isBottom()) {
             if (exact) hasUnknown = true; // The union is incomplete, wala/ML#718.
@@ -2848,11 +2875,34 @@ public abstract class TensorGenerator {
             ret.addAll(generatorShapes.members());
             if (exact && generatorShapes.hasUnknown())
               hasUnknown = true; // Incomplete union, wala/ML#718.
-          } else if (exact) hasUnknown = true;
+            if (replay) {
+              TensorGenerator dispatched = generator;
+              LOGGER.fine(
+                  () ->
+                      "REPLAY member "
+                          + describe(asin)
+                          + " via "
+                          + dispatched.getClass().getSimpleName()
+                          + " => members="
+                          + generatorShapes.members()
+                          + ", unknown="
+                          + generatorShapes.hasUnknown()
+                          + ".");
+            }
+          } else {
+            if (exact) hasUnknown = true;
+            if (replay)
+              LOGGER.fine(
+                  () ->
+                      "REPLAY member "
+                          + describe(asin)
+                          + " => no dispatchable generator (same operation or unresolved).");
+          }
         } catch (IllegalArgumentException e) {
           // Not a recognized generator.
           LOGGER.log(Level.FINE, "No generator found for variable: " + var, e);
           if (exact) hasUnknown = true;
+          if (replay) LOGGER.fine(() -> "REPLAY member " + describe(asin) + " => factory IAE.");
         }
       } else {
         throw new IllegalStateException("Unknown value type: " + valueIK.getClass() + ".");
@@ -2916,6 +2966,8 @@ public abstract class TensorGenerator {
     boolean hasUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     CGNode readDataNode = asin.getNode();
+    WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
+    boolean replay = activeEngine != null && activeEngine.isReplaying();
 
     // Support allocations directly in 'do' methods (preferred for 1-CFA context separation).
     if (readDataNode.getMethod().getName().toString().equals(DO_METHOD_NAME)) {
@@ -2934,6 +2986,14 @@ public abstract class TensorGenerator {
         if (generator != null) {
           // Avoid infinite recursion for manual generators
           if (this.manualNode != null && this.manualNode.equals(readDataNode)) {
+            if (replay)
+              LOGGER.fine(
+                  () ->
+                      "REPLAY delegation "
+                          + describe(asin)
+                          + " => ⊥ by the manual self-recursion guard of "
+                          + this.getClass().getSimpleName()
+                          + ".");
             return ShapeResult.bottom();
           }
           LOGGER.fine("Delegating shape inference to: " + generator);
@@ -2941,9 +3001,31 @@ public abstract class TensorGenerator {
           ret.addAll(delegatedShapes.members());
           if (exact && delegatedShapes.hasUnknown())
             hasUnknown = true; // Incomplete union, wala/ML#718.
+          if (replay) {
+            TensorGenerator manual = generator;
+            LOGGER.fine(
+                () ->
+                    "REPLAY delegation "
+                        + describe(asin)
+                        + " via manual "
+                        + manual.getClass().getSimpleName()
+                        + " => members="
+                        + delegatedShapes.members()
+                        + ", unknown="
+                        + delegatedShapes.hasUnknown()
+                        + ".");
+          }
         } else if (defSource != null) {
           // Avoid infinite recursion if the current generator is for the same source.
           if (this.getSource() != null && this.getSource().equals(defSource)) {
+            if (replay)
+              LOGGER.fine(
+                  () ->
+                      "REPLAY delegation "
+                          + describe(asin)
+                          + " => ⊥ by the source self-recursion guard of "
+                          + this.getClass().getSimpleName()
+                          + ".");
             return ShapeResult.bottom();
           }
           try {
@@ -2959,7 +3041,26 @@ public abstract class TensorGenerator {
             ret.addAll(delegatedShapes.members());
             if (exact && delegatedShapes.hasUnknown())
               hasUnknown = true; // Incomplete union, wala/ML#718.
-          } else if (exact) hasUnknown = true;
+            if (replay) {
+              TensorGenerator dispatched = generator;
+              LOGGER.fine(
+                  () ->
+                      "REPLAY delegation "
+                          + describe(asin)
+                          + " via "
+                          + dispatched.getClass().getSimpleName()
+                          + " => members="
+                          + delegatedShapes.members()
+                          + ", unknown="
+                          + delegatedShapes.hasUnknown()
+                          + ".");
+            }
+          } else {
+            if (exact) hasUnknown = true;
+            if (replay)
+              LOGGER.fine(
+                  () -> "REPLAY delegation " + describe(asin) + " => no generator resolved.");
+          }
         }
       }
       return new ShapeResult(ret, hasUnknown);
@@ -2999,7 +3100,24 @@ public abstract class TensorGenerator {
           Set<List<Dimension<?>>> delegatedShapes = generator.getShapes(builder);
           if (delegatedShapes != null) ret.addAll(delegatedShapes);
           else if (exact) hasUnknown = true; // Incomplete union, wala/ML#718.
-        } else if (exact) hasUnknown = true;
+          if (replay) {
+            TensorGenerator dispatched = generator;
+            LOGGER.fine(
+                () ->
+                    "REPLAY delegation "
+                        + describe(asin)
+                        + " via caller "
+                        + dispatched.getClass().getSimpleName()
+                        + " => "
+                        + (delegatedShapes == null ? "⊤" : delegatedShapes)
+                        + ".");
+          }
+        } else {
+          if (exact) hasUnknown = true;
+          if (replay)
+            LOGGER.fine(
+                () -> "REPLAY delegation " + describe(asin) + " => no caller generator resolved.");
+        }
       }
     }
     return new ShapeResult(ret, hasUnknown);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1937,6 +1937,8 @@ public abstract class TensorGenerator {
       if (paramPos >= -1) { // -1 is 'self'
         boolean callerUnknown = false;
         Set<List<Dimension<?>>> combinedRet = HashSetFactory.make();
+        WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
+        boolean replay = activeEngine != null && activeEngine.isReplaying();
         for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
             getCallerInvokes(builder, node)) {
           CGNode caller = callerInvoke.fst;
@@ -1959,8 +1961,7 @@ public abstract class TensorGenerator {
             // default mode keeps the resolvable subset (wala/ML#716, wala/ML#718).
             if (argShapes.hasUnknown() && exact) callerUnknown = true;
             combinedRet.addAll(argShapes.members());
-            WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
-            if (activeEngine != null && activeEngine.isReplaying()) {
+            if (replay) {
               int arg = argVn;
               LOGGER.fine(
                   () ->

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -113,6 +113,9 @@ final class WorklistTypeResolver {
   /** Queries whose first (inline) evaluation has completed. */
   private final Set<Object> evaluated = HashSetFactory.make();
 
+  /** Whether the post-settlement replay diagnostic is running; see {@link #replaySettled}. */
+  private boolean replaying;
+
   /**
    * Whether an on-stack read (a cycle) occurred since the last promotion pass. The SCC promotion
    * needs a Tarjan pass over every recorded edge, and each key's hash recursively walks its calling
@@ -404,6 +407,69 @@ final class WorklistTypeResolver {
     if (value instanceof ShapeResult) return ((ShapeResult) value).isBottom();
     if (value instanceof Set) return ((Set<?>) value).isEmpty();
     return false;
+  }
+
+  /**
+   * Returns whether the post-settlement replay diagnostic is running, i.e. the per-member replay
+   * logs in the aggregation bodies should fire.
+   *
+   * @return {@code true} iff inside {@link #replaySettled}.
+   */
+  boolean isReplaying() {
+    return this.replaying;
+  }
+
+  /**
+   * Diagnostic (wala/ML#753): re-runs the transfer of every settled pure-⊤ shape query (no members,
+   * unknown remainder) whose key string contains any of the filter's comma-separated substrings,
+   * logging the recomputed value against the settled one. The replay runs after every demand has
+   * settled, so each nested read returns a final value and the recomputation observes the
+   * aggregation's per-member results free of the evaluation-order effects an in-flight probe would
+   * perturb; the recomputed values are logged, never written back.
+   *
+   * @param filter Comma-separated key-string substrings selecting the queries to replay.
+   */
+  void replaySettled(String filter) {
+    String[] alternatives = filter.split(",");
+    List<Object> marked = new ArrayList<>();
+    for (Map.Entry<Object, Object> entry : this.state.entrySet()) {
+      Object value = entry.getValue();
+      if (!(value instanceof ShapeResult)) continue;
+      ShapeResult shapes = (ShapeResult) value;
+      if (!shapes.members().isEmpty() || !shapes.hasUnknown()) continue;
+      String keyString = String.valueOf(entry.getKey());
+      for (String alternative : alternatives)
+        if (keyString.contains(alternative)) {
+          marked.add(entry.getKey());
+          break;
+        }
+    }
+    LOGGER.fine(
+        () -> "REPLAY sweeping " + marked.size() + " settled pure-⊤ shape queries: " + filter);
+    this.replaying = true;
+    try {
+      for (Object key : marked) {
+        Supplier<Object> transfer = this.transfers.get(key);
+        if (transfer == null) continue;
+        LOGGER.fine(() -> "REPLAY BEGIN " + brief(key));
+        Object result;
+        this.evaluating.push(key);
+        this.inStack.add(key);
+        try {
+          result = transfer.get();
+        } catch (IllegalArgumentException e) {
+          LOGGER.log(Level.FINE, e, () -> "REPLAY IAE for " + brief(key) + ".");
+          continue;
+        } finally {
+          this.evaluating.pop();
+          this.inStack.remove(key);
+        }
+        Object recomputed = result;
+        LOGGER.fine(() -> "REPLAY END " + brief(key) + " := " + brief(recomputed));
+      }
+    } finally {
+      this.replaying = false;
+    }
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -430,7 +430,14 @@ final class WorklistTypeResolver {
    * @param filter Comma-separated key-string substrings selecting the queries to replay.
    */
   void replaySettled(String filter) {
-    String[] alternatives = filter.split(",");
+    // Blank segments (a stray comma or whitespace) would contain-match every key and replay the
+    // whole pure-⊤ population; drop them.
+    List<String> alternatives = new ArrayList<>();
+    for (String alternative : filter.split(",")) {
+      String trimmed = alternative.trim();
+      if (!trimmed.isEmpty()) alternatives.add(trimmed);
+    }
+    if (alternatives.isEmpty()) return;
     List<Object> marked = new ArrayList<>();
     for (Map.Entry<Object, Object> entry : this.state.entrySet()) {
       Object value = entry.getValue();
@@ -464,8 +471,18 @@ final class WorklistTypeResolver {
           this.evaluating.pop();
           this.inStack.remove(key);
         }
-        Object recomputed = result;
-        LOGGER.fine(() -> "REPLAY END " + brief(key) + " := " + brief(recomputed));
+        // The sweep selects only shape-kind queries; mirror evaluate's null normalization.
+        Object recomputed = result == null ? ShapeResult.unknown() : result;
+        Object settled = this.state.get(key);
+        LOGGER.fine(
+            () ->
+                "REPLAY END "
+                    + brief(key)
+                    + " := "
+                    + brief(recomputed)
+                    + " (settled := "
+                    + brief(settled)
+                    + ")");
       }
     } finally {
       this.replaying = false;


### PR DESCRIPTION
Advances wala/ML#753.

Adds a read-only diagnostic to the worklist engine: setting `ariadne.typeResolution.replayFilter` (system property, `ARIADNE_REPLAY_FILTER` environment fallback) to comma-separated key-string substrings re-runs the transfers of the matching settled pure-⊤ shape queries after every demand has settled, logging the recomputed value against the settled one plus each aggregation's per-member delegated results (`REPLAY BEGIN`/`REPLAY member`/`REPLAY delegation`/`REPLAY caller arg`/`REPLAY END` at `FINE`). Because the replay runs post-settlement, its nested reads return final values only: it observes the per-member aggregation results an in-flight probe would perturb, and it never writes back. With the property unset (the default, including CI), no behavior changes.

The first run of this diagnostic on the wala/ML#753 seed-11 witness localized the flip mechanism to the shared producer-delegation queries; findings are on the issue.