### PR TITLE
Chase dead library-default field writes to the flow-refined constant

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1363,6 +1363,32 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * Distilled guard for the dead library-default field write (<a
+   * href="https://github.com/wala/ML/issues/769">wala/ML#769</a>): the factory writes {@code
+   * batch_size = 10; maxlen = 100} into the holder and the driver overwrites both before any read,
+   * so the iterator elements are {@code (2, 10)} and never a default-times-override product ({@code
+   * (10, 100)}, {@code (2, 100)}, {@code (10, 10)}). The flow-sensitive store chase resolves the
+   * shape-argument element and the batch size to the same-body overrides.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDeadDefaultFieldStore()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"deadstore_proj/lib.py", "deadstore_proj/driver.py"},
+        "driver.py",
+        "consume",
+        "deadstore_proj",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(10))))));
+  }
+
+  /**
    * Pins wala/ML#665: {@code tf} reached through {@code from helpers import *} binds, matching
    * Python's wildcard semantics (every public module-level name is exported, including modules the
    * source module imported).

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1389,6 +1389,39 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * The decline direction of {@link #testDeadDefaultFieldStore()} (<a
+   * href="https://github.com/wala/ML/issues/769">wala/ML#769</a>): two disagreeing same-body
+   * overrides make the chase decline, so the element keeps the points-to union of the factory
+   * default and both overrides, batched to one member per surviving size. The runtime value is the
+   * later store's {@code (2, 30)}; the union is the documented conservative degradation.
+   *
+   * <p>TODO: An order-aware same-body chase could pick the dominating later store; see <a
+   * href="https://github.com/wala/ML/issues/769">wala/ML#769</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDeadDefaultFieldStoreConflict()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"deadstore_proj/lib.py", "deadstore_proj/driver_conflict.py"},
+        "driver_conflict.py",
+        "consume",
+        "deadstore_proj",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(100))),
+                new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(20))),
+                new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(30))))));
+  }
+
+  /**
    * Pins wala/ML#665: {@code tf} reached through {@code from helpers import *} binds, matching
    * Python's wildcard semantics (every public module-level name is exported, including modules the
    * source module imported).

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetBatchGenerator.java
@@ -126,6 +126,16 @@ public class DatasetBatchGenerator extends DatasetGenerator {
     // an unspecified batch size (the symbolic-batching path below).
     if (batchSizes == null) batchSizes = Collections.emptySet();
 
+    // A multi-valued batch size is commonly a dead library default unioned with the live caller
+    // override (wala/ML#769); the flow-refined argument is the one that holds at the call, and a
+    // declined refinement keeps the union.
+    if (batchSizes.size() > 1) {
+      Integer refined =
+          this.refineArgumentIntFlowSensitively(
+              builder, Parameters.BATCH_SIZE.getIndex(), Parameters.BATCH_SIZE.getName());
+      if (refined != null) batchSizes = Collections.singleton(refined.longValue());
+    }
+
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
 
     Set<Long> datasetSizes = this.getDatasetSizes(builder);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -639,6 +639,24 @@ public abstract class TensorGenerator {
             }
           }
 
+          // A multi-constant element is commonly a dead library default unioned with the live
+          // caller override (wala/ML#769); the same-body store's flow-refined value is the one
+          // that holds at the read, and a declined refinement keeps the union.
+          if (tensorDimensions.size() > 1) {
+            Integer refined = refineAmbiguousFieldConstant(builder, asin, fieldIndex);
+            if (refined != null) {
+              LOGGER.fine(
+                  () ->
+                      "Refined ambiguous shape element "
+                          + tensorDimensions
+                          + " to "
+                          + refined
+                          + " via the flow-sensitive store chase (wala/ML#769).");
+              tensorDimensions.clear();
+              tensorDimensions.add(new NumericDim(refined));
+            }
+          }
+
           LOGGER.fine(
               "Found possible shape dimensions: "
                   + tensorDimensions
@@ -1481,6 +1499,389 @@ public abstract class TensorGenerator {
       found = stored;
     }
     return found;
+  }
+
+  /**
+   * Ceiling on the flow-sensitive constant resolution's recursion depth (wala/ML#769). The chase
+   * crosses a handful of hops in practice (a same-body store, a receiver-matched constructor write,
+   * and the constructor chain's argument forwarding); the cap bounds pathological chains.
+   */
+  private static final int FLOW_SENSITIVE_CONSTANT_DEPTH_CAP = 8;
+
+  /**
+   * Resolves a value to the integer constant that holds at its read, preferring flow-refined stores
+   * over the flow-insensitive points-to union (wala/ML#769). A library factory commonly writes a
+   * default into a holder field that the caller immediately overwrites (NLPGNN's {@code
+   * load_bert_param} defaults against the drivers' {@code param.maxlen} overrides), so the field's
+   * points-to set unions the dead default with the live override, and every shape composed from the
+   * union pairs values that co-occur at runtime nowhere. The resolution extends the wala/ML#717
+   * contract chase's assumption &mdash; the same-body write is the one that holds at the read
+   * &mdash; across the receiver and constructor hops:
+   *
+   * <ul>
+   *   <li>a symbol-table constant resolves directly;
+   *   <li>a non-{@code self} attribute read chases the same-body writes ({@link
+   *       #resolveLocalObjectAttributeDim}'s criterion), recursing on the stored value;
+   *   <li>a {@code self} attribute read chases the writes across the receiver class's method
+   *       bodies, restricted to bodies whose {@code self} may alias the read's receiver instance
+   *       (so sibling instances' constructors do not conflict), recursing on each stored value;
+   *   <li>a parameter resolves through every caller invoke's argument, all of which must agree;
+   *   <li>otherwise a singleton constant in the points-to set resolves, and anything else declines.
+   * </ul>
+   *
+   * <p>Every multi-candidate step declines on disagreement rather than unioning, so the refinement
+   * never invents a value: a {@code null} result leaves the caller on today's points-to-union
+   * behavior.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR defines {@code vn}.
+   * @param vn The value number to resolve.
+   * @param visited The {@code (node, vn)} pairs already on this chase, breaking cycles.
+   * @param depth The remaining recursion budget.
+   * @return The flow-refined integer constant, or {@code null} when the chase declines.
+   */
+  static Integer resolveIntFlowSensitively(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int vn,
+      Set<Pair<CGNode, Integer>> visited,
+      int depth) {
+    if (vn <= 0 || depth <= 0 || node.getIR() == null || node.getDU() == null) return null;
+    if (!visited.add(Pair.make(node, vn))) return null;
+    SymbolTable st = node.getIR().getSymbolTable();
+    if (st.isNumberConstant(vn)) return intProjectionOrNull((Number) st.getConstantValue(vn));
+
+    SSAInstruction def = node.getDU().getDef(vn);
+
+    if (def instanceof PythonPropertyRead) {
+      PythonPropertyRead read = (PythonPropertyRead) def;
+      int memberVn = read.getMemberRef();
+      if (!st.isStringConstant(memberVn)) return null;
+      String attributeName = st.getStringValue(memberVn);
+      int objectVn = read.getObjectRef();
+
+      if (node.getMethod().getNumberOfParameters() >= 2 && objectVn == node.getIR().getParameter(1))
+        return resolveSelfAttributeIntFlowSensitively(
+            builder, node, objectVn, attributeName, visited, depth);
+
+      Integer viaObject =
+          resolveObjectAttributeIntFlowSensitively(
+              builder, node, objectVn, attributeName, visited, depth);
+      if (viaObject != null) return viaObject;
+      // No chased write resolved: fall through to the points-to fallback below.
+    }
+
+    if (def == null) {
+      // A parameter: resolve through every caller invoke's argument; all must agree.
+      int paramPos = -1;
+      for (int i = 0; i < node.getIR().getNumberOfParameters(); i++)
+        if (node.getIR().getParameter(i) == vn) {
+          paramPos = node.getMethod().isStatic() ? i : i - 1;
+          break;
+        }
+      if (paramPos >= 0) {
+        Integer agreed = null;
+        boolean any = false;
+        for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+            getCallerInvokes(builder, node)) {
+          SSAAbstractInvokeInstruction call = callerInvoke.snd;
+          int argVn = -1;
+          if (call instanceof PythonInvokeInstruction) {
+            if (paramPos + 1 < call.getNumberOfUses()) argVn = call.getUse(paramPos + 1);
+          } else if (paramPos < call.getNumberOfUses()) argVn = call.getUse(paramPos);
+          if (argVn <= 0) return null;
+          Integer viaCaller =
+              resolveIntFlowSensitively(builder, callerInvoke.fst, argVn, visited, depth - 1);
+          if (viaCaller == null) return null;
+          if (agreed != null && !agreed.equals(viaCaller)) return null; // Disagreeing callers.
+          agreed = viaCaller;
+          any = true;
+        }
+        if (any) return agreed;
+      }
+      return null;
+    }
+
+    PointerKey pk = builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+    if (pk == null || builder.getPropagationSystem().isImplicit(pk)) return null;
+    OrdinalSet<InstanceKey> pts = builder.getPointerAnalysis().getPointsToSet(pk);
+    if (pts == null || pts.size() != 1) return null;
+    InstanceKey only = pts.iterator().next();
+    if (!(only instanceof ConstantKey) || !(((ConstantKey<?>) only).getValue() instanceof Number))
+      return null;
+    return intProjectionOrNull((Number) ((ConstantKey<?>) only).getValue());
+  }
+
+  /**
+   * The {@code self}-attribute arm of {@link #resolveIntFlowSensitively}: chases the attribute's
+   * writes across the receiver class's method-body nodes, keeping only bodies whose {@code self}
+   * may alias the read's receiver instance, so a per-context constructor's write resolves for its
+   * own receiver without conflicting with sibling instances' values.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR contains the read.
+   * @param objectVn The read's {@code self} value number.
+   * @param attributeName The attribute being read.
+   * @param visited The {@code (node, vn)} pairs already on this chase.
+   * @param depth The remaining recursion budget.
+   * @return The flow-refined constant, or {@code null} when the chase declines.
+   */
+  private static Integer resolveSelfAttributeIntFlowSensitively(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int objectVn,
+      String attributeName,
+      Set<Pair<CGNode, Integer>> visited,
+      int depth) {
+    PointerKey selfPk =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, objectVn);
+    Integer agreed = null;
+    boolean any = false;
+    for (InstanceKey ik : builder.getPointerAnalysis().getPointsToSet(selfPk)) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin == null) return null;
+      String classPrefix =
+          asin.getNode().getMethod().getDeclaringClass().getReference().getName().toString() + "/";
+      Integer perInstance = null;
+      for (CGNode candidate : builder.getCallGraph()) {
+        if (candidate.getIR() == null || candidate.getDU() == null) continue;
+        IMethod method = candidate.getMethod();
+        if (!(method instanceof AstMethod)) continue;
+        if (!method.getDeclaringClass().getReference().getName().toString().startsWith(classPrefix))
+          continue;
+        if (method.getNumberOfParameters() < 2) continue;
+        int selfVn = candidate.getIR().getParameter(1);
+        // Receiver matching: only bodies whose `self` may alias the read's instance write it.
+        boolean aliases = false;
+        for (InstanceKey writerSelf :
+            builder
+                .getPointerAnalysis()
+                .getPointsToSet(
+                    builder
+                        .getPointerAnalysis()
+                        .getHeapModel()
+                        .getPointerKeyForLocal(candidate, selfVn)))
+          if (writerSelf.equals(ik)) {
+            aliases = true;
+            break;
+          }
+        if (!aliases) continue;
+        SymbolTable candidateSt = candidate.getIR().getSymbolTable();
+        for (SSAInstruction inst : candidate.getIR().getInstructions()) {
+          if (!(inst instanceof PythonPropertyWrite)) continue;
+          PythonPropertyWrite write = (PythonPropertyWrite) inst;
+          int memberVn = write.getMemberRef();
+          if (write.getObjectRef() != selfVn
+              || !candidateSt.isStringConstant(memberVn)
+              || !attributeName.equals(candidateSt.getStringValue(memberVn))) continue;
+          Integer stored =
+              resolveIntFlowSensitively(builder, candidate, write.getValue(), visited, depth - 1);
+          if (stored == null) return null; // An unresolvable write declines the attribute.
+          if (perInstance != null && !perInstance.equals(stored)) return null; // Conflict.
+          perInstance = stored;
+        }
+      }
+      if (perInstance == null) return null;
+      if (agreed != null && !agreed.equals(perInstance)) return null; // Conflicting receivers.
+      agreed = perInstance;
+      any = true;
+    }
+    return any ? agreed : null;
+  }
+
+  /**
+   * The non-{@code self} arm of {@link #resolveIntFlowSensitively}: chases the attribute's writes
+   * on the given local object within the same code body ({@link #resolveLocalObjectAttributeDim}'s
+   * criterion), and when the body holds no write and the object is itself a parameter, hops to each
+   * caller's argument and retries there (the constructor idiom {@code self.batch_size =
+   * param.batch_size}, whose override write lives in the constructing driver's body), all callers
+   * agreeing.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR contains the read.
+   * @param objectVn The read's object value number.
+   * @param attributeName The attribute being read.
+   * @param visited The {@code (node, vn)} pairs already on this chase.
+   * @param depth The remaining recursion budget.
+   * @return The flow-refined constant, or {@code null} when no chased write resolves or distinct
+   *     writes disagree.
+   */
+  private static Integer resolveObjectAttributeIntFlowSensitively(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int objectVn,
+      String attributeName,
+      Set<Pair<CGNode, Integer>> visited,
+      int depth) {
+    if (depth <= 0 || node.getIR() == null || node.getDU() == null) return null;
+    Integer sameBody =
+        resolveSameBodyStoreInt(builder, node, objectVn, attributeName, visited, depth);
+    if (sameBody != null) return sameBody;
+
+    // The object is a parameter: the write may live in the frame the object came from.
+    int paramPos = -1;
+    if (node.getDU().getDef(objectVn) == null)
+      for (int i = 0; i < node.getIR().getNumberOfParameters(); i++)
+        if (node.getIR().getParameter(i) == objectVn) {
+          paramPos = node.getMethod().isStatic() ? i : i - 1;
+          break;
+        }
+    if (paramPos < 0) return null;
+    if (!visited.add(Pair.make(node, -objectVn))) return null; // Object-hop cycle break.
+    Integer agreed = null;
+    boolean any = false;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, node)) {
+      SSAAbstractInvokeInstruction call = callerInvoke.snd;
+      int argVn = -1;
+      if (call instanceof PythonInvokeInstruction) {
+        if (paramPos + 1 < call.getNumberOfUses()) argVn = call.getUse(paramPos + 1);
+      } else if (paramPos < call.getNumberOfUses()) argVn = call.getUse(paramPos);
+      if (argVn <= 0) return null;
+      Integer viaCaller =
+          resolveObjectAttributeIntFlowSensitively(
+              builder, callerInvoke.fst, argVn, attributeName, visited, depth - 1);
+      if (viaCaller == null) return null;
+      if (agreed != null && !agreed.equals(viaCaller)) return null; // Disagreeing callers.
+      agreed = viaCaller;
+      any = true;
+    }
+    return any ? agreed : null;
+  }
+
+  /**
+   * The same-body leg of {@link #resolveObjectAttributeIntFlowSensitively}: chases the attribute's
+   * writes on the given local object within one code body, recursing on each stored value.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param node The {@link CGNode} whose IR contains the read and the chased writes.
+   * @param objectVn The read's object value number.
+   * @param attributeName The attribute being read.
+   * @param visited The {@code (node, vn)} pairs already on this chase.
+   * @param depth The remaining recursion budget.
+   * @return The flow-refined constant, or {@code null} when no same-body write resolves or distinct
+   *     writes disagree.
+   */
+  private static Integer resolveSameBodyStoreInt(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int objectVn,
+      String attributeName,
+      Set<Pair<CGNode, Integer>> visited,
+      int depth) {
+    SymbolTable st = node.getIR().getSymbolTable();
+    Integer found = null;
+    for (Iterator<SSAInstruction> uses = node.getDU().getUses(objectVn); uses.hasNext(); ) {
+      SSAInstruction use = uses.next();
+      if (!(use instanceof PythonPropertyWrite)) continue;
+      PythonPropertyWrite write = (PythonPropertyWrite) use;
+      int memberVn = write.getMemberRef();
+      if (write.getObjectRef() != objectVn
+          || !st.isStringConstant(memberVn)
+          || !attributeName.equals(st.getStringValue(memberVn))) continue;
+      Integer stored =
+          resolveIntFlowSensitively(builder, node, write.getValue(), visited, depth - 1);
+      if (stored == null) return null; // An unresolvable write makes the attribute unresolvable.
+      if (found != null && !found.equals(stored)) return null; // Conflicting writes.
+      found = stored;
+    }
+    return found;
+  }
+
+  /**
+   * Refines a container field whose points-to set unions multiple constants to the single constant
+   * its same-body store holds (wala/ML#769): finds the store into the container's field within the
+   * allocating node and resolves the stored value via {@link #resolveIntFlowSensitively}. The
+   * dead-default class this serves stores exactly once per container (a shape-literal element), so
+   * multiple agreeing stores resolve and disagreeing ones decline.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param asin The container's allocation site.
+   * @param fieldIndex The element index being read.
+   * @return The flow-refined constant, or {@code null} when the chase declines.
+   */
+  private static Integer refineAmbiguousFieldConstant(
+      PropagationCallGraphBuilder builder, AllocationSiteInNode asin, int fieldIndex) {
+    CGNode node = asin.getNode();
+    if (node.getIR() == null || node.getDU() == null) return null;
+    int allocVn = findDefinition(node, asin);
+    if (allocVn <= 0) return null;
+    SymbolTable st = node.getIR().getSymbolTable();
+    Integer found = null;
+    for (Iterator<SSAInstruction> uses = node.getDU().getUses(allocVn); uses.hasNext(); ) {
+      SSAInstruction use = uses.next();
+      if (!(use instanceof PythonPropertyWrite)) continue;
+      PythonPropertyWrite write = (PythonPropertyWrite) use;
+      int memberVn = write.getMemberRef();
+      if (write.getObjectRef() != allocVn || !st.isConstant(memberVn)) continue;
+      Object member = st.getConstantValue(memberVn);
+      if (member == null || !String.valueOf(fieldIndex).equals(String.valueOf(member))) continue;
+      Integer stored =
+          resolveIntFlowSensitively(
+              builder,
+              node,
+              write.getValue(),
+              HashSetFactory.make(),
+              FLOW_SENSITIVE_CONSTANT_DEPTH_CAP);
+      if (stored == null) return null;
+      if (found != null && !found.equals(stored)) return null;
+      found = stored;
+    }
+    return found;
+  }
+
+  /**
+   * Refines an ambiguous scalar argument of this generator's call to the flow-sensitive constant
+   * that holds at the call (wala/ML#769): resolves the argument's value number through {@link
+   * #resolveIntFlowSensitively} at the anchoring invoke, or, for a manual anchor, through every
+   * caller invoke, all of which must agree. A {@code null} result leaves the caller on the
+   * points-to union.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used for call graph and PA lookup.
+   * @param paramPos The argument's positional index (excluding {@code self}).
+   * @param paramName The argument's keyword name, or {@code null}.
+   * @return The flow-refined constant, or {@code null} when the chase declines.
+   */
+  protected Integer refineArgumentIntFlowSensitively(
+      PropagationCallGraphBuilder builder, int paramPos, String paramName) {
+    PythonInvokeInstruction call = this.getInvokeInstruction();
+    if (call != null) {
+      int argVn = paramName != null ? call.getUse(paramName) : -1;
+      if (argVn == -1 && paramPos >= 0) {
+        int numKeywords = call.getKeywords() != null ? call.getKeywords().size() : 0;
+        int numPosParams = call.getNumberOfUses() - 1 - numKeywords;
+        if (paramPos < numPosParams) argVn = call.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) return null;
+      return resolveIntFlowSensitively(
+          builder, this.getNode(), argVn, HashSetFactory.make(), FLOW_SENSITIVE_CONSTANT_DEPTH_CAP);
+    }
+    Integer agreed = null;
+    boolean any = false;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) return null;
+      PythonInvokeInstruction callerCall = (PythonInvokeInstruction) callerInvoke.snd;
+      int argVn = paramName != null ? callerCall.getUse(paramName) : -1;
+      if (argVn == -1 && paramPos >= 0) {
+        int numKeywords = callerCall.getKeywords() != null ? callerCall.getKeywords().size() : 0;
+        int numPosParams = callerCall.getNumberOfUses() - 1 - numKeywords;
+        if (paramPos < numPosParams) argVn = callerCall.getUse(paramPos + 1);
+      }
+      if (argVn <= 0) return null;
+      Integer viaCaller =
+          resolveIntFlowSensitively(
+              builder,
+              callerInvoke.fst,
+              argVn,
+              HashSetFactory.make(),
+              FLOW_SENSITIVE_CONSTANT_DEPTH_CAP);
+      if (viaCaller == null) return null;
+      if (agreed != null && !agreed.equals(viaCaller)) return null;
+      agreed = viaCaller;
+      any = true;
+    }
+    return any ? agreed : null;
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/deadstore_proj/driver.py
+++ b/com.ibm.wala.cast.python.test/data/deadstore_proj/driver.py
@@ -1,0 +1,22 @@
+# Test the dead library-default field write (wala/ML#769): the factory defaults are overwritten
+# before any read, so the iterator elements are (2, 10), never a default-times-override product.
+
+import tensorflow as tf
+from lib import make_param
+
+
+def consume(x):
+    pass
+
+
+param = make_param()
+param.batch_size = 2
+param.maxlen = 10
+
+dataset = tf.data.Dataset.from_tensor_slices(tf.ones((6, param.maxlen))).batch(
+    batch_size=param.batch_size, drop_remainder=True
+)
+for x in dataset:
+    assert x.shape == (2, 10)
+    assert x.dtype == tf.float32
+    consume(x)

