### PR TITLE
Make the shape-delegation transfers reader-neutral

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -316,10 +316,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   public static final String SHUFFLE_CYCLES_VARIABLE = "ARIADNE_SHUFFLE_CYCLES";
 
   /**
-   * System property naming the wala/ML#753 post-settlement replay filter: comma-separated
-   * key-string substrings selecting the settled pure-⊤ shape queries whose transfers re-run
-   * read-only against the settled state, logging each aggregation's per-member results. The {@link
-   * #REPLAY_FILTER_VARIABLE} environment variable is its fallback.
+   * System property naming the wala/ML#753 post-settlement replay filter: semicolon-separated
+   * substrings selecting the settled shape queries whose transfers re-run read-only against the
+   * settled state, logging each aggregation's per-member results. Plain segments match pure-⊤
+   * queries by key string; {@code value:}-prefixed segments match any shape query by value string.
+   * The {@link #REPLAY_FILTER_VARIABLE} environment variable is its fallback.
    */
   public static final String REPLAY_FILTER_PROPERTY = "ariadne.typeResolution.replayFilter";
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2942,11 +2942,18 @@ public abstract class TensorGenerator {
     // The engine converges the cycle from its non-cyclic base instead of recursing without bound
     // or inheriting a whole-read ⊤ (wala/ML#718).
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
-    if (engine == null) return this.doGetShapeResultFromTensor(builder, asin, exact);
-    Object key = Pair.make("shape-delegation", asin);
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback; only that
+    // recursive path needs the in-body self-recursion guards.
+    if (engine == null) return this.doGetShapeResultFromTensor(builder, asin, exact, true);
+    // The key carries everything the transfer depends on: the query is shared by every reader of
+    // the allocation site, so a closure capturing the first reader's identity or mode would
+    // settle the value by sighting order (wala/ML#753) — a self-reader first-sighting would pin
+    // the query at an edge-free ⊥ invisible to promotion and canonicalization. The guards are
+    // recursion breaks, and engine reads never recurse, so the transfer runs unguarded; the
+    // self-read participates as an ordinary cycle edge that converges from the acyclic base.
+    Object key = Pair.make("shape-delegation", Pair.make(asin, exact));
     java.util.function.Supplier<Object> transfer =
-        () -> this.doGetShapeResultFromTensor(builder, asin, exact);
+        () -> this.doGetShapeResultFromTensor(builder, asin, exact, false);
     return (ShapeResult)
         (engine.isEvaluating()
             ? engine.read(key, transfer, true)
@@ -2960,10 +2967,16 @@ public abstract class TensorGenerator {
    * @param builder the propagation call graph builder
    * @param asin the allocation site of the tensor
    * @param exact whether an unresolvable member marks the unknown remainder
+   * @param applyRecursionGuards whether the reader's self-recursion guards run; {@code true} only
+   *     on the null-engine recursive path, since an engine transfer must not depend on the reader
+   *     that first sighted its query (wala/ML#753)
    * @return the resolution result; ⊥ when no producer resolves
    */
   private ShapeResult doGetShapeResultFromTensor(
-      PropagationCallGraphBuilder builder, AllocationSiteInNode asin, boolean exact) {
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode asin,
+      boolean exact,
+      boolean applyRecursionGuards) {
     boolean hasUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     CGNode readDataNode = asin.getNode();
@@ -2986,7 +2999,9 @@ public abstract class TensorGenerator {
 
         if (generator != null) {
           // Avoid infinite recursion for manual generators
-          if (this.manualNode != null && this.manualNode.equals(readDataNode)) {
+          if (applyRecursionGuards
+              && this.manualNode != null
+              && this.manualNode.equals(readDataNode)) {
             if (replay)
               LOGGER.fine(
                   () ->
@@ -3018,7 +3033,9 @@ public abstract class TensorGenerator {
           }
         } else if (defSource != null) {
           // Avoid infinite recursion if the current generator is for the same source.
-          if (this.getSource() != null && this.getSource().equals(defSource)) {
+          if (applyRecursionGuards
+              && this.getSource() != null
+              && this.getSource().equals(defSource)) {
             if (replay)
               LOGGER.fine(
                   () ->
@@ -3807,10 +3824,15 @@ public abstract class TensorGenerator {
     // than UNKNOWN, since an in-band UNKNOWN would collapse the caller's union to {UNKNOWN} under
     // the lattice normalization, erasing the sibling members' resolved dtypes.
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
-    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
-    if (engine == null) return this.doGetDTypesFromTensor(builder, asin);
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback. Unlike the shape
+    // side, the transfer keeps the reader's self-recursion guards: an unguarded dtype delegation
+    // feeds the null-⊤ delegated result's UNKNOWN into unions whose normalization absorbs it,
+    // composing unknown-dtype twins of otherwise-resolved members (the wala/ML#753 round-6
+    // measurement); the shared-query first-sighting hazard stands for the shape side only.
+    if (engine == null) return this.doGetDTypesFromTensor(builder, asin, true);
     Object key = Pair.make("dtype-delegation", asin);
-    java.util.function.Supplier<Object> transfer = () -> this.doGetDTypesFromTensor(builder, asin);
+    java.util.function.Supplier<Object> transfer =
+        () -> this.doGetDTypesFromTensor(builder, asin, true);
     @SuppressWarnings("unchecked")
     Set<DType> diverted =
         (Set<DType>)
@@ -3826,10 +3848,15 @@ public abstract class TensorGenerator {
    *
    * @param builder the propagation call graph builder
    * @param asin the allocation site of the tensor
+   * @param applyRecursionGuards whether the reader's self-recursion guards run; {@code true} only
+   *     on the null-engine recursive path, since an engine transfer must not depend on the reader
+   *     that first sighted its query (wala/ML#753)
    * @return the resolved dtypes; empty when no producer resolves
    */
   private Set<DType> doGetDTypesFromTensor(
-      PropagationCallGraphBuilder builder, AllocationSiteInNode asin) {
+      PropagationCallGraphBuilder builder,
+      AllocationSiteInNode asin,
+      boolean applyRecursionGuards) {
     Set<DType> ret = EnumSet.noneOf(DType.class);
     CGNode readDataNode = asin.getNode();
 
@@ -3848,7 +3875,9 @@ public abstract class TensorGenerator {
             createManualGenerator(readDataNode, asin.concreteType().getReference(), builder);
 
         if (generator != null) {
-          if (this.manualNode != null && this.manualNode.equals(readDataNode)) {
+          if (applyRecursionGuards
+              && this.manualNode != null
+              && this.manualNode.equals(readDataNode)) {
             return ret;
           }
           LOGGER.fine("Delegating dtype inference to: " + generator);
@@ -3857,7 +3886,9 @@ public abstract class TensorGenerator {
           // the points-to set nor the caller walk); contribute UNKNOWN rather than NPE-ing.
           ret.addAll(delegated == null ? EnumSet.of(UNKNOWN) : delegated);
         } else if (defSource != null) {
-          if (this.getSource() != null && this.getSource().equals(defSource)) {
+          if (applyRecursionGuards
+              && this.getSource() != null
+              && this.getSource().equals(defSource)) {
             return ret;
           }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -421,38 +421,58 @@ final class WorklistTypeResolver {
 
   /**
    * Diagnostic (wala/ML#753): re-runs the transfer of every settled pure-⊤ shape query (no members,
-   * unknown remainder) whose key string contains any of the filter's comma-separated substrings,
-   * logging the recomputed value against the settled one. The replay runs after every demand has
-   * settled, so each nested read returns a final value and the recomputation observes the
-   * aggregation's per-member results free of the evaluation-order effects an in-flight probe would
-   * perturb; the recomputed values are logged, never written back.
+   * unknown remainder) whose key string contains any of the filter's semicolon-separated
+   * substrings, logging the recomputed value against the settled one. A segment prefixed with
+   * {@code value:} instead matches against the settled value's rendering and selects any shape
+   * query regardless of its settled value, so a resolved-but-suspect member population (e.g. a
+   * spurious self-consistent fixpoint's) can be replayed to its deriving transfer. The replay runs
+   * after every demand has settled, so each nested read returns a final value and the recomputation
+   * observes the aggregation's per-member results free of the evaluation-order effects an in-flight
+   * probe would perturb; the recomputed values are logged, never written back.
    *
-   * @param filter Comma-separated key-string substrings selecting the queries to replay.
+   * @param filter Semicolon-separated substrings selecting the queries to replay: plain segments
+   *     match pure-⊤ queries by key string, {@code value:}-prefixed segments match any shape query
+   *     by value string. The separator is a semicolon because dimension renderings contain commas.
    */
   void replaySettled(String filter) {
-    // Blank segments (a stray comma or whitespace) would contain-match every key and replay the
-    // whole pure-⊤ population; drop them.
-    List<String> alternatives = new ArrayList<>();
-    for (String alternative : filter.split(",")) {
+    // Blank segments (a stray separator or whitespace) would contain-match every key and replay
+    // the whole pure-⊤ population; drop them.
+    List<String> keyAlternatives = new ArrayList<>();
+    List<String> valueAlternatives = new ArrayList<>();
+    for (String alternative : filter.split(";")) {
       String trimmed = alternative.trim();
-      if (!trimmed.isEmpty()) alternatives.add(trimmed);
+      if (trimmed.isEmpty()) continue;
+      if (trimmed.startsWith("value:")) {
+        String pattern = trimmed.substring("value:".length()).trim();
+        if (!pattern.isEmpty()) valueAlternatives.add(pattern);
+      } else keyAlternatives.add(trimmed);
     }
-    if (alternatives.isEmpty()) return;
+    if (keyAlternatives.isEmpty() && valueAlternatives.isEmpty()) return;
     List<Object> marked = new ArrayList<>();
     for (Map.Entry<Object, Object> entry : this.state.entrySet()) {
       Object value = entry.getValue();
       if (!(value instanceof ShapeResult)) continue;
       ShapeResult shapes = (ShapeResult) value;
-      if (!shapes.members().isEmpty() || !shapes.hasUnknown()) continue;
-      String keyString = String.valueOf(entry.getKey());
-      for (String alternative : alternatives)
-        if (keyString.contains(alternative)) {
-          marked.add(entry.getKey());
-          break;
-        }
+      boolean selected = false;
+      if (shapes.members().isEmpty() && shapes.hasUnknown()) {
+        String keyString = String.valueOf(entry.getKey());
+        for (String alternative : keyAlternatives)
+          if (keyString.contains(alternative)) {
+            selected = true;
+            break;
+          }
+      }
+      if (!selected && !valueAlternatives.isEmpty()) {
+        String valueString = String.valueOf(value);
+        for (String alternative : valueAlternatives)
+          if (valueString.contains(alternative)) {
+            selected = true;
+            break;
+          }
+      }
+      if (selected) marked.add(entry.getKey());
     }
-    LOGGER.fine(
-        () -> "REPLAY sweeping " + marked.size() + " settled pure-⊤ shape queries: " + filter);
+    LOGGER.fine(() -> "REPLAY sweeping " + marked.size() + " settled shape queries: " + filter);
     this.replaying = true;
     try {
       for (Object key : marked) {


### PR DESCRIPTION
Advances wala/ML#753.

The round-5 replay located the flip mechanism: the shared `shape-delegation` query's transfer closure captured whichever reader first sighted it. A self-reader first-sighting baked its self-recursion guard's ⊥ into the shared transfer permanently, and a guard-⊥ transfer reads nothing, so the query had no dependency edges and neither the pure-cycle promotion nor the canonicalization sweep could reach it. Which context copies were poisoned was decided by sighting order, the per-copy lottery behind the seed-11/-3 witness flips.

This makes the shape-side engine transfer reader-neutral: it runs unguarded (engine reads never recurse, so the guards' recursion-break duty is moot there) with the exactness mode joined into the query key; the null-engine recursive path keeps the guards. Under the seed-11 witness the reshape-family ⊥-settled delegations disappear (they now converge through the manual `Reshape` cycle). The dtype delegation deliberately keeps its guards: measured unguarded, the null-⊤ delegated result's `UNKNOWN` composes unknown-dtype twins of otherwise-resolved members. The remaining ⊥ delegations on the witness chain are the `einsum` dispatch-table gap, filed as wala/ML#757 with its measured dtype blocker.

Also extends the wala/ML#753 replay diagnostic with `value:`-prefixed filter segments matching settled values (separator now a semicolon, since dimension renderings contain commas), which is what identified the attention-mask member leak and the twin injection.

The witness itself still flips (baseline 16 members, seeds 3/11 add a sound ⊤ member), so wala/ML#753 stays open; the residual decider is upstream in the seed-marking arm gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX