### PR TITLE
Keep per-possibility members when folding shape-list elements over multi-member sources

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -797,6 +797,35 @@ public class TestShapeOps extends AbstractTensorTest {
   }
 
   /**
+   * Fold-granularity guard for wala/ML#748: {@code f}'s parameter carries a two-member shape union
+   * (the concrete {@code (2, 3, 8)} constant and the dynamic-batch Keras input) through a
+   * conditional's φ, so the {@code tf.shape(x)[i]} extractions fold against a multi-member source.
+   * Each member keeps its own axis classification &mdash; the concrete-sourced member folds to its
+   * constants, the dynamic-sourced one to {@link DynamicDim} on the batch axis &mdash; instead of
+   * the ambiguity joining every member to the wider marker.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testReshapeTfShapeUnion()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reshape_tf_shape_union.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                TensorType.of(FLOAT_32, 2, 3, 8),
+                new TensorType(
+                    FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(3), new NumericDim(8))))));
+  }
+
+  /**
    * A configuration attribute as a literal concat element (wala/ML#712): the reshape target
    * concatenates a shape-vector slice with {@code [self.units]}, whose stored value is the
    * constructor argument, exercising the constant fallback of the attribute chase.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -323,7 +323,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
-      Map<PointsToSetVariable, TensorType> reshapeNodes,
+      Map<PointsToSetVariable, Set<TensorType>> reshapeNodes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
@@ -419,7 +419,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             @Override
             public boolean equals(Object o) {
               return this == o
-                  || ((o instanceof ReshapeOp) && setShapeTo.equals(((ReshapeOp) o).reshapeTo));
+                  || ((o instanceof SetShapeOp) && setShapeTo.equals(((SetShapeOp) o).setShapeTo));
             }
 
             @Override
@@ -672,68 +672,79 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
           }
 
           final class ReshapeOp extends UnaryOperator<TensorVariable> {
-            private final TensorType reshapeTo;
+            private final Set<TensorType> reshapeTos;
             private final PointsToSetVariable v;
 
-            public ReshapeOp(TensorType reshapeTo, PointsToSetVariable v) {
+            public ReshapeOp(Set<TensorType> reshapeTos, PointsToSetVariable v) {
               this.v = v;
-              this.reshapeTo = reshapeTo;
+              this.reshapeTos = reshapeTos;
             }
 
             @Override
             public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
               boolean changed = false;
-              int ssz = reshapeTo.symbolicDims();
-              int csz = reshapeTo.concreteSize();
               if (rhs != null && rhs.state != null) {
                 for (TensorType t : rhs.state) {
-                  TensorType newType = reshapeTo;
-                  // If there is exactly one dynamic dimension (symbolic), try to resolve it by
-                  // comparing the total size of the input tensor with the concrete size of the
-                  // target shape.
-                  if (ssz == 1 && t.symbolicDims() == 0 && t.concreteSize() != -1) {
-                    int totalSize = t.concreteSize();
-                    int partialSize = 1;
-                    for (Dimension<?> d : reshapeTo.getDims()) {
-                      if (d instanceof NumericDim) {
-                        partialSize *= ((NumericDim) d).value();
-                      }
-                    }
+                  // The target carries one pinned member per resolved shape possibility
+                  // (wala/ML#748); each incoming member is reshaped against every one, and a
+                  // mismatch is only an error when no target agrees.
+                  boolean anyTargetAgrees = false;
 
-                    if (partialSize > 0 && totalSize % partialSize == 0) {
-                      int missingDim = totalSize / partialSize;
-                      List<Dimension<?>> newDims = new ArrayList<>();
+                  for (TensorType reshapeTo : reshapeTos) {
+                    int ssz = reshapeTo.symbolicDims();
+                    int csz = reshapeTo.concreteSize();
+                    TensorType newType = reshapeTo;
+                    // If there is exactly one dynamic dimension (symbolic), try to resolve it by
+                    // comparing the total size of the input tensor with the concrete size of the
+                    // target shape.
+                    if (ssz == 1 && t.symbolicDims() == 0 && t.concreteSize() != -1) {
+                      int totalSize = t.concreteSize();
+                      int partialSize = 1;
                       for (Dimension<?> d : reshapeTo.getDims()) {
-                        if (d instanceof SymbolicDim) {
-                          newDims.add(new NumericDim(missingDim));
-                        } else {
-                          newDims.add(d);
+                        if (d instanceof NumericDim) {
+                          partialSize *= ((NumericDim) d).value();
                         }
                       }
-                      // Use the source tensor's cell type to ensure precision in the reshaped type.
-                      newType = new TensorType(t.getCellType(), newDims);
+
+                      if (partialSize > 0 && totalSize % partialSize == 0) {
+                        int missingDim = totalSize / partialSize;
+                        List<Dimension<?>> newDims = new ArrayList<>();
+                        for (Dimension<?> d : reshapeTo.getDims()) {
+                          if (d instanceof SymbolicDim) {
+                            newDims.add(new NumericDim(missingDim));
+                          } else {
+                            newDims.add(d);
+                          }
+                        }
+                        // Use the source tensor's cell type to ensure precision in the reshaped
+                        // type.
+                        newType = new TensorType(t.getCellType(), newDims);
+                      } else {
+                        newType = new TensorType(t.getCellType(), reshapeTo.getDims());
+                      }
                     } else {
                       newType = new TensorType(t.getCellType(), reshapeTo.getDims());
                     }
-                  } else {
-                    newType = new TensorType(t.getCellType(), reshapeTo.getDims());
+
+                    // Process the reshape normally regardless of whether there is a shape mismatch
+                    // so that tensor type propagation continues. The shape may be inaccurate, but
+                    // users can inspect the error messages to find out about it. See
+                    // https://github.com/wala/ML/issues/195.
+                    if (lhs.state == null) {
+                      lhs.state = HashSetFactory.make();
+                    }
+                    changed |= lhs.state.add(newType);
+
+                    if (t.symbolicDims() == ssz && t.concreteSize() == csz) anyTargetAgrees = true;
                   }
 
-                  // Process the reshape normally regardless of whether there is a shape mismatch so
-                  // that tensor type propagation continues. The shape may be inaccurate, but users
-                  // can inspect the error messages to find out about it. See
-                  // https://github.com/wala/ML/issues/195.
-                  if (lhs.state == null) {
-                    lhs.state = HashSetFactory.make();
-                  }
-                  changed |= lhs.state.add(newType);
-
-                  if (t.symbolicDims() != ssz || t.concreteSize() != csz) {
+                  if (!anyTargetAgrees && !reshapeTos.isEmpty()) {
                     Position pos = getTargetPos(v.getPointerKey());
                     assert pos != null;
                     errorLog.put(
                         v.getPointerKey(),
-                        new ReshapeError(t, reshapeTo, pos, getTargetDef(v.getPointerKey())));
+                        new ReshapeError(
+                            t, reshapeTos.iterator().next(), pos, getTargetDef(v.getPointerKey())));
                   }
                 }
                 // `tf.reshape` is a TensorFlow operation; its result is TensorFlow-origin
@@ -745,18 +756,18 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
 
             @Override
             public int hashCode() {
-              return reshapeTo.hashCode();
+              return reshapeTos.hashCode();
             }
 
             @Override
             public boolean equals(Object o) {
               return this == o
-                  || ((o instanceof ReshapeOp) && reshapeTo.equals(((ReshapeOp) o).reshapeTo));
+                  || ((o instanceof ReshapeOp) && reshapeTos.equals(((ReshapeOp) o).reshapeTos));
             }
 
             @Override
             public String toString() {
-              return "reshape to " + reshapeTo;
+              return "reshape to " + reshapeTos;
             }
           }
 
@@ -917,7 +928,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, Set<TensorType>> init,
       Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
-      Map<PointsToSetVariable, TensorType> reshapeTypes,
+      Map<PointsToSetVariable, Set<TensorType>> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
@@ -958,7 +969,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, Set<TensorType>> init,
       Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
-      Map<PointsToSetVariable, TensorType> reshapeTypes,
+      Map<PointsToSetVariable, Set<TensorType>> reshapeTypes,
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1069,9 +1069,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     return new TensorType(cellType, merged);
   }
 
-  private Map<PointsToSetVariable, TensorType> getShapeSourceCalls(
+  private Map<PointsToSetVariable, Set<TensorType>> getShapeSourceCalls(
       MethodReference op, PropagationCallGraphBuilder builder, int param) {
-    Map<PointsToSetVariable, TensorType> targets = HashMapFactory.make();
+    Map<PointsToSetVariable, Set<TensorType>> targets = HashMapFactory.make();
     getSourceCalls(
         op,
         builder,
@@ -1109,7 +1109,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             if (builder.getPropagationSystem().isImplicit(defKey)) return;
             PointsToSetVariable defVariable =
                 builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
-            TensorType pinned = null;
+            Set<TensorType> pinned;
             if (literalContainer) {
               // Merge the generator-side computation into the pinned type so the pin agrees with
               // the seeded result instead of contributing a weaker parallel member (wala/ML#713).
@@ -1117,18 +1117,22 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               // embedded interpreter (e.g. an `np.prod(..., axis=0)` the provenance walk refuses),
               // while the generator side also resolves field reads, shape-vector subscripts, and
               // `build`-computed attributes; the pointwise merge keeps the more precise dimension
-              // from each.
+              // from each. A multi-member generator result merges per member, so the pin carries
+              // one member per resolved shape possibility instead of discarding the generator's
+              // precision for the weaker interpreter type (wala/ML#748).
               TensorType shapeArgType = TensorType.shapeArg(src, shapeVn, builder);
               Set<TensorType> generatorTypes = this.getTensorTypes(defVariable, builder);
-              pinned =
-                  generatorTypes != null && generatorTypes.size() == 1
-                      ? mergePinnedTypes(generatorTypes.iterator().next(), shapeArgType)
-                      : shapeArgType;
+              if (generatorTypes != null && !generatorTypes.isEmpty()) {
+                pinned = HashSetFactory.make();
+                for (TensorType generatorType : generatorTypes)
+                  pinned.add(mergePinnedTypes(generatorType, shapeArgType));
+              } else pinned = Collections.singleton(shapeArgType);
             } else
               pinned =
-                  new TensorType(
-                      TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),
-                      null);
+                  Collections.singleton(
+                      new TensorType(
+                          TensorFlowTypes.DType.FLOAT32.name().toLowerCase(java.util.Locale.ROOT),
+                          null));
             targets.put(defVariable, pinned);
           }
         });
@@ -1421,12 +1425,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         if (!origins.isEmpty()) initOrigins.put(v, origins);
       }
 
-      Map<PointsToSetVariable, TensorType> placeholders =
+      Map<PointsToSetVariable, Set<TensorType>> placeholders =
           handleShapeSourceOp(builder, dataflow, placeholder, 2);
       LOGGER.fine("Placeholders: " + placeholders);
 
-      for (Map.Entry<PointsToSetVariable, TensorType> e : placeholders.entrySet()) {
-        init.put(e.getKey(), Set.of(e.getValue()));
+      for (Map.Entry<PointsToSetVariable, Set<TensorType>> e : placeholders.entrySet()) {
+        init.put(e.getKey(), e.getValue());
         // `tf.compat.v1.placeholder` is a TensorFlow API (wala/ML#724).
         initOrigins.put(e.getKey(), EnumSet.of(TensorOrigin.TENSORFLOW));
       }
@@ -1555,7 +1559,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         LOGGER.fine(
             () -> "  feed " + f.getValue().kind() + ": " + describe(f.getKey().getPointerKey()));
 
-      Map<PointsToSetVariable, TensorType> shapeOps = HashMapFactory.make();
+      Map<PointsToSetVariable, Set<TensorType>> shapeOps = HashMapFactory.make();
       shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));
 
       handlePassThroughOp(builder, dataflow, convert_to_tensor, 1);
@@ -1791,12 +1795,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     }
   }
 
-  private Map<PointsToSetVariable, TensorType> handleShapeSourceOp(
+  private Map<PointsToSetVariable, Set<TensorType>> handleShapeSourceOp(
       PropagationCallGraphBuilder builder,
       Graph<PointsToSetVariable> dataflow,
       MethodReference op,
       int shapeSrcOperand) {
-    Map<PointsToSetVariable, TensorType> reshapeTypes =
+    Map<PointsToSetVariable, Set<TensorType>> reshapeTypes =
         getShapeSourceCalls(op, builder, shapeSrcOperand);
     for (PointsToSetVariable to : reshapeTypes.keySet()) {
       assert to.getPointerKey() instanceof LocalPointerKey;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -665,16 +665,22 @@ public abstract class TensorGenerator {
             resolved.add(s);
             continue;
           }
-          // An empty position holds no resolved constant. Before degrading, try to fold a binary
-          // op over constant-valued operands (e.g. `self.heads * self.out_features`) via the
-          // analysis. `interpretAsInt` in `TensorType.shapeArg` only handles pure-literal source
-          // text; this generator-side path resolves field reads and globals through the PTS,
-          // reconciling the two shape-argument-extraction paths (wala/ML#581). An unfoldable
-          // position is a fixed runtime size the analysis could not compute — `UnresolvedDim`,
-          // not `DynamicDim`; an explicit `None` resolves through the constant path above
+          // An empty position holds no resolved constant. Before degrading, try the dimension
+          // folds — a binary op over constant-valued operands (e.g. `self.heads *
+          // self.out_features`), a shape-vector product/subscript, or a stored attribute — via
+          // the analysis. `interpretAsInt` in `TensorType.shapeArg` only handles pure-literal
+          // source text; this generator-side path resolves field reads and globals through the
+          // PTS, reconciling the two shape-argument-extraction paths (wala/ML#581). A
+          // multi-member source contributes one option per possibility, which the product below
+          // expands into per-possibility members (wala/ML#748). An unfoldable position is a
+          // fixed runtime size the analysis could not compute — `UnresolvedDim`, not
+          // `DynamicDim`; an explicit `None` resolves through the constant path above
           // (wala/ML#721).
-          Dimension<?> folded = foldArithmeticShapeDim(builder, asin, k);
-          resolved.add(Collections.singleton(folded != null ? folded : UnresolvedDim.INSTANCE));
+          Set<Dimension<?>> folded = this.foldArithmeticShapeDims(builder, asin, k);
+          resolved.add(
+              folded != null && !folded.isEmpty()
+                  ? folded
+                  : Collections.singleton(UnresolvedDim.INSTANCE));
         }
 
         List<List<Dimension<?>>> shapes = new ArrayList<>();
@@ -816,23 +822,25 @@ public abstract class TensorGenerator {
 
   /**
    * Attempts to fold the shape dimension at {@code fieldIndex} of the shape list/tuple allocated at
-   * {@code listAsin} when that element is a binary op over constant-valued operands (e.g. {@code
-   * self.heads * self.out_features}).
+   * {@code listAsin} through the dimension-fold arms: a binary op over constant-valued operands
+   * (e.g. {@code self.heads * self.out_features}), a shape-vector product, subscript, or subscript
+   * arithmetic, or a stored attribute.
    *
    * <p>The element write is located in the list's allocating node IR, and the binary op's operands
    * are resolved to constants through the points-to analysis (so field reads and globals resolve,
    * not just source-text literals). This is the generator-side half of the shape-argument
    * reconciliation in wala/ML#581: {@link TensorType#shapeArg(CGNode, int,
    * PropagationCallGraphBuilder)} can fold literal source text via the embedded interpreter but has
-   * no points-to analysis to resolve {@code self.X}.
+   * no points-to analysis to resolve {@code self.X}. An element over a multi-member source (e.g. a
+   * {@code tf.shape(x)[i]} extraction whose {@code x} unions several shapes) folds to one option
+   * per source possibility rather than degrading (wala/ML#748).
    *
    * @param builder The propagation call graph builder, used to resolve operand points-to sets.
    * @param listAsin The allocation site of the shape list/tuple.
    * @param fieldIndex The position whose dimension is being folded.
-   * @return A {@link NumericDim} holding the folded value, or {@code null} if the element is not a
-   *     constant-foldable binary op.
+   * @return The folded dimension options, or {@code null} if no arm resolves the element.
    */
-  private Dimension<?> foldArithmeticShapeDim(
+  private Set<Dimension<?>> foldArithmeticShapeDims(
       PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin, int fieldIndex) {
     CGNode node = listAsin.getNode();
     if (node.getIR() == null) return null;
@@ -877,15 +885,27 @@ public abstract class TensorGenerator {
       if (objRef != listVn || index == null || index.intValue() != fieldIndex) continue;
 
       // Shared with `TensorType.shapeArg` so the two shape-argument paths agree (wala/ML#581).
+      // Each arm pairs the single-member resolver with its multi-member counterpart
+      // (wala/ML#717), so an element over a multi-member source contributes one option per
+      // source possibility instead of degrading the position wholesale (wala/ML#748).
       Dimension<?> folded = TensorType.foldArithmeticDim(builder, node, st, du, writtenVal);
-      if (folded != null) return folded;
+      if (folded != null) return Collections.singleton(folded);
       folded = this.prodOfShapeVectorDim(builder, node, st, writtenVal);
-      if (folded != null) return folded;
+      if (folded != null) return Collections.singleton(folded);
+      Set<Dimension<?>> products = this.prodOfShapeVectorDims(builder, node, st, writtenVal);
+      if (products != null) return products;
       folded = this.resolveShapeVectorElementDim(builder, node, st, writtenVal);
-      if (folded != null) return folded;
+      if (folded != null) return Collections.singleton(folded);
+      Set<Dimension<?>> elements =
+          this.resolveShapeVectorElementDims(builder, node, st, writtenVal);
+      if (elements != null) return elements;
       folded = this.resolveArithmeticOverSubscriptDim(builder, node, st, writtenVal);
-      if (folded != null) return folded;
-      return this.resolveStoredAttributeDim(builder, node, writtenVal);
+      if (folded != null) return Collections.singleton(folded);
+      Set<Dimension<?>> arithmetic =
+          this.resolveArithmeticOverSubscriptDims(builder, node, st, writtenVal);
+      if (arithmetic != null) return arithmetic;
+      folded = this.resolveStoredAttributeDim(builder, node, writtenVal);
+      return folded == null ? null : Collections.singleton(folded);
     }
     return null;
   }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reshape_tf_shape_union.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reshape_tf_shape_union.py
@@ -1,0 +1,34 @@
+import os
+
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+# Fold-granularity witness (wala/ML#748): `f`'s parameter carries a two-member
+# shape union — the concrete (2, 3, 8) constant and the dynamic-batch Keras
+# input — through the conditional's φ, so the `tf.shape(x)` extractions fold
+# against a multi-member source. Each member must keep its own axis
+# classification (the concrete-sourced member folds to the constants, the
+# dynamic-sourced one to *dynamic* on the batch axis), rather than the
+# ambiguity joining every member to the wider marker.
+def f(x):
+    b = tf.shape(x)[0]
+    s = tf.shape(x)[1]
+    y = tf.reshape(x, [b, s, 8])
+    consume(y)
+    return y
+
+
+flag = os.environ.get("ARIADNE_TEST_FLAG") == "1"
+
+a = tf.ones((2, 3, 8))
+inp = tf.keras.Input(shape=(3, 8))
+x = inp if flag else a
+
+out = f(x)
+
+assert out.shape == (2, 3, 8)
+assert out.dtype == tf.float32


### PR DESCRIPTION
The wala/ML#748 granularity loss, repaired at its surviving reproducer: a shape-list element folded over a multi-member source (e.g. `tf.shape(x)[i]` where `x` unions a concrete shape with a dynamic-batch one) degraded the whole position to `Unresolved`, because the shape-argument chase only consulted the single-member resolvers and the reshape pin could carry a single type. The fixture's two-member union collapsed to the lone `(U, U, 8)`; it now keeps `(2, 3, 8)` alongside `(Dynamic, 3, 8)`.

Two halves, one mechanism:

- `TensorGenerator`'s shape-argument element chase pairs each single-member resolver with its wala/ML#717 multi-member counterpart, so an ambiguous source contributes one option per possibility and the existing cartesian composition expands them into per-possibility members.
- The reshape pin (`handleShapeSourceOp` → `ReshapeOp`) carries a set of pinned members, per-member merged with the `shapeArg` interpreter type (extending the wala/ML#713 pointwise merge), instead of discarding the generator's precision for the weaker interpreter type whenever the generator resolved more than one member. A reshape mismatch is an error only when no pinned member agrees.

The issue's original in-vivo witness signature (concrete `(2, 3, 8)`-family first evaluations in the vendored gpt-2 decoder chain, degraded on re-evaluation) no longer exists on master: the full `testGpt2GetLossVendored` FINE log carries no such members, and its pinned `(Dynamic, Dynamic, 10)` logits union is the runtime-true form per the dataset entry. All corpus pins, including that one and the wala/ML#753 transformer pin, are unchanged by this fix.

Advances wala/ML#748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
