### PR TITLE
Suppress decidably-infeasible flow: dead φ arms and dead-site caller invokes (wala/ML#763)

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -388,12 +388,13 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * shape-⊤ members carry equation-proven ranks since the einsum-operand refinement (wala/ML#704):
    * {@code DenseLayer3d.call}'s {@code use_einsum} arm makes its input an operand of the rank-3
    * {@code "BFH"} term and {@code DenseLayer3dProj.call}'s of the rank-4 {@code "BFND"} term, and
-   * the refined parameter states transport through the call boundary into this helper. Every proven
-   * axis stays {@link UnresolvedDim} in vivo, since {@code w}'s extents are config-derived; the
-   * union is dtype-homogeneous {@code float32} since the dtype feed (wala/ML#736) replaced the
-   * attention path's pure-⊤ seeds. The {@code w} parameter keeps rank 3 and {@code float32} (its
-   * chain is layer-local) but no numeric dimensions, since the {@code build}-computed head sizes
-   * also derive from the config.
+   * the refined parameter states transport through the call boundary into this helper; the
+   * dead-site rank-2/3 matmul artifacts are gone with the caller-walk filtering (wala/ML#763).
+   * Every proven axis stays {@link UnresolvedDim} in vivo, since {@code w}'s extents are
+   * config-derived; the union is dtype-homogeneous {@code float32} since the dtype feed
+   * (wala/ML#736) replaced the attention path's pure-⊤ seeds. The {@code w} parameter keeps rank 3
+   * and {@code float32} (its chain is layer-local) but no numeric dimensions, since the {@code
+   * build}-computed head sizes also derive from the config.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -421,13 +422,9 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                         UnresolvedDim.INSTANCE,
                         UnresolvedDim.INSTANCE)),
                 new TensorType(FLOAT_32, asList(new NumericDim(8), UnresolvedDim.INSTANCE)),
-                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
                 new TensorType(
                     FLOAT_32,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
-                new TensorType(
-                    FLOAT_32,
-                    asList(new NumericDim(8), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
                 new TensorType(
                     FLOAT_32,
                     asList(new NumericDim(8), new NumericDim(10), UnresolvedDim.INSTANCE)),
@@ -477,12 +474,11 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * {@code (8, 100)}/{@code (8, 10)} leading pairs are the entry contracts (wala/ML#717); the ranks
    * are the einsum operand refinement's (wala/ML#704).
    *
-   * <p>TODO: Drop the rank-4 {@code (8, 100, ?, ?)}/{@code (8, 10, ?, ?)} members once <a
-   * href="https://github.com/wala/ML/issues/763">wala/ML#763</a> prunes the ALBERT pipeline's
-   * cross-rank members: the {@code use_einsum} guard folds (wala/ML#761, wala/ML#762) and the union
-   * is depth-invariant (wala/ML#601, depths 2 through 6), so the members are variable-level imports
-   * from the pipeline's states, the loop-carried layer-stack φ the prime suspect. The {@code (8, ?,
-   * ?, ?)} member is the legitimate wala/ML#737 partial and stays regardless.
+   * <p>The former rank-4 {@code (8, 100, ?, ?)}/{@code (8, 10, ?, ?)} members and the rank-2/3
+   * dead-arm artifacts are gone (wala/ML#763): with the {@code use_einsum} guard folding
+   * (wala/ML#761, wala/ML#762), the dead {@code einsum_via_matmul} sites no longer contribute, to
+   * either the caller walks or the dataflow φs. The {@code (8, ?, ?, ?)} member is the legitimate
+   * wala/ML#737 partial.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -512,10 +508,6 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                 new TensorType(
                     FLOAT_32,
                     asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
-                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
-                new TensorType(
-                    FLOAT_32,
-                    asList(new NumericDim(8), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
                 // The wala/ML#737 partial composition proves the rank-4 attention form's batch
                 // axis even when the remaining operand axes stay unresolved.
                 new TensorType(
@@ -523,20 +515,6 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                     asList(
                         new NumericDim(8),
                         UnresolvedDim.INSTANCE,
-                        UnresolvedDim.INSTANCE,
-                        UnresolvedDim.INSTANCE)),
-                new TensorType(
-                    FLOAT_32,
-                    asList(
-                        new NumericDim(8),
-                        new NumericDim(100),
-                        UnresolvedDim.INSTANCE,
-                        UnresolvedDim.INSTANCE)),
-                new TensorType(
-                    FLOAT_32,
-                    asList(
-                        new NumericDim(8),
-                        new NumericDim(10),
                         UnresolvedDim.INSTANCE,
                         UnresolvedDim.INSTANCE)))));
   }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestEinsum.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestEinsum.java
@@ -323,9 +323,11 @@ public class TestEinsum extends AbstractTensorTest {
   }
 
   /**
-   * Two einsum call sites prove disagreeing constraints for the same operand (wala/ML#704) — rank 2
-   * with a trailing 3 versus rank 3 with a trailing 5 — so neither is asserted and the parameter
-   * keeps its unknown shape: the conflicting refinement drops.
+   * Two einsum call sites once proved disagreeing constraints for the same operand (wala/ML#704),
+   * but the guard's flag is the constant {@code True} at the call, so the rank-3 site is dead and
+   * no longer contributes (wala/ML#763): the surviving site's constraint asserts the runtime-true
+   * rank 2 with the trailing 3. {@link #testEinsumOperandRefinement5()} keeps the disagreement
+   * scenario alive on an opaque flag.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -338,6 +340,34 @@ public class TestEinsum extends AbstractTensorTest {
     test(
         "tf2_test_einsum_operand_refinement.py",
         "choose",
+        3,
+        5,
+        Map.of(
+            2,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(3)))),
+            3,
+            Set.of(TensorType.of(FLOAT_32, 3, 4)),
+            4,
+            Set.of(TensorType.of(FLOAT_32, 5, 6))));
+  }
+
+  /**
+   * Two einsum call sites prove disagreeing constraints for the same operand (wala/ML#704), rank 2
+   * with a trailing 3 versus rank 3 with a trailing 5, and the guard's flag is an opaque
+   * environment read no fold decides (wala/ML#763), so neither is asserted and the parameter keeps
+   * its unknown shape: the conflicting refinement drops.
+   *
+   * @throws ClassHierarchyException if the class hierarchy cannot be built.
+   * @throws IllegalArgumentException if the input fixture is malformed.
+   * @throws CancelException if the analysis is cancelled.
+   * @throws IOException if the input fixture cannot be read.
+   */
+  @Test
+  public void testEinsumOperandRefinement5()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_einsum_operand_refinement.py",
+        "choose2",
         3,
         5,
         Map.of(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -65,6 +65,7 @@ import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSABinaryOpInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SSANewInstruction;
+import com.ibm.wala.ssa.SSAPhiInstruction;
 import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.MethodReference;
@@ -1779,6 +1780,44 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         }
       }
       LOGGER.fine(() -> "wala/ML#746 arm-suppressed call results: " + armSuppressions.size());
+
+      // A φ whose governing branch folds must not receive its infeasible arm's flow either: the
+      // dataflow union has no branch sensitivity, so a decided guard's dead arm (a helper call
+      // that never runs, a dead reassignment) leaks its members into the φ and onward
+      // (wala/ML#763). Suppress the dead arm's edge, keeping at least one live arm.
+      int phiSuppressions = 0;
+      for (CGNode node : builder.getCallGraph()) {
+        IR ir = node.getIR();
+        if (ir == null) continue;
+        for (Iterator<? extends SSAInstruction> it = ir.iteratePhis(); it.hasNext(); ) {
+          SSAInstruction phi = it.next();
+          if (!(phi instanceof SSAPhiInstruction)) continue;
+          PointsToSetVariable phiVar =
+              flowVarsByKey.get(heapModel.getPointerKeyForLocal(node, phi.getDef()));
+          if (phiVar == null) continue;
+          List<PointsToSetVariable> infeasible = new ArrayList<>();
+          boolean liveArm = false;
+          for (int i = 0; i < phi.getNumberOfUses(); i++) {
+            int useVn = phi.getUse(i);
+            PointsToSetVariable armVar =
+                useVn > 0 ? flowVarsByKey.get(heapModel.getPointerKeyForLocal(node, useVn)) : null;
+            if (Boolean.FALSE.equals(
+                TensorGenerator.computePhiArmFeasibility(
+                    builder, node, (SSAPhiInstruction) phi, i))) {
+              if (armVar != null && dataflow.hasEdge(armVar, phiVar)) infeasible.add(armVar);
+            } else {
+              liveArm = true;
+            }
+          }
+          if (!liveArm || infeasible.isEmpty()) continue;
+          for (PointsToSetVariable armVar : infeasible) {
+            armSuppressions.computeIfAbsent(phiVar, k -> HashSetFactory.make()).add(armVar);
+            phiSuppressions++;
+          }
+        }
+      }
+      int phiCount = phiSuppressions;
+      LOGGER.fine(() -> "wala/ML#763 arm-suppressed phi edges: " + phiCount);
 
       TensorTypeAnalysis tt =
           new TensorTypeAnalysis(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -2123,7 +2123,7 @@ public abstract class TensorGenerator {
    * @return {@link Boolean#FALSE} iff the arm is decidably infeasible; {@link Boolean#TRUE} when
    *     decidably taken; {@code null} when undecidable (the arm is kept).
    */
-  private Boolean computePhiArmFeasibility(
+  static Boolean computePhiArmFeasibility(
       PropagationCallGraphBuilder builder, CGNode node, SSAPhiInstruction phi, int armIndex) {
     IR ir = node.getIR();
     if (ir == null) return null;
@@ -2171,7 +2171,7 @@ public abstract class TensorGenerator {
    * @return Whether the runtime takes the edge, or {@code null} when the block does not end with a
    *     decidable two-way conditional branch over the successor.
    */
-  private Boolean decideEdgeFromBranchBlock(
+  private static Boolean decideEdgeFromBranchBlock(
       PropagationCallGraphBuilder builder,
       CGNode node,
       SSACFG cfg,
@@ -2208,7 +2208,7 @@ public abstract class TensorGenerator {
    * @param branch The conditional branch.
    * @return The comparison's outcome, or {@code null} when either side does not fold.
    */
-  private Boolean evaluateBranchComparison(
+  private static Boolean evaluateBranchComparison(
       PropagationCallGraphBuilder builder, CGNode node, SSAConditionalBranchInstruction branch) {
     return evaluateBranchComparison(builder, node, branch, Collections.emptyMap());
   }
@@ -4676,13 +4676,26 @@ public abstract class TensorGenerator {
       PropagationCallGraphBuilder builder, CGNode node) {
     List<Pair<CGNode, SSAAbstractInvokeInstruction>> ret = new ArrayList<>();
     CallGraph callGraph = builder.getCallGraph();
+    Map<CGNode, Set<ISSABasicBlock>> reachableByCaller = HashMapFactory.make();
     for (Iterator<CGNode> it = callGraph.getPredNodes(node); it.hasNext(); ) {
       CGNode caller = it.next();
       if (caller.getIR() == null) continue;
+      // A call site in a block the caller's decided guards prove unreachable never runs, so its
+      // arguments must not contribute to the callee's parameter reads (wala/ML#763): the shared
+      // helper called only from a folded-dead arm otherwise unions every dead site's values.
+      Set<ISSABasicBlock> reachable =
+          reachableByCaller.computeIfAbsent(
+              caller, c -> computeReachableBlocksUnderBindings(builder, c, Collections.emptyMap()));
       for (Iterator<CallSiteReference> sites = callGraph.getPossibleSites(caller, node);
           sites.hasNext(); )
-        for (SSAAbstractInvokeInstruction call : caller.getIR().getCalls(sites.next()))
+        for (SSAAbstractInvokeInstruction call : caller.getIR().getCalls(sites.next())) {
+          if (call.iIndex() >= 0) {
+            ISSABasicBlock block =
+                caller.getIR().getControlFlowGraph().getBlockForInstruction(call.iIndex());
+            if (block != null && !reachable.contains(block)) continue;
+          }
           ret.add(Pair.make(caller, call));
+        }
     }
     return ret;
   }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_einsum_operand_refinement.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_einsum_operand_refinement.py
@@ -1,3 +1,5 @@
+import os
+
 import tensorflow as tf
 
 
@@ -37,6 +39,12 @@ def blur(x, w):
 # versus rank 3 with a trailing 5) for the same operand, so neither is
 # asserted: the conflicting refinement drops.
 def choose(x, a, b, flag):
+    if flag:
+        return tf.einsum("ij,jk->ik", x, a)
+    return tf.einsum("ijk,kl->ijl", x, b)
+
+
+def choose2(x, a, b, flag):
     if flag:
         return tf.einsum("ij,jk->ik", x, a)
     return tf.einsum("ijk,kl->ijl", x, b)
@@ -108,5 +116,15 @@ r4 = choose(z, tf.ones((3, 4)), tf.ones((5, 6)), True)
 assert r4.shape == (2, 4)
 assert r4.dtype == tf.float32
 k(r4)
+
+# The flag below is opaque to the analysis (an environment read), so both of `choose2`'s
+# einsum sites stay live and their disagreeing operand constraints drop (wala/ML#704); at
+# run time the unset variable takes the rank-2 arm.
+flag2 = os.environ.get("ARIADNE_CHOOSE2", "") == ""
+z2 = opaque(z0, z0.shape.ndims)
+r5 = choose2(z2, tf.ones((3, 4)), tf.ones((5, 6)), flag2)
+assert r5.shape == (2, 4)
+assert r5.dtype == tf.float32
+f(r5)
 
 dead(False, x)


### PR DESCRIPTION
Closes wala/ML#763: a decided guard's dead arm no longer contributes its flow, in either of the two branch-blind carriers the issue's traces isolated.

The dataflow union has no branch sensitivity, so a φ received its folded-dead arm variable's members; and the caller walks have none either, so a call site in a dead block still contributed its arguments to the callee's parameter reads. Through the second, the shared `einsum_via_matmul` helper (every call to which sits in a dead `use_einsum=False` arm in the vendored corpus) unioned all dense layers' inputs and re-exported cross-rank compositions into the live paths' seeds. The engine sweep now suppresses a decided φ's infeasible-arm edges with the wala/ML#746 `ArmSuppressOp` vocabulary, keeping at least one live arm, and `getCallerInvokes` skips call sites in blocks the caller's folds prove unreachable, so all ten of its consumers inherit the filter. Both selections read only analysis-stable substrate (wala/ML#758).

Witness outcomes are exact. The vendored NLPGNN `DenseLayer3d.call` input drops both runtime-infeasible concrete rank-4 members and the rank-2/3 dead-arm artifacts, leaving the runtime-true forms plus the legitimate wala/ML#737 partial; the shared helper's own input pin drops its dead-site matmul artifacts. The constant-flag `choose` fixture's formerly conflicting einsum constraints now resolve to the surviving site's runtime-true `(?, 3)`, and the disagreement scenario stays guarded by the new opaque-flag `choose2` (`testEinsumOperandRefinement5`, runtime-verified addition).