--- a/com.ibm.wala.cast.python.test/data/deadstore_proj/driver_conflict.py
+++ b/com.ibm.wala.cast.python.test/data/deadstore_proj/driver_conflict.py
@@ -1,0 +1,23 @@
+# Companion to driver.py (wala/ML#769): two disagreeing same-body overrides make the chase
+# decline, so the analysis keeps the points-to union rather than picking either store. At
+# runtime the later store wins; the union is the documented conservative degradation.
+
+import tensorflow as tf
+from lib import make_param
+
+
+def consume(x):
+    pass
+
+
+param = make_param()
+param.maxlen = 20
+param.maxlen = 30
+
+dataset = tf.data.Dataset.from_tensor_slices(tf.ones((6, param.maxlen))).batch(
+    batch_size=2, drop_remainder=True
+)
+for x in dataset:
+    assert x.shape == (2, 30)
+    assert x.dtype == tf.float32
+    consume(x)

--- a/com.ibm.wala.cast.python.test/data/deadstore_proj/lib.py
+++ b/com.ibm.wala.cast.python.test/data/deadstore_proj/lib.py
@@ -1,0 +1,12 @@
+# The factory writes library defaults that the caller overwrites (wala/ML#769).
+
+
+class Holder:
+    pass
+
+
+def make_param():
+    p = Holder()
+    p.batch_size = 10
+    p.maxlen = 100
+    return p


