### PR TITLE
Guard materialized parameter defaults with in-vitro fixtures (wala/ML#743)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -256,6 +256,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_4_4_FLOAT32 = TensorType.of(FLOAT_32, 4, 4);
 
+  protected static final TensorType TENSOR_4_2_FLOAT32 = TensorType.of(FLOAT_32, 4, 2);
+
   protected static final TensorType TENSOR_2_5_INT32 = TensorType.of(INT_32, 2, 5);
 
   protected static final TensorType TENSOR_3_3_FLOAT32 = TensorType.of(FLOAT_32, 3, 3);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1154,4 +1154,20 @@ public class TestConstructors extends AbstractTensorTest {
 
     test("tf2_test_variable_positional_dtype.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_FLOAT64)));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/743">wala/ML#743</a> value-sensitively: the
+   * unpassed integer default {@code n} determines the constructed tensor's leading dimension, so
+   * the shape resolves only if the default materializes in the pointer analysis.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testParamDefault2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_param_default2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_2_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -1633,4 +1633,21 @@ public class TestElementwiseOps extends AbstractTensorTest {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_multiply7.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/743">wala/ML#743</a>: an unpassed parameter
+   * default (the float scalar {@code eps}) must materialize in the pointer analysis for the
+   * elementwise addition to resolve. The result keeps the tensor operand's shape (scalar broadcast)
+   * and dtype.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testParamDefault()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_param_default.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_param_default.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_param_default.py
@@ -1,0 +1,19 @@
+# Probe for wala/ML#743: an unpassed parameter default (the float scalar `eps`) must
+# materialize in the pointer analysis for the elementwise addition to resolve. The result
+# keeps the tensor operand's shape (scalar broadcast) and dtype.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def add_eps(x, eps=1e-6):
+    return x + eps
+
+
+y = add_eps(tf.ones((2, 3)))
+consume(y)
+
+assert y.shape == (2, 3)
+assert y.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_param_default2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_param_default2.py
@@ -1,0 +1,19 @@
+# Probe for wala/ML#743: the unpassed integer default `n` determines the constructed
+# tensor's leading dimension, so the shape resolves only if the default materializes in
+# the pointer analysis.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def make(n=4):
+    return tf.ones((n, 2))
+
+
+y = make()
+consume(y)
+
+assert y.shape == (4, 2)
+assert y.dtype == tf.float32


### PR DESCRIPTION
Advances wala/ML#743: direct in-vitro regression guards for the landed main track (ponder-lab/ML#622), whose regression evidence was corpus-pin updates only.

Two runtime-verified fixtures pin the materialization behavior directly. `tf2_test_param_default.py` resolves an unpassed float default through an elementwise addition, so the result keeps the tensor operand's shape under scalar broadcast; this is the class of the original `variance + epsilon` flooring witness. `tf2_test_param_default2.py` is value-sensitive: the unpassed integer default determines the constructed tensor's leading dimension, so `(4, 2)` resolves only if the default's constant reaches the pointer analysis.

Verified against the filing-time commit that both probes' substrate reproduces the original gap there (the `LayerNormalization` defaults global is empty at c4579840c and holds the constant on master).
