### PR TITLE
Migrate the ragged, sparse, comparison, and softmax-cross-entropy families and `enumerate` to the shared dispatch

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ComparisonOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ComparisonOperation.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.EnumSet;
@@ -21,6 +22,15 @@ public class ComparisonOperation extends ElementWiseOperation {
 
   public ComparisonOperation(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public ComparisonOperation(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedConstant.java
@@ -17,6 +17,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -68,6 +69,15 @@ public class RaggedConstant extends Constant {
 
   public RaggedConstant(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedConstant(CGNode node) {
+    super(node);
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNested.java
@@ -13,6 +13,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.core.util.strings.Atom;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
@@ -55,6 +56,15 @@ public abstract class RaggedFromNested extends RaggedTensorFromValues {
 
   public RaggedFromNested(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromNested(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowLengths.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -15,6 +16,15 @@ public class RaggedFromNestedRowLengths extends RaggedFromNested {
 
   public RaggedFromNestedRowLengths(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromNestedRowLengths(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedRowSplits.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 
 /**
@@ -17,6 +18,15 @@ public class RaggedFromNestedRowSplits extends RaggedFromNested {
 
   public RaggedFromNestedRowSplits(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromNestedRowSplits(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromNestedValueRowIds.java
@@ -21,6 +21,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.core.util.strings.Atom;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -63,6 +64,15 @@ public class RaggedFromNestedValueRowIds extends RaggedTensorFromValues {
 
   public RaggedFromNestedValueRowIds(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromNestedValueRowIds(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLengths.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -42,6 +43,15 @@ public class RaggedFromRowLengths extends RaggedTensorFromValues {
 
   public RaggedFromRowLengths(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromRowLengths(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowLimits.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptySet;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -42,6 +43,15 @@ public class RaggedFromRowLimits extends RaggedTensorFromValues {
 
   public RaggedFromRowLimits(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromRowLimits(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowSplits.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptySet;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -41,6 +42,15 @@ public class RaggedFromRowSplits extends RaggedTensorFromValues {
 
   public RaggedFromRowSplits(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromRowSplits(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromRowStarts.java
@@ -6,6 +6,7 @@ import static java.util.Collections.emptySet;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -43,6 +44,15 @@ public class RaggedFromRowStarts extends RaggedTensorFromValues {
 
   public RaggedFromRowStarts(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromRowStarts(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedFromValueRowIds.java
@@ -14,6 +14,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -60,6 +61,15 @@ public class RaggedFromValueRowIds extends RaggedTensorFromValues {
 
   public RaggedFromValueRowIds(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedFromValueRowIds(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedRange.java
@@ -5,6 +5,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
@@ -51,6 +52,15 @@ public class RaggedRange extends Range {
 
   public RaggedRange(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedRange(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/RaggedTensorFromValues.java
@@ -5,6 +5,7 @@ import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
@@ -27,6 +28,15 @@ public abstract class RaggedTensorFromValues extends TensorGenerator {
 
   public RaggedTensorFromValues(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public RaggedTensorFromValues(CGNode node) {
+    super(node);
   }
 
   protected abstract int getValuesParameterPosition();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseAdd.java
@@ -7,6 +7,7 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
@@ -44,6 +45,15 @@ public class SparseAdd extends ElementWiseOperation {
 
   public SparseAdd(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public SparseAdd(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseFromDense.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseFromDense.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import java.util.Locale;
 
@@ -33,6 +34,15 @@ public class SparseFromDense extends ConvertToTensor {
 
   public SparseFromDense(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public SparseFromDense(CGNode node) {
+    super(node);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseTensor.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseTensor.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.Locale;
@@ -35,6 +36,15 @@ public class SparseTensor extends TensorTypeAllocator {
 
   public SparseTensor(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public SparseTensor(CGNode node) {
+    super(node);
   }
 
   /** The dtype is inferred from the 'values' argument. */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseToDense.java
@@ -2,6 +2,7 @@ package com.ibm.wala.cast.python.ml.client;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import java.util.List;
@@ -38,6 +39,15 @@ public class SparseToDense extends TensorTypeAllocator {
 
   public SparseToDense(PointsToSetVariable source) {
     super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public SparseToDense(CGNode node) {
+    super(node);
   }
 
   /** The dense result's shape is the {@code sp_input} SparseTensor's (its {@code dense_shape}). */

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -6678,8 +6678,6 @@ public abstract class TensorGenerator {
       return new NpOnes(node);
     } else if (type.equals(NumpyTypes.ZEROS.getDeclaringClass())) {
       return new NpZeros(node);
-    } else if (type.equals(TensorFlowTypes.SPARSE_EYE.getDeclaringClass())) {
-      return new SparseEye(node);
     } else if (type.equals(TensorFlowTypes.EYE.getDeclaringClass())) {
       return new Eye(node);
     } else if (type.equals(TensorFlowTypes.UNIFORM.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -461,6 +461,57 @@ public class TensorGeneratorFactory {
     if (isType(type, REDUCE_SUM.getDeclaringClass()))
       return anchor.makeGenerator(ReduceSum::new, ReduceSum::new);
 
+    if (isType(type, EQUAL.getDeclaringClass())
+        || isType(type, NOT_EQUAL.getDeclaringClass())
+        || isType(type, LESS.getDeclaringClass())
+        || isType(type, LESS_EQUAL.getDeclaringClass())
+        || isType(type, GREATER.getDeclaringClass())
+        || isType(type, GREATER_EQUAL.getDeclaringClass()))
+      return anchor.makeGenerator(ComparisonOperation::new, ComparisonOperation::new);
+
+    if (isType(type, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
+        || isType(type, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))
+      return anchor.makeGenerator(SoftmaxCrossEntropy::new, SoftmaxCrossEntropy::new);
+
+    if (isType(type, SPARSE_TENSOR.getDeclaringClass()))
+      return anchor.makeGenerator(SparseTensor::new, SparseTensor::new);
+    if (isType(type, SPARSE_ADD.getDeclaringClass()))
+      return anchor.makeGenerator(SparseAdd::new, SparseAdd::new);
+    if (isType(type, SPARSE_FROM_DENSE.getDeclaringClass()))
+      return anchor.makeGenerator(SparseFromDense::new, SparseFromDense::new);
+    if (isType(type, SPARSE_TO_DENSE.getDeclaringClass()))
+      return anchor.makeGenerator(SparseToDense::new, SparseToDense::new);
+    if (isType(type, SPARSE_EYE.getDeclaringClass()))
+      return anchor.makeGenerator(SparseEye::new, SparseEye::new);
+
+    if (isType(type, RAGGED_CONSTANT.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedConstant::new, RaggedConstant::new);
+    if (isType(type, RAGGED_RANGE.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedRange::new, RaggedRange::new);
+    if (isType(type, FROM_VALUE_ROWIDS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromValueRowIds::new, RaggedFromValueRowIds::new);
+    if (isType(type, FROM_ROW_STARTS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromRowStarts::new, RaggedFromRowStarts::new);
+    if (isType(type, FROM_ROW_SPLITS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromRowSplits::new, RaggedFromRowSplits::new);
+    if (isType(type, FROM_ROW_LENGTHS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromRowLengths::new, RaggedFromRowLengths::new);
+    if (isType(type, FROM_NESTED_ROW_LENGTHS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromNestedRowLengths::new, RaggedFromNestedRowLengths::new);
+    if (isType(type, FROM_NESTED_ROW_SPLITS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromNestedRowSplits::new, RaggedFromNestedRowSplits::new);
+    if (isType(type, FROM_NESTED_VALUE_ROWIDS.getDeclaringClass()))
+      return anchor.makeGenerator(
+          RaggedFromNestedValueRowIds::new, RaggedFromNestedValueRowIds::new);
+    if (isType(type, FROM_ROW_LIMITS.getDeclaringClass()))
+      return anchor.makeGenerator(RaggedFromRowLimits::new, RaggedFromRowLimits::new);
+
+    // `enumerate` carries index/tuple element semantics its generator models; the manual-side
+    // DATA_PACKAGE_PREFIX catch-all would otherwise swallow it into a plain pass-through
+    // DatasetGenerator (the wala/ML#759 mis-dispatch class).
+    if (isType(type, DATASET_ENUMERATE_TYPE))
+      return anchor.makeGenerator(DatasetEnumerateGenerator::new, DatasetEnumerateGenerator::new);
+
     return null;
   }
 
@@ -1356,40 +1407,12 @@ public class TensorGeneratorFactory {
       return new ConvertToTensor(source);
     else if (isType(calledFunction, ONE_HOT.getDeclaringClass())) return new OneHot(source);
     else if (isType(calledFunction, EYE.getDeclaringClass())) return new Eye(source);
-    else if (isType(calledFunction, SPARSE_EYE.getDeclaringClass())) return new SparseEye(source);
-    else if (isType(calledFunction, SPARSE_TENSOR.getDeclaringClass()))
-      return new SparseTensor(source);
     else if (isType(calledFunction, GAMMA.getDeclaringClass()) || isType(calledFunction, GAMMA_OP))
       return new Gamma(source);
     else if (isType(calledFunction, INPUT.getDeclaringClass())) return new Input(source);
     else if (isType(calledFunction, POISSON.getDeclaringClass())
         || isType(calledFunction, POISSON_OP)) return new Poisson(source);
-    else if (isType(calledFunction, RAGGED_CONSTANT.getDeclaringClass()))
-      return new RaggedConstant(source);
     else if (isType(calledFunction, VARIABLE.getDeclaringClass())) return new Variable(source);
-    else if (isType(calledFunction, RAGGED_RANGE.getDeclaringClass()))
-      return new RaggedRange(source);
-    else if (isType(calledFunction, FROM_VALUE_ROWIDS.getDeclaringClass()))
-      return new RaggedFromValueRowIds(source);
-    else if (isType(calledFunction, FROM_ROW_STARTS.getDeclaringClass()))
-      return new RaggedFromRowStarts(source);
-    else if (isType(calledFunction, FROM_ROW_SPLITS.getDeclaringClass()))
-      return new RaggedFromRowSplits(source);
-    else if (isType(calledFunction, FROM_ROW_LENGTHS.getDeclaringClass()))
-      return new RaggedFromRowLengths(source);
-    else if (isType(calledFunction, FROM_NESTED_ROW_LENGTHS.getDeclaringClass()))
-      return new RaggedFromNestedRowLengths(source);
-    else if (isType(calledFunction, FROM_NESTED_ROW_SPLITS.getDeclaringClass()))
-      return new RaggedFromNestedRowSplits(source);
-    else if (isType(calledFunction, FROM_NESTED_VALUE_ROWIDS.getDeclaringClass()))
-      return new RaggedFromNestedValueRowIds(source);
-    else if (isType(calledFunction, FROM_ROW_LIMITS.getDeclaringClass()))
-      return new RaggedFromRowLimits(source);
-    else if (isType(calledFunction, SPARSE_ADD.getDeclaringClass())) return new SparseAdd(source);
-    else if (isType(calledFunction, SPARSE_FROM_DENSE.getDeclaringClass()))
-      return new SparseFromDense(source);
-    else if (isType(calledFunction, SPARSE_TO_DENSE.getDeclaringClass()))
-      return new SparseToDense(source);
     else if (isType(calledFunction, VAR_LEN_FEATURE.getDeclaringClass()))
       return new VarLenFeature(source);
     else if (isType(calledFunction, FIXED_LEN_FEATURE.getDeclaringClass()))
@@ -1426,8 +1449,6 @@ public class TensorGeneratorFactory {
       return new DatasetChooseFromDatasetsGenerator(source);
     else if (isType(calledFunction, DATASET_SAMPLE_FROM_DATASETS_TYPE))
       return new DatasetSampleFromDatasetsGenerator(source);
-    else if (isType(calledFunction, DATASET_ENUMERATE_TYPE))
-      return new DatasetEnumerateGenerator(source);
     else if (isType(calledFunction, DATASET_SHUFFLE_TYPE)
         || isType(calledFunction, DATASET_MAP_TYPE)
         || isType(calledFunction, DATASET_REPEAT_TYPE)
@@ -1510,21 +1531,6 @@ public class TensorGeneratorFactory {
       return new UnsortedSegmentReduction(source);
     else if (isType(calledFunction, PLACEHOLDER.getDeclaringClass()))
       return new Placeholder(source);
-    else if (isType(calledFunction, EQUAL.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, NOT_EQUAL.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, LESS.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, LESS_EQUAL.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, GREATER.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, GREATER_EQUAL.getDeclaringClass()))
-      return new ComparisonOperation(source);
-    else if (isType(calledFunction, SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass())
-        || isType(calledFunction, SPARSE_SOFTMAX_CROSS_ENTROPY_WITH_LOGITS.getDeclaringClass()))
-      return new SoftmaxCrossEntropy(source);
     else if (isType(calledFunction, MATMUL.getDeclaringClass())) return new MatMul(source);
     else if (isType(calledFunction, SIGMOID.getDeclaringClass())) return new Sigmoid(source);
     else if (isType(calledFunction, EXP.getDeclaringClass())) return new Exp(source);


### PR DESCRIPTION
Batch 2 of the wala/ML#760 unification (also advances wala/ML#469): eleven ragged constructors, the five sparse generators, the six comparison operations, both softmax-cross-entropy forms, and `tf.data.Dataset.enumerate` migrate to `dispatchShared`, gaining their node-anchored forms. All were source-only except `SparseEye`, which is consolidated from both residual chains.

Two findings from the triage while migrating: the pass-through dataset stages (`filter`/`reduce`/`concatenate`) were already consistent on both sides (plain `DatasetGenerator` via the catch-all), so the audit's "semantic stages" concern reduces to `enumerate`, which node-side fell to the catch-all and lost its index/tuple element semantics (the wala/ML#759 mis-dispatch class, now fixed by its shared arm). Sixteen concrete classes and two abstract bases (`RaggedTensorFromValues`, `RaggedFromNested`) gain `(CGNode)` constructors.

Remaining under wala/ML#760 after this batch: the keras dataset loaders and the long tail of singleton ops (`gather_nd`/`boolean_mask`/`tensordot`/`stack`/`where` and friends), then the anchor-as-resolution-API endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX