### PR TITLE
Re-anchor the `DenseLayer3d` input pin's residual members to wala/ML#761

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -478,11 +478,11 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * are the einsum operand refinement's (wala/ML#704).
    *
    * <p>TODO: Drop the rank-4 {@code (8, 100, ?, ?)}/{@code (8, 10, ?, ?)} members once <a
-   * href="https://github.com/wala/ML/issues/746">wala/ML#746</a>'s arm filtering reaches the
-   * argument reads' points-to stage; the members ride the sibling {@code DenseLayer3dProj}'s
-   * einsum-refined operands through the shared helper's conditional-reshape φ, whose infeasible arm
-   * the points-to union cannot distinguish (the cross-context half was separated by the caller-node
-   * context propagation).
+   * href="https://github.com/wala/ML/issues/761">wala/ML#761</a> folds branch guards over constant
+   * instance attributes; they enter through the undecided {@code use_einsum} guard, whose compared
+   * value is a receiver field the wala/ML#746 call-site bindings cannot reach, and ride the shared
+   * {@code einsum_via_matmul} helper's cross-layer members into the input's state. The {@code (8,
+   * ?, ?, ?)} member is the legitimate wala/ML#737 partial and stays regardless.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.


### PR DESCRIPTION
Doc-only: the pin's TODO named wala/ML#746, whose landed call-site bindings cannot reach the operative guard. The members enter through the undecided `use_einsum` instance-attribute guard, re-diagnosed on the closed issue; wala/ML#761 tracks the attribute-constant fold that would drop them. Advances wala/ML#761.