### PR TITLE
Recover an unresolved transpose input's rank from its constant permutation

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
@@ -1597,4 +1597,33 @@ public class TestMathOps extends AbstractTensorTest {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_ndarray_reshape.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_60000_784_UINT8)));
   }
+
+  /**
+   * A constant transpose permutation fixes its unresolved input's rank (<a
+   * href="https://github.com/wala/ML/issues/734">wala/ML#734</a>): {@code inputs} arrives
+   * shape-opaque with a proven dtype (a cast of an unmodeled {@code tf.roll} result), and the
+   * explicit-perm {@code tf.transpose(inputs, [1, 0, 2])} proves it rank-3, the {@code crf_forward}
+   * pattern. Runtime-verified {@code (4, 3, 5) float32}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTransposeRankRecovery()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_transpose_rank.py",
+        "f",
+        1,
+        2,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(
+                    FLOAT_32,
+                    asList(
+                        UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)))));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Einsum.java
@@ -65,7 +65,7 @@ import java.util.logging.Logger;
  * @see <a href="https://github.com/wala/ML/issues/507">wala/ML#507</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
-public class Einsum extends PassThroughUnaryTensorGenerator {
+public class Einsum extends PassThroughUnaryTensorGenerator implements OperandShapeConstraining {
 
   private static final Logger LOGGER = Logger.getLogger(Einsum.class.getName());
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OperandShapeConstraining.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/OperandShapeConstraining.java
@@ -1,0 +1,30 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A generator whose operation statically constrains its operands' shapes (wala/ML#704,
+ * wala/ML#734): the einsum equation fixes each operand's rank and proves shared-label extents; a
+ * constant transpose permutation fixes its input's rank. The engine refines — rather than pins —
+ * each constrained operand destination with the proven shape, so unknown-shape members recover the
+ * proven axes while concrete members pass through untouched.
+ */
+public interface OperandShapeConstraining {
+
+  /**
+   * Derives, for each operand whose own shape does not resolve, the shape the operation proves for
+   * it. An axis the operation leaves unconstrained carries {@link
+   * com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim} (wala/ML#721).
+   *
+   * @param builder The propagation call graph builder.
+   * @return A map from each caller-side operand's {@link PointerKey} to the shape the operation
+   *     proves for it; empty when nothing is proven. An operand whose call sites prove disagreeing
+   *     constraints is omitted.
+   */
+  Map<PointerKey, List<Dimension<?>>> getOperandShapeConstraints(
+      PropagationCallGraphBuilder builder);
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1471,12 +1471,12 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         setCalls.put(src, onlyType);
       }
 
-      // An einsum call site with a constant equation constrains each tensor operand: the
-      // operand's term fixes its rank, and shared labels take their extents from operands whose
-      // shapes are statically known (wala/ML#704). Refine — rather than pin — the operand
-      // destinations, so unknown-shape members recover the proven axes while concrete members
-      // pass through untouched. An operand whose call sites prove disagreeing constraints is
-      // left alone.
+      // A shape-constraining consumer proves operand shapes its call alone fixes: an einsum
+      // equation fixes each operand's rank and shared-label extents (wala/ML#704), and a constant
+      // transpose permutation fixes its input's rank (wala/ML#734). Refine — rather than pin —
+      // the operand destinations, so unknown-shape members recover the proven axes while concrete
+      // members pass through untouched. An operand whose call sites prove disagreeing constraints
+      // is left alone.
       Map<PointsToSetVariable, List<Dimension<?>>> refinements = HashMapFactory.make();
       Set<PointsToSetVariable> conflictingRefinements = HashSetFactory.make();
       for (PointsToSetVariable src : sources) {
@@ -1486,9 +1486,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         } catch (IllegalArgumentException e) {
           continue;
         }
-        if (!(generator instanceof Einsum)) continue;
+        if (!(generator instanceof OperandShapeConstraining constraining)) continue;
         for (Map.Entry<PointerKey, List<Dimension<?>>> entry :
-            ((Einsum) generator).getOperandShapeConstraints(builder).entrySet()) {
+            constraining.getOperandShapeConstraints(builder).entrySet()) {
           if (builder.getPropagationSystem().isImplicit(entry.getKey())) continue;
           PointsToSetVariable operand =
               builder.getPropagationSystem().findOrCreatePointsToSet(entry.getKey());

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Transpose.java
@@ -4,17 +4,24 @@ import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -31,7 +38,7 @@ import java.util.logging.Logger;
  * @see <a href="https://www.tensorflow.org/api_docs/python/tf/transpose">tf.transpose</a>
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
-public class Transpose extends PassThroughUnaryTensorGenerator {
+public class Transpose extends PassThroughUnaryTensorGenerator implements OperandShapeConstraining {
 
   private static final Logger LOGGER = Logger.getLogger(Transpose.class.getName());
 
@@ -112,6 +119,50 @@ public class Transpose extends PassThroughUnaryTensorGenerator {
       else ret.add(out);
     }
     return ret.isEmpty() ? ShapeResult.unknown() : new ShapeResult(ret, hasUnknown);
+  }
+
+  /**
+   * A constant explicit permutation fixes the {@code a} operand's rank at the permutation's length
+   * (wala/ML#734): when the operand's own shape does not resolve, the call proves a rank-only shape
+   * whose every axis is {@link UnresolvedDim} (wala/ML#721). An absent or {@code None} perm (the
+   * reversal default) applies at any rank and proves nothing, and a call site whose operand
+   * resolves on its own needs no constraint.
+   *
+   * @param builder The propagation call graph builder.
+   * @return A map from each caller-side {@code a} operand's {@link PointerKey} to its rank-only
+   *     proven shape; empty when nothing is proven. An operand whose call sites prove disagreeing
+   *     ranks is omitted.
+   */
+  @Override
+  public Map<PointerKey, List<Dimension<?>>> getOperandShapeConstraints(
+      PropagationCallGraphBuilder builder) {
+    Map<PointerKey, List<Dimension<?>>> ret = new LinkedHashMap<>();
+    Set<PointerKey> conflicting = new HashSet<>();
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      CGNode caller = callerInvoke.fst;
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction invoke)) continue;
+      // Uses are (callee, a, perm); a keyword-only perm is left to a follow-up.
+      if (invoke.getNumberOfPositionalParameters() < 3) continue;
+      int aVn = invoke.getUse(1);
+      int permVn = invoke.getUse(2);
+      PointerKey permKey =
+          builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, permVn);
+      OrdinalSet<InstanceKey> permPts = builder.getPointerAnalysis().getPointsToSet(permKey);
+      if (isAbsentOrNone(permPts)) continue;
+      List<Integer> perm = resolvePermList(builder, permPts);
+      if (perm == null || perm.isEmpty()) continue;
+      Set<List<Dimension<?>>> own = this.getShapes(builder, caller, aVn, true);
+      if (own != null && !own.isEmpty()) continue; // Resolves on its own; nothing to prove.
+      PointerKey aKey =
+          builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, aVn);
+      List<Dimension<?>> constraint =
+          new ArrayList<>(Collections.nCopies(perm.size(), (Dimension<?>) UnresolvedDim.INSTANCE));
+      List<Dimension<?>> previous = ret.putIfAbsent(aKey, constraint);
+      if (previous != null && !previous.equals(constraint)) conflicting.add(aKey);
+    }
+    ret.keySet().removeAll(conflicting);
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_transpose_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_transpose_rank.py
@@ -1,0 +1,17 @@
+# Test wala/ML#734: a constant transpose permutation fixes its unresolved input's
+# rank. `t` is shape-opaque with a proven dtype (a cast of a `tf.roll` result the
+# analysis does not model), and `f`'s explicit-perm transpose proves `inputs`
+# rank-3 (the `crf_forward` pattern).
+import tensorflow as tf
+
+
+def f(inputs):
+    assert inputs.shape == (4, 3, 5)
+    assert inputs.dtype == tf.float32
+    x = tf.transpose(inputs, [1, 0, 2])
+    assert x.shape == (3, 4, 5)
+    return x
+
+
+t = tf.cast(tf.roll(tf.ones((4, 3, 5)), shift=1, axis=0), tf.float32)
+f(t)


### PR DESCRIPTION
Advances wala/ML#734 (its transpose instance; the einsum instance landed with the wala/ML#704 refinement, and whether more consumer operators should join is the issue's remaining question).

The engine's einsum-only operand-refinement loop generalizes to an `OperandShapeConstraining` interface; `Einsum` implements it unchanged, and `Transpose` now derives, per call site, a rank-only constraint (every axis `UnresolvedDim`, wala/ML#721) for an `a` operand whose own shape does not resolve, whenever the permutation is a constant explicit list. The reversal default applies at any rank and proves nothing; call sites proving disagreeing ranks are omitted; keyword-only permutations are deferred. `RefineShapeOp` needed no changes: a ⊤-shape member takes the proven shape outright, so a fully-⊤ parameter becomes rank-known with unresolved extents, which is what distinguishes a retracing-reducing shape from a fully-open one.

The runtime-verified fixture mirrors the NLPGNN `crf_forward` pattern (`tf.transpose(inputs, [1, 0, 2])` on a shape-opaque, dtype-proven input): `inputs` now types `(?, ?, ?) float32` instead of `? of float32` (`testTransposeRankRecovery`). No pinned corpus unions move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX