### PR TITLE
Skip the opaque-operand pin only when the generator types the reshape result

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNlpgnnTransformer.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNlpgnnTransformer.java
@@ -41,7 +41,10 @@ public class TestNlpgnnTransformer extends AbstractTensorTest {
    * each trailing hidden dimension a config-derived {@link UnresolvedDim} (wala/ML#721) &mdash;
    * plus each pair's loop-carried degraded-rank siblings ({@code (batch, U)} and {@code (batch, U,
    * U)} from the {@code reshape_to_matrix}/{@code reshape_from_matrix} round trip's non-entry
-   * contexts) and the fully-unresolved rank-2/rank-3 members. The {@code mask} (value number 4)
+   * contexts) and the fully-unresolved rank-2/rank-3 members, plus the unknown-rank {@code float32}
+   * member the restored {@code reshape_from_matrix} opaque-operand pin contributes (wala/ML#765):
+   * that reshape's result is generator-⊥ here, so the pin is its only tensor evidence, and its
+   * conservative unknown-rank type joins the loop-carried union. The {@code mask} (value number 4)
    * union is the attention mask's {@code (batch, seq, seq)} broadcast per the same six entry
    * pipelines.
    *
@@ -60,6 +63,7 @@ public class TestNlpgnnTransformer extends AbstractTensorTest {
     expected.put(
         3,
         Set.of(
+            new TensorType(FLOAT_32, null),
             new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
             new TensorType(FLOAT_32, asList(new NumericDim(2), UnresolvedDim.INSTANCE)),
             new TensorType(FLOAT_32, asList(new NumericDim(6), UnresolvedDim.INSTANCE)),

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1090,7 +1090,6 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             // type for it; pin a tensor of unknown rank instead, which keeps the result
             // tensor-classified without asserting a wrong shape.
             int shapeVn = call.getUse(param);
-            if (TensorGenerator.isShapeVectorChain(builder, src, shapeVn)) return;
             SSAInstruction shapeDef = src.getDU().getDef(shapeVn);
             boolean literalContainer =
                 shapeDef instanceof SSANewInstruction
@@ -1113,6 +1112,17 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             if (builder.getPropagationSystem().isImplicit(defKey)) return;
             PointsToSetVariable defVariable =
                 builder.getPropagationSystem().findOrCreatePointsToSet(defKey);
+            // A chain-classified operand is the provenance walk's territory only when the
+            // generator side actually types the result: any nonempty generator result already
+            // tensor-classifies the destination (a precise resolution the pin would only pollute,
+            // wala/ML#703, wala/ML#706; a dtype-only member says what the pin would say). The pin's
+            // unique value is the chain the generator resolves to nothing at all, so only that
+            // falls through to the unknown-rank pin below; the bare structural skip withdrew the
+            // pin there too and starved consumers whose only tensor evidence it was (wala/ML#765).
+            if (TensorGenerator.isShapeVectorChain(builder, src, shapeVn)) {
+              Set<TensorType> generatorTypes = this.getTensorTypes(defVariable, builder);
+              if (generatorTypes != null && !generatorTypes.isEmpty()) return;
+            }
             Set<TensorType> pinned;
             if (literalContainer) {
               // Merge the generator-side computation into the pinned type so the pin agrees with


### PR DESCRIPTION
The wala/ML#706 mirror of the parameter arm into `isShapeVectorChain` made the engine's reshape pin site withdraw the opaque-operand unknown-rank pin from chain-classified shape operands unconditionally, on the assumption the provenance walk resolves them precisely. Where the walk delivers nothing, the pin was the result's only tensor evidence: `tf.reshape`'s result is unconditionally a tensor at runtime, so the withdrawal degrades it to "not a tensor". The instrumented consumer comparison pinned the carrier to `reshape_from_matrix`'s reshape (pinned on 0.52.36 with the full NLPGNN evidence population, skipped on master with eight per-parameter inferences gone).

The skip now requires a nonempty generator result: a typed result keeps the precise resolution unpolluted (the wala/ML#703 rationale, and a dtype-only member already says what the pin would say), while a generator-⊥ chain falls through to the unknown-rank pin. The wala/ML#706 guards (`testShapeHelperParam`, `testShapeHelperFull`) pin the resolvable direction and stay green. The transformer witness gains the restored pin's conservative unknown-rank member, re-derived and documented; that member doubles as the in-suite guard of the pin's presence, since this site's generator result is ⊥ in the suite configuration as well.

Advances wala/ML#765. The pin restoration alone does not restore the eight consumer-visible inferences on current master: a second mechanism, located by a fix-on-release bisect (alive at 0.52.45, dead at 0.52.46), is the wala/ML#763 dead-arm and dead-site suppression cutting the fold-infeasible union path that had carried the pinned type to the GNN parameters. That path was a genuine leak, so its removal stands; the remaining gap is that the parameters' real feed does not type in the consumer configuration, tracked separately.
