### PR TITLE
Feed the shape axis of dtype-proven shape-⊤ seeds

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -667,7 +667,11 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                 // whatever produced the input (wala/ML#724).
                 changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
               }
-              return changed ? CHANGED_AND_FIXED : NOT_CHANGED;
+              // Never FIXED: the composition consumes the predecessor's members, so an edge fixed
+              // on an early evaluation (e.g. against a suppressed seed whose feed delivers later,
+              // wala/ML#758) would hold the pin's output stale at whatever the predecessor carried
+              // first. The transfer only adds members, so re-evaluation is monotone.
+              return changed ? CHANGED : NOT_CHANGED;
             }
 
             @Override
@@ -766,7 +770,11 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                 // whatever produced the input (wala/ML#724).
                 changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
               }
-              return changed ? CHANGED_AND_FIXED : NOT_CHANGED;
+              // Never FIXED: the composition consumes the predecessor's members, so an edge fixed
+              // on an early evaluation (e.g. against a suppressed seed whose feed delivers later,
+              // wala/ML#758) would hold the pin's output stale at whatever the predecessor carried
+              // first. The transfer only adds members, so re-evaluation is monotone.
+              return changed ? CHANGED : NOT_CHANGED;
             }
 
             @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -309,21 +309,44 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
   }
 
   /**
-   * A type feed installed on a destination (wala/ML#736, wala/ML#682): the composition kind, the
-   * feeding operand variables in operand order, and the dtype the suppressed seed had resolved
-   * (kept when known, since the operands' dataflow dtype can be weaker than what the generator
-   * proved).
+   * Which axes of the suppressed seed a type feed trusts (wala/ML#758): a fill keeps the axis the
+   * generator proved and composes only the unproven one from the operands' converged state, so
+   * proven evidence is never lost to a weaker operand member.
+   */
+  public enum FeedMode {
+    /** The whole member composes from the operands per the declared kind (wala/ML#736). */
+    REPLACE,
+
+    /**
+     * The generator proved the seed's shape but not its dtype: each retained seed member keeps its
+     * dims and takes the operand member's dtype. The dtype is kind-independent, so the declared
+     * kind is not consulted.
+     */
+    DTYPE_FILL,
+
+    /**
+     * The generator proved the seed's dtype but some member's shape stayed at ⊤: shape-resolved
+     * seed members are retained verbatim, and each ⊤-shape member takes its dims from the operand
+     * state composed per the declared kind, keeping its own dtype when proven.
+     */
+    SHAPE_FILL
+  }
+
+  /**
+   * A type feed installed on a destination (wala/ML#736, wala/ML#682): the generator-declared
+   * composition kind, the trusted-axes mode, the feeding operand variables in operand order, and
+   * the suppressed seed's members.
    *
-   * @param kind The composition kind.
+   * @param kind The generator-declared composition kind.
+   * @param mode Which axes of the suppressed seed the feed trusts (wala/ML#758).
    * @param operands The feeding operand variables, in operand order.
-   * @param seedDType The suppressed seed's dtype; {@link DType#UNKNOWN} when it had none.
-   * @param seedMembers The suppressed seed's retained members for {@link
-   *     TensorGenerator.TypeFeedKind#DTYPE_FILL} (wala/ML#758); empty for the other kinds.
+   * @param seedMembers The suppressed seed's retained members for the fill modes; empty for {@link
+   *     FeedMode#REPLACE}.
    */
   public record FeedPlan(
       TensorGenerator.TypeFeedKind kind,
+      FeedMode mode,
       List<PointsToSetVariable> operands,
-      DType seedDType,
       Set<TensorType> seedMembers) {}
 
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
@@ -522,15 +545,19 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
           /**
            * A transfer function for the synthetic type-feed edge from a generator's operand to its
            * result (wala/ML#736, wala/ML#682): the result variable, whose generator seed did not
-           * resolve its shape (and possibly not its dtype), instead composes members from the
-           * operands' converged dataflow state, which the PTS-based walks cannot see. Composition
-           * follows the plan's kind: {@code DTYPE_ONLY} lifts each operand member's dtype as an
-           * unknown-shape member; {@code PASS_THROUGH} forwards each member unchanged; {@code
-           * BROADCAST} pairs each incoming member with the other operand's current members and
-           * broadcasts their shapes (a pair whose shapes don't broadcast statically degrades to an
-           * unknown shape, and no member composes until both operands carry state, so the result is
-           * order-independent). A seed dtype the generator had proven wins over the operand
-           * members' dtype, which can be weaker.
+           * resolve some axis, instead composes members from the operands' converged dataflow
+           * state, which the PTS-based walks cannot see. Under {@link FeedMode#REPLACE} the whole
+           * member composes per the declared kind: {@code DTYPE_ONLY} lifts each operand member's
+           * dtype as an unknown-shape member; {@code PASS_THROUGH} forwards each member unchanged;
+           * {@code BROADCAST} pairs each incoming member with the other operand's current members
+           * and broadcasts their shapes (a pair whose shapes don't broadcast statically degrades to
+           * an unknown shape, and no member composes until both operands carry state, so the result
+           * is order-independent). The fill modes trust the axis the generator proved and compose
+           * only the other (wala/ML#758): {@link FeedMode#DTYPE_FILL} keeps each retained seed
+           * member's dims and takes the operand member's dtype; {@link FeedMode#SHAPE_FILL} retains
+           * shape-resolved seed members verbatim and gives each ⊤-shape member the dims the
+           * declared kind composes from the operand state, keeping a proven member dtype over the
+           * operand's, which can be weaker.
            */
           final class TypeFeedOp extends UnaryOperator<TensorVariable> {
             private final FeedPlan plan;
@@ -547,36 +574,41 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                 return NOT_CHANGED;
               boolean changed = false;
               if (lhs.state == null) lhs.state = HashSetFactory.make();
-              switch (this.plan.kind()) {
-                case DTYPE_ONLY:
-                  for (TensorType t : rhs.state)
-                    changed |= lhs.state.add(new TensorType(this.pickDType(t), null));
-                  break;
+              switch (this.plan.mode()) {
                 case DTYPE_FILL:
-                  // The generator proved the seed's shape but not its dtype (wala/ML#758): each
-                  // retained seed member keeps its dims and takes the operand member's dtype. An
-                  // unknown operand dtype composes the member as the seed asserted it, so the
+                  // An unknown operand dtype composes the member as the seed asserted it, so the
                   // destination never loses the shape evidence.
                   for (TensorType t : rhs.state)
                     for (TensorType s : this.plan.seedMembers())
                       changed |=
                           lhs.state.add(TensorType.of(t.getDType(), s.getDims(), s.layout()));
                   break;
-                case PASS_THROUGH:
-                  for (TensorType t : rhs.state)
-                    changed |=
-                        lhs.state.add(TensorType.of(this.pickDType(t), t.getDims(), t.layout()));
+                case SHAPE_FILL:
+                  for (TensorType composed : this.composeOperandMembers(rhs))
+                    for (TensorType s : this.plan.seedMembers())
+                      changed |=
+                          lhs.state.add(
+                              s.getDims() != null
+                                  ? s
+                                  : TensorType.of(
+                                      s.getDType() != DType.UNKNOWN
+                                          ? s.getDType()
+                                          : composed.getDType(),
+                                      composed.getDims(),
+                                      composed.layout()));
                   break;
-                case BROADCAST:
-                  PointsToSetVariable other =
-                      this.plan.operands().get(0).equals(this.source)
-                          ? this.plan.operands().get(1)
-                          : this.plan.operands().get(0);
-                  TensorVariable otherOut = outAccessor.get().apply(other);
-                  if (otherOut == null || otherOut.state == null) return NOT_CHANGED;
-                  for (TensorType t : rhs.state)
-                    for (TensorType u : otherOut.state)
-                      changed |= lhs.state.add(this.broadcastMembers(t, u));
+                case REPLACE:
+                  switch (this.plan.kind()) {
+                    case DTYPE_ONLY:
+                      for (TensorType t : rhs.state)
+                        changed |= lhs.state.add(new TensorType(t.getDType(), null));
+                      break;
+                    case PASS_THROUGH:
+                    case BROADCAST:
+                      for (TensorType composed : this.composeOperandMembers(rhs))
+                        changed |= lhs.state.add(composed);
+                      break;
+                  }
                   break;
               }
               // The fed result is a TensorFlow op's product regardless of what produced the
@@ -586,16 +618,49 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             }
 
             /**
+             * Composes the incoming operand state into result members per the declared kind: {@code
+             * PASS_THROUGH} forwards each member, {@code BROADCAST} pairs each incoming member with
+             * the other operand's current members (empty until both operands carry state), and
+             * {@code DTYPE_ONLY} composes no shape-bearing members (the engine never installs a
+             * shape-consuming feed for it).
+             *
+             * @param rhs The incoming operand's variable.
+             * @return The composed members.
+             */
+            private Set<TensorType> composeOperandMembers(TensorVariable rhs) {
+              Set<TensorType> composed = HashSetFactory.make();
+              switch (this.plan.kind()) {
+                case PASS_THROUGH:
+                  composed.addAll(rhs.state);
+                  break;
+                case BROADCAST:
+                  PointsToSetVariable other =
+                      this.plan.operands().get(0).equals(this.source)
+                          ? this.plan.operands().get(1)
+                          : this.plan.operands().get(0);
+                  TensorVariable otherOut = outAccessor.get().apply(other);
+                  if (otherOut == null || otherOut.state == null) break;
+                  for (TensorType t : rhs.state)
+                    for (TensorType u : otherOut.state) composed.add(this.broadcastMembers(t, u));
+                  break;
+                case DTYPE_ONLY:
+                  break;
+              }
+              return composed;
+            }
+
+            /**
              * Broadcasts one member pair: the shapes broadcast right-aligned when both are known
              * and compatible, and degrade to unknown otherwise (an unmarked non-numeric dimension
-             * or statically incompatible sizes).
+             * or statically incompatible sizes). The dtype is the pair's proven one when either
+             * member carries it.
              *
              * @param t The incoming operand's member.
              * @param u The other operand's member.
              * @return The composed member.
              */
             private TensorType broadcastMembers(TensorType t, TensorType u) {
-              DType dtype = this.pickDType(t.getDType() != DType.UNKNOWN ? t : u);
+              DType dtype = t.getDType() != DType.UNKNOWN ? t.getDType() : u.getDType();
               if (t.getDims() == null || u.getDims() == null) return new TensorType(dtype, null);
               try {
                 return new TensorType(
@@ -603,17 +668,6 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               } catch (IllegalArgumentException e) {
                 return new TensorType(dtype, null);
               }
-            }
-
-            /**
-             * Picks the composed member's dtype: the suppressed seed's when the generator had
-             * proven one, else the operand member's.
-             *
-             * @param t The operand member.
-             * @return The dtype for the composed member.
-             */
-            private DType pickDType(TensorType t) {
-              return this.plan.seedDType() != DType.UNKNOWN ? this.plan.seedDType() : t.getDType();
             }
 
             @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1514,18 +1514,28 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       Map<PointsToSetVariable, Set<TensorOrigin>> suppressedOrigins = HashMapFactory.make();
       for (PointsToSetVariable src : sources) {
         Set<TensorType> types = init.get(src);
-        // Two eligible seed classes, both entirely dtype-unproven: a single pure-⊤ member is
+        // Three eligible seed classes. Entirely dtype-unproven seeds: a single pure-⊤ member is
         // replaced by the generator-declared composition, and any other all-unknown-dtype seed
         // (shape-resolved members, several members, or a mix) keeps its members with only the
         // dtype fed (wala/ML#758's DTYPE_FILL, the class the einsum producer registration
-        // surfaces, wala/ML#757). Suppressing a seed with any dtype the generator PROVED couples
-        // into the engine-side pin computations that read seeded state (the vendored Conv1d and
-        // gather probes are the witnesses), so the known-dtype widening stays with wala/ML#682's
-        // residual.
+        // surfaces, wala/ML#757). A seed with a PROVEN dtype and a ⊤-shape member takes the
+        // mirror SHAPE_FILL: its members are retained — the shape-resolved ones verbatim — and
+        // only the ⊤-shape members' dims compose from the operands, per the declared kind, so
+        // the proven-dtype evidence the engine-side pin computations read is never lost (the
+        // vendored Conv1d and gather probes are wala/ML#682's witnesses for wholesale
+        // suppression). DTYPE_ONLY declares no operand→result shape relation, so proven-dtype
+        // seeds under it stay untouched.
         if (types == null || types.isEmpty()) continue;
-        if (types.stream().anyMatch(t -> t.getDType() != DType.UNKNOWN)) continue;
-        boolean pureTopSeed = types.size() == 1 && types.iterator().next().getDims() == null;
-        boolean fillSeed = !pureTopSeed;
+        boolean anyProvenDType = types.stream().anyMatch(t -> t.getDType() != DType.UNKNOWN);
+        boolean anyTopShape = types.stream().anyMatch(t -> t.getDims() == null);
+        TensorTypeAnalysis.FeedMode mode;
+        if (!anyProvenDType)
+          mode =
+              types.size() == 1 && anyTopShape
+                  ? TensorTypeAnalysis.FeedMode.REPLACE
+                  : TensorTypeAnalysis.FeedMode.DTYPE_FILL;
+        else if (anyTopShape) mode = TensorTypeAnalysis.FeedMode.SHAPE_FILL;
+        else continue; // Both axes proven on every member: nothing to fill.
         TensorGenerator generator;
         try {
           generator = getGenerator(src, builder);
@@ -1534,6 +1544,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         }
         TensorGenerator.TypeFeed feed = generator.getTypeFeed(builder);
         if (feed == null) continue;
+        if (mode == TensorTypeAnalysis.FeedMode.SHAPE_FILL
+            && feed.kind() == TensorGenerator.TypeFeedKind.DTYPE_ONLY) continue;
         List<PointsToSetVariable> feedSources = new ArrayList<>();
         for (PointerKey operandKey : feed.operands()) {
           if (builder.getPropagationSystem().isImplicit(operandKey)) continue;
@@ -1542,11 +1554,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           if (operand.equals(src)) continue; // A self-loop feeds nothing.
           feedSources.add(operand);
         }
-        // A broadcast composes pairs, so it needs both operands; the other kinds need at least
-        // one located operand. Otherwise keep the seed. A fill seed always fills from any
-        // located operand, since only the dtype is borrowed.
+        // A broadcast composes pairs, so any mode that consumes the composed shape needs both
+        // operands; the other kinds need at least one located operand. Otherwise keep the seed.
+        // A dtype fill always fills from any located operand, since only the dtype is borrowed.
         if (feedSources.isEmpty()
-            || (pureTopSeed
+            || (mode != TensorTypeAnalysis.FeedMode.DTYPE_FILL
                 && feed.kind() == TensorGenerator.TypeFeedKind.BROADCAST
                 && feedSources.size() != 2)) continue;
         for (PointsToSetVariable operand : feedSources) {
@@ -1556,10 +1568,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         typeFeeds.put(
             src,
             new TensorTypeAnalysis.FeedPlan(
-                fillSeed ? TensorGenerator.TypeFeedKind.DTYPE_FILL : feed.kind(),
+                feed.kind(),
+                mode,
                 feedSources,
-                DType.UNKNOWN,
-                fillSeed ? types : Collections.emptySet()));
+                mode == TensorTypeAnalysis.FeedMode.REPLACE ? Collections.emptySet() : types));
         suppressedSeeds.put(src, types);
         Set<TensorOrigin> origins = initOrigins.get(src);
         if (origins != null) suppressedOrigins.put(src, origins);
@@ -1569,7 +1581,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       LOGGER.fine(() -> "wala/ML#736 type feeds: " + typeFeeds.size());
       for (Map.Entry<PointsToSetVariable, TensorTypeAnalysis.FeedPlan> f : typeFeeds.entrySet())
         LOGGER.fine(
-            () -> "  feed " + f.getValue().kind() + ": " + describe(f.getKey().getPointerKey()));
+            () ->
+                "  feed "
+                    + f.getValue().mode()
+                    + "/"
+                    + f.getValue().kind()
+                    + ": "
+                    + describe(f.getKey().getPointerKey()));
 
       Map<PointsToSetVariable, Set<TensorType>> shapeOps = HashMapFactory.make();
       shapeOps.putAll(handleShapeSourceOp(builder, dataflow, reshape, 2));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4133,15 +4133,7 @@ public abstract class TensorGenerator {
     PASS_THROUGH,
 
     /** The two operands' member shapes broadcast pairwise (element-wise semantics). */
-    BROADCAST,
-
-    /**
-     * Each operand member's dtype fills the suppressed seed's retained shape members (wala/ML#758):
-     * the generator proved the shape but not the dtype, so the composition keeps the seed's dims
-     * and takes the operand's dtype. Selected engine-side for shape-resolved unknown-dtype seeds;
-     * generators declare one of the other kinds.
-     */
-    DTYPE_FILL
+    BROADCAST
   }
 
   /**


### PR DESCRIPTION
This PR implements the shape-side fill, the mirror of `DTYPE_FILL` (#664), and fixes the pin-edge staleness that made the wala/ML#682 guard load-bearing. Advances wala/ML#758.

## The Seed Class

A seed whose dtype the generator proves but whose shape walk fails composes a `? of <dtype>` member that no later evidence can remove. The wala/ML#682 guard categorically skips proven-dtype seeds, so the member rides to the destination union even when the operands' converged dataflow state holds the shape. Under predecessor-JVM orders this is the surviving `16+⊤` class on the `Transformer.call` pin (wala/ML#758): the generator marks the shape eval, `getTensorTypes` emits `? of float32`, the feed gate skips it, and the parameter transfer keeps it in the union.

## Why the Guard Was Load-Bearing

The `ReshapeOp` and `ConvOp` pin-edge transfers returned `CHANGED_AND_FIXED`, yet their output consumes the predecessor's members. An edge whose first evaluation ran against an empty predecessor (a suppressed seed whose feed delivers or restores later) added only the TensorFlow origin and froze, holding the pin's output permanently stale. Suppressing a proven-dtype seed therefore starved the downstream reshape pin and its consumers; the vendored `Conv1d` and gather witnesses fail exactly this way. The first commit unfixes the two transfers; they only add members, so re-evaluation is monotone. `SetShapeOp` and `DropOp` stay fixed since their outputs do not depend on predecessor members.

## The Fill

The second commit adds a `FeedMode` axis to `FeedPlan` (`REPLACE`/`DTYPE_FILL`/`SHAPE_FILL`), replacing the engine-side-only `TypeFeedKind.DTYPE_FILL` constant: the dtype fill is kind-independent, but a shape fill must compose dims per the generator-declared kind, so the plan carries both. `SHAPE_FILL` retains the seed's members (shape-resolved ones verbatim) and composes only the ⊤-shape members' dims from the operands, keeping a proven member dtype over the operand's. `DTYPE_ONLY` feeds declare no operand-to-result shape relation, so proven-dtype seeds under them stay untouched, which preserves the wala/ML#682 witnesses.

## Effect on the Predecessor Reproducer

With `TestCorpusFixtures.testNlpgnnFullInteractive` and `TestNlpgnnTransformer` paired in one JVM (a temporary `reuseForks=true` flip), master fails 2/4 with the vn3 `16+⊤` signature; this branch is 8/8 green on the exact pin. The lone surviving `{? of float32}` member was precisely the wala/ML#682-guarded class, now filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
