### PR TITLE
Fold branch guards over constant instance attributes (wala/ML#761)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1194,4 +1194,20 @@ public class TestShapeOps extends AbstractTensorTest {
     test("tf2_test_mode_guard.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
     test("tf2_test_mode_guard.py", "consume2", 1, 1, Map.of(2, Set.of(TENSOR_6_FLOAT32)));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/761">wala/ML#761</a>: a guard over a constant
+   * instance attribute decides its arm, so the untaken arm's differently-ranked member never
+   * reaches the sink.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testAttrGuardDispatch()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_attr_guard.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1690,17 +1690,27 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       // represent, keep the merged edge untouched.
       Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions = HashMapFactory.make();
       HeapModel heapModel = builder.getPointerAnalysis().getHeapModel();
-      PropagationSystem system = builder.getPropagationSystem();
+      // Resolve pointer keys against the duplicated flow graph itself: the graph includes
+      // implicit-constraint nodes (synthetic-method locals and returns have implicit pointer
+      // keys), which the propagation system's find-or-create cannot represent.
+      Map<PointerKey, PointsToSetVariable> flowVarsByKey = HashMapFactory.make();
+      for (PointsToSetVariable flowVar : dataflow)
+        flowVarsByKey.putIfAbsent(flowVar.getPointerKey(), flowVar);
       for (CGNode caller : builder.getCallGraph()) {
         IR callerIR = caller.getIR();
         if (callerIR == null) continue;
         for (Iterator<SSAInstruction> it = callerIR.iterateAllInstructions(); it.hasNext(); ) {
           SSAInstruction inst = it.next();
-          if (!(inst instanceof PythonInvokeInstruction)) continue;
-          PythonInvokeInstruction call = (PythonInvokeInstruction) inst;
+          // Synthetic forwarding invokes (trampoline bodies) are not PythonInvokeInstructions but
+          // still carry the hop whose callee holds the guard; the bindings computation declines
+          // them and the reachability fold still decides via node-wide points-to singletons and
+          // constant instance attributes (wala/ML#761).
+          if (!(inst instanceof SSAAbstractInvokeInstruction)) continue;
+          SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) inst;
           if (call.getNumberOfReturnValues() == 0) continue;
-          PointerKey destPK = heapModel.getPointerKeyForLocal(caller, call.getReturnValue(0));
-          if (system.isImplicit(destPK)) continue;
+          PointsToSetVariable dest =
+              flowVarsByKey.get(heapModel.getPointerKeyForLocal(caller, call.getReturnValue(0)));
+          if (dest == null) continue;
           for (CGNode callee :
               builder.getCallGraph().getPossibleTargets(caller, call.getCallSite())) {
             if (callee.getIR() == null) continue;
@@ -1720,25 +1730,39 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                   continue;
                 }
                 if (retVn < 0) continue;
-                if (system.isImplicit(heapModel.getPointerKeyForLocal(callee, retVn))) {
+                if (flowVarsByKey.get(heapModel.getPointerKeyForLocal(callee, retVn)) == null) {
                   unrepresentable = true;
                   continue;
                 }
                 feasibleReturns.add(retVn);
               }
             }
+            {
+              boolean prunedF = prunedReturn;
+              boolean unrepF = unrepresentable;
+              int feasF = feasibleReturns.size();
+              CGNode calleeF = callee;
+              LOGGER.fine(
+                  () ->
+                      "ARM-SWEEP callee "
+                          + describe(calleeF)
+                          + ": pruned="
+                          + prunedF
+                          + " feasible="
+                          + feasF
+                          + " unrepresentable="
+                          + unrepF
+                          + " bindings="
+                          + bindings.size()
+                          + ".");
+            }
             if (!prunedReturn || feasibleReturns.isEmpty() || unrepresentable) continue;
-            PointerKey mergedPK = heapModel.getPointerKeyForReturnValue(callee);
-            if (system.isImplicit(mergedPK)) continue;
-            PointsToSetVariable dest = system.findOrCreatePointsToSet(destPK);
-            PointsToSetVariable merged = system.findOrCreatePointsToSet(mergedPK);
-            if (!dataflow.containsNode(dest)
-                || !dataflow.containsNode(merged)
-                || !dataflow.hasEdge(merged, dest)) continue;
+            PointsToSetVariable merged =
+                flowVarsByKey.get(heapModel.getPointerKeyForReturnValue(callee));
+            if (merged == null || !dataflow.hasEdge(merged, dest)) continue;
             for (int retVn : feasibleReturns) {
               PointsToSetVariable retVar =
-                  system.findOrCreatePointsToSet(heapModel.getPointerKeyForLocal(callee, retVn));
-              if (!dataflow.containsNode(retVar)) dataflow.addNode(retVar);
+                  flowVarsByKey.get(heapModel.getPointerKeyForLocal(callee, retVn));
               if (!dataflow.hasEdge(retVar, dest)) dataflow.addEdge(retVar, dest);
             }
             armSuppressions.computeIfAbsent(dest, k -> HashSetFactory.make()).add(merged);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2317,11 +2317,90 @@ public abstract class TensorGenerator {
       return outcome == null ? null : (outcome ? 1 : 0);
     }
 
+    // A receiver-field read folds when every instance holds the same single constant in the
+    // field (wala/ML#761): guards like `if self.use_einsum:` compare a configuration constant
+    // the local points-to set cannot see.
+    if (def instanceof PythonPropertyRead) {
+      Object viaField = resolveInstanceFieldConstant(builder, node, (PythonPropertyRead) def);
+      if (viaField != null) return viaField;
+    }
+
     PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
     OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
     if (pts == null || pts.size() != 1) return null;
     InstanceKey only = pts.iterator().next();
     return only instanceof ConstantKey ? ((ConstantKey<?>) only).getValue() : null;
+  }
+
+  /**
+   * Resolves a receiver-field read to a constant for the branch fold (wala/ML#761): every instance
+   * the object resolves to must hold the same single {@link ConstantKey} in the named field.
+   * Disagreeing instances, non-constant field values, and unresolvable names all decline.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The CG node whose IR contains the property read.
+   * @param propRead The property-read instruction.
+   * @return The field's constant, or {@code null} when the read does not fold.
+   */
+  private static Object resolveInstanceFieldConstant(
+      PropagationCallGraphBuilder builder, CGNode node, PythonPropertyRead propRead) {
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    String fieldName = null;
+    for (InstanceKey ik :
+        pa.getPointsToSet(pa.getHeapModel().getPointerKeyForLocal(node, propRead.getMemberRef()))) {
+      if (ik instanceof ConstantKey && ((ConstantKey<?>) ik).getValue() instanceof String) {
+        fieldName = (String) ((ConstantKey<?>) ik).getValue();
+        break;
+      }
+    }
+    if (fieldName == null) {
+      LOGGER.fine(() -> "ATTR-FOLD no field name in " + describe(node) + ".");
+      return null;
+    }
+    String fn = fieldName;
+    IField f =
+        builder
+            .getClassHierarchy()
+            .resolveField(
+                FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldName), Root));
+    if (f == null) {
+      LOGGER.fine(() -> "ATTR-FOLD unresolved field " + fn + ".");
+      return null;
+    }
+    Object constant = null;
+    for (InstanceKey objIK :
+        pa.getPointsToSet(pa.getHeapModel().getPointerKeyForLocal(node, propRead.getObjectRef()))) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(objIK);
+      if (asin == null) {
+        LOGGER.fine(() -> "ATTR-FOLD non-allocation instance for " + fn + ".");
+        return null;
+      }
+      OrdinalSet<InstanceKey> fieldPts =
+          pa.getPointsToSet(builder.getPointerKeyForInstanceField(asin, f));
+      if (fieldPts == null || fieldPts.size() != 1) {
+        LOGGER.fine(
+            () ->
+                "ATTR-FOLD field pts size "
+                    + (fieldPts == null ? "null" : fieldPts.size())
+                    + " for "
+                    + fn
+                    + " on "
+                    + describe(asin)
+                    + ".");
+        return null;
+      }
+      InstanceKey only = fieldPts.iterator().next();
+      if (!(only instanceof ConstantKey)) {
+        LOGGER.fine(() -> "ATTR-FOLD non-constant field value for " + fn + ".");
+        return null;
+      }
+      Object value = ((ConstantKey<?>) only).getValue();
+      if (value == null || (constant != null && !constant.equals(value))) return null;
+      constant = value;
+    }
+    Object folded = constant;
+    LOGGER.fine(() -> "ATTR-FOLD " + fn + " => " + folded + " in " + describe(node) + ".");
+    return constant;
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_attr_guard.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_attr_guard.py
@@ -1,0 +1,26 @@
+# Probe for wala/ML#761: a guard over a constant instance attribute decides its arm, so the
+# untaken arm's differently-ranked member never reaches the sink.
+import tensorflow as tf
+
+
+class Dispatcher:
+    def __init__(self):
+        self.use_expand = True
+
+    def run(self, x):
+        if self.use_expand:
+            return tf.expand_dims(x, -1)
+        else:
+            return tf.reshape(x, (6,))
+
+
+def consume(t):
+    pass
+
+
+d = Dispatcher()
+y = d.run(tf.ones((2, 3)))
+consume(y)
+
+assert y.shape == (2, 3, 1)
+assert y.dtype == tf.float32


### PR DESCRIPTION
Advances wala/ML#761: a guard comparing a receiver field that every instance resolves to the same single constant now decides its arm. The comparable-constant fold gains a receiver-field arm, reading the named field off the object's instances through the finished pointer analysis (the wala/ML#570 access pattern), and declining on disagreeing instances, non-constant values, and unresolvable names.

Two arm-suppression sweep repairs ride along, found while wiring the witness: the sweep now accepts synthetic forwarding invokes (trampoline bodies carry the hop whose callee holds the guard, and the environment-free fold still decides through node-wide singletons and constant attributes), and it resolves its variables against the duplicated flow graph itself, whose implicit-constraint nodes cover the synthetic locals and returns the propagation system's find-or-create cannot represent.

The runtime-verified `tf2_test_attr_guard.py` pins the attribute-guarded dispatch to its taken arm. The vendored NLPGNN witness stays pinned unchanged: its `use_einsum` fields never hold their constants because constructor parameter defaults do not bind at class-instantiation calls (wala/ML#762, filed from this probe with the isolated evidence), which blocks the fold exactly there. With wala/ML#762 fixed, the fold should reach the `DenseLayer3d` members with no further changes.
