### PR TITLE
Filter constant-decidable branch arms per call site (wala/ML#746)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -826,10 +826,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * suite/single-test modes. Analyzed statically here, like the consumer's vendoring; it runs in
    * the perf-eval with its tfrecord/data setup.
    *
-   * <p>TODO: Drop the {@code (32, Dynamic, 8, 8)}/{@code (?, Dynamic, 8, 8)} members once <a
-   * href="https://github.com/wala/ML/issues/746">wala/ML#746</a> filters constant-decidable branch
-   * arms per call site; they are the {@code mode="projection"} call's rank-3 input crossing into
-   * the embedding-mode lookup, runtime-infeasible at that site.
+   * <p>The former {@code (32, Dynamic, 8, 8)}/{@code (?, Dynamic, 8, 8)} members, the {@code
+   * mode="projection"} call's rank-3 input crossing into the embedding-mode lookup, are gone: <a
+   * href="https://github.com/wala/ML/issues/746">wala/ML#746</a>'s per-call-site arm filtering
+   * prunes the embedding arm at that site.
    */
   @Test
   public void testGpt2GetLossVendored()
@@ -862,21 +862,7 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                     FLOAT_32, asList(new NumericDim(32), DynamicDim.INSTANCE, new NumericDim(10))),
                 new TensorType(
                     FLOAT_32,
-                    asList(new SymbolicDim("?"), DynamicDim.INSTANCE, new NumericDim(10))),
-                new TensorType(
-                    FLOAT_32,
-                    asList(
-                        new NumericDim(32),
-                        DynamicDim.INSTANCE,
-                        new NumericDim(8),
-                        new NumericDim(8))),
-                new TensorType(
-                    FLOAT_32,
-                    asList(
-                        new SymbolicDim("?"),
-                        DynamicDim.INSTANCE,
-                        new NumericDim(8),
-                        new NumericDim(8))))));
+                    asList(new SymbolicDim("?"), DynamicDim.INSTANCE, new NumericDim(10))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1180,9 +1180,10 @@ public class TestDatasets extends AbstractTensorTest {
 
   /**
    * Pins the vendored gpt-2 {@code EmbeddingLayer} forward result (wala/ML#618): the {@code
-   * add_weight}-created weight dispatches and both {@code mode} branches contribute to the result
-   * union. With {@code add_weight} consuming its {@code shape}/{@code dtype} arguments
-   * (wala/ML#667), the embedding-mode member is fully concrete: {@code (2, 3, 8)} float32.
+   * add_weight}-created weight dispatches, and the call's default {@code mode} decides the
+   * embedding arm per call site (wala/ML#746), so the projection arm's one-hot member no longer
+   * crosses in. With {@code add_weight} consuming its {@code shape}/{@code dtype} arguments
+   * (wala/ML#667), the result is fully concrete: {@code (2, 3, 8)} float32.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1192,8 +1193,6 @@ public class TestDatasets extends AbstractTensorTest {
   @Test
   public void testCollectionProbeVendoredEmbedding()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // Count-only: the parameter's type is a union across the `mode` branches whose exact
-    // members shift with modeling precision.
     test(
         new String[] {
           "gpt2_vendored/layers/__init__.py",
@@ -1205,13 +1204,7 @@ public class TestDatasets extends AbstractTensorTest {
         "gpt2_vendored",
         1,
         1,
-        Map.of(
-            2,
-            Set.of(
-                TensorType.of(FLOAT_32, 2, 3, 8),
-                // The one-hot member's leading dims fold to the runtime-true (2, 3) through the
-                // tf.shape shape-vector arm (wala/ML#722).
-                TensorType.of(INT_32, 2, 3, 10))));
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 3, 8))));
   }
 
   /**
@@ -1240,10 +1233,10 @@ public class TestDatasets extends AbstractTensorTest {
    * gone: with the decoder-stack output resolving, {@code OutputLayer.call}'s dead {@code
    * self.porj_weights} arm no longer contributes a member.
    *
-   * <p>TODO: Drop the {@code (2, 3, 8, 8)} member once <a
-   * href="https://github.com/wala/ML/issues/746">wala/ML#746</a> filters constant-decidable branch
-   * arms per call site; it is the {@code mode="projection"} call's rank-3 input crossing into the
-   * embedding-mode lookup, runtime-infeasible at that site.
+   * <p>The former {@code (2, 3, 8, 8)} member, the {@code mode="projection"} call's rank-3 input
+   * crossing into the embedding-mode lookup, is gone: <a
+   * href="https://github.com/wala/ML/issues/746">wala/ML#746</a>'s per-call-site arm filtering
+   * prunes the embedding arm at that site.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1271,7 +1264,6 @@ public class TestDatasets extends AbstractTensorTest {
             2,
             Set.of(
                 TensorType.of(FLOAT_32, 2, 3, 10),
-                TensorType.of(FLOAT_32, 2, 3, 8, 8),
                 new TensorType(
                     FLOAT_32,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, new NumericDim(10))))));

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1176,4 +1176,22 @@ public class TestShapeOps extends AbstractTensorTest {
                 new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE)),
                 TensorType.of(FLOAT_32, 24))));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/746">wala/ML#746</a>: a string-guarded
+   * dispatch whose arms return different ranks. Each call site's {@code mode} constant (the keyword
+   * at the second site, the materialized default at the first, wala/ML#743) decides its arm, so
+   * neither sink sees the other site's member.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testModeGuardDispatch()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_mode_guard.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
+    test("tf2_test_mode_guard.py", "consume2", 1, 1, Map.of(2, Set.of(TENSOR_6_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -225,6 +225,39 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
   }
 
   /**
+   * A transfer function for a call-site-infeasible return edge (wala/ML#746): the destination is a
+   * call result whose site's constant bindings decide the callee's guard, and this edge carries the
+   * merged return value that includes the pruned arms. The edge contributes nothing; the feasible
+   * returns' values arrive over the direct edges installed alongside the suppression. Unlike {@link
+   * DropOp} the destination's state is untouched, so every other predecessor contributes as usual.
+   */
+  static final class ArmSuppressOp extends UnaryOperator<TensorVariable> {
+    static final ArmSuppressOp INSTANCE = new ArmSuppressOp();
+
+    private ArmSuppressOp() {}
+
+    @Override
+    public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+      return NOT_CHANGED;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x746A0501; // arbitrary constant; this is a singleton
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof ArmSuppressOp;
+    }
+
+    @Override
+    public String toString() {
+      return "suppress a call-site-infeasible return edge (wala/ML#746)";
+    }
+  }
+
+  /**
    * A transfer function for parameter destinations (wala/ML#726): tensor types flow through
    * unchanged, but the origins union is skipped, so a parameter keeps its seeded {@link
    * TensorOrigin#PARAMETER} instead of inheriting its call sites' origins. Mirrors the plain node
@@ -355,6 +388,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -918,6 +952,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               PointsToSetVariable src, PointsToSetVariable dst) {
             if (drops.contains(dst)) {
               return DropOp.INSTANCE;
+            } else if (armSuppressions.containsKey(dst) && armSuppressions.get(dst).contains(src)) {
+              return ArmSuppressOp.INSTANCE;
             } else if (typeFeeds.containsKey(dst) && typeFeeds.get(dst).operands().contains(src)) {
               return new TypeFeedOp(typeFeeds.get(dst), src);
             } else if (set_shapes.containsKey(dst)) {
@@ -1009,6 +1045,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -1023,6 +1060,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
         set_shapes,
         refinements,
         typeFeeds,
+        armSuppressions,
         conv2ds,
         conv3ds,
         drops,
@@ -1050,6 +1088,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, TensorType> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,
       Set<PointsToSetVariable> conv2ds,
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
@@ -1064,6 +1103,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             set_shapes,
             refinements,
             typeFeeds,
+            armSuppressions,
             conv2ds,
             conv3ds,
             drops,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -46,6 +46,7 @@ import com.ibm.wala.ipa.callgraph.impl.ContextInsensitiveSelector;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
 import com.ibm.wala.ipa.callgraph.propagation.ConcreteTypeKey;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.HeapModel;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
@@ -59,10 +60,12 @@ import com.ibm.wala.ipa.callgraph.propagation.cfa.nCFAContextSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.DefUse;
 import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
@@ -1679,6 +1682,80 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       }
       LOGGER.fine(() -> "wala/ML#729 iteration-product destinations: " + iterationProducts.size());
 
+      // A call site whose constant bindings decide a callee guard must not receive the callee's
+      // merged return flow: the merged return-value key unions every arm, including those the
+      // site's constants prove untaken (wala/ML#746). Suppress the merged edge per such site and
+      // wire the feasible returns' values directly to the call result instead. Sites whose
+      // bindings prune nothing, or whose feasible returns the propagation system cannot
+      // represent, keep the merged edge untouched.
+      Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions = HashMapFactory.make();
+      HeapModel heapModel = builder.getPointerAnalysis().getHeapModel();
+      PropagationSystem system = builder.getPropagationSystem();
+      for (CGNode caller : builder.getCallGraph()) {
+        IR callerIR = caller.getIR();
+        if (callerIR == null) continue;
+        for (Iterator<SSAInstruction> it = callerIR.iterateAllInstructions(); it.hasNext(); ) {
+          SSAInstruction inst = it.next();
+          if (!(inst instanceof PythonInvokeInstruction)) continue;
+          PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+          if (call.getNumberOfReturnValues() == 0) continue;
+          PointerKey destPK = heapModel.getPointerKeyForLocal(caller, call.getReturnValue(0));
+          if (system.isImplicit(destPK)) continue;
+          for (CGNode callee :
+              builder.getCallGraph().getPossibleTargets(caller, call.getCallSite())) {
+            if (callee.getIR() == null) continue;
+            Map<Integer, Object> bindings =
+                TensorGenerator.computeCallSiteConstantBindings(builder, caller, call, callee);
+            Set<ISSABasicBlock> reachable =
+                TensorGenerator.computeReachableBlocksUnderBindings(builder, callee, bindings);
+            List<Integer> feasibleReturns = new ArrayList<>();
+            boolean prunedReturn = false;
+            boolean unrepresentable = false;
+            for (ISSABasicBlock block : callee.getIR().getControlFlowGraph()) {
+              for (SSAInstruction member : block) {
+                if (!(member instanceof SSAReturnInstruction)) continue;
+                int retVn = ((SSAReturnInstruction) member).getResult();
+                if (!reachable.contains(block)) {
+                  prunedReturn = true;
+                  continue;
+                }
+                if (retVn < 0) continue;
+                if (system.isImplicit(heapModel.getPointerKeyForLocal(callee, retVn))) {
+                  unrepresentable = true;
+                  continue;
+                }
+                feasibleReturns.add(retVn);
+              }
+            }
+            if (!prunedReturn || feasibleReturns.isEmpty() || unrepresentable) continue;
+            PointerKey mergedPK = heapModel.getPointerKeyForReturnValue(callee);
+            if (system.isImplicit(mergedPK)) continue;
+            PointsToSetVariable dest = system.findOrCreatePointsToSet(destPK);
+            PointsToSetVariable merged = system.findOrCreatePointsToSet(mergedPK);
+            if (!dataflow.containsNode(dest)
+                || !dataflow.containsNode(merged)
+                || !dataflow.hasEdge(merged, dest)) continue;
+            for (int retVn : feasibleReturns) {
+              PointsToSetVariable retVar =
+                  system.findOrCreatePointsToSet(heapModel.getPointerKeyForLocal(callee, retVn));
+              if (!dataflow.containsNode(retVar)) dataflow.addNode(retVar);
+              if (!dataflow.hasEdge(retVar, dest)) dataflow.addEdge(retVar, dest);
+            }
+            armSuppressions.computeIfAbsent(dest, k -> HashSetFactory.make()).add(merged);
+            LOGGER.fine(
+                () ->
+                    "Suppressing the merged return edge into "
+                        + describe(dest.getPointerKey())
+                        + " from "
+                        + describe(callee)
+                        + " under the site bindings "
+                        + bindings
+                        + " (wala/ML#746).");
+          }
+        }
+      }
+      LOGGER.fine(() -> "wala/ML#746 arm-suppressed call results: " + armSuppressions.size());
+
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(
               dataflow,
@@ -1688,6 +1765,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               setCalls,
               refinements,
               typeFeeds,
+              armSuppressions,
               conv2ds,
               conv3ds,
               drops,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -54,6 +54,7 @@ import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
+import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -65,6 +66,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
+import com.ibm.wala.ipa.callgraph.propagation.StaticFieldKey;
 import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.shrike.shrikeBT.IConditionalBranchInstruction;
 import com.ibm.wala.ssa.DefUse;
@@ -83,12 +85,15 @@ import com.ibm.wala.ssa.SSAUnaryOpInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2196,8 +2201,27 @@ public abstract class TensorGenerator {
    */
   private Boolean evaluateBranchComparison(
       PropagationCallGraphBuilder builder, CGNode node, SSAConditionalBranchInstruction branch) {
-    Object left = resolveComparableConstant(builder, node, branch.getUse(0));
-    Object right = resolveComparableConstant(builder, node, branch.getUse(1));
+    return evaluateBranchComparison(builder, node, branch, Collections.emptyMap());
+  }
+
+  /**
+   * Environment-aware variant of {@link #evaluateBranchComparison(PropagationCallGraphBuilder,
+   * CGNode, SSAConditionalBranchInstruction)} (wala/ML#746): the environment supplies per-call-site
+   * constants for parameter value numbers, taking precedence over the node's points-to union.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for points-to constant lookup.
+   * @param node The {@link CGNode} whose IR contains the branch.
+   * @param branch The conditional branch.
+   * @param env Per-call-site constants keyed by value number.
+   * @return The comparison's outcome, or {@code null} when either side does not fold.
+   */
+  private static Boolean evaluateBranchComparison(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      SSAConditionalBranchInstruction branch,
+      Map<Integer, Object> env) {
+    Object left = resolveComparableConstant(builder, node, branch.getUse(0), env);
+    Object right = resolveComparableConstant(builder, node, branch.getUse(1), env);
     if (left == null || right == null) {
       LOGGER.finer(
           () ->
@@ -2237,7 +2261,24 @@ public abstract class TensorGenerator {
    */
   private Object resolveComparableConstant(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    return resolveComparableConstant(builder, node, vn, Collections.emptyMap());
+  }
+
+  /**
+   * Environment-aware variant of {@link #resolveComparableConstant(PropagationCallGraphBuilder,
+   * CGNode, int)} (wala/ML#746): a value number bound in the environment resolves to its
+   * per-call-site constant before any other source.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for points-to constant lookup.
+   * @param node The {@link CGNode} whose IR defines the value.
+   * @param vn The value number.
+   * @param env Per-call-site constants keyed by value number.
+   * @return The constant, or {@code null} when the value does not fold.
+   */
+  private static Object resolveComparableConstant(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, Map<Integer, Object> env) {
     if (vn <= 0 || node.getIR() == null) return null;
+    if (env.containsKey(vn)) return env.get(vn);
     SymbolTable st = node.getIR().getSymbolTable();
     if (st.isConstant(vn)) return st.getConstantValue(vn);
 
@@ -2245,8 +2286,8 @@ public abstract class TensorGenerator {
     if (def instanceof SSABinaryOpInstruction) {
       SSABinaryOpInstruction binop = (SSABinaryOpInstruction) def;
       if (!(binop.getOperator() instanceof CAstBinaryOp)) return null;
-      Object left = resolveComparableConstant(builder, node, binop.getUse(0));
-      Object right = resolveComparableConstant(builder, node, binop.getUse(1));
+      Object left = resolveComparableConstant(builder, node, binop.getUse(0), env);
+      Object right = resolveComparableConstant(builder, node, binop.getUse(1), env);
       if (left == null || right == null) return null;
       Boolean outcome;
       switch ((CAstBinaryOp) binop.getOperator()) {
@@ -2300,6 +2341,182 @@ public abstract class TensorGenerator {
     if (l instanceof Number && r instanceof Number)
       return ((Number) l).doubleValue() == ((Number) r).doubleValue();
     return l.equals(r);
+  }
+
+  /**
+   * Computes a call site's constant parameter bindings for a callee (wala/ML#746): each callee
+   * parameter value number whose argument at this site folds to a constant maps to that constant.
+   * Positional and keyword arguments mirror {@code
+   * PythonSSAPropagationCallGraphBuilder.processCallingConstraints}'s binding, and an unpassed
+   * defaulted parameter takes its materialized default global's constant (wala/ML#743). Every
+   * source is analysis-stable substrate (symbol tables, the finished pointer analysis), so the
+   * binding is a function of the call site alone.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for constant lookup.
+   * @param caller The calling {@link CGNode}.
+   * @param invoke The call-site invoke.
+   * @param callee The callee {@link CGNode}.
+   * @return The bindings, keyed by callee parameter value number; empty when none fold.
+   */
+  static Map<Integer, Object> computeCallSiteConstantBindings(
+      PropagationCallGraphBuilder builder,
+      CGNode caller,
+      SSAAbstractInvokeInstruction invoke,
+      CGNode callee) {
+    if (!(invoke instanceof PythonInvokeInstruction)) return Collections.emptyMap();
+    PythonInvokeInstruction call = (PythonInvokeInstruction) invoke;
+    IR calleeIR = callee.getIR();
+    if (calleeIR == null) return Collections.emptyMap();
+    int numParams = callee.getMethod().getNumberOfParameters();
+    Map<Integer, Object> bindings = HashMapFactory.make();
+    Set<Integer> boundParams = HashSetFactory.make();
+
+    for (int i = 0; i < call.getNumberOfPositionalParameters() && i < numParams; i++) {
+      boundParams.add(i);
+      Object constant = resolveFrameConstant(builder, caller, call.getUse(i));
+      if (constant != null) bindings.put(i + 1, constant);
+    }
+
+    for (String argName : call.getKeywords()) {
+      for (int i = 0; i < numParams; i++) {
+        String[] paramNames = calleeIR.getLocalNames(0, i + 1);
+        if (paramNames == null) continue;
+        boolean matches = false;
+        for (String destName : paramNames) matches |= argName.equals(destName);
+        if (!matches) continue;
+        boundParams.add(i);
+        Object constant = resolveFrameConstant(builder, caller, call.getUse(argName));
+        if (constant != null) bindings.put(i + 1, constant);
+        break;
+      }
+    }
+
+    int firstDefaulted = numParams - callee.getMethod().getNumberOfDefaultParameters();
+    for (int i = firstDefaulted; i < numParams; i++) {
+      if (boundParams.contains(i)) continue;
+      Object constant = resolveDefaultGlobalConstant(builder, callee, i);
+      if (constant != null) bindings.put(i + 1, constant);
+    }
+    return bindings;
+  }
+
+  /**
+   * Resolves a caller-frame value number to a constant: a symbol-table constant, or a points-to set
+   * holding a single {@link ConstantKey}.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for points-to lookup.
+   * @param caller The frame's {@link CGNode}.
+   * @param vn The value number.
+   * @return The constant, or {@code null} when the value does not fold.
+   */
+  private static Object resolveFrameConstant(
+      PropagationCallGraphBuilder builder, CGNode caller, int vn) {
+    if (vn <= 0 || caller.getIR() == null) return null;
+    SymbolTable st = caller.getIR().getSymbolTable();
+    if (st.isConstant(vn)) return st.getConstantValue(vn);
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(caller, vn);
+    OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
+    if (pts == null || pts.size() != 1) return null;
+    InstanceKey only = pts.iterator().next();
+    return only instanceof ConstantKey ? ((ConstantKey<?>) only).getValue() : null;
+  }
+
+  /**
+   * Resolves a defaulted parameter's materialized default to a constant, reading the {@code
+   * <class>_defaults_<i>} global the translator writes and the call processing binds unpassed
+   * parameters to (wala/ML#743).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for points-to lookup.
+   * @param callee The callee {@link CGNode}.
+   * @param paramIndex The zero-based parameter index.
+   * @return The default's constant, or {@code null} when the global holds anything but a single
+   *     constant.
+   */
+  private static Object resolveDefaultGlobalConstant(
+      PropagationCallGraphBuilder builder, CGNode callee, int paramIndex) {
+    String name = callee.getMethod().getDeclaringClass().getName() + "_defaults_" + paramIndex;
+    FieldReference global =
+        FieldReference.findOrCreate(Root, Atom.findOrCreateUnicodeAtom("global " + name), Root);
+    IField f = builder.getClassHierarchy().resolveField(global);
+    if (f == null) return null;
+    OrdinalSet<InstanceKey> pts =
+        builder.getPointerAnalysis().getPointsToSet(new StaticFieldKey(f));
+    if (pts == null || pts.size() != 1) return null;
+    InstanceKey only = pts.iterator().next();
+    return only instanceof ConstantKey ? ((ConstantKey<?>) only).getValue() : null;
+  }
+
+  /**
+   * Computes the callee blocks reachable from entry when every conditional branch decidable under
+   * the call site's constant bindings takes only its decided edge (wala/ML#746). Undecidable
+   * branches keep both edges, and exceptional edges always follow, so the walk only ever prunes
+   * edges the site's constants prove untaken.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for constant lookup.
+   * @param callee The callee {@link CGNode}.
+   * @param env The call site's constant bindings, keyed by parameter value number.
+   * @return The reachable blocks.
+   */
+  static Set<ISSABasicBlock> computeReachableBlocksUnderBindings(
+      PropagationCallGraphBuilder builder, CGNode callee, Map<Integer, Object> env) {
+    SSACFG cfg = callee.getIR().getControlFlowGraph();
+    Set<ISSABasicBlock> reachable = HashSetFactory.make();
+    Deque<ISSABasicBlock> work = new ArrayDeque<>();
+    reachable.add(cfg.entry());
+    work.add(cfg.entry());
+    while (!work.isEmpty()) {
+      ISSABasicBlock block = work.poll();
+      Collection<ISSABasicBlock> normals = cfg.getNormalSuccessors(block);
+      Collection<ISSABasicBlock> kept = normals;
+      if (normals.size() == 2
+          && block.getLastInstructionIndex() >= block.getFirstInstructionIndex()
+          && block.getLastInstructionIndex() >= 0
+          && block.getLastInstruction() instanceof SSAConditionalBranchInstruction) {
+        SSAConditionalBranchInstruction branch =
+            (SSAConditionalBranchInstruction) block.getLastInstruction();
+        Boolean condition = evaluateBranchComparison(builder, callee, branch, env);
+        if (condition != null) {
+          ISSABasicBlock target = cfg.getBlockForInstruction(branch.getTarget());
+          if (target != null && normals.contains(target)) {
+            List<ISSABasicBlock> taken = new ArrayList<>();
+            for (ISSABasicBlock successor : normals)
+              if (successor.equals(target) == condition) taken.add(successor);
+            kept = taken;
+          }
+        }
+      }
+      for (ISSABasicBlock successor : kept) if (reachable.add(successor)) work.add(successor);
+      for (ISSABasicBlock successor : cfg.getExceptionalSuccessors(block))
+        if (reachable.add(successor)) work.add(successor);
+    }
+    return reachable;
+  }
+
+  /**
+   * Computes a callee's feasible return value numbers under the given (possibly empty) constant
+   * bindings (wala/ML#746): with an empty environment the fold still decides guards whose compared
+   * values are node-wide points-to singletons, which covers callees whose contexts are per call
+   * site. Returns {@code null} when no return-bearing block prunes, so callers can skip filtering
+   * entirely.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for constant lookup.
+   * @param callee The callee {@link CGNode}.
+   * @param env The call site's constant bindings, possibly empty.
+   * @return The feasible return value numbers, or {@code null} when nothing prunes.
+   */
+  static Set<Integer> computeFeasibleReturnValueNumbers(
+      PropagationCallGraphBuilder builder, CGNode callee, Map<Integer, Object> env) {
+    if (callee.getIR() == null) return null;
+    Set<ISSABasicBlock> reachable = computeReachableBlocksUnderBindings(builder, callee, env);
+    Set<Integer> feasible = HashSetFactory.make();
+    boolean pruned = false;
+    for (ISSABasicBlock block : callee.getIR().getControlFlowGraph())
+      for (SSAInstruction instruction : block) {
+        if (!(instruction instanceof SSAReturnInstruction)) continue;
+        if (!reachable.contains(block)) pruned = true;
+        else feasible.add(((SSAReturnInstruction) instruction).getResult());
+      }
+    return pruned && !feasible.isEmpty() ? feasible : null;
   }
 
   /**
@@ -5257,23 +5474,30 @@ public abstract class TensorGenerator {
       if (callee.getIR() == null || callee.getDU() == null) return ShapeResult.unknown();
       if (!visited.add(callee)) return ShapeResult.unknown(); // Recursive helper: unmodeled.
       try {
+        // Returns in blocks this call site's constant bindings prove unreachable are skipped,
+        // like the tensor-value twin's (wala/ML#746).
+        Map<Integer, Object> bindings =
+            computeCallSiteConstantBindings(builder, node, invoke, callee);
+        Set<ISSABasicBlock> reachable =
+            computeReachableBlocksUnderBindings(builder, callee, bindings);
         boolean sawReturn = false;
-        for (Iterator<SSAInstruction> it = callee.getIR().iterateAllInstructions();
-            it.hasNext(); ) {
-          SSAInstruction instruction = it.next();
-          if (!(instruction instanceof SSAReturnInstruction)) continue;
-          SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
-          // A bare `return` means the helper can produce no value (None) on some path, so the
-          // call's result isn't a resolvable shape vector.
-          if (ret.getResult() < 0) return ShapeResult.unknown();
-          sawReturn = true;
-          ShapeResult shapes =
-              this.getShapeResultOfShapeVector(builder, callee, ret.getResult(), visited);
-          // Every return must resolve; an unresolvable remainder is marked rather than
-          // collapsing the resolvable members (wala/ML#718).
-          if (shapes.members().isEmpty()) return ShapeResult.unknown();
-          if (shapes.hasUnknown()) hasUnknown = true;
-          combined.addAll(shapes.members());
+        for (ISSABasicBlock block : callee.getIR().getControlFlowGraph()) {
+          if (!reachable.contains(block)) continue;
+          for (SSAInstruction instruction : block) {
+            if (!(instruction instanceof SSAReturnInstruction)) continue;
+            SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
+            // A bare `return` means the helper can produce no value (None) on some path, so the
+            // call's result isn't a resolvable shape vector.
+            if (ret.getResult() < 0) return ShapeResult.unknown();
+            sawReturn = true;
+            ShapeResult shapes =
+                this.getShapeResultOfShapeVector(builder, callee, ret.getResult(), visited);
+            // Every return must resolve; an unresolvable remainder is marked rather than
+            // collapsing the resolvable members (wala/ML#718).
+            if (shapes.members().isEmpty()) return ShapeResult.unknown();
+            if (shapes.hasUnknown()) hasUnknown = true;
+            combined.addAll(shapes.members());
+          }
         }
         if (!sawReturn) return ShapeResult.unknown();
       } finally {
@@ -5314,29 +5538,39 @@ public abstract class TensorGenerator {
     Set<List<Dimension<?>>> combined = HashSetFactory.make();
     for (CGNode callee : targets) {
       if (callee.getIR() == null || callee.getDU() == null) return ShapeResult.unknown();
+      // A return whose block this call site's constant bindings prove unreachable contributes
+      // nothing: the site's guard constants decide the arm, so the other arms' returns are
+      // runtime-infeasible here (wala/ML#746).
+      Map<Integer, Object> bindings =
+          computeCallSiteConstantBindings(builder, node, invoke, callee);
+      Set<ISSABasicBlock> reachable =
+          computeReachableBlocksUnderBindings(builder, callee, bindings);
       boolean sawReturn = false;
-      for (Iterator<SSAInstruction> it = callee.getIR().iterateAllInstructions(); it.hasNext(); ) {
-        SSAInstruction instruction = it.next();
-        if (!(instruction instanceof SSAReturnInstruction)) continue;
-        SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
-        sawReturn = true;
-        if (ret.getResult() < 0) {
-          hasUnknown = true;
-          continue;
+      for (ISSABasicBlock block : callee.getIR().getControlFlowGraph()) {
+        if (!reachable.contains(block)) continue;
+        for (SSAInstruction instruction : block) {
+          if (!(instruction instanceof SSAReturnInstruction)) continue;
+          SSAReturnInstruction ret = (SSAReturnInstruction) instruction;
+          sawReturn = true;
+          if (ret.getResult() < 0) {
+            hasUnknown = true;
+            continue;
+          }
+          ShapeResult shapes;
+          try {
+            shapes = this.getShapeResult(builder, callee, ret.getResult(), exact);
+          } catch (IllegalArgumentException e) {
+            LOGGER.log(
+                Level.FINE,
+                e,
+                () ->
+                    "shapeResultOfCalleeReturnValues: IAE reading a return of " + describe(callee));
+            hasUnknown = true;
+            continue;
+          }
+          if (shapes.hasUnknown() || shapes.isBottom()) hasUnknown = true;
+          combined.addAll(shapes.members());
         }
-        ShapeResult shapes;
-        try {
-          shapes = this.getShapeResult(builder, callee, ret.getResult(), exact);
-        } catch (IllegalArgumentException e) {
-          LOGGER.log(
-              Level.FINE,
-              e,
-              () -> "shapeResultOfCalleeReturnValues: IAE reading a return of " + describe(callee));
-          hasUnknown = true;
-          continue;
-        }
-        if (shapes.hasUnknown() || shapes.isBottom()) hasUnknown = true;
-        combined.addAll(shapes.members());
       }
       if (!sawReturn) hasUnknown = true;
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1719,11 +1719,24 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, SLICE_BUILTIN)) return new SliceBuiltinOperation(source);
     else {
       if (source.getPointerKey() instanceof ReturnValueKey) {
+        // A pruned return's local must not decide the dispatch: when the callee node's guard
+        // folds (a per-call-site context makes the compared parameter a points-to singleton),
+        // only the feasible returns' predecessors are candidates (wala/ML#746). The historical
+        // first-match walk over all predecessors picked an arbitrary arm.
+        CGNode calleeOfReturn = ((ReturnValueKey) source.getPointerKey()).getNode();
+        Set<Integer> feasibleReturns =
+            TensorGenerator.computeFeasibleReturnValueNumbers(
+                builder, calleeOfReturn, Collections.emptyMap());
         Graph<PointsToSetVariable> assignmentGraph =
             builder.getPropagationSystem().getAssignmentGraph();
         for (Iterator<PointsToSetVariable> it = assignmentGraph.getPredNodes(source);
             it.hasNext(); ) {
           PointsToSetVariable pred = it.next();
+          if (feasibleReturns != null
+              && pred.getPointerKey() instanceof LocalPointerKey
+              && ((LocalPointerKey) pred.getPointerKey()).getNode().equals(calleeOfReturn)
+              && !feasibleReturns.contains(
+                  ((LocalPointerKey) pred.getPointerKey()).getValueNumber())) continue;
           try {
             TensorGenerator gen = getGenerator(pred, builder, visited);
             if (gen != null) {

--- a/com.ibm.wala.cast.python.test/data/tf2_test_mode_guard.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_mode_guard.py
@@ -1,0 +1,32 @@
+# Probe for wala/ML#746: a string-guarded dispatch whose arms return different ranks. Each
+# call site's mode constant (the keyword at the second site, the materialized default at the
+# first) decides its arm, so neither sink sees the other site's member.
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+def dispatch(x, mode="embedding"):
+    if mode == "embedding":
+        return tf.expand_dims(x, -1)
+    elif mode == "projection":
+        return tf.reshape(x, (6,))
+    else:
+        raise ValueError("mode {} is not valid.".format(mode))
+
+
+a = dispatch(tf.ones((2, 3)))
+b = dispatch(tf.ones((2, 3)), mode="projection")
+consume(a)
+consume2(b)
+
+assert a.shape == (2, 3, 1)
+assert b.shape == (6,)
+assert a.dtype == tf.float32
+assert b.dtype == tf.float32


### PR DESCRIPTION
Advances wala/ML#746: a callee guard that compares a parameter against string or numeric constants is now decided per call site, from the site's argument constants and its materialized defaults (wala/ML#743), and the infeasible arms drop from that site's view.

The decision is a reachability fold over the callee's CFG: branches whose comparisons resolve under the site's bindings (with node-wide points-to singletons as the environment-free fallback) take only their decided edge, and everything the fold cannot decide keeps both edges, so the walk only ever prunes edges the constants prove untaken. Every input is analysis-stable substrate (symbol tables, the finished pointer analysis), so the selection is a function of the call site alone and evaluation-order-independent (wala/ML#758).

Three carriers consumed the cross-arm union and all three now filter:

- The callee-return descents (`shapeResultOfCalleeReturnValues` and the shape-vector twin) skip returns in site-infeasible blocks.
- The dataflow analysis: a decidable site's call result no longer receives the callee's merged return flow, whose return-value key unions every arm at the pointer-analysis level. The merged edge is suppressed per site (`ArmSuppressOp`, an edge-specific no-op unlike `DropOp`'s destination-wide clear) and the feasible returns' values wire directly to the call result.
- `TensorGeneratorFactory`'s return-value dispatch walks only feasible returns; the historical first-match walk over all predecessors picked an arbitrary arm, itself an iteration-order dependence.

The runtime-verified `tf2_test_mode_guard.py` pins both sites of a two-mode dispatch to their own arms. On the vendored gpt-2 witness, the `get_loss` logits union drops exactly its two runtime-infeasible rank-4 members (the `mode="projection"` call's rank-3 input crossing into the embedding-mode lookup), leaving the runtime-true forms.

Remaining under the issue: the argument-read stage. The vendored NLPGNN `DenseLayer3d` pin still carries the rank-4 members that ride a shared helper's conditional-reshape φ, reached through argument reads rather than return unions; pruning there needs the site bindings threaded into the φ-arm feasibility fold along the descent chain.
