### PR TITLE
Divert the shape-vector walk and element reads through the engine and lift the `Concat` clause-3 withhold

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -116,6 +116,7 @@ public class Concat extends TensorGenerator {
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
 
+    boolean sawConvergingElement = false;
     for (InstanceKey valIk : valuesPts) {
       AllocationSiteInNode asin = getAllocationSiteInNode(valIk);
       if (asin == null) continue;
@@ -139,13 +140,20 @@ public class Concat extends TensorGenerator {
         ShapeResult appended = computeAppendedShape(builder, asin, axis);
         if (!appended.members().isEmpty()) outShape = appended;
       }
+      if (outShape.isBottom()) sawConvergingElement = true;
       ret.addAll(outShape.members());
     }
-    // A memberless evaluation stays ⊤ at this legacy view: this method also composes seeds, where
-    // an empty set reads as "not a tensor" and would pair a ⊥ shape with a resolved dtype. The
-    // clause-3 ⊥ contribution for still-unresolved elements needs the element reads themselves to
-    // be engine-visible first (wala/ML#758).
-    return ret.isEmpty() ? null : ret;
+    if (ret.isEmpty()) {
+      // Clause 3 (wala/ML#758): with the element reads engine-visible, a memberless evaluation
+      // that consumed a still-converging (⊥) element contributes ⊥, so the ascent delivers the
+      // resolved shape instead of freezing a transient ⊤ mark; the settled recomputation restores
+      // the legacy ⊤ when the elements finally resolve nothing. Seed composition only ever reads
+      // the settled value, so the interim ⊥ never pairs with a resolved dtype there. A memberless
+      // evaluation with no ⊥ element keeps the legacy ⊤ outright.
+      if (sawConvergingElement && !isObservationFinal(builder)) return Collections.emptySet();
+      return null;
+    }
+    return ret;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1119,22 +1119,22 @@ public abstract class TensorGenerator {
   }
 
   /**
-   * Decides whether the wala/ML#717 contract seed may fire on the emptiness the calling arm just
-   * observed. The seed covers a {@code call} input whose runtime feed finally resolves nothing, but
-   * under the engine an observed emptiness can be interim (a still-converging read): firing on it
-   * would join contract members alongside the runtime members a later delivery adds, which no
-   * settled evaluation would produce (the wala/ML#758 clause-1/clause-2 contract). The observation
-   * is provably final — and the seed may fire — outside the engine, outside an evaluation, during
-   * the settlement (canonicalization) pass, and whenever no interim value is observable at all;
-   * otherwise the arm is withheld and the query registers for a settled recomputation, where a
-   * still-empty feed is final ⊥ and the seed fires with delivery guaranteed (the read-version
-   * staleness scheduling re-runs the reader on any interim feed's growth, and the settlement pass
-   * replaces an interim firing's join history).
+   * Decides whether an emptiness the calling arm just observed is provably final, registering the
+   * evaluating query for a settled recomputation when it is not. Under the engine an observed
+   * emptiness can be interim (a still-converging read), and a finality-dependent arm firing on it
+   * violates the wala/ML#758 arm contract: the wala/ML#717 contract seed would join contract
+   * members alongside the runtime members a later delivery adds (clause 1/2), and a legacy-⊤
+   * fallback for a still-converging element read would freeze the transient mark (clause 3). The
+   * observation is provably final outside the engine, outside an evaluation, during the settlement
+   * (canonicalization) pass, and whenever no interim value is observable at all; otherwise the arm
+   * defers, and the settled recomputation re-fires it against final reads with delivery guaranteed
+   * (the read-version staleness scheduling re-runs the reader on any interim read's growth, and the
+   * settlement pass replaces an interim firing's join history).
    *
    * @param builder The {@link PropagationCallGraphBuilder} whose engine (if any) is resolving.
-   * @return {@code true} iff the observed feed emptiness is final and the contract seed may fire.
+   * @return {@code true} iff the observed emptiness is final and a finality-dependent arm may fire.
    */
-  private static boolean mayFireContractSeed(PropagationCallGraphBuilder builder) {
+  protected static boolean isObservationFinal(PropagationCallGraphBuilder builder) {
     WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
     if (engine == null || !engine.isEvaluating() || engine.isSettling()) return true;
     if (!engine.mayObserveInterim()) return true;
@@ -1871,7 +1871,7 @@ public abstract class TensorGenerator {
         // its shape does not resolve, exactly the case the declared contract covers
         // (wala/ML#717). The seed fires only on a provably final emptiness; a possibly-interim
         // observation defers it to the settlement pass (wala/ML#758).
-        if (fromValue.members().isEmpty() && mayFireContractSeed(builder)) {
+        if (fromValue.members().isEmpty() && isObservationFinal(builder)) {
           Set<List<Dimension<?>>> contract =
               this.contractSeedForCallInput(builder, node, valueNumber);
           if (contract != null && !contract.isEmpty()) return ShapeResult.of(contract);
@@ -2049,7 +2049,7 @@ public abstract class TensorGenerator {
         // contract (built layers validate call inputs against the built shape), so seed the
         // parameter from it (wala/ML#717). The seed fires only on a provably final emptiness; a
         // possibly-interim observation defers it to the settlement pass (wala/ML#758).
-        if (mayFireContractSeed(builder)) {
+        if (isObservationFinal(builder)) {
           Set<List<Dimension<?>>> contract =
               this.contractSeedForCallInput(builder, node, valueNumber);
           if (contract != null && !contract.isEmpty()) return ShapeResult.of(contract);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3092,6 +3092,36 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Reads a container element's shapes through the engine (wala/ML#758): the list/tuple arm's
+   * direct recursion was the largest engine-invisible transfer population of the wala/ML#753
+   * witness (the zero-edge {@code get_shape_list} queries), so an element whose shapes were
+   * consumed interim had no dependency edge to reschedule its reader. The query is keyed by the
+   * element's pointer key and the exactness mode, both of which determine the transfer.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param elementKey The container element's pointer key, identifying the query.
+   * @param elementPointsToSet The element's points-to set, the transfer's input.
+   * @param exact Whether an unresolvable union member marks the unknown remainder.
+   * @return The resolution result.
+   */
+  private ShapeResult readElementShapes(
+      PropagationCallGraphBuilder builder,
+      PointerKey elementKey,
+      OrdinalSet<InstanceKey> elementPointsToSet,
+      boolean exact) {
+    WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return this.getShapeResultOfValue(builder, elementPointsToSet, exact);
+    Object key = Pair.make("element-shapes", Pair.make(elementKey, exact));
+    java.util.function.Supplier<Object> transfer =
+        () -> this.getShapeResultOfValue(builder, elementPointsToSet, exact);
+    return (ShapeResult)
+        (engine.isEvaluating()
+            ? engine.read(key, transfer, true)
+            : engine.demand(key, transfer, true));
+  }
+
+  /**
    * Record-carrying core of {@link #getShapesOfValue(PropagationCallGraphBuilder, OrdinalSet,
    * boolean)} (wala/ML#718): in exact mode, a member whose shapes do not resolve marks the unknown
    * remainder and the resolvable members keep collecting, so a partially resolvable points-to union
@@ -3164,7 +3194,9 @@ public abstract class TensorGenerator {
                 "Points-to set for instance field: " + describe(instanceFieldPointsToSet) + ".");
 
             Set<List<Dimension<?>>> shapesOfField =
-                this.getShapesOfValue(builder, instanceFieldPointsToSet, exact);
+                this.readElementShapes(
+                        builder, pointerKeyForInstanceField, instanceFieldPointsToSet, exact)
+                    .toLegacy();
 
             if (shapesOfField == null) {
               // An unresolvable element makes the union incomplete: mark the remainder and keep
@@ -4911,7 +4943,35 @@ public abstract class TensorGenerator {
    */
   protected ShapeResult getShapeResultOfShapeVector(
       PropagationCallGraphBuilder builder, CGNode node, int vn) {
-    return getShapeResultOfShapeVector(builder, node, vn, HashSetFactory.make());
+    return this.walkShapeVector(builder, node, vn, HashSetFactory.make());
+  }
+
+  /**
+   * Dispatches one step of the shape-vector walk. Under the engine, each step is a {@code (node,
+   * vn)}-keyed query, so the walk's reads record dependency edges and its recursive chains converge
+   * as engine cycles instead of breaking at the {@code visited} guard with an order-dependent
+   * unknown; the wala/ML#758 census measured the guarded walk as the largest engine-invisible
+   * transfer population (all 70 zero-edge marked keys of the wala/ML#753 witness). On the
+   * null-engine recursive path the {@code visited} guard keeps bounding the recursion as before.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to resolve.
+   * @param visited The nodes already on the walk, consulted only on the null-engine path.
+   * @return The resolution result.
+   */
+  private ShapeResult walkShapeVector(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<CGNode> visited) {
+    WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
+    // See memoizedShapeResult on the null-engine (outside-an-analysis) fallback.
+    if (engine == null) return this.getShapeResultOfShapeVector(builder, node, vn, visited);
+    Object key = Pair.make("shape-vector", Pair.make(node, vn));
+    java.util.function.Supplier<Object> transfer =
+        () -> this.getShapeResultOfShapeVector(builder, node, vn, HashSetFactory.make());
+    return (ShapeResult)
+        (engine.isEvaluating()
+            ? engine.read(key, transfer, true)
+            : engine.demand(key, transfer, true));
   }
 
   /**
@@ -4980,9 +5040,7 @@ public abstract class TensorGenerator {
             }
           } else if (outerCall.getNumberOfUses() >= 2 && visited.add(outerCaller))
             // An explicit `x.build(shape)` call: walk the actual argument.
-            shapes =
-                this.getShapeResultOfShapeVector(
-                    builder, outerCaller, outerCall.getUse(1), visited);
+            shapes = this.walkShapeVector(builder, outerCaller, outerCall.getUse(1), visited);
           // The parameter unions all callers; an unresolved caller marks the unknown remainder
           // and the resolvable callers' members still stand (wala/ML#718).
           if (shapes.hasUnknown() || shapes.isBottom()) callerUnknown = true;
@@ -5032,7 +5090,7 @@ public abstract class TensorGenerator {
             continue;
           }
           try {
-            ShapeResult shapes = this.getShapeResultOfShapeVector(builder, caller, argVn, visited);
+            ShapeResult shapes = this.walkShapeVector(builder, caller, argVn, visited);
             if (shapes.hasUnknown() || shapes.isBottom()) callerUnknown = true;
             if (!shapes.members().isEmpty()) {
               if (combined == null) combined = HashSetFactory.make();
@@ -5094,14 +5152,13 @@ public abstract class TensorGenerator {
         PythonPropertyRead funcRead = (PythonPropertyRead) funcDef;
         int memberVn = funcRead.getMemberRef();
         if (st.isStringConstant(memberVn) && "as_list".equals(st.getStringValue(memberVn)))
-          return this.getShapeResultOfShapeVector(builder, node, funcRead.getObjectRef(), visited);
+          return this.walkShapeVector(builder, node, funcRead.getObjectRef(), visited);
         return ShapeResult.unknown();
       }
 
       // v[a:b]: a slice-builtin invoke of the form slice(receiver, lower, upper, step).
       if (dispatchesToSliceBuiltin(builder, node, invoke) && invoke.getNumberOfUses() >= 2) {
-        ShapeResult base =
-            this.getShapeResultOfShapeVector(builder, node, invoke.getUse(1), visited);
+        ShapeResult base = this.walkShapeVector(builder, node, invoke.getUse(1), visited);
         if (base.members().isEmpty()) return ShapeResult.unknown();
 
         // A nested slice object as a bound means a multi-dim subscript; a shape vector is 1-D, so
@@ -5222,7 +5279,7 @@ public abstract class TensorGenerator {
    */
   private ShapeResult shapeResultOfShapeVectorOrLiteralList(
       PropagationCallGraphBuilder builder, CGNode node, int vn, Set<CGNode> visited) {
-    ShapeResult shapes = this.getShapeResultOfShapeVector(builder, node, vn, visited);
+    ShapeResult shapes = this.walkShapeVector(builder, node, vn, visited);
     if (!shapes.members().isEmpty()) return shapes;
 
     SSAInstruction def = node.getDU().getDef(vn);
@@ -5619,8 +5676,7 @@ public abstract class TensorGenerator {
             // call's result isn't a resolvable shape vector.
             if (ret.getResult() < 0) return ShapeResult.unknown();
             sawReturn = true;
-            ShapeResult shapes =
-                this.getShapeResultOfShapeVector(builder, callee, ret.getResult(), visited);
+            ShapeResult shapes = this.walkShapeVector(builder, callee, ret.getResult(), visited);
             // Every return must resolve; an unresolvable remainder is marked rather than
             // collapsing the resolvable members (wala/ML#718).
             if (shapes.members().isEmpty()) return ShapeResult.unknown();


### PR DESCRIPTION
This lands the element-read engine diversion, the last scheduling item on the work-item list, and the `Concat` clause-3 contribution it unlocks.

## Element-Read Diversion

Salvaged from the round-11 draft (ponder-lab/ML#658's diversions, rebased across the arm and scheduling work since): each shape-vector walk step becomes a `(node, vn)`-keyed engine query and each container-element read a pointer-keyed query, so their recursive chains converge as engine cycles and their reads record dependency edges instead of breaking at the `visited` guard with an order-dependent unknown. The null-engine recursive path keeps the `visited` guard as before (the draft's null-engine arm accidentally self-recursed; fixed during the salvage). The walk's interior recursion points that landed since the draft (the wala/ML#746 reachability-filtered callee-return descent among them) route through the diverted entry as well.

## Concat Clause-3 Contribution

The reconciliation that landed the `Concat` unit withheld its method-level ⊥: `getDefaultShapes` also composes seeds, where an empty set reads as "not a tensor" and would pair a ⊥ shape with a resolved dtype, and the element reads were not yet engine-visible, so a ⊥ return had no dependency edge to reschedule the evaluation. Both blockers are now gone: a memberless evaluation that consumed a still-converging (⊥) element contributes ⊥, the ascent re-runs it when the element resolves (the read-version staleness criterion guarantees this), and the settled recomputation restores the legacy ⊤ when the elements finally resolve nothing. Seed composition only ever reads the settled value, so the interim ⊥ never pairs with a resolved dtype there. The finality primitive factors out of the contract-seed gate as `isObservationFinal`, shared by both arms.

Advances wala/ML#758. With this, both scheduling work items (read-version staleness in ponder-lab/ML#683 and the diversions here) and all arm items on the list are landed; disposition of the tracker is yours.
