### PR TITLE
Restore the `Transformer.call` exact-set pin in a fork-isolated class

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,6 +150,8 @@ jobs:
         include:
           - shard: nlpgnn
             tests: 'TestCorpusFixtures#testNlpgnnFull*+testNlpgnnSlice*'
+          - shard: transformer-pin
+            tests: 'TestNlpgnnTransformer'
           - shard: subjects
             tests: 'TestCorpusFixtures#testGpt*+testMusicTransformer*+testBilstm*+testTextcnn*'
           - shard: logging-volume

--- a/com.ibm.wala.cast.python.ml.test/pom.xml
+++ b/com.ibm.wala.cast.python.ml.test/pom.xml
@@ -58,6 +58,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Fork a fresh JVM per test class: a settled type union can flip under same-JVM
+            predecessor analyses, whose `identityHashCode`/ASLR variance perturbs
+            WALA-internal collection orders (wala/ML#753). Single-analysis JVMs are the
+            measured deterministic baseline, and `TestNlpgnnTransformer`'s exact-set pin
+            relies on it. -->
+          <reuseForks>false</reuseForks>
+        </configuration>
       </plugin>
     </plugins>
     <sourceDirectory>source</sourceDirectory>

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -200,9 +200,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
   /**
    * The complete NLPGNN subject vendored verbatim under {@code nlpgnn_full_proj} (wala/ML#690);
    * shared by {@link #testNlpgnnFullGeneration()} and {@link #testNlpgnnFullInteractive()} so the
-   * two sibling guards cannot diverge as the fixture changes.
+   * two sibling guards cannot diverge as the fixture changes. Package-visible so {@link
+   * TestNlpgnnTransformer} analyzes the same vendored project without duplicating the file list.
    */
-  private static final String[] NLPGNN_FULL_PROJECT_FILES = {
+  static final String[] NLPGNN_FULL_PROJECT_FILES = {
     "nlpgnn_full_proj/nlpgnn/__init__.py",
     "nlpgnn_full_proj/nlpgnn/abandoned/GCNConvv0.py",
     "nlpgnn_full_proj/nlpgnn/abandoned/__init__.py",

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNlpgnnTransformer.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNlpgnnTransformer.java
@@ -1,0 +1,122 @@
+package com.ibm.wala.cast.python.ml.test.tensorflow.v2;
+
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.FLOAT_32;
+import static java.util.Arrays.asList;
+
+import com.ibm.wala.cast.python.ml.test.categories.WholeProjectFixtures;
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * In-vivo exact-set pin for the NLPGNN BERT encoder loop ({@code Transformer.call} in {@code
+ * nlpgnn/layers/transformer.py}), the wala/ML#753 witness. Deliberately a single-test class: the
+ * pinned unions are deterministic in a fresh JVM but can flip under same-JVM predecessor analyses,
+ * whose {@code identityHashCode}/ASLR variance perturbs WALA-internal collection orders
+ * (wala/ML#753) &mdash; so this module's Surefire configuration forks a fresh JVM per test class,
+ * and the class gets its own wala/ML#755 CI shard. Do not add further tests to this class: a
+ * same-JVM predecessor analysis would reintroduce the flake.
+ */
+@Category(WholeProjectFixtures.class)
+public class TestNlpgnnTransformer extends AbstractTensorTest {
+
+  /**
+   * Pins the {@code Transformer.call} parameter unions the encoder loop settles on. PR
+   * ponder-lab/ML#629 (wala/ML#706) had to drop this pin as order-flaky; the wala/ML#753 arc (PRs
+   * ponder-lab/ML#650&ndash;659) made the analysis deterministic per configuration, leaving only
+   * the JVM-history carrier the per-class fork removes.
+   *
+   * <p>The {@code input_tensor} (value number 3) union carries one {@code (batch, seq, U)} member
+   * per entry pipeline reaching the encoder &mdash; the {@code (2, 4)}, {@code (2, 10)}, {@code (8,
+   * 10)}, {@code (8, 100)}, {@code (6, 128)}, and {@code (16, 100)} leading pairs from the entry
+   * scripts' {@code model.build} contracts (wala/ML#717) through the embedding's output reshape,
+   * each trailing hidden dimension a config-derived {@link UnresolvedDim} (wala/ML#721) &mdash;
+   * plus each pair's loop-carried degraded-rank siblings ({@code (batch, U)} and {@code (batch, U,
+   * U)} from the {@code reshape_to_matrix}/{@code reshape_from_matrix} round trip's non-entry
+   * contexts) and the fully-unresolved rank-2/rank-3 members. The {@code mask} (value number 4)
+   * union is the attention mask's {@code (batch, seq, seq)} broadcast per the same six entry
+   * pipelines.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNlpgnnFullTransformerInput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    // LinkedHashMap fixes the assertion order (value number 3 before 4) so a regression names the
+    // same value number on every run; Map.of iteration order varies per JVM.
+    Map<Integer, Set<TensorType>> expected = new LinkedHashMap<>();
+
+    expected.put(
+        3,
+        Set.of(
+            new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(FLOAT_32, asList(new NumericDim(2), UnresolvedDim.INSTANCE)),
+            new TensorType(FLOAT_32, asList(new NumericDim(6), UnresolvedDim.INSTANCE)),
+            new TensorType(FLOAT_32, asList(new NumericDim(8), UnresolvedDim.INSTANCE)),
+            new TensorType(FLOAT_32, asList(new NumericDim(16), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(new NumericDim(2), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(2), new NumericDim(4), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(2), new NumericDim(10), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(new NumericDim(6), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(6), new NumericDim(128), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(new NumericDim(8), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(8), new NumericDim(10), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(8), new NumericDim(100), UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(new NumericDim(16), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+            new TensorType(
+                FLOAT_32,
+                asList(new NumericDim(16), new NumericDim(100), UnresolvedDim.INSTANCE))));
+
+    expected.put(
+        4,
+        Set.of(
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(2), new NumericDim(4), new NumericDim(4))),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(2), new NumericDim(10), new NumericDim(10))),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(6), new NumericDim(128), new NumericDim(128))),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(8), new NumericDim(10), new NumericDim(10))),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(8), new NumericDim(100), new NumericDim(100))),
+            new TensorType(
+                FLOAT_32, asList(new NumericDim(16), new NumericDim(100), new NumericDim(100)))));
+
+    test(
+        TestCorpusFixtures.NLPGNN_FULL_PROJECT_FILES,
+        "nlpgnn/layers/transformer.py",
+        "Transformer.call",
+        "nlpgnn_full_proj",
+        2,
+        17,
+        expected);
+  }
+}


### PR DESCRIPTION
Restores the in-vivo exact-set pin that PR #629 had to drop (wala/ML#706): the `Transformer.call` `input_tensor` and `mask` parameter unions on the vendored NLPGNN BERT encoder loop, the wala/ML#753 witness.

The wala/ML#753 arc made the analysis deterministic per configuration; the residual flake carrier is same-JVM predecessor analyses, whose `identityHashCode`/ASLR variance perturbs WALA-internal collection orders, outside this repo's control. Fresh-JVM runs are deterministic (8/8 in the round-19 measurement; 4/4 on this branch). The pin therefore lands as a deliberately single-test class:

- `reuseForks=false` in the ML test module gives every test class its own forked JVM: the measured deterministic baseline, and a suite-wide de-flake since no class now inherits another's JVM history.
- `TestNlpgnnTransformer` holds the pin under the `WholeProjectFixtures` category, with its own `transformer-pin` shard in the `whole-project-fixtures` CI matrix (wala/ML#755).

Advances wala/ML#753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
