### PR TITLE
Bind constructor parameter defaults at class-instantiation calls (wala/ML#762)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1210,4 +1210,20 @@ public class TestShapeOps extends AbstractTensorTest {
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_attr_guard.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
   }
+
+  /**
+   * Probes <a href="https://github.com/wala/ML/issues/762">wala/ML#762</a> driving wala/ML#761: the
+   * guard attribute takes its value from an unpassed constructor default, so the arm decision
+   * requires the default to bind at the class-instantiation call.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testAttrGuardDispatch2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_attr_guard2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -572,6 +572,15 @@ public abstract class TensorGenerator {
               ConstantKey<?> instanceFieldConstant = (ConstantKey<?>) instanceFieldIK;
               Object instanceFieldValue = instanceFieldConstant.getValue();
 
+              // A non-numeric constant (e.g., a boolean flag reaching a shape slot through a
+              // materialized default, wala/ML#762) is not a dimension; skip it rather than abort
+              // the walk.
+              if (instanceFieldValue != null && !(instanceFieldValue instanceof Number)) {
+                LOGGER.fine(
+                    () -> "Skipping non-numeric shape constant: " + instanceFieldValue + ".");
+                continue;
+              }
+
               // We have a shape value.
               Number shapeValue = (Number) instanceFieldValue;
               LOGGER.fine(

--- a/com.ibm.wala.cast.python.test/data/tf2_test_attr_guard2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_attr_guard2.py
@@ -1,0 +1,27 @@
+# Probe for wala/ML#762 driving wala/ML#761: the guard attribute takes its value from an
+# unpassed constructor default, so the arm decision requires the default to bind at the
+# class-instantiation call.
+import tensorflow as tf
+
+
+class Dispatcher:
+    def __init__(self, use_expand=True):
+        self.use_expand = use_expand
+
+    def run(self, x):
+        if self.use_expand:
+            return tf.expand_dims(x, -1)
+        else:
+            return tf.reshape(x, (6,))
+
+
+def consume(t):
+    pass
+
+
+d = Dispatcher()
+y = d.run(tf.ones((2, 3)))
+consume(y)
+
+assert y.shape == (2, 3, 1)
+assert y.dtype == tf.float32

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonConstructorTargetSelector.java
@@ -410,7 +410,10 @@ public class PythonConstructorTargetSelector implements MethodTargetSelector {
             ctor.setValueNames(Collections.singletonMap(1, Atom.findOrCreateUnicodeAtom("self")));
           }
 
-          ctors.put(receiver, new PythonConstructorFunction(ref, ctor, receiver));
+          ctors.put(
+              receiver,
+              new PythonConstructorFunction(
+                  ref, ctor, receiver, init == null ? 0 : init.getNumberOfDefaultParameters()));
         }
 
         return ctors.get(receiver);

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/callgraph/PythonSSAPropagationCallGraphBuilder.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.python.ipa.callgraph;
 import static com.ibm.wala.cast.python.types.PythonTypes.CALLABLE_METHOD_NAME;
 import static com.ibm.wala.cast.python.types.PythonTypes.CALLABLE_METHOD_NAME_FOR_KERAS_MODELS;
 import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
+import static com.ibm.wala.cast.python.types.PythonTypes.INIT_METHOD_NAME;
 import static com.ibm.wala.cast.python.util.Util.IMPORT_WILDCARD_CHARACTER;
 import static com.ibm.wala.cast.python.util.Util.MODULE_INITIALIZATION_FILENAME;
 import static com.ibm.wala.cast.python.util.Util.PYTHON_FILE_EXTENSION;
@@ -25,6 +26,7 @@ import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
 import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
 import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
 import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.python.ipa.summaries.PythonConstructorFunction;
 import com.ibm.wala.cast.python.ipa.summaries.PythonInstanceMethodTrampoline;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.ssa.ForElementGetInstruction;
@@ -1000,18 +1002,33 @@ public class PythonSSAPropagationCallGraphBuilder extends AstSSAPropagationCallG
         paramNumber++;
       }
 
-      int dflts =
-          target.getMethod().getNumberOfParameters()
-              - target.getMethod().getNumberOfDefaultParameters();
-      for (int i = dflts; i < target.getMethod().getNumberOfParameters(); i++) {
+      // A synthesized constructor's summary declares the wrapped `__init__`'s parameter count,
+      // although its own formals stop one short (formal i mirrors `__init__`'s parameter i + 1),
+      // so its defaulted range shifts down by one (wala/ML#762).
+      boolean ctorTarget = target.getMethod() instanceof PythonConstructorFunction;
+      int numParams = target.getMethod().getNumberOfParameters() - (ctorTarget ? 1 : 0);
+      int dflts = numParams - target.getMethod().getNumberOfDefaultParameters();
+      for (int i = dflts; i < numParams; i++) {
         if (!args.contains(i)) {
-          String name = target.getMethod().getDeclaringClass().getName() + "_defaults_" + i;
+          // A synthesized constructor's trailing formal i mirrors `__init__`'s parameter i + 1,
+          // and the default globals are written under `__init__`'s entity name, so the lookup
+          // follows that mapping (wala/ML#762). Every other target reads its own entity's global.
+          String name =
+              target.getMethod() instanceof PythonConstructorFunction
+                  ? target.getMethod().getDeclaringClass().getName()
+                      + "/"
+                      + INIT_METHOD_NAME
+                      + "_defaults_"
+                      + (i + 1)
+                  : target.getMethod().getDeclaringClass().getName() + "_defaults_" + i;
           FieldReference global =
               FieldReference.findOrCreate(
                   PythonTypes.Root,
                   Atom.findOrCreateUnicodeAtom("global " + name),
                   PythonTypes.Root);
           IField f = getClassHierarchy().resolveField(global);
+          logger.fine(
+              "DEFAULTS-BIND target " + target + " param " + i + " global " + name + " field " + f);
           PointerKey lval = getPointerKeyForLocal(target, i + 1);
           getSystem().newConstraint(lval, assignOperator, new StaticFieldKey(f));
         }

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonConstructorFunction.java
@@ -29,14 +29,37 @@ import com.ibm.wala.types.MethodReference;
 public class PythonConstructorFunction extends PythonSummarizedFunction {
 
   /**
+   * The wrapped {@code __init__}'s defaulted-parameter count; see {@link
+   * #getNumberOfDefaultParameters()}.
+   */
+  private final int initDefaultParameters;
+
+  /**
    * Constructs a {@link PythonConstructorFunction}.
    *
    * @param ref The constructor's method reference.
    * @param summary The synthesized constructor body.
    * @param declaringClass The class being constructed.
+   * @param initDefaultParameters The wrapped {@code __init__}'s defaulted-parameter count.
    */
   public PythonConstructorFunction(
-      MethodReference ref, MethodSummary summary, IClass declaringClass) {
+      MethodReference ref,
+      MethodSummary summary,
+      IClass declaringClass,
+      int initDefaultParameters) {
     super(ref, summary, declaringClass);
+    this.initDefaultParameters = initDefaultParameters;
+  }
+
+  /**
+   * The constructor's trailing formals mirror the wrapped {@code __init__}'s parameters, so its
+   * defaulted-parameter count carries over: an instantiation that leaves them unpassed binds them
+   * from {@code __init__}'s default globals (wala/ML#762).
+   *
+   * @return The wrapped {@code __init__}'s defaulted-parameter count.
+   */
+  @Override
+  public int getNumberOfDefaultParameters() {
+    return this.initDefaultParameters;
   }
 }


### PR DESCRIPTION
Closes wala/ML#762 and advances wala/ML#761: constructor parameter defaults now bind at class-instantiation calls.

The gap had two halves. The synthesized constructor forwards every `__init__` slot, so the constructor-to-`__init__` hop saw all parameters as passed and the defaults loop never fired there; and the instantiation hop bound nothing because `PythonConstructorFunction` reported no defaulted parameters. The constructor now carries the wrapped `__init__`'s defaulted-parameter count, and the builder's defaults loop maps a constructor target's formals onto `__init__`'s parameters: the defaulted range shifts down by one, since the summary declares `__init__`'s parameter count although its formals stop one short (formal `i` mirrors parameter `i + 1`), and the lookup reads the `<class>/__init___defaults_<i + 1>` global the translator writes.

A hardening rides along: a boolean flag reaching a shape slot through a newly materialized default crashed the shape-argument field walk's unguarded numeric cast; a non-numeric constant is not a dimension and now skips.

The runtime-verified `tf2_test_attr_guard2.py` pins an unpassed constructor default deciding an attribute guard end to end, completing the wala/ML#761 in-vitro chain. The vendored NLPGNN `DenseLayer3d` pin stays unchanged: its `use_einsum` travels a further hop (read off one instance's field and passed as another constructor's argument), where the property-read result's points-to gap (the wala/ML#570 class) still interposes.
