### PR TITLE
Recover rank through the SciPy densification chain

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -6,7 +6,6 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_5_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_3_FLOAT32;
-import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.UNKNOWN;
 import static java.util.Arrays.asList;
@@ -526,13 +525,11 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * row-normalized features. With {@code norm=True} constant at every {@code Planetoid} site, the
    * wala/ML#763 φ-arm suppression correctly cuts the un-normalized {@code np.array} arm, so the
    * parameter's type must arrive through the normalization itself: {@code
-   * sp.diags(r_inv).dot(features)}, typed by the SciPy sparse product modeling ({@code scipy.xml}
-   * plus {@code SparseMatrixDot}) as {@code ? of float32}: dtype from the dense operand, shape
-   * unknown because the dense operand's extents are pickle-loaded data.
-   *
-   * <p>TODO: The shape should improve to {@code (Unresolved, Unresolved)} once rank flows through
-   * the dense-ification chain ({@code todense}); see <a
-   * href="https://github.com/wala/ML/issues/768">wala/ML#768</a>.
+   * sp.diags(r_inv).dot(features)}, typed by the SciPy sparse modeling ({@code scipy.xml} plus
+   * {@code SparseMatrixDot} and {@code SparseDensify}) as {@code (Unresolved, Unresolved) of
+   * float32}: dtype from the dense operand, rank 2 through the densification chain ({@code
+   * vstack}/{@code tolil}/{@code todense}, wala/ML#768; a SciPy sparse matrix is two-dimensional by
+   * construction), and both extents pickle-loaded data the analysis cannot compute.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -549,7 +546,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         "nlpgnn_full_proj",
         1,
         5,
-        Map.of(3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)))));
   }
 
   /**
@@ -573,7 +573,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         "nlpgnn_full_proj",
         1,
         3,
-        Map.of(3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)))));
   }
 
   /**
@@ -597,7 +600,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         "nlpgnn_full_proj",
         1,
         3,
-        Map.of(3, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+        Map.of(
+            3,
+            Set.of(
+                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/scipy.xml
+++ b/com.ibm.wala.cast.python.ml/data/scipy.xml
@@ -9,6 +9,8 @@
         <putfield class="LRoot" field="sparse" fieldType="LRoot" ref="x" value="sparse"/>
         <new def="diags_fn" class="Lscipy/sparse/diags"/>
         <putfield class="LRoot" field="diags" fieldType="LRoot" ref="sparse" value="diags_fn"/>
+        <new def="vstack_fn" class="Lscipy/sparse/vstack"/>
+        <putfield class="LRoot" field="vstack" fieldType="LRoot" ref="sparse" value="vstack_fn"/>
         <return value="x"/>
       </method>
     </class>
@@ -24,6 +26,24 @@
           <new def="ret" class="Lscipy/sparse/spmatrix"/>
           <new def="dot_fn" class="Lscipy/sparse/spmatrix/dot"/>
           <putfield class="LRoot" field="dot" fieldType="LRoot" ref="ret" value="dot_fn"/>
+          <new def="tolil_fn" class="Lscipy/sparse/spmatrix/tolil"/>
+          <putfield class="LRoot" field="tolil" fieldType="LRoot" ref="ret" value="tolil_fn"/>
+          <new def="todense_fn" class="Lscipy/sparse/spmatrix/todense"/>
+          <putfield class="LRoot" field="todense" fieldType="LRoot" ref="ret" value="todense_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.vstack.html -->
+      <!-- Modeled as a class-per-function (same pattern as `diags`); the stacked result is a sparse matrix carrying the same method fields. -->
+      <class name="vstack" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self blocks format">
+          <new def="ret" class="Lscipy/sparse/spmatrix"/>
+          <new def="dot_fn" class="Lscipy/sparse/spmatrix/dot"/>
+          <putfield class="LRoot" field="dot" fieldType="LRoot" ref="ret" value="dot_fn"/>
+          <new def="tolil_fn" class="Lscipy/sparse/spmatrix/tolil"/>
+          <putfield class="LRoot" field="tolil" fieldType="LRoot" ref="ret" value="tolil_fn"/>
+          <new def="todense_fn" class="Lscipy/sparse/spmatrix/todense"/>
+          <putfield class="LRoot" field="todense" fieldType="LRoot" ref="ret" value="todense_fn"/>
           <return value="ret"/>
         </method>
       </class>
@@ -31,6 +51,32 @@
       <class name="spmatrix" allocatable="true"></class>
     </package>
     <package name="scipy/sparse/spmatrix">
+      <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.tolil.html -->
+      <!-- Format conversion: still a sparse matrix, so the result carries the same method fields. -->
+      <class name="tolil" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Lscipy/sparse/spmatrix"/>
+          <new def="dot_fn" class="Lscipy/sparse/spmatrix/dot"/>
+          <putfield class="LRoot" field="dot" fieldType="LRoot" ref="ret" value="dot_fn"/>
+          <new def="tolil_fn" class="Lscipy/sparse/spmatrix/tolil"/>
+          <putfield class="LRoot" field="tolil" fieldType="LRoot" ref="ret" value="tolil_fn"/>
+          <new def="todense_fn" class="Lscipy/sparse/spmatrix/todense"/>
+          <putfield class="LRoot" field="todense" fieldType="LRoot" ref="ret" value="todense_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.todense.html -->
+      <!-- Densification: a SciPy sparse matrix is two-dimensional by construction, so the dense result is rank-2 with extents the analysis cannot compute; see `SparseDensify` (wala/ML#768). -->
+      <class name="todense" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
       <!-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.dot.html -->
       <!-- Modeled as a class-per-function (same pattern as `numpy/ndarray/astype`) so that attribute access `A.dot` on a sparse-matrix value resolves to this class via a field lookup, and the subsequent invocation dispatches to its `do` method. The product of a sparse matrix and a dense array is dense, so the result is a `numpy/ndarray`; its type is computed by `SparseMatrixDot`. -->
       <class name="dot" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseDensify.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SparseDensify.java
@@ -1,0 +1,91 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for {@code scipy.sparse} densification ({@code A.todense()}). A SciPy sparse matrix is
+ * two-dimensional by construction, so the dense result is rank-2 with extents the analysis cannot
+ * compute ({@link UnresolvedDim}, wala/ML#721) and a dtype the untyped sparse operand does not
+ * carry. The recovered rank is what lets a consuming allocation (NLPGNN's {@code
+ * np.array(features.todense(), dtype=np.float32)}) carry a rank-2 type through to the GNN {@code
+ * call} parameters instead of shape-⊤ (wala/ML#768).
+ *
+ * @see <a
+ *     href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.todense.html">scipy.sparse.csr_matrix.todense</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class SparseDensify extends TensorGenerator {
+
+  public SparseDensify(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public SparseDensify(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * The dense form of a SciPy sparse matrix is always rank 2; both extents are fixed runtime
+   * integers the analysis cannot compute ({@link UnresolvedDim}, wala/ML#721).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The singleton rank-2 unresolved shape.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    return Set.of(List.of(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE));
+  }
+
+  /**
+   * The sparse operand is a SciPy-internal value the analysis never types, so the dense result's
+   * dtype is unknown.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The unknown dtype, singleton.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(DType.UNKNOWN);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+
+  /**
+   * Returns the producing library of the modeled value: a densified SciPy matrix is a dense NumPy
+   * value (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -7522,6 +7522,8 @@ public abstract class TensorGenerator {
       return new NpZeros(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
       return new SparseMatrixDot(node);
+    } else if (type.equals(ScipyTypes.SPARSE_MATRIX_TODENSE.getDeclaringClass())) {
+      return new SparseDensify(node);
     } else if (type.equals(TensorFlowTypes.EYE.getDeclaringClass())) {
       return new Eye(node);
     } else if (type.equals(TensorFlowTypes.UNIFORM.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1346,6 +1346,26 @@ public class TensorGeneratorFactory {
             return new SparseMatrixDot(source);
           }
 
+          // If we're calling `scipy.sparse`'s matrix `todense`, the result is a rank-2 dense
+          // matrix with unresolved extents. See wala/ML#768.
+          if (callee
+              .getMethod()
+              .getReference()
+              .getDeclaringClass()
+              .equals(ScipyTypes.SPARSE_MATRIX_TODENSE.getDeclaringClass())) {
+            LOGGER.fine(
+                () ->
+                    TensorGeneratorFactory.class.getSimpleName()
+                        + ": dispatching sparse-matrix todense call at "
+                        + describe(node)
+                        + " v"
+                        + vn
+                        + " to "
+                        + SparseDensify.class.getSimpleName()
+                        + ".");
+            return new SparseDensify(source);
+          }
+
           // If we're calling `next`, the result is an element of the collection.
           if (callee
               .getMethod()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/ScipyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/ScipyTypes.java
@@ -26,6 +26,13 @@ public class ScipyTypes extends PythonTypes {
               PythonTypes.pythonLoader, TypeName.string2TypeName("Lscipy/sparse/diags")),
           AstMethodReference.fnSelector);
 
+  /** https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.todense.html */
+  public static final MethodReference SPARSE_MATRIX_TODENSE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lscipy/sparse/spmatrix/todense")),
+          AstMethodReference.fnSelector);
+
   /** https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.dot.html */
   public static final MethodReference SPARSE_MATRIX_DOT =
       MethodReference.findOrCreate(


### PR DESCRIPTION
Closes wala/ML#768.

A SciPy sparse matrix is two-dimensional by construction, so its dense form is rank 2 with extents the analysis cannot compute. Model `sp.vstack`, `tolil`, and `todense` in `scipy.xml` and pair the densification with a `SparseDensify` generator (registered in both dispatch tables): the NLPGNN `Planetoid` loader's `np.array(features.todense(), dtype=np.float32)` now carries `(Unresolved, Unresolved) of float32` through the normalization product (whose rank-2 composition arm now fires in vivo) to the GNN `call` parameters, replacing the unknown-rank member outright. The three per-family corpus guards upgrade from shape-unknown to the rank-2 pin, and the suite is otherwise unchanged; the transformer-pin witness is green on four consecutive runs.

Consumer witness (probe build, bundled version verified): statuses identical for all six subjects; `parameters.csv` shows 16 paired row replacements, all NLPGNN, each `FLOAT32[TOP]` to `FLOAT32[Unresolved; Unresolved]` on the GNN-family parameters. In the inference-enabled configuration, those parameters are now specification-ready (a rank-2 unresolved type is exactly a `(None, None)` spec, per the populations that already mint them); the GNN functions' whole-function signatures remain withheld by their sibling parameters (the adjacency container's element-dtype conflict, where one element member is an unresolved dtype worth its own follow-up, and the supplied-default policy on `training`), so the inferred-signature count is unchanged until those resolve. The baseline fold follows the release, citing wala/ML#768 as the losses' disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
