### PR TITLE
Type the SciPy sparse product so the GNN entry feed reaches the `call` parameters

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_5_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_3_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.UNKNOWN;
 import static java.util.Arrays.asList;
@@ -517,6 +518,38 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                         UnresolvedDim.INSTANCE,
                         UnresolvedDim.INSTANCE,
                         UnresolvedDim.INSTANCE)))));
+  }
+
+  /**
+   * In-vivo anchor for the wala/ML#766 GNN entry feed: the vendored NLPGNN {@code GCNLayer.call}'s
+   * {@code node_embeddings}, whose only runtime feed is the {@code Planetoid} loader's
+   * row-normalized features. With {@code norm=True} constant at every {@code Planetoid} site, the
+   * wala/ML#763 φ-arm suppression correctly cuts the un-normalized {@code np.array} arm, so the
+   * parameter's type must arrive through the normalization itself: {@code
+   * sp.diags(r_inv).dot(features)}, typed by the SciPy sparse product modeling ({@code scipy.xml}
+   * plus {@code SparseMatrixDot}) as {@code ? of float32}: dtype from the dense operand, shape
+   * unknown because the dense operand's extents are pickle-loaded data.
+   *
+   * <p>TODO: The shape should improve to {@code (Unresolved, Unresolved)} once rank flows through
+   * the dense-ification chain ({@code todense}); see <a
+   * href="https://github.com/wala/ML/issues/768">wala/ML#768</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNlpgnnFullGcnCallInput()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        NLPGNN_FULL_PROJECT_FILES,
+        "nlpgnn/models/GCN.py",
+        "GCNLayer.call",
+        "nlpgnn_full_proj",
+        1,
+        5,
+        Map.of(3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
@@ -121,6 +121,33 @@ public class TestMathOps extends AbstractTensorTest {
     test("tf2_test_sigmoid.py", "f", 1, 1, Map.of(2, Set.of(TENSOR_4_FLOAT32)));
   }
 
+  /**
+   * Distilled guard for the SciPy sparse matrix product (<a
+   * href="https://github.com/wala/ML/issues/766">wala/ML#766</a>): the NLPGNN {@code Planetoid}
+   * loader's row normalization {@code sp.diags(r_inv).dot(features)} is the real feed of the GNN
+   * {@code call} parameters. The product's dtype follows the dense operand, and its shape composes
+   * the sparse operand's row extent — a fixed runtime integer the analysis cannot compute ({@code
+   * UnresolvedDim}, wala/ML#721), since the sparse operand is a SciPy-internal value it never types
+   * — with the dense operand's trailing extent (here the fixture's static {@code 2}).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testScipySparseDot()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_scipy_sparse_dot.py",
+        "consume",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, new NumericDim(2))))));
+  }
+
   @Test
   public void testAbs()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml/data/scipy.xml
+++ b/com.ibm.wala.cast.python.ml/data/scipy.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!DOCTYPE summary-spec>
+<summary-spec>
+  <classloader name="PythonLoader">
+    <class name="scipy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lscipy;">
+        <new def="x" class="Lscipy"/>
+        <new def="sparse" class="Lscipy/sparse"/>
+        <putfield class="LRoot" field="sparse" fieldType="LRoot" ref="x" value="sparse"/>
+        <new def="diags_fn" class="Lscipy/sparse/diags"/>
+        <putfield class="LRoot" field="diags" fieldType="LRoot" ref="sparse" value="diags_fn"/>
+        <return value="x"/>
+      </method>
+    </class>
+    <package name="scipy">
+      <!-- The `scipy.sparse` submodule object, reachable as a field of the `scipy` module so that both `import scipy.sparse as sp` (an `import("scipy")` followed by an `OBJECT_REF` on `sparse`) and `from scipy import sparse` resolve to it. Declared `allocatable="true"` for the same reason as `numpy/ndarray`: it is only referenced as a `<new>` target inside `scipy`'s `import()`. -->
+      <class name="sparse" allocatable="true"></class>
+    </package>
+    <package name="scipy/sparse">
+      <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.diags.html -->
+      <!-- Modeled as a class-per-function (same pattern as `numpy/array`) so that `sp.diags` resolves to this class via a field lookup on the `scipy.sparse` submodule, and the invocation dispatches to its `do` method. The returned sparse matrix carries a `dot` method field (the same per-allocation field-population pattern as `numpy/ndarray`'s `astype`/`reshape`; see the 1-CFA aliasing note in `numpy.xml`). -->
+      <class name="diags" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self diagonals offsets">
+          <new def="ret" class="Lscipy/sparse/spmatrix"/>
+          <new def="dot_fn" class="Lscipy/sparse/spmatrix/dot"/>
+          <putfield class="LRoot" field="dot" fieldType="LRoot" ref="ret" value="dot_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- The sparse-matrix value class. Declared `allocatable="true"` so `<new class="Lscipy/sparse/spmatrix"/>` in `diags`'s `do()` resolves to a concrete `InstanceKey`; deliberately has no method body because it is only referenced as a `<new>` target. -->
+      <class name="spmatrix" allocatable="true"></class>
+    </package>
+    <package name="scipy/sparse/spmatrix">
+      <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.dot.html -->
+      <!-- Modeled as a class-per-function (same pattern as `numpy/ndarray/astype`) so that attribute access `A.dot` on a sparse-matrix value resolves to this class via a field lookup, and the subsequent invocation dispatches to its `do` method. The product of a sparse matrix and a dense array is dense, so the result is a `numpy/ndarray`; its type is computed by `SparseMatrixDot`. -->
+      <class name="dot" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self b">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+    </package>
+  </classloader>
+</summary-spec>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -2178,8 +2178,10 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
   protected void addBypassLogic(IClassHierarchy cha, AnalysisOptions options) {
     super.addBypassLogic(cha, options);
     // Load numpy before tensorflow so tensorflow-level generators can reference numpy types via
-    // `NumpyTypes` constants without depending on load order side effects.
+    // `NumpyTypes` constants without depending on load order side effects. scipy.xml's sparse
+    // product allocates a `numpy/ndarray`, so it loads after numpy too.
     addSummaryBypassLogic(options, "numpy.xml");
+    addSummaryBypassLogic(options, "scipy.xml");
     addSummaryBypassLogic(options, "tensorflow.xml");
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseMatrixDot.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseMatrixDot.java
@@ -1,0 +1,109 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code scipy.sparse} matrix products ({@code A.dot(b)}, e.g. on a {@code
+ * sp.diags(...)} result). The product of a sparse matrix and a dense array is a dense array whose
+ * dtype follows the dense operand {@code b} and whose shape composes the sparse operand's
+ * unresolved row extent with {@code b}'s trailing extent; the sparse operand {@code A} is a
+ * SciPy-internal value the analysis does not type. See wala/ML#766: the NLPGNN {@code Planetoid}
+ * loader's row normalization {@code r_mat_inv.dot(features)} is the real feed of the GNN {@code
+ * call} parameters, and without this generator the normalized arm of the feed φ types to ⊥.
+ *
+ * @see <a
+ *     href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.dot.html">scipy.sparse.csr_matrix.dot</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class SparseMatrixDot extends PassThroughUnaryTensorGenerator {
+
+  public SparseMatrixDot(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public SparseMatrixDot(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "b";
+  }
+
+  /**
+   * Derives the product's shape from the dense operand: {@code A.dot(b)} has shape {@code (A.rows,
+   * b.cols)} for a rank-2 {@code b} and {@code (A.rows,)} for a rank-1 {@code b}. The sparse
+   * operand's row extent is a fixed runtime integer the analysis cannot compute (the sparse operand
+   * is a SciPy-internal value it never types), so that axis is {@link UnresolvedDim} (wala/ML#721);
+   * the trailing axis carries over from {@code b} when its shape resolves.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The set of possible output shapes, or {@code null} (⊤) when the dense operand's shape
+   *     is unknown or no candidate has rank 1 or 2 (a SciPy sparse product is defined over
+   *     rank-1/rank-2 dense operands only).
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes =
+        this.shapesOfArg(builder, this.getInputParameterPosition(), this.getInputParameterName());
+    if (inputShapes == null) return null;
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      if (inputShape.size() == 1) ret.add(List.of(UnresolvedDim.INSTANCE));
+      else if (inputShape.size() == 2) ret.add(List.of(UnresolvedDim.INSTANCE, inputShape.get(1)));
+    }
+    return ret.isEmpty() ? null : ret;
+  }
+
+  /**
+   * Collapse-safe record view (wala/ML#718): this generator transforms its input shapes in {@link
+   * #getDefaultShapes}, which the base's pass-through identity record path would bypass, so the
+   * record view routes through the legacy transform until a member-wise upgrade.
+   *
+   * @param builder The propagation call graph builder.
+   * @return The transformed result, with any partial input collapsed by the legacy view.
+   */
+  @Override
+  protected ShapeResult getDefaultShapeResult(PropagationCallGraphBuilder builder) {
+    return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
+  }
+
+  /**
+   * This generator discards its input's shape, so forwarding operand shapes would overclaim; the
+   * feed carries dtype only (wala/ML#682).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype-only feed over the caller-side dense-operand keys, or {@code null} when none
+   *     is located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    return this.getTypeFeed(builder, TypeFeedKind.DTYPE_ONLY);
+  }
+
+  /**
+   * Returns the producing library of the modeled value: a SciPy sparse-by-dense product is a dense
+   * NumPy value (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -35,6 +35,7 @@ import com.ibm.wala.cast.ir.ssa.CAstUnaryOp;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
+import com.ibm.wala.cast.python.ml.types.ScipyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
@@ -7118,6 +7119,8 @@ public abstract class TensorGenerator {
       return new NpOnes(node);
     } else if (type.equals(NumpyTypes.ZEROS.getDeclaringClass())) {
       return new NpZeros(node);
+    } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
+      return new SparseMatrixDot(node);
     } else if (type.equals(TensorFlowTypes.EYE.getDeclaringClass())) {
       return new Eye(node);
     } else if (type.equals(TensorFlowTypes.UNIFORM.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -216,6 +216,7 @@ import static java.util.logging.Logger.getLogger;
 import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
 import com.ibm.wala.cast.python.ml.types.NumpyTypes;
+import com.ibm.wala.cast.python.ml.types.ScipyTypes;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ssa.PythonPropertyRead;
@@ -1155,6 +1156,10 @@ public class TensorGeneratorFactory {
       if (ik instanceof AllocationSiteInNode) {
         TypeReference allocated = ((AllocationSiteInNode) ik).getSite().getDeclaredType();
         if (allocated.equals(PythonTypes.list) || allocated.equals(PythonTypes.tuple)) continue;
+        // A SciPy sparse matrix (`sp.diags(...)`, wala/ML#766) is a deliberately untyped SciPy
+        // internal: a binop over it is sparse-matrix algebra, not a tensor op. Only its dense
+        // `dot` product boundary is typed (`SparseMatrixDot`).
+        if (allocated.equals(ScipyTypes.SPARSE_MATRIX_TYPE)) continue;
       }
       return true;
     }
@@ -1318,6 +1323,27 @@ public class TensorGeneratorFactory {
                         + vn
                         + " to NdarrayReshape.");
             return new NdarrayReshape(source);
+          }
+
+          // If we're calling `scipy.sparse`'s matrix `dot`, the result is a dense product whose
+          // dtype follows the dense operand; the sparse receiver is never typed, so the shape is
+          // unknown. See wala/ML#766.
+          if (callee
+              .getMethod()
+              .getReference()
+              .getDeclaringClass()
+              .equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
+            LOGGER.fine(
+                () ->
+                    TensorGeneratorFactory.class.getSimpleName()
+                        + ": dispatching sparse-matrix dot call at "
+                        + describe(node)
+                        + " v"
+                        + vn
+                        + " to "
+                        + SparseMatrixDot.class.getSimpleName()
+                        + ".");
+            return new SparseMatrixDot(source);
           }
 
           // If we're calling `next`, the result is an element of the collection.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/ScipyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/ScipyTypes.java
@@ -1,0 +1,37 @@
+package com.ibm.wala.cast.python.ml.types;
+
+import com.ibm.wala.cast.python.types.PythonTypes;
+import com.ibm.wala.cast.types.AstMethodReference;
+import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
+
+/**
+ * Types found in the SciPy library, as modeled in {@code scipy.xml}.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ScipyTypes extends PythonTypes {
+
+  public static final TypeReference SCIPY_TYPE =
+      TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Lscipy"));
+
+  public static final TypeReference SPARSE_MATRIX_TYPE =
+      TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Lscipy/sparse/spmatrix"));
+
+  /** https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.diags.html */
+  public static final MethodReference DIAGS =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lscipy/sparse/diags")),
+          AstMethodReference.fnSelector);
+
+  /** https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.dot.html */
+  public static final MethodReference SPARSE_MATRIX_DOT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lscipy/sparse/spmatrix/dot")),
+          AstMethodReference.fnSelector);
+
+  private ScipyTypes() {}
+}