### PR DESCRIPTION
Advances wala/ML#769.

## Diagnosis

`LoadCheckpoint.load_bert_param` writes library defaults (`bert_param.batch_size = 10; bert_param.maxlen = 100`) that every BERT-family driver immediately overwrites. The pointer analysis is flow-insensitive on fields, so each driver's `param` fields read `{default, override}`, and every downstream shape composition pairs the axes: the vendored NLPGNN settles 493 context-level states whose member sets contain default-times-override products that exist at runtime nowhere (`(2, 100)`, `(10, 10)` in a driver whose contract is `(2, 10)`), pervading the drivers, their shared metric calls, and the dataset element seeds.

## Fix

A flow-sensitive constant resolution (`resolveIntFlowSensitively`) extending the wala/ML#717 contract chase's assumption, that the same-body write is the one that holds at the read, across the receiver and constructor hops: same-body stores, receiver-matched class-body writes (so sibling instances' constructors do not conflict), an object-origin hop to the constructing frame for parameter-held objects (the `self.batch_size = param.batch_size` idiom, whose override lives in the driver's body), and caller-argument agreement. Every arm declines on disagreement, so the refinement never invents a value and a declined chase keeps today's points-to-union behavior. Wired at the two ambiguity points that mint the products: a multi-constant shape-argument element (`getShapesFromShapeArgument`) and a multi-valued `Dataset.batch` size (`applyBatching`).

The vendored NLPGNN mixing census drops 493 to 98; the residue reads the holder through an attribute-of-attribute hop (`self.param.label_size`, the CRF chain) and stays a follow-up arm on the issue, which is why this advances rather than closes it.

## Consumer Witness

Six-subject reference-configuration run against the probe build (bundled version and class markers verified): `statuses.csv` is identical to the baseline for all six subjects, and `parameters.csv` changes are 37 paired row replacements, all in NLPGNN, each a strict tightening. Example: `SparseAccuracy.__call__`'s `y_predict` drops from 18 members to 10, keeping exactly the real per-driver triples (`(2, 10, *)`, `(6, 128, *)`, `(8, 100, *)`) and losing only impossible members. The baseline fold follows the release carrying this change, citing wala/ML#769 as the losses' disposition per the wala/ML#767 protocol.

The distilled two-file fixture (`deadstore_proj`) pins the corrected `(2, 10)` element end to end; the transformer-pin witness is green on four consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
