### PR TITLE
Monotonize the φ-arm and `Concat` fallback evaluations under the worklist engine (wala/ML#758)

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -27,6 +27,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -114,6 +115,8 @@ public class Concat extends TensorGenerator {
 
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    boolean sawUnknown = false;
+    boolean sawBottom = false;
 
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
@@ -125,15 +128,26 @@ public class Concat extends TensorGenerator {
           pa.getPointsToSet(
               ((AstPointerKeyFactory) builder.getPointerKeyFactory())
                   .getPointerKeyForObjectCatalog(asin));
-      List<Dimension<?>> outShape =
-          catalog.size() == 0 ? null : computeConcatenatedShape(builder, asin, catalog, axis);
+      ShapeResult outShape =
+          catalog.size() == 0
+              ? ShapeResult.bottom()
+              : computeConcatenatedShape(builder, asin, catalog, axis);
       // An append-populated list has no numeric catalog entries; its elements live under the
       // synthetic append-contents field. The element count is not statically known, so the axis
       // dim is dynamic while the rank and non-axis dims survive (wala/ML#570).
-      if (outShape == null) outShape = computeAppendedShape(builder, asin, axis);
-      if (outShape != null) ret.add(outShape);
+      if (outShape.isBottom()) outShape = computeAppendedShape(builder, asin, axis);
+      ret.addAll(outShape.members());
+      if (outShape.hasUnknown()) sawUnknown = true;
+      else if (outShape.isBottom()) sawBottom = true;
     }
-    return ret.isEmpty() ? null : ret;
+    if (!ret.isEmpty()) return ret;
+    if (sawUnknown) return null;
+    // Every operand's elements are still unresolved (wala/ML#758 clause 3): contribute the
+    // engine's ⊥ so the evaluation ascends when the elements resolve, instead of freezing a
+    // transient ⊤ into the join. The pure-cycle promotion supplies the sound ⊤ for elements that
+    // stay baseless.
+    if (sawBottom) return Collections.emptySet();
+    return null;
   }
 
   @Override
@@ -177,31 +191,34 @@ public class Concat extends TensorGenerator {
    * @param builder The propagation call graph builder.
    * @param listAsin The list allocation whose appended contents to read.
    * @param axis The resolved concatenation axis.
-   * @return The output shape, or {@code null} if the appended values' shapes cannot be resolved or
-   *     disagree.
+   * @return The resolution result: the single output shape, ⊥ while the appended values are still
+   *     unresolved, or the unknown element when they are settled-unknown or disagree.
    */
-  private List<Dimension<?>> computeAppendedShape(
+  private ShapeResult computeAppendedShape(
       PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin, int axis) {
     OrdinalSet<InstanceKey> contentsPts = getAppendedContentsPts(builder, listAsin);
-    if (contentsPts == null) return null;
-    Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, contentsPts);
-    if (shapes == null || shapes.isEmpty()) return null;
+    if (contentsPts == null) return ShapeResult.unknown();
+    ShapeResult contents = this.getShapeResultOfValue(builder, contentsPts, true);
+    if (contents.isBottom()) return ShapeResult.bottom();
+    if (contents.hasUnknown()) return ShapeResult.unknown();
+    Set<List<Dimension<?>>> shapes = contents.members();
 
     List<Dimension<?>> template = null;
     for (List<Dimension<?>> shape : shapes) {
       if (template == null) template = shape;
-      else if (shape.size() != template.size()) return null; // rank mismatch — can't concat soundly
+      else if (shape.size() != template.size())
+        return ShapeResult.unknown(); // rank mismatch — can't concat soundly
     }
 
     int rank = template.size();
     int normalizedAxis = axis < 0 ? axis + rank : axis;
-    if (normalizedAxis < 0 || normalizedAxis >= rank) return null;
+    if (normalizedAxis < 0 || normalizedAxis >= rank) return ShapeResult.unknown();
 
     List<Dimension<?>> outShape = new ArrayList<>(template);
     for (List<Dimension<?>> shape : shapes)
       for (int d = 0; d < rank; d++)
         if (d != normalizedAxis && !shape.get(d).equals(outShape.get(d)))
-          return null; // non-axis dim disagreement — can't pick a sound template
+          return ShapeResult.unknown(); // non-axis dim disagreement — can't pick a sound template
 
     // The concatenation axis sums the appended elements' axis sizes over an unknown element
     // count: a sum involving any `None` axis is itself `None` at run time; otherwise it is a
@@ -210,50 +227,57 @@ public class Concat extends TensorGenerator {
     boolean anyDynamicAxis =
         shapes.stream().anyMatch(shape -> shape.get(normalizedAxis) instanceof DynamicDim);
     outShape.set(normalizedAxis, anyDynamicAxis ? DynamicDim.INSTANCE : UnresolvedDim.INSTANCE);
-    return outShape;
+    return ShapeResult.of(Collections.singleton(outShape));
   }
 
   /**
    * Computes the concatenated shape: takes the first input's shape verbatim except at the {@code
-   * axis} position, where the dim is replaced by the sum across all inputs. Returns {@code null} if
-   * any input's shape can't be resolved or has a non-{@link NumericDim} at the axis.
+   * axis} position, where the dim is replaced by the sum across all inputs. Propagates ⊥ while any
+   * input is still unresolved and the unknown element when an input is settled-unknown, ambiguous,
+   * or has a non-{@link NumericDim} at the axis.
    */
-  private List<Dimension<?>> computeConcatenatedShape(
+  private ShapeResult computeConcatenatedShape(
       PropagationCallGraphBuilder builder,
       AllocationSiteInNode listAsin,
       OrdinalSet<InstanceKey> catalog,
       int axis) {
-    // Get the first element's shape as the template.
+    // Get the first element's shape as the template. A still-unresolved element is the engine's ⊥
+    // and propagates as ⊥ so the evaluation ascends when it resolves; a settled-unknown or
+    // ambiguous (multi-shape) element makes the output unknown (wala/ML#758). The previous
+    // arbitrary pick from a multi-shape element followed hash order, itself a run-to-run
+    // nondeterminism.
     OrdinalSet<InstanceKey> firstElemPts = getElementPts(builder, listAsin, catalog, 0);
-    if (firstElemPts == null) return null;
-    Set<List<Dimension<?>>> firstShapes = this.getShapesOfValue(builder, firstElemPts);
-    if (firstShapes == null || firstShapes.isEmpty()) return null;
-    // Pick any one; in practice we expect a single shape for the list.
-    List<Dimension<?>> firstShape = firstShapes.iterator().next();
+    if (firstElemPts == null) return ShapeResult.unknown();
+    ShapeResult firstResult = this.getShapeResultOfValue(builder, firstElemPts, true);
+    if (firstResult.isBottom()) return ShapeResult.bottom();
+    if (firstResult.hasUnknown() || firstResult.members().size() != 1) return ShapeResult.unknown();
+    List<Dimension<?>> firstShape = firstResult.members().iterator().next();
     int rank = firstShape.size();
     int normalizedAxis = axis < 0 ? axis + rank : axis;
-    if (normalizedAxis < 0 || normalizedAxis >= rank) return null;
+    if (normalizedAxis < 0 || normalizedAxis >= rank) return ShapeResult.unknown();
 
     // Sum the axis dim across all elements.
     long sum = 0;
     for (InstanceKey catalogIK : catalog) {
-      if (!(catalogIK instanceof ConstantKey)) return null;
+      if (!(catalogIK instanceof ConstantKey)) return ShapeResult.unknown();
       Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
-      if (fieldIndex == null) return null;
+      if (fieldIndex == null) return ShapeResult.unknown();
       OrdinalSet<InstanceKey> elemPts = getElementPts(builder, listAsin, catalog, fieldIndex);
-      if (elemPts == null) return null;
-      Set<List<Dimension<?>>> elemShapes = this.getShapesOfValue(builder, elemPts);
-      if (elemShapes == null || elemShapes.isEmpty()) return null;
-      List<Dimension<?>> elemShape = elemShapes.iterator().next();
-      if (elemShape.size() != rank) return null; // rank mismatch — can't concat soundly
+      if (elemPts == null) return ShapeResult.unknown();
+      ShapeResult elemResult = this.getShapeResultOfValue(builder, elemPts, true);
+      if (elemResult.isBottom()) return ShapeResult.bottom();
+      if (elemResult.hasUnknown() || elemResult.members().size() != 1) return ShapeResult.unknown();
+      List<Dimension<?>> elemShape = elemResult.members().iterator().next();
+      if (elemShape.size() != rank)
+        return ShapeResult.unknown(); // rank mismatch — can't concat soundly
       Dimension<?> axisDim = elemShape.get(normalizedAxis);
-      if (!(axisDim instanceof NumericDim)) return null; // non-numeric → can't sum
+      if (!(axisDim instanceof NumericDim)) return ShapeResult.unknown(); // non-numeric → can't sum
       sum += ((NumericDim) axisDim).value();
     }
 
     List<Dimension<?>> outShape = new ArrayList<>(firstShape);
     outShape.set(normalizedAxis, new NumericDim((int) sum));
-    return outShape;
+    return ShapeResult.of(Collections.singleton(outShape));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -115,8 +115,6 @@ public class Concat extends TensorGenerator {
 
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
-    boolean sawUnknown = false;
-    boolean sawBottom = false;
 
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
@@ -132,22 +130,22 @@ public class Concat extends TensorGenerator {
           catalog.size() == 0
               ? ShapeResult.bottom()
               : computeConcatenatedShape(builder, asin, catalog, axis);
-      // An append-populated list has no numeric catalog entries; its elements live under the
-      // synthetic append-contents field. The element count is not statically known, so the axis
-      // dim is dynamic while the rank and non-axis dims survive (wala/ML#570).
-      if (outShape.isBottom()) outShape = computeAppendedShape(builder, asin, axis);
+      // An append-populated list resolves nothing through the catalog: its elements live under
+      // the synthetic append-contents field, and its catalog is empty or carries only attribute
+      // keys. Whenever the catalog path yields no members, the appended contents decide; the
+      // element count is not statically known there, so the axis dim is dynamic while the rank
+      // and non-axis dims survive (wala/ML#570).
+      if (outShape.members().isEmpty()) {
+        ShapeResult appended = computeAppendedShape(builder, asin, axis);
+        if (!appended.members().isEmpty()) outShape = appended;
+      }
       ret.addAll(outShape.members());
-      if (outShape.hasUnknown()) sawUnknown = true;
-      else if (outShape.isBottom()) sawBottom = true;
     }
-    if (!ret.isEmpty()) return ret;
-    if (sawUnknown) return null;
-    // Every operand's elements are still unresolved (wala/ML#758 clause 3): contribute the
-    // engine's ⊥ so the evaluation ascends when the elements resolve, instead of freezing a
-    // transient ⊤ into the join. The pure-cycle promotion supplies the sound ⊤ for elements that
-    // stay baseless.
-    if (sawBottom) return Collections.emptySet();
-    return null;
+    // A memberless evaluation stays ⊤ at this legacy view: this method also composes seeds, where
+    // an empty set reads as "not a tensor" and would pair a ⊥ shape with a resolved dtype. The
+    // clause-3 ⊥ contribution for still-unresolved elements needs the element reads themselves to
+    // be engine-visible first (wala/ML#758).
+    return ret.isEmpty() ? null : ret;
   }
 
   @Override
@@ -198,9 +196,13 @@ public class Concat extends TensorGenerator {
       PropagationCallGraphBuilder builder, AllocationSiteInNode listAsin, int axis) {
     OrdinalSet<InstanceKey> contentsPts = getAppendedContentsPts(builder, listAsin);
     if (contentsPts == null) return ShapeResult.unknown();
-    ShapeResult contents = this.getShapeResultOfValue(builder, contentsPts, true);
+    // The appended template computes from the resolvable subset, this path's historical
+    // default-mode contract (wala/ML#716); an exact read would collapse a partial's members at
+    // every legacy-view boundary. A memberless unmarked result is the engine's ⊥ and propagates;
+    // only a memberless unknown collapses the result.
+    ShapeResult contents = this.getShapeResultOfValue(builder, contentsPts, false);
     if (contents.isBottom()) return ShapeResult.bottom();
-    if (contents.hasUnknown()) return ShapeResult.unknown();
+    if (contents.members().isEmpty()) return ShapeResult.unknown();
     Set<List<Dimension<?>>> shapes = contents.members();
 
     List<Dimension<?>> template = null;
@@ -248,7 +250,7 @@ public class Concat extends TensorGenerator {
     // nondeterminism.
     OrdinalSet<InstanceKey> firstElemPts = getElementPts(builder, listAsin, catalog, 0);
     if (firstElemPts == null) return ShapeResult.unknown();
-    ShapeResult firstResult = this.getShapeResultOfValue(builder, firstElemPts, true);
+    ShapeResult firstResult = this.getShapeResultOfValue(builder, firstElemPts, false);
     if (firstResult.isBottom()) return ShapeResult.bottom();
     if (firstResult.hasUnknown() || firstResult.members().size() != 1) return ShapeResult.unknown();
     List<Dimension<?>> firstShape = firstResult.members().iterator().next();
@@ -264,7 +266,7 @@ public class Concat extends TensorGenerator {
       if (fieldIndex == null) return ShapeResult.unknown();
       OrdinalSet<InstanceKey> elemPts = getElementPts(builder, listAsin, catalog, fieldIndex);
       if (elemPts == null) return ShapeResult.unknown();
-      ShapeResult elemResult = this.getShapeResultOfValue(builder, elemPts, true);
+      ShapeResult elemResult = this.getShapeResultOfValue(builder, elemPts, false);
       if (elemResult.isBottom()) return ShapeResult.bottom();
       if (elemResult.hasUnknown() || elemResult.members().size() != 1) return ShapeResult.unknown();
       List<Dimension<?>> elemShape = elemResult.members().iterator().next();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1906,6 +1906,7 @@ public abstract class TensorGenerator {
     // vendored einsum-via-matmul's inner-dimension count is a single constant per context, so
     // the conditional-reshape φ keeps only its runtime arm.
     if (def instanceof SSAPhiInstruction) {
+      boolean engineActive = WorklistTypeResolver.active(builder) != null;
       boolean armUnknown = false;
       Set<List<Dimension<?>>> armMembers = HashSetFactory.make();
       for (int i = 0; i < def.getNumberOfUses(); i++) {
@@ -1937,7 +1938,12 @@ public abstract class TensorGenerator {
           armUnknown = true;
           continue;
         }
-        if (armResult.hasUnknown() || armResult.isBottom()) armUnknown = true;
+        // Under the engine a ⊥ arm read is still converging or holds no tensor; it contributes
+        // nothing, and the pure-cycle promotion turns a finally-baseless arm into the marked ⊤,
+        // which arrives here as hasUnknown on re-evaluation (wala/ML#758 clause 3). A mark taken
+        // from an interim ⊥ would survive the join permanently. Outside the engine a ⊥ read is
+        // final, so it keeps the conservative mark.
+        if (armResult.hasUnknown() || (!engineActive && armResult.isBottom())) armUnknown = true;
         armMembers.addAll(armResult.members());
       }
       if (!armMembers.isEmpty()) return new ShapeResult(armMembers, armUnknown);
@@ -2042,6 +2048,7 @@ public abstract class TensorGenerator {
    */
   private ShapeResult shapeResultOfFeasibleArms(
       PropagationCallGraphBuilder builder, CGNode node, SSAPhiInstruction phi, boolean exact) {
+    boolean engineActive = WorklistTypeResolver.active(builder) != null;
     boolean pruned = false;
     boolean armUnknown = false;
     Set<List<Dimension<?>>> armMembers = HashSetFactory.make();
@@ -2074,11 +2081,18 @@ public abstract class TensorGenerator {
         armUnknown = true;
         continue;
       }
-      if (armResult.hasUnknown() || armResult.isBottom()) armUnknown = true;
+      // Same ⊥-arm convention as the unpruned φ union: under the engine a ⊥ read contributes
+      // nothing and the pure-cycle promotion marks finally-baseless arms; outside the engine the
+      // final ⊥ keeps the conservative mark (wala/ML#758 clause 3).
+      if (armResult.hasUnknown() || (!engineActive && armResult.isBottom())) armUnknown = true;
       armMembers.addAll(armResult.members());
     }
     if (!pruned) return null;
-    return armMembers.isEmpty() ? ShapeResult.unknown() : new ShapeResult(armMembers, armUnknown);
+    if (armMembers.isEmpty())
+      // With no members, an unknown-marked arm set is the answered ⊤; an all-⊥ arm set under the
+      // engine is the ⊥ that ascends when the arms resolve (wala/ML#758 clause 3).
+      return armUnknown || !engineActive ? ShapeResult.unknown() : ShapeResult.bottom();
+    return new ShapeResult(armMembers, armUnknown);
   }
 
   /**


### PR DESCRIPTION
Advances wala/ML#758: the arm-monotonicity contract's audit sweep and its first landed fixes.

**The φ-arm unions** (`computeShapes` and the wala/ML#746 feasible-arms variant) took the unknown mark from a ⊥ arm read. Under the engine a ⊥ read is a still-converging or no-tensor value, and since the join disjoins the mark permanently, a still-converging arm froze a transient ⊤ into the settled state (clause 3). A ⊥ arm now contributes nothing: the pure-cycle promotion marks finally-baseless arms, which arrive as the answered unknown on re-evaluation, and an all-⊥ arm set reads as the ⊥ that ascends when the arms resolve. The null-engine recursive path keeps the legacy conservative mark, where a ⊥ read is final.

**The `Concat` element resolution** becomes record-aware and deterministic (the wala/ML#758 round-11 unit): element reads distinguish the engine's interim ⊥, which routes the catalog-versus-appended fallback choice, from settled-unknown and ambiguous elements, and the multi-shape arbitrary pick (hash-order nondeterminism) reads as unresolved. Two reconciliations for the standalone landing: the appended-contents fallback fires whenever the catalog path yields no members, since an append-populated list's catalog is empty or carries only attribute keys, which the catalog path answers as unknown; and a memberless evaluation stays ⊤ at the method's legacy view, which also composes seeds, where an empty set would pair a ⊥ shape with a resolved dtype. The clause-3 ⊥ contribution for still-unresolved elements needs engine-visible element reads first.

The audit verdicts on the remaining named arms (`DenseCall`, `getShapesOrSSAChain`, the caller-walk's contract-seed arm, and the wala/ML#570/wala/ML#742 import) are posted on the issue.
