### PR TITLE
Register `einsum` in `createManualGenerator` and feed the dtype axis of shape-resolved seeds

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -317,9 +317,14 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param kind The composition kind.
    * @param operands The feeding operand variables, in operand order.
    * @param seedDType The suppressed seed's dtype; {@link DType#UNKNOWN} when it had none.
+   * @param seedMembers The suppressed seed's retained members for {@link
+   *     TensorGenerator.TypeFeedKind#DTYPE_FILL} (wala/ML#758); empty for the other kinds.
    */
   public record FeedPlan(
-      TensorGenerator.TypeFeedKind kind, List<PointsToSetVariable> operands, DType seedDType) {}
+      TensorGenerator.TypeFeedKind kind,
+      List<PointsToSetVariable> operands,
+      DType seedDType,
+      Set<TensorType> seedMembers) {}
 
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
@@ -546,6 +551,16 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                 case DTYPE_ONLY:
                   for (TensorType t : rhs.state)
                     changed |= lhs.state.add(new TensorType(this.pickDType(t), null));
+                  break;
+                case DTYPE_FILL:
+                  // The generator proved the seed's shape but not its dtype (wala/ML#758): each
+                  // retained seed member keeps its dims and takes the operand member's dtype. An
+                  // unknown operand dtype composes the member as the seed asserted it, so the
+                  // destination never loses the shape evidence.
+                  for (TensorType t : rhs.state)
+                    for (TensorType s : this.plan.seedMembers())
+                      changed |=
+                          lhs.state.add(TensorType.of(t.getDType(), s.getDims(), s.layout()));
                   break;
                 case PASS_THROUGH:
                   for (TensorType t : rhs.state)

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1514,13 +1514,18 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       Map<PointsToSetVariable, Set<TensorOrigin>> suppressedOrigins = HashMapFactory.make();
       for (PointsToSetVariable src : sources) {
         Set<TensorType> types = init.get(src);
-        if (types == null || types.size() != 1) continue;
-        TensorType only = types.iterator().next();
-        // Only a pure-⊤ seed is replaced: suppressing a seed whose dtype the generator proved
-        // couples into the engine-side pin computations that read seeded state (the vendored
-        // Conv1d and gather probes are the witnesses), so the known-dtype widening stays with
-        // wala/ML#682's residual.
-        if (only.getDims() != null || only.getDType() != DType.UNKNOWN) continue;
+        // Two eligible seed classes, both entirely dtype-unproven: a single pure-⊤ member is
+        // replaced by the generator-declared composition, and any other all-unknown-dtype seed
+        // (shape-resolved members, several members, or a mix) keeps its members with only the
+        // dtype fed (wala/ML#758's DTYPE_FILL, the class the einsum producer registration
+        // surfaces, wala/ML#757). Suppressing a seed with any dtype the generator PROVED couples
+        // into the engine-side pin computations that read seeded state (the vendored Conv1d and
+        // gather probes are the witnesses), so the known-dtype widening stays with wala/ML#682's
+        // residual.
+        if (types == null || types.isEmpty()) continue;
+        if (types.stream().anyMatch(t -> t.getDType() != DType.UNKNOWN)) continue;
+        boolean pureTopSeed = types.size() == 1 && types.iterator().next().getDims() == null;
+        boolean fillSeed = !pureTopSeed;
         TensorGenerator generator;
         try {
           generator = getGenerator(src, builder);
@@ -1538,16 +1543,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           feedSources.add(operand);
         }
         // A broadcast composes pairs, so it needs both operands; the other kinds need at least
-        // one located operand. Otherwise keep the seed.
+        // one located operand. Otherwise keep the seed. A fill seed always fills from any
+        // located operand, since only the dtype is borrowed.
         if (feedSources.isEmpty()
-            || (feed.kind() == TensorGenerator.TypeFeedKind.BROADCAST && feedSources.size() != 2))
-          continue;
+            || (pureTopSeed
+                && feed.kind() == TensorGenerator.TypeFeedKind.BROADCAST
+                && feedSources.size() != 2)) continue;
         for (PointsToSetVariable operand : feedSources) {
           if (!dataflow.containsNode(operand)) dataflow.addNode(operand);
           if (!dataflow.hasEdge(operand, src)) dataflow.addEdge(operand, src);
         }
         typeFeeds.put(
-            src, new TensorTypeAnalysis.FeedPlan(feed.kind(), feedSources, only.getDType()));
+            src,
+            new TensorTypeAnalysis.FeedPlan(
+                fillSeed ? TensorGenerator.TypeFeedKind.DTYPE_FILL : feed.kind(),
+                feedSources,
+                DType.UNKNOWN,
+                fillSeed ? types : Collections.emptySet()));
         suppressedSeeds.put(src, types);
         Set<TensorOrigin> origins = initOrigins.get(src);
         if (origins != null) suppressedOrigins.put(src, origins);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4133,7 +4133,15 @@ public abstract class TensorGenerator {
     PASS_THROUGH,
 
     /** The two operands' member shapes broadcast pairwise (element-wise semantics). */
-    BROADCAST
+    BROADCAST,
+
+    /**
+     * Each operand member's dtype fills the suppressed seed's retained shape members (wala/ML#758):
+     * the generator proved the shape but not the dtype, so the composition keeps the seed's dims
+     * and takes the operand's dtype. Selected engine-side for shape-resolved unknown-dtype seeds;
+     * generators declare one of the other kinds.
+     */
+    DTYPE_FILL
   }
 
   /**
@@ -6740,6 +6748,8 @@ public abstract class TensorGenerator {
       return new ElementWiseOperation(node);
     } else if (type.equals(TensorFlowTypes.TRANSPOSE.getDeclaringClass())) {
       return new Transpose(node);
+    } else if (type.equals(TensorFlowTypes.EINSUM.getDeclaringClass())) {
+      return new Einsum(node);
     } else if (type.equals(TensorFlowTypes.RESHAPE.getDeclaringClass())) {
       return new Reshape(node);
     } else if (type.equals(TensorFlowTypes.SQUEEZE.getDeclaringClass())) {


### PR DESCRIPTION
Registers `tf.einsum` in the producer-delegation dispatch table (`createManualGenerator`), closing the two-table gap wala/ML#757 filed: every producer delegation to an einsum allocation dead-ended at ⊥ (24 ⊥-settled members on the NLPGNN attention chain in the wala/ML#753 round-5 replay), a standing ⊤-pressure on the encoder-loop resolution.

The registration alone regresses dtype precision, and the issue's lighter remedy does not help: the twins are in-band settled `UNKNOWN`s, not the null-delegation arm's (round-1 measurement on the issue). The mechanism is a feed-gate coupling: with einsum shapes resolving, the affected seeds (einsum results, and the element-wise seeds their operands feed) are no longer pure-⊤, fall outside the wala/ML#682 feed guard, and their unresolved dtype rides to the union as shape-twins of the resolved members.

The companion change decouples the feed by axis (the first wala/ML#758 unit): a new `DTYPE_FILL` feed kind serves seeds that are entirely dtype-unproven but carry resolved shape members (single- or multi-member). The seed's members are retained with their dims and only the dtype composes from the operands' converged dataflow state; an unfed destination restores its seed as before. The wala/ML#682 guard's substance is preserved: any seed with a generator-proven dtype is untouched, which is the class whose suppression the vendored Conv1d and gather probes guard.

Both twin witnesses (`testNlpgnnFullEinsumViaMatmul`, `testNlpgnnFullDense3dInput`) pass with their expectations unchanged, as do `TestEinsum` and the wala/ML#753 transformer pin.

Closes wala/ML#757. Advances wala/ML#758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
