### PR TITLE
Add the canonicalization-target probe diagnostic

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -338,6 +338,7 @@ final class WorklistTypeResolver {
    */
   private void canonicalize() {
     int replaced = 0;
+    String probeFilter = System.getProperty("ariadne.typeResolution.canonProbe");
     Set<Object> changed = HashSetFactory.make();
     for (List<Object> scc : this.tarjan()) {
       boolean cyclic =
@@ -348,6 +349,28 @@ final class WorklistTypeResolver {
         if (cyclic
             || !Collections.disjoint(this.reads.getOrDefault(key, Collections.emptySet()), changed))
           targets.add(key);
+      if (probeFilter != null)
+        for (Object key : scc) {
+          Object settled = this.state.get(key);
+          if (!(settled instanceof ShapeResult)) continue;
+          ShapeResult shapes = (ShapeResult) settled;
+          if (!shapes.members().isEmpty() || !shapes.hasUnknown()) continue;
+          if (!String.valueOf(key).contains(probeFilter)) continue;
+          boolean targeted = targets.contains(key);
+          boolean inCycle = cyclic;
+          LOGGER.fine(
+              () ->
+                  "CANON-PROBE "
+                      + brief(key)
+                      + " cyclic="
+                      + inCycle
+                      + " sccSize="
+                      + scc.size()
+                      + " targeted="
+                      + targeted
+                      + " edges="
+                      + this.reads.getOrDefault(key, Collections.emptySet()).size());
+        }
       if (targets.isEmpty()) continue;
       Map<Object, Object> replacements = HashMapFactory.make();
       for (Object key : targets) replacements.put(key, this.recomputeSettled(key));
@@ -355,6 +378,8 @@ final class WorklistTypeResolver {
         Object key = replacement.getKey();
         Object value = replacement.getValue();
         Object settled = this.state.get(key);
+        if (probeFilter != null && String.valueOf(key).contains(probeFilter))
+          LOGGER.fine(() -> "CANON-PROBE recompute " + brief(key) + " := " + brief(value));
         if (value == null || value.equals(settled)) continue;
         if (isBottomValue(value) && !isBottomValue(settled)) continue;
         this.state.put(key, value);


### PR DESCRIPTION
Advances wala/ML#758.

Property-gated diagnostic in the family of the replay and dump probes: `ariadne.typeResolution.canonProbe` logs, for each matching settled pure-⊤ shape query at canonicalization time, its SCC membership, target-set inclusion, and recorded edge count, plus each matching recomputation result. No behavior change with the property unset.

Its first run completed the wala/ML#753 mechanism map: 342 of 397 marked witness keys are untargeted Tarjan singletons (70 with no recorded engine edges at all), while the 55 keys inside the detected cycle are recomputed and resolve. Findings and the resulting target-criterion refinement (read-version staleness) are on wala/ML#758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX