### PR TITLE
Guard the module qualification of intermediate default globals (wala/ML#745)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1170,4 +1170,73 @@ public class TestConstructors extends AbstractTensorTest {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_param_default2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_2_FLOAT32)));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/745">wala/ML#745</a>: two modules each define
+   * {@code make} with a different integer default, so any cross-module union of the intermediate
+   * default globals shows up as the sibling's shape in either sink.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testParamDefaultCollision()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    String[] files = {
+      "defaults_collision/mod_a.py", "defaults_collision/mod_b.py", "defaults_collision/driver.py"
+    };
+    test(
+        files,
+        "driver.py",
+        "consume",
+        "defaults_collision",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_2_FLOAT32)));
+    test(
+        files,
+        "driver.py",
+        "consume2",
+        "defaults_collision",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 5, 3))));
+  }
+
+  /**
+   * Class-method variant of {@link #testParamDefaultCollision()} (wala/ML#745): two modules each
+   * define {@code Maker.make} with a different integer default.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testParamDefaultCollision2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    String[] files = {
+      "defaults_collision/cls_a.py",
+      "defaults_collision/cls_b.py",
+      "defaults_collision/driver_cls.py"
+    };
+    test(
+        files,
+        "driver_cls.py",
+        "consume",
+        "defaults_collision",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_2_FLOAT32)));
+    test(
+        files,
+        "driver_cls.py",
+        "consume2",
+        "defaults_collision",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 5, 3))));
+  }
 }

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/cls_a.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/cls_a.py
@@ -1,0 +1,6 @@
+import tensorflow as tf
+
+
+class Maker:
+    def make(self, n=4):
+        return tf.ones((n, 2))

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/cls_b.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/cls_b.py
@@ -1,0 +1,6 @@
+import tensorflow as tf
+
+
+class Maker:
+    def make(self, n=5):
+        return tf.ones((n, 3))

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/driver.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/driver.py
@@ -1,0 +1,21 @@
+# Probe for wala/ML#745: two modules each define `make` with a different integer default.
+# Distinct result shapes detect any cross-module union of the defaults globals.
+import mod_a
+import mod_b
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+a = mod_a.make()
+b = mod_b.make()
+consume(a)
+consume2(b)
+
+assert a.shape == (4, 2)
+assert b.shape == (5, 3)

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/driver_cls.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/driver_cls.py
@@ -1,0 +1,22 @@
+# Probe for wala/ML#745, class-method variant: two modules each define `Maker.make` with a
+# different integer default, so any cross-module union of the intermediate default globals
+# shows up as the sibling's shape in either sink.
+import cls_a
+import cls_b
+
+
+def consume(t):
+    pass
+
+
+def consume2(t):
+    pass
+
+
+a = cls_a.Maker().make()
+b = cls_b.Maker().make()
+consume(a)
+consume2(b)
+
+assert a.shape == (4, 2)
+assert b.shape == (5, 3)

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/mod_a.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/mod_a.py
@@ -1,0 +1,5 @@
+import tensorflow as tf
+
+
+def make(n=4):
+    return tf.ones((n, 2))

--- a/com.ibm.wala.cast.python.test/data/defaults_collision/mod_b.py
+++ b/com.ibm.wala.cast.python.test/data/defaults_collision/mod_b.py
@@ -1,0 +1,5 @@
+import tensorflow as tf
+
+
+def make(n=5):
+    return tf.ones((n, 3))


### PR DESCRIPTION
Advances wala/ML#745: the issue's premise does not reproduce on master. Both named cases, module-level functions and class methods, resolve per module: the translator's write names carry the defining script through `composeEntityName`, and the builder's read reconstructs the same script-qualified name from the function class. Two runtime-verified probe pairs with different integer defaults across modules pin the separation; a collision would surface as the sibling module's shape in either sink.