### PR TITLE
Register `padded_batch` in `createManualGenerator` so batch transforms survive post-batch pass-throughs

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -788,27 +788,30 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * transform after {@code map} keeps the mapped type (wala/ML#649, {@link
    * #testDatasetMapRepeat()}); {@code TFRecordDataset} is chainable ({@link #testTfrecordMap()});
    * the dataset survives the list (wala/ML#648, {@link #testFitLoop()}); and the {@code
-   * padded_batch} dims apply (wala/ML#673). So {@code real} resolves to the batched element {@code
-   * (32, ?)} int32 (the pipeline's {@code batch_size=32} with the pad-to-longest sequence dim),
-   * unioned with the standard partial-batch sibling {@code (?, ?)}.
+   * padded_batch} dims apply (wala/ML#673) through the tuple element and the post-batch
+   * pass-throughs (wala/ML#759, {@link TestDatasets#testPaddedBatchTupleEnumerate()}). So {@code
+   * real} resolves to the batched element {@code (32, Dynamic)} int32 (the pipeline's {@code
+   * batch_size=32} default with the pad-to-longest sequence axis), unioned with the standard
+   * partial-batch sibling {@code (?, Dynamic)}.
    *
    * <p>{@code pred} types too (wala/ML#665): the model forward output is a tensor union. With
    * {@code add_weight} consuming its {@code shape}/{@code dtype} arguments (wala/ML#667),
    * constructor keyword arguments forwarded to {@code __init__} (wala/ML#664), the wala/ML#739
    * operand-walk repairs, and parameter defaults materializing in the pointer analysis
-   * (wala/ML#743), the decoder stack resolves end to end under the fit-path contexts: the
-   * runtime-true logits form is {@code (Dynamic, Dynamic, 10)} float32 (the batch and sequence axes
-   * ride the dataset's dynamic dims), alongside the {@code (?, ?, 10)} partial. The wala/ML#680
-   * {@code unknown}-dtype phantom is gone: with the decoder-stack output resolving, {@code
+   * (wala/ML#743), the decoder stack resolves end to end under the fit-path contexts: the logits
+   * forms are {@code (32, Dynamic, 10)} float32 and its partial-batch sibling {@code (?, Dynamic,
+   * 10)} (the batch axis rides the wala/ML#759-batched dataset element, the sequence axis the
+   * dataset's dynamic pad), alongside the {@code (?, ?, 10)} partial. The wala/ML#680 {@code
+   * unknown}-dtype phantom is gone: with the decoder-stack output resolving, {@code
    * OutputLayer.call}'s dead {@code self.porj_weights} arm no longer contributes a member. The
    * union is the order-independent fixed point (wala/ML#674): identical across runs and across
    * suite/single-test modes. Analyzed statically here, like the consumer's vendoring; it runs in
    * the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: Drop the {@code (Dynamic, Dynamic, 8, 8)} member once <a
+   * <p>TODO: Drop the {@code (32, Dynamic, 8, 8)}/{@code (?, Dynamic, 8, 8)} members once <a
    * href="https://github.com/wala/ML/issues/746">wala/ML#746</a> filters constant-decidable branch
-   * arms per call site; it is the {@code mode="projection"} call's rank-3 input crossing into the
-   * embedding-mode lookup, runtime-infeasible at that site.
+   * arms per call site; they are the {@code mode="projection"} call's rank-3 input crossing into
+   * the embedding-mode lookup, runtime-infeasible at that site.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -829,18 +832,30 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         8,
         Map.of(
             3,
-            Set.of(new TensorType(INT_32, asList(DynamicDim.INSTANCE))),
+            Set.of(
+                new TensorType(INT_32, asList(new NumericDim(32), DynamicDim.INSTANCE)),
+                new TensorType(INT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE))),
             4,
             Set.of(
                 new TensorType(
                     FLOAT_32,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))),
                 new TensorType(
-                    FLOAT_32, asList(DynamicDim.INSTANCE, DynamicDim.INSTANCE, new NumericDim(10))),
+                    FLOAT_32, asList(new NumericDim(32), DynamicDim.INSTANCE, new NumericDim(10))),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new SymbolicDim("?"), DynamicDim.INSTANCE, new NumericDim(10))),
                 new TensorType(
                     FLOAT_32,
                     asList(
+                        new NumericDim(32),
                         DynamicDim.INSTANCE,
+                        new NumericDim(8),
+                        new NumericDim(8))),
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        new SymbolicDim("?"),
                         DynamicDim.INSTANCE,
                         new NumericDim(8),
                         new NumericDim(8))))));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1538,6 +1538,49 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * The full vendored-{@code input_fn} chain shape in miniature (<a
+   * href="https://github.com/wala/ML/issues/759">wala/ML#759</a>): like {@link
+   * #testPaddedBatchPair()} but with {@code repeat} and {@code prefetch} after the batch stage and
+   * the fit-loop's {@code enumerate} nested unpack. Both tuple halves are runtime-verified {@code
+   * (4, 3) int32}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPaddedBatchTupleEnumerate()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_padded_batch_tuple.py",
+        "consume_first",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 4, 3))));
+  }
+
+  /**
+   * Sibling half of {@link #testPaddedBatchTupleEnumerate()} (wala/ML#759): the second tuple
+   * member.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPaddedBatchTupleEnumerate2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_padded_batch_tuple.py",
+        "consume_second",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 4, 3))));
+  }
+
+  /**
    * Pins the <a href="https://github.com/wala/ML/issues/618">wala/ML#618</a> {@code
    * TuckERLoader.target_convert} row on the vendored subject: the loader is vendored verbatim from
    * {@code kyzhouhzau/NLPGNN} ({@code nlpgnn/datas/graphloader.py}); the driver, the tiny {@code

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -6714,6 +6714,13 @@ public abstract class TensorGenerator {
       return new DatasetRandomGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_BATCH_TYPE)) {
       return new DatasetBatchGenerator(node);
+    } else if (type.equals(TensorFlowTypes.DATASET_PADDED_BATCH_TYPE)) {
+      // Without this arm, a padded-batch-allocated dataset falls to the DATA_PACKAGE_PREFIX
+      // catch-all below: a plain pass-through DatasetGenerator that inherits from
+      // padded_batch.do's own receiver, so a downstream pass-through stage (repeat/prefetch)
+      // resolves the chain to the pre-batch element and the batch transform never applies
+      // (wala/ML#759).
+      return new DatasetPaddedBatchGenerator(node);
     } else if (type.equals(TensorFlowTypes.IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE)) {
       return new FlowFromDirectoryGenerator(node);
     } else if (type.equals(TensorFlowTypes.MNIST_X_TRAIN)) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_padded_batch_tuple.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_padded_batch_tuple.py
@@ -1,0 +1,30 @@
+# Test wala/ML#759: batch transforms must distribute into tuple-structured dataset
+# elements. The chain mirrors the vendored gpt-2 `input_fn`: a `map` producing a
+# tuple element, then `padded_batch`, `repeat`, and `prefetch`, iterated with the
+# nested-unpack `enumerate` pattern.
+import tensorflow as tf
+
+
+def to_pair(x):
+    return x, x
+
+
+def consume_first(t):
+    assert t.shape == (4, 3)
+    assert t.dtype == tf.int32
+
+
+def consume_second(t):
+    assert t.shape == (4, 3)
+    assert t.dtype == tf.int32
+
+
+dataset = tf.data.Dataset.from_tensor_slices(tf.ones((8, 3), dtype=tf.int32))
+dataset = dataset.map(to_pair)
+dataset = dataset.padded_batch(4, padded_shapes=([-1], [-1]))
+dataset = dataset.repeat(2)
+dataset = dataset.prefetch(1)
+
+for step, (a, b) in enumerate(dataset):
+    consume_first(a)
+    consume_second(b)


### PR DESCRIPTION
Closes wala/ML#759. Advances wala/ML#680 (its `real` anchor was re-attributed to this gap).

## Mechanism

`createManualGenerator` had a `DATASET_BATCH_TYPE` arm but no `DATASET_PADDED_BATCH_TYPE` arm, so a padded-batch-allocated dataset resolved through the `DATA_PACKAGE_PREFIX` catch-all to a plain pass-through `DatasetGenerator` that inherits from `padded_batch.do`'s own receiver. Any post-batch pass-through stage (`repeat`/`prefetch`) resolving its receiver chain therefore skipped the batch transform and landed on the map stage, and the iterated element typed as the un-batched map element. The two-table registration rule already documents this failure class; `batch` was registered, `padded_batch` was not.

The in-vitro bisect pins the trigger precisely: `testPaddedBatchPair` (no post-batch stages) and the enumerate-only variant both applied the batch, while the direct-destructure variant with `repeat`/`prefetch` reproduced the un-batched element. The per-index distribution machinery (`DatasetBatchGenerator.getShapesForIndex` delegating to the receiver's `TupleElementProvider` and applying batching per component) needed no changes.

## Witnesses

- New fixture `tf2_test_dataset_padded_batch_tuple.py` (runtime-verified): the vendored `input_fn` chain in miniature: map-to-tuple, `padded_batch`, `repeat`, `prefetch`, iterated with the fit-loop's `enumerate` nested unpack. Both tuple halves now type the runtime-true `(4, 3) int32` (`testPaddedBatchTupleEnumerate`/`2`).
- `testGpt2GetLossVendored` re-derived: `real` rises from the un-batched `(Dynamic,)` to the batched pair `{(32, Dynamic), (?, Dynamic)} int32` (the `batch_size=32` default with the pad-to-longest axis, plus the standard partial-batch sibling), and the `pred` logits' batch axis concretizes the same way (`{(32, Dynamic, 10), (?, Dynamic, 10), (?, ?, 10)}` float32, with the wala/ML#746-tracked runtime-infeasible siblings). Strict precision improvements on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
