### PR TITLE
Chase the dead default through the `Dense` units field

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1422,6 +1422,32 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * The {@code Dense}-units face of {@link #testDeadDefaultFieldStore()} (<a
+   * href="https://github.com/wala/ML/issues/769">wala/ML#769</a>): the factory default reaches the
+   * layer width through a stored attribute ({@code self.width = param.maxlen}; {@code
+   * Dense(self.width)}), so the instance's units field unions the dead default with the live
+   * override, and the flow-sensitive constructor-argument chase resolves the width to the override
+   * alone.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDeadDefaultDenseUnits()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"deadstore_proj/lib.py", "deadstore_proj/driver_dense.py"},
+        "driver_dense.py",
+        "consume",
+        "deadstore_proj",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(FLOAT_32, asList(new NumericDim(2), new NumericDim(10))))));
+  }
+
+  /**
    * Pins wala/ML#665: {@code tf} reached through {@code from helpers import *} binds, matching
    * Python's wildcard semantics (every public module-level name is exported, including modules the
    * source module imported).

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -154,6 +154,25 @@ public class DenseCall extends TensorGenerator {
           LOGGER.finer(
               "Possible `units` values: " + unitValues + " for points-to set: " + unitsPTS + ".");
 
+          // A multi-valued field is commonly a dead library default unioned with the live
+          // override reaching the constructor argument (wala/ML#769); the flow-refined
+          // constructor argument is the value that holds for this instance, and a declined
+          // refinement keeps the union.
+          if (unitValues != null && unitValues.size() > 1) {
+            CGNode constructorNode = selfASIN.getNode();
+            if (constructorNode.getIR() != null
+                && constructorNode.getIR().getNumberOfParameters() > 1) {
+              Integer refined =
+                  TensorGenerator.resolveIntFlowSensitively(
+                      builder,
+                      constructorNode,
+                      constructorNode.getIR().getParameter(1),
+                      HashSetFactory.make(),
+                      FLOW_SENSITIVE_CONSTANT_DEPTH_CAP);
+              if (refined != null) unitValues = Set.of(refined.longValue());
+            }
+          }
+
           // A null result means `units` is not statically resolvable (wala/ML#669); skip it
           // rather than crashing or claiming a partial value.
           if (unitValues != null) ret.addAll(unitValues);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -1506,7 +1506,7 @@ public abstract class TensorGenerator {
    * crosses a handful of hops in practice (a same-body store, a receiver-matched constructor write,
    * and the constructor chain's argument forwarding); the cap bounds pathological chains.
    */
-  private static final int FLOW_SENSITIVE_CONSTANT_DEPTH_CAP = 8;
+  static final int FLOW_SENSITIVE_CONSTANT_DEPTH_CAP = 8;
 
   /**
    * Resolves a value to the integer constant that holds at its read, preferring flow-refined stores

--- a/com.ibm.wala.cast.python.test/data/deadstore_proj/driver_dense.py
+++ b/com.ibm.wala.cast.python.test/data/deadstore_proj/driver_dense.py
@@ -1,0 +1,32 @@
+# The Dense-units face of wala/ML#769: the factory default flows into the layer width through a
+# stored attribute (`self.width = param.maxlen`; `Dense(self.width)`), so the units field unions
+# the dead default with the live override without the flow-sensitive constructor-argument chase.
+
+import tensorflow as tf
+from lib import make_param
+
+
+def consume(x):
+    pass
+
+
+param = make_param()
+param.maxlen = 10
+param.batch_size = 2
+
+
+class Model(tf.keras.Model):
+    def __init__(self, param):
+        super(Model, self).__init__()
+        self.width = param.maxlen
+        self.dense = tf.keras.layers.Dense(self.width)
+
+    def call(self, inputs):
+        return self.dense(inputs)
+
+
+model = Model(param)
+y = model(tf.ones((2, 4)))
+assert y.shape == (2, 10)
+assert y.dtype == tf.float32
+consume(y)


### PR DESCRIPTION
Advances wala/ML#769.

The remaining arm: the factory default reaches a layer width through a stored attribute (`self.label_size = param.label_size`; `Dense(self.label_size)`), so the `Dense` instance's units field unions the dead default with the live override and the layer's output dimension forks, feeding the CRF chain (`num_tags = input_shape[2]`) both label counts. Refine a multi-valued units field to the flow-sensitive constructor argument via the wala/ML#769 chase, declining on disagreement as everywhere else.

Measured: the vendored NLPGNN mixing census drops 98 to 46, and the residue no longer matches the dead-default signature (legitimate multi-value unions at genuinely polymorphic sites, plus one unrelated `(0, 1)` oddity). The distilled `testDeadDefaultDenseUnits` pins the corrected `(2, 10)` output end to end. Suite green with zero pin churn; transformer-pin witness green on four consecutive runs.

Consumer witness (probe build, bundled version and class markers verified): `statuses.csv` identical for all six subjects, `parameters.csv` changes are 20 paired row replacements, all NLPGNN, each a strict tightening in the CRF and metric family (e.g. `crf_forward`'s `state` loses the dead label-default `(*, 2)` and batch-default `(10, *)` members, keeping the real `(8, 46)`/`(16, 46)` family). The baseline fold follows the release carrying this change, citing wala/ML#769 per the wala/ML#767 protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