--- a/com.ibm.wala.cast.python.test/data/tf2_test_scipy_sparse_dot.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_scipy_sparse_dot.py
@@ -1,0 +1,20 @@
+# Test the scipy.sparse matrix product (wala/ML#766). The row-normalization idiom from NLPGNN's
+# Planetoid loader: the product of a SciPy sparse matrix and a dense float32 array is a dense
+# float32 array.
+
+import numpy as np
+import scipy.sparse as sp
+
+
+def consume(features):
+    pass
+
+
+features = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+rowsum = np.array(features.sum(1))
+r_inv = np.power(rowsum, -1).flatten()
+r_mat_inv = sp.diags(r_inv)
+features = r_mat_inv.dot(features)
+assert features.shape == (2, 2)
+assert features.dtype == np.float32
+consume(features)


### PR DESCRIPTION
Closes wala/ML#766.

## Diagnosis

The eight missing NLPGNN inferences (the GAAE/GAT/GCN families' `node_embeddings`) share one feed: every driver unpacks `features` from `Planetoid.load()` (`nlpgnn/datas/graphloader.py`), which builds `features = np.array(features.todense(), dtype=np.float32)` and then, under `if self.norm:`, reassigns `features = self.feature_normalize(features)`. With `norm=True` constant at every `Planetoid` site, `computePhiArmFeasibility` proves the un-normalized arm of the resulting φ infeasible in all three driver contexts, so the wala/ML#763 dead-arm suppression correctly cuts the only typed member (the `np.array` result, `? of float32`). The surviving arm, `feature_normalize`'s return `sp.diags(r_inv).dot(features)`, was an unmodeled SciPy chain typing to ⊥, so nothing reached the `call` parameters in either configuration. (The pre-0.52.37 delivery was the wala/ML#765 leak; this is the principled replacement. The in-suite no-calling-contexts observation recorded on the issue did not reproduce: `GCNLayer.call` dispatches fine, and the flow-graph path from the loader to the parameters is intact up to exactly this φ.)

## Fix

Type the normalization product itself:

- **`scipy.xml`** (new, loaded between `numpy.xml` and `tensorflow.xml`): the `scipy.sparse` submodule object with `diags`, whose result carries a `dot` method field, per the class-per-function pattern; the product allocates a `numpy/ndarray`.
- **`SparseMatrixDot`** (registered in both dispatch tables): dtype follows the dense operand, with a `DTYPE_ONLY` type feed for dataflow-carried operands (wala/ML#736); the shape composes the sparse operand's row extent, a fixed runtime integer the analysis cannot compute (`UnresolvedDim`, wala/ML#721), with the dense operand's trailing extent when it resolves.
- **wala/ML#451 gate**: a `scipy/sparse/spmatrix` allocation is excluded from binop tensor evidence, mirroring the `list`/`tuple` exclusions. Binops over sparse matrices are sparse-matrix algebra; without this, the vendored Cora subject's `graph.T - sp.diags(...)` seeded an elementwise op and a `TENSORFLOW`-origin local broke the wala/ML#726 decline contract.

The rank residual (recovering 2-D evidence through `todense` so the parameters improve from shape-⊤ to `(Unresolved, Unresolved)`) is filed as wala/ML#768 and marked as a TODO on the new corpus guard.

## Consumer Witness

Reference-configuration NLPGNN run against the probe build (bundled `cast.python.ml` version verified in the product's `plugins/` before trusting the run): the `statuses.csv` rows `Used tensor type analysis to infer tensor type for parameter: node_embeddings` go 9 to 17, restoring exactly the GAAE/GAT/GCN set, and `parameters.csv` reports `GCNLayer.call` parameter 1 `tensor=true` with `FLOAT32[TOP]`. Subject wall 58.9s vs 52.5s on 0.52.50, consistent with eight more typed parameters flowing into downstream inference. The verified run seeds the wala/ML#767 baseline.

Transformer-pin witness: `TestNlpgnnTransformer` green on four consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX

