### PR TITLE
Round-8 scheduling and arm-gate experiment for order-dependent fixpoints

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -251,6 +251,7 @@ public class DenseCall extends TensorGenerator {
             builder, Parameters.INPUTS.getIndex(), Parameters.INPUTS.getName());
 
     Set<List<Dimension<?>>> ret = new HashSet<>();
+    boolean primaryUnknown = false;
 
     for (InstanceKey inputIK : inputPts) {
       LOGGER.fine(() -> "Found input tensor instance key: " + describe(inputIK));
@@ -277,6 +278,7 @@ public class DenseCall extends TensorGenerator {
         ShapeResult generatorShapes = memoizedShapeResult(builder, generator);
         LOGGER.fine(() -> "Found input shapes: " + generatorShapes + ".");
         ret.addAll(generatorShapes.members());
+        if (generatorShapes.hasUnknown()) primaryUnknown = true;
       } else {
         LOGGER.fine(
             () ->
@@ -289,6 +291,13 @@ public class DenseCall extends TensorGenerator {
     }
 
     if (!ret.isEmpty()) return ret;
+
+    // A primary delegation that resolved to the sound unknown is an answered question: the
+    // fallback's caller-side trace-back unions saturated foreign contexts and imports members the
+    // primary would never produce, and whether it fired used to depend on the interim emptiness
+    // of a still-converging delegation (wala/ML#753). The walk below recovers only the genuinely
+    // unanswered (⊥) case, where no delegation resolved at all.
+    if (primaryUnknown) return null;
 
     // Fallback: chained layer calls. The input's allocating node is a layer `__call__` summary
     // whose class isn't recognised by `createManualGenerator` (Flatten, Dense, Dropout, ...).

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -502,6 +502,8 @@ final class WorklistTypeResolver {
                     + brief(recomputed)
                     + " (settled := "
                     + brief(settled)
+                    + ", evaluations := "
+                    + this.evaluationCounts.getOrDefault(key, 0)
                     + ")");
       }
     } finally {
@@ -597,15 +599,19 @@ final class WorklistTypeResolver {
     joined = this.widen(key, joined);
     if (!joined.equals(old)) {
       this.state.put(key, joined);
+      // The reader whose in-flight read triggered this evaluation (the stack top after the pop)
+      // consumes the fresh value as that read returns, so re-enqueueing it would only repeat the
+      // same transfer; every first inline evaluation would otherwise schedule its parent for a
+      // redundant second run. Deeper on-stack dependents are NOT spared: their edges come from
+      // earlier reads (this run or a prior one) whose consumed values are now stale, and skipping
+      // them left evaluations settled on interim reads with no re-run, order-dependently
+      // (wala/ML#753 round 8: 443 of 448 stale pure-⊤ evaluations had never been re-polled). A
+      // key still re-enqueues itself: a changed self-loop needs another pass to stabilize.
+      Object consumer = this.evaluating.peek();
       for (Object dependent :
           this.orderDependentsForReEnqueue(
               this.dependents.getOrDefault(key, Collections.emptySet())))
-        // An on-stack reader consumes this fresh value as its own evaluation completes (the
-        // read returns after this update), so re-enqueueing it would only repeat the same
-        // transfer; every first inline evaluation would otherwise schedule its whole reader
-        // chain for a redundant second run. A key still re-enqueues itself: a changed
-        // self-loop needs another pass to stabilize.
-        if (dependent.equals(key) || !this.inStack.contains(dependent)) this.enqueue(dependent);
+        if (dependent.equals(key) || !dependent.equals(consumer)) this.enqueue(dependent);
     }
   }
 


### PR DESCRIPTION
Advances wala/ML#753. DRAFT: measured not-landable alone; preserved as the concrete starting diff for the arm-monotonicity program (findings on the issue).

Contains the two coupled round-8 pieces: the dependent re-enqueue correction (only the immediate consumer is spared; deeper on-stack dependents were never rescheduled and settled on stale interim reads) and the `DenseCall` fallback gate (the caller-side trace-back fires only when no primary delegation resolved at all). Witness measurements: the pair is per-run unstable because the corrected schedule re-exposes the remaining non-monotone fallback arms (Concat, SSA-chain walks); with them, runs land in the attention-mask import mode on most executions, baseline included, which is why this stays a draft pending the arm audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX