### PR TITLE
Introduce the shared anchor-parameterized generator dispatch and migrate the elementwise and reduce families

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/TestTensorGeneratorDispatchCoverage.java
@@ -28,14 +28,15 @@ import org.junit.Test;
  * constructed by their enclosing class anyway, but the limitation is real — a class-file- scanning
  * enumeration would be a strict improvement (see wala/ML#485).
  *
- * <p>Until the dispatch-table unification proposed in wala/ML#469 lands, every new {@code
- * TensorGenerator} subclass has to be added to both {@code getGeneratorBody} (factory-side) and
- * {@code createManualGenerator} (manual-walker side). Forgetting one is silent (wala/ML#468). This
- * coverage guard catches the most-common failure mode — an entirely orphan subclass that's not
- * wired to either dispatch — at test time. (The stricter "appears in <em>both</em>" check the
- * issue's original spec proposes requires either dynamic dispatch construction or per-class
- * annotation tagging for the dispatch-asymmetric subclasses; this test scopes to the orphan
- * detection that's implementable without those.)
+ * <p>The dispatch-table unification (wala/ML#469, wala/ML#760) is landing incrementally: arms
+ * migrated to the shared {@code TensorGeneratorFactory.dispatchShared} chain name both construction
+ * forms as {@code X::new} references in one arm, which makes the stricter "appears in
+ * <em>both</em>" property structural for them. Until the migration completes, every new {@code
+ * TensorGenerator} subclass registers in the shared chain (preferred) or in both {@code
+ * getGeneratorBody} (factory-side) and {@code createManualGenerator} (manual-walker side).
+ * Forgetting one is silent (wala/ML#468). This coverage guard catches the most-common failure mode
+ * — an entirely orphan subclass that's not wired to any dispatch — at test time, matching both
+ * {@code new X(} constructions and {@code X::new} references.
  *
  * <p>Subclasses that are legitimately exempt (constructed by another generator rather than from
  * either dispatch table) can carry a {@link DispatchExempt} annotation. Abstract bases are skipped
@@ -75,9 +76,15 @@ public class TestTensorGeneratorDispatchCoverage {
       if (c.isAnonymousClass() || c.isSynthetic()) continue;
 
       String simpleName = c.getSimpleName();
-      // Tolerate spotless/IDE formatting variants — `new X(...)`, `new\n        X(...)`, etc.
+      // Tolerate spotless/IDE formatting variants — `new X(...)`, `new\n        X(...)`, etc. —
+      // and the shared dispatch chain's constructor references (`X::new`, wala/ML#760).
       Pattern constructionPattern =
-          Pattern.compile("\\bnew\\s+" + Pattern.quote(simpleName) + "\\s*\\(");
+          Pattern.compile(
+              "\\bnew\\s+"
+                  + Pattern.quote(simpleName)
+                  + "\\s*\\(|\\b"
+                  + Pattern.quote(simpleName)
+                  + "::new\\b");
       boolean inFactory = constructionPattern.matcher(factorySource).find();
       boolean inTensorGenerator = constructionPattern.matcher(tensorGeneratorSource).find();
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GeneratorAnchor.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/GeneratorAnchor.java
@@ -1,0 +1,91 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.types.TypeReference;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * An anchoring for a {@link TensorGenerator} under construction (wala/ML#760): either
+ * <em>source-based</em> (a {@link PointsToSetVariable} whose defining call site names the
+ * operation, dispatched by {@link TensorGeneratorFactory#getGenerator}) or <em>manual</em> (the
+ * operation's allocating synthetic {@link CGNode}, dispatched by {@code
+ * TensorGenerator.createManualGenerator} during producer delegation and receiver walks).
+ *
+ * <p>The shared dispatch chain ({@code TensorGeneratorFactory.dispatchShared}) matches an arm on
+ * {@link #declaredType()} and constructs through {@link #makeGenerator}, so every migrated arm
+ * names both construction forms in one place: an operation registered for one anchoring cannot
+ * silently lack the other, the failure class behind the wala/ML#757 and wala/ML#759 delegation
+ * dead-ends. An operation that genuinely has no form for one anchoring declares that in its arm
+ * rather than by omission.
+ */
+public sealed interface GeneratorAnchor {
+
+  /**
+   * The declared type the dispatch matches on: the (sanitized) called function's type for a source
+   * anchoring, the allocating node's declaring class for a manual one.
+   *
+   * @return The declared type.
+   */
+  TypeReference declaredType();
+
+  /**
+   * The propagation call graph builder in scope for this construction.
+   *
+   * @return The builder.
+   */
+  PropagationCallGraphBuilder builder();
+
+  /**
+   * Constructs the generator through the form matching this anchoring.
+   *
+   * @param fromSource The source-anchored construction.
+   * @param fromNode The node-anchored construction.
+   * @return The constructed generator.
+   */
+  TensorGenerator makeGenerator(
+      Function<PointsToSetVariable, TensorGenerator> fromSource,
+      Function<CGNode, TensorGenerator> fromNode);
+
+  /**
+   * A source-based anchoring (wala/ML#760).
+   *
+   * @param source The {@link PointsToSetVariable} whose defining call produces the value.
+   * @param declaredType The sanitized called function's type.
+   * @param builder The propagation call graph builder.
+   * @param visited The factory's creator-walk visited set, for arms whose source path consults
+   *     operand evidence (e.g. the wala/ML#451 binary-operation gate).
+   */
+  record SourceAnchor(
+      PointsToSetVariable source,
+      TypeReference declaredType,
+      PropagationCallGraphBuilder builder,
+      Set<PointsToSetVariable> visited)
+      implements GeneratorAnchor {
+    @Override
+    public TensorGenerator makeGenerator(
+        Function<PointsToSetVariable, TensorGenerator> fromSource,
+        Function<CGNode, TensorGenerator> fromNode) {
+      return fromSource.apply(this.source());
+    }
+  }
+
+  /**
+   * A manual (node-based) anchoring (wala/ML#760).
+   *
+   * @param node The allocating synthetic {@code do()} {@link CGNode}.
+   * @param declaredType The node's declaring class, sanitized of the trampoline suffix.
+   * @param builder The propagation call graph builder.
+   */
+  record NodeAnchor(CGNode node, TypeReference declaredType, PropagationCallGraphBuilder builder)
+      implements GeneratorAnchor {
+    @Override
+    public TensorGenerator makeGenerator(
+        Function<PointsToSetVariable, TensorGenerator> fromSource,
+        Function<CGNode, TensorGenerator> fromNode) {
+      return fromNode.apply(this.node());
+    }
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceAll.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceAll.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.EnumSet;
@@ -19,6 +20,15 @@ public class ReduceAll extends Reduction {
 
   public ReduceAll(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceAll(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceLogSumExp.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceLogSumExp.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -16,5 +17,14 @@ public class ReduceLogSumExp extends Reduction {
 
   public ReduceLogSumExp(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceLogSumExp(CGNode node) {
+    super(node);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMax.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMax.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -14,5 +15,14 @@ public class ReduceMax extends Reduction {
 
   public ReduceMax(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceMax(CGNode node) {
+    super(node);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceMin.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -15,5 +16,14 @@ public class ReduceMin extends Reduction {
 
   public ReduceMin(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceMin(CGNode node) {
+    super(node);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceProd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceProd.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -14,5 +15,14 @@ public class ReduceProd extends Reduction {
 
   public ReduceProd(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceProd(CGNode node) {
+    super(node);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceSum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ReduceSum.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -12,5 +13,14 @@ public class ReduceSum extends Reduction {
 
   public ReduceSum(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ReduceSum(CGNode node) {
+    super(node);
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -6664,6 +6664,10 @@ public abstract class TensorGenerator {
 
     LOGGER.fine("createManualGenerator checking sanitized type: " + type.getName());
 
+    TensorGenerator shared =
+        TensorGeneratorFactory.dispatchShared(new GeneratorAnchor.NodeAnchor(node, type, builder));
+    if (shared != null) return shared;
+
     if (type.equals(TensorFlowTypes.SPLIT.getDeclaringClass())) {
       return new Split(node);
     } else if (type.equals(TensorFlowTypes.ONES.getDeclaringClass())) {
@@ -6743,8 +6747,6 @@ public abstract class TensorGenerator {
       return new DatasetGenerator(node);
     } else if (type.equals(TensorFlowTypes.MATMUL.getDeclaringClass())) {
       return new MatMul(node);
-    } else if (type.equals(TensorFlowTypes.MULTIPLY.getDeclaringClass())) {
-      return new ElementWiseOperation(node);
     } else if (type.equals(TensorFlowTypes.TRANSPOSE.getDeclaringClass())) {
       return new Transpose(node);
     } else if (type.equals(TensorFlowTypes.EINSUM.getDeclaringClass())) {
@@ -6759,8 +6761,6 @@ public abstract class TensorGenerator {
       return new Fill(node);
     } else if (type.equals(TensorFlowTypes.ONE_HOT.getDeclaringClass())) {
       return new OneHot(node);
-    } else if (type.equals(TensorFlowTypes.REDUCE_MEAN.getDeclaringClass())) {
-      return new ReduceMean(node);
     } else if (type.equals(TensorFlowTypes.CONVERT_TO_TENSOR.getDeclaringClass())) {
       return new ConvertToTensor(node);
     } else if (type.equals(TensorFlowTypes.RANGE.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -394,6 +394,77 @@ public class TensorGeneratorFactory {
   }
 
   /**
+   * The shared source/manual dispatch chain (wala/ML#760). Every arm here serves both anchorings by
+   * naming both construction forms through {@link GeneratorAnchor#makeGenerator}, so an operation
+   * registered for call-site dispatch cannot silently lack its node-anchored form (the
+   * wala/ML#757/wala/ML#759 delegation dead-end class). Arms migrate here from the two
+   * anchor-specific chains family by family; new operations register here. Anchor-specific concerns
+   * stay expressible by matching the anchor kind (e.g. the wala/ML#451 gate below applies only to
+   * source anchorings).
+   *
+   * @param anchor The anchoring to construct for.
+   * @return The generator, or {@code null} when no shared arm matches and the caller's residual
+   *     chain should dispatch.
+   */
+  static TensorGenerator dispatchShared(GeneratorAnchor anchor) {
+    TypeReference type = anchor.declaredType();
+
+    if (isType(type, MULTIPLY.getDeclaringClass())
+        || isType(type, ADD.getDeclaringClass())
+        || isType(type, SUBTRACT.getDeclaringClass())
+        || isType(type, DIVIDE.getDeclaringClass())
+        || isType(type, ATAN2.getDeclaringClass())
+        || isType(type, MAXIMUM.getDeclaringClass())
+        || isType(type, MINIMUM.getDeclaringClass())
+        || isType(type, POW.getDeclaringClass())) {
+      // For SSABinaryOp sources (`a - b` rather than `tf.subtract(a, b)`), gate
+      // ElementWiseOperation dispatch on at least one operand showing tensor
+      // evidence — see {@link #operandHasTensorEvidence} for the three-axis
+      // definition (implicit PK / structural `tryGetGenerator` resolution /
+      // non-`ConstantKey` PTS content). Without this gate, every Python-int
+      // arithmetic expression (e.g. `n - 1` in a recursive function whose only
+      // call sites pass ints) gets classified as a tensor — `getDataflowSources`
+      // adds every binary-op result as a candidate source, and EWO's "always a
+      // tensor" assumption turns Integer constants in operand PTS into INT32
+      // dtypes, which then back-propagate to parameters via the PA assignment
+      // graph at the recursive-call edge. The TF-API path (`tf.add(...)`, etc.)
+      // is unaffected: those are SSAAbstractInvoke, not SSABinaryOp, so the
+      // structural check below skips them. A manual anchoring is by construction
+      // an API synthetic's allocating node, so the gate does not apply. See
+      // wala/ML#451.
+      if (anchor instanceof GeneratorAnchor.SourceAnchor sourceAnchor
+          && isBinopWithoutTensorOperand(
+              sourceAnchor.source(), sourceAnchor.builder(), sourceAnchor.visited())) {
+        LOGGER.fine(
+            () ->
+                "Rejecting ElementWiseOperation dispatch — no operand has tensor"
+                    + " evidence. source="
+                    + describe(sourceAnchor.source()));
+        throw new IllegalArgumentException(
+            "Binary op with no tensor operand: " + describe(sourceAnchor.source()) + ".");
+      }
+      return anchor.makeGenerator(ElementWiseOperation::new, ElementWiseOperation::new);
+    }
+
+    if (isType(type, REDUCE_MEAN.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceMean::new, ReduceMean::new);
+    if (isType(type, REDUCE_MAX.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceMax::new, ReduceMax::new);
+    if (isType(type, REDUCE_MIN.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceMin::new, ReduceMin::new);
+    if (isType(type, REDUCE_PROD.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceProd::new, ReduceProd::new);
+    if (isType(type, REDUCE_LOGSUMEXP.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceLogSumExp::new, ReduceLogSumExp::new);
+    if (isType(type, REDUCE_ALL.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceAll::new, ReduceAll::new);
+    if (isType(type, REDUCE_SUM.getDeclaringClass()))
+      return anchor.makeGenerator(ReduceSum::new, ReduceSum::new);
+
+    return null;
+  }
+
+  /**
    * Traces the dataflow graph backwards from the given source {@link PointsToSetVariable} to find
    * its creator. The creator is defined as either a return value of a function or a variable
    * defined by a relevant instruction such as an invoke, an iteration instruction, or a property
@@ -1258,6 +1329,10 @@ public class TensorGeneratorFactory {
 
     LOGGER.fine("Getting tensor generator for sanitized call to: " + calledFunction + ".");
 
+    TensorGenerator shared =
+        dispatchShared(new GeneratorAnchor.SourceAnchor(source, calledFunction, builder, visited));
+    if (shared != null) return shared;
+
     if (isType(calledFunction, ONES.getDeclaringClass())) return new Ones(source);
     else if (isType(calledFunction, CONSTANT.getDeclaringClass())) return new Constant(source);
     else if (isType(calledFunction, RANGE.getDeclaringClass())) return new Range(source);
@@ -1310,34 +1385,7 @@ public class TensorGeneratorFactory {
       return new RaggedFromNestedValueRowIds(source);
     else if (isType(calledFunction, FROM_ROW_LIMITS.getDeclaringClass()))
       return new RaggedFromRowLimits(source);
-    else if (isType(calledFunction, MULTIPLY.getDeclaringClass())
-        || isType(calledFunction, ADD.getDeclaringClass())
-        || isType(calledFunction, SUBTRACT.getDeclaringClass())
-        || isType(calledFunction, DIVIDE.getDeclaringClass())) {
-      // For SSABinaryOp sources (`a - b` rather than `tf.subtract(a, b)`), gate
-      // ElementWiseOperation dispatch on at least one operand showing tensor
-      // evidence — see {@link #operandHasTensorEvidence} for the three-axis
-      // definition (implicit PK / structural `tryGetGenerator` resolution /
-      // non-`ConstantKey` PTS content). Without this gate, every Python-int
-      // arithmetic expression (e.g. `n - 1` in a recursive function whose only
-      // call sites pass ints) gets classified as a tensor — `getDataflowSources`
-      // adds every binary-op result as a candidate source, and EWO's "always a
-      // tensor" assumption turns Integer constants in operand PTS into INT32
-      // dtypes, which then back-propagate to parameters via the PA assignment
-      // graph at the recursive-call edge. The TF-API path (`tf.add(...)`, etc.)
-      // is unaffected: those are SSAAbstractInvoke, not SSABinaryOp, so the
-      // structural check below skips them. See wala/ML#451.
-      if (isBinopWithoutTensorOperand(source, builder, visited)) {
-        LOGGER.fine(
-            () ->
-                "Rejecting ElementWiseOperation dispatch — no operand has tensor"
-                    + " evidence. source="
-                    + describe(source));
-        throw new IllegalArgumentException(
-            "Binary op with no tensor operand: " + describe(source) + ".");
-      }
-      return new ElementWiseOperation(source);
-    } else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
+    else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
     else if (isType(calledFunction, SPARSE_FROM_DENSE.getDeclaringClass()))
       return new SparseFromDense(source);
     else if (isType(calledFunction, SPARSE_TO_DENSE.getDeclaringClass()))
@@ -1456,17 +1504,10 @@ public class TensorGeneratorFactory {
       return new BostonHousingInputData(source, BostonHousingInputData.X_TEST_SHAPE);
     else if (isType(calledFunction, BOSTON_HOUSING_Y_TEST))
       return new BostonHousingInputData(source, BostonHousingInputData.Y_TEST_SHAPE);
-    else if (isType(calledFunction, REDUCE_MEAN.getDeclaringClass())) return new ReduceMean(source);
-    else if (isType(calledFunction, REDUCE_MAX.getDeclaringClass())) return new ReduceMax(source);
-    else if (isType(calledFunction, REDUCE_MIN.getDeclaringClass())) return new ReduceMin(source);
-    else if (isType(calledFunction, REDUCE_PROD.getDeclaringClass())) return new ReduceProd(source);
-    else if (isType(calledFunction, REDUCE_LOGSUMEXP.getDeclaringClass()))
-      return new ReduceLogSumExp(source);
     else if (isType(calledFunction, UNSORTED_SEGMENT_SUM.getDeclaringClass())
         || isType(calledFunction, UNSORTED_SEGMENT_MAX.getDeclaringClass())
         || isType(calledFunction, UNSORTED_SEGMENT_MEAN.getDeclaringClass()))
       return new UnsortedSegmentReduction(source);
-    else if (isType(calledFunction, REDUCE_ALL.getDeclaringClass())) return new ReduceAll(source);
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);
     else if (isType(calledFunction, EQUAL.getDeclaringClass()))
@@ -1484,7 +1525,6 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
         || isType(calledFunction, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))
       return new SoftmaxCrossEntropy(source);
-    else if (isType(calledFunction, REDUCE_SUM.getDeclaringClass())) return new ReduceSum(source);
     else if (isType(calledFunction, MATMUL.getDeclaringClass())) return new MatMul(source);
     else if (isType(calledFunction, SIGMOID.getDeclaringClass())) return new Sigmoid(source);
     else if (isType(calledFunction, EXP.getDeclaringClass())) return new Exp(source);
@@ -1534,12 +1574,6 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, SQUARE.getDeclaringClass())) return new Square(source);
     else if (isType(calledFunction, ERF.getDeclaringClass())) return new Erf(source);
     else if (isType(calledFunction, ERFC.getDeclaringClass())) return new Erfc(source);
-    else if (isType(calledFunction, ATAN2.getDeclaringClass()))
-      return new ElementWiseOperation(source);
-    else if (isType(calledFunction, MAXIMUM.getDeclaringClass()))
-      return new ElementWiseOperation(source);
-    else if (isType(calledFunction, MINIMUM.getDeclaringClass()))
-      return new ElementWiseOperation(source);
     else if (isType(calledFunction, EINSUM.getDeclaringClass())) return new Einsum(source);
     else if (isType(calledFunction, RELU.getDeclaringClass())) return new Relu(source);
     else if (isType(calledFunction, CAST.getDeclaringClass())) return new Cast(source);
@@ -1551,8 +1585,6 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, MESHGRID.getDeclaringClass())) return new Meshgrid(source);
     else if (isType(calledFunction, WHERE.getDeclaringClass())) return new Where(source);
     else if (isType(calledFunction, LEAKY_RELU.getDeclaringClass())) return new LeakyRelu(source);
-    else if (isType(calledFunction, POW.getDeclaringClass()))
-      return new ElementWiseOperation(source);
     else if (isType(calledFunction, CONCAT.getDeclaringClass())) return new Concat(source);
     else if (isType(calledFunction, STACK.getDeclaringClass())) return new Stack(source);
     else if (isType(calledFunction, SQRT.getDeclaringClass())) return new Sqrt(source);


### PR DESCRIPTION
First batch of the dispatch-table unification: the shared anchor-parameterized mechanism plus the elementwise and reduce families. Advances wala/ML#469 and wala/ML#760.

## Mechanism

`GeneratorAnchor` (sealed: `SourceAnchor`/`NodeAnchor`) carries the anchoring's payload and match type; `TensorGeneratorFactory.dispatchShared` is the shared chain both entry points consult before their residual arms. Every shared arm constructs through `GeneratorAnchor.makeGenerator`, naming both the source-based and node-anchored constructor in one place, so an operation registered for call-site dispatch structurally cannot lack its manual form (the wala/ML#757/wala/ML#759 delegation dead-end class). Anchor-specific logic stays expressible by matching the anchor kind: the wala/ML#451 binop tensor-evidence gate applies only to source anchorings, verbatim.

## Migrated and Registered

- Elementwise family (`multiply`/`add`/`subtract`/`divide`/`atan2`/`maximum`/`minimum`/`pow`): previously only `multiply` had a manual arm; the other seven were source-only. All eight now dispatch to `ElementWiseOperation` under both anchorings.
- Reduce family (`reduce_mean`/`max`/`min`/`prod`/`logsumexp`/`all`/`sum`): previously only `reduce_mean` had a manual arm. The six siblings gain `(CGNode)` constructors (all inherit `Reduction`'s node-anchored machinery) and all seven dispatch under both anchorings.

Existing correct arms elsewhere stay in the residual chains and migrate family-by-family per the wala/ML#760 plan; new operations register in the shared chain. The wala/ML#470 coverage meta-test now also recognizes `X::new` references, and for migrated arms its stricter "appears in both" aspiration is structural rather than scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
