### PR TITLE
Document the value-number frame contract on `getArgumentValueNumber`

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -6306,12 +6306,19 @@ public abstract class TensorGenerator {
   /**
    * Returns the value number for the argument at the specified position or with the specified name.
    *
+   * <p><strong>Frame contract (wala/ML#760):</strong> the returned value number is always in {@link
+   * #getNode()}'s frame, whichever anchoring resolved it — a source anchoring reads the defining
+   * invoke or binary operation in the source's node, and a manual anchoring falls back to the
+   * synthetic method's own parameter. A consumer must resolve it against {@code getNode()}'s IR and
+   * nothing else; pairing a value number from one frame with another frame's IR silently resolves
+   * garbage (the wala/ML#718 {@code ElementWiseOperation} trap class).
+   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @param paramPos The position of the argument in the function call.
    * @param paramName The name of the argument in the function call.
    * @param optional Whether the argument is optional.
    * @return The value number for the argument at the specified position or with the specified name
-   *     or -1 if the argument is optional and not present.
+   *     or -1 if the argument is optional and not present; always in {@link #getNode()}'s frame.
    * @throws IllegalStateException If the argument is mandatory and not present.
    */
   protected int getArgumentValueNumber(


### PR DESCRIPTION
Advances wala/ML#760: the anchor-tighten audit, with a better-than-expected verdict.

All 20 anchor-kind branches across the eight files with explicit `source == null`-style checks classify as benign null-safe accessors (logging, candidate recording), correct anchor splits (`ElementWiseOperation`'s explicit manual route, `DatasetMapGenerator`'s stored-instance split, the walk recursion guards), or consistently-framed value-number resolution: the 4-argument `getArgumentValueNumber` returns a value number in `getNode()`'s frame on every arm, including the manual fallback to the synthetic's own parameters. The post-wala/ML#718 fixes centralized the resolution seam organically, so the planned anchor-as-resolution-API growth is unnecessary; what remained was to state the invariant where it lives, which this PR does. The remaining wala/ML#760 scope is therefore only the four judgment-case operations and the allocation-type prelude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX