### PR TITLE
Consume type-annotation sidecars for content-dependent tensor values

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,28 @@ Since it is built using [WALA], you need to have WALA on your system to use it. 
 
 To test, for example, run `TestCalls` in the `com.ibm.wala.cast.python.test` project.
 
+## Type Annotation Sidecars
+
+Tensor values loaded from data files (`np.load`, `pickle.load`, `tf.io.read_file`) have types the analysis cannot compute from code. A project may declare them in a sidecar file named `ariadne-types.json` at a Python-path root, or in the file named by the `ariadne.typeAnnotations.file` system property:
+
+```json
+{
+"types": [
+	{
+	"module": "datas/loader.py",
+	"function": "Planetoid.load",
+	"variable": "allx",
+	"dtype": "float32",
+	"shape": "1708 3703",
+	"attribution": "Extent of the pickled Cora feature matrix."
+	}
+]
+}
+```
+
+`module` is the root-relative script path; `function` is the dotted qualified name within the module, omitted or empty for module level; `variable` is the source-level name of the annotated binding. `dtype` and `shape` are each optional (an absent axis stays unknown). The shape is a whitespace-separated dimension string of integers or symbolic names; `...` alone declares an unknown rank, and the empty string declares rank 0. The optional `attribution` cites the evidence that the value is content-dependent and is echoed in every report about the entry.
+
+Annotations extend the analysis but never override it. An entry seeds a binding only where inference produced no type; a disagreement with an inferred type is reported, and the annotation is not applied. Entries that match no analyzed binding are also reported. Applied seeds carry a dedicated `ANNOTATION` provenance, keeping evidence that rests on user-supplied facts auditable downstream. See [wala/ML#370](https://github.com/wala/ML/issues/370).
+
 [WALA]: https://github.com/wala/WALA
 [CONTRIBUTING.md]: CONTRIBUTING.md#building

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -632,4 +632,53 @@ public class TestMisc extends AbstractTensorTest {
     assertEquals(new TensorType(FLOAT_32, asList(new NumericDim(3))), TensorType.of(FLOAT_32, 3));
     assertTrue(TensorType.of(FLOAT32, 2, 2).asSparse().isSparse());
   }
+
+  /**
+   * Distilled guard for the type-annotation sidecar (<a
+   * href="https://github.com/wala/ML/issues/370">wala/ML#370</a>): {@code np.load} is an opaque
+   * content-dependent read the analysis cannot type, and the project's {@code ariadne-types.json}
+   * supplies {@code (4, 3) float32} for the loaded binding without touching the program. The seeded
+   * type flows to the consuming parameter.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarFillsOpaqueLoad()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver.py"},
+        "driver.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 3))));
+  }
+
+  /**
+   * The decline direction of {@link #testTypeAnnotationSidecarFillsOpaqueLoad()} (<a
+   * href="https://github.com/wala/ML/issues/370">wala/ML#370</a>): the sidecar's {@code (5, 5)}
+   * claim disagrees with the inferred {@code (2, 2) float32}, so the annotation is reported and not
+   * applied; inference wins wherever it has a type (the fill-only, check-and-report semantics).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarDoesNotOverrideInference()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_conflict.py"},
+        "driver_conflict.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 2))));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/pom.xml
+++ b/com.ibm.wala.cast.python.ml/pom.xml
@@ -9,6 +9,10 @@
   <artifactId>com.ibm.wala.cast.python.ml</artifactId>
   <dependencies>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.python</groupId>
       <artifactId>jython3</artifactId>
     </dependency>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -282,7 +282,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                       + entry.type()
                       + " conflicts with the inferred "
                       + inferred
-                      + "; the annotation is not applied (wala/ML#370).");
+                      + "; the annotation is not applied (wala/ML#370)"
+                      + entry.attributionSuffix()
+                      + ".");
             continue; // Fill-only: inference wins wherever it has a type.
           }
           if (!dataflow.containsNode(var)) dataflow.addNode(var);
@@ -296,7 +298,9 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                       + entry.type()
                       + " at "
                       + describe(var.getPointerKey())
-                      + " (wala/ML#370).");
+                      + " (wala/ML#370)"
+                      + entry.attributionSuffix()
+                      + ".");
         }
       }
       if (!matched)

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -87,6 +87,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -202,6 +203,108 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
     super(pythonPath);
     this.targetFramework = targetFramework;
     this.targetedCfaDepth = checkTargetedCfaDepth(targetedCfaDepth);
+    this.sidecarSearchPath = pythonPath;
+  }
+
+  /**
+   * The Python-path roots searched for a type-annotation sidecar (wala/ML#370); retained here
+   * because the base engine consumes its path without keeping it.
+   */
+  private List<File> sidecarSearchPath;
+
+  /**
+   * Seeds user-supplied type annotations from the project's sidecar (wala/ML#370). Fill-only and
+   * check-and-report: an entry seeds a binding only when inference produced no type for it; where
+   * an inferred seed exists, a disagreeing annotation is reported and not applied, so annotations
+   * can extend the analysis but never change or mask what it computes. Every applied seed carries
+   * {@link TensorOrigin#ANNOTATION}, keeping user-supplied evidence auditable downstream. An entry
+   * applies to every definition of the named binding that lacks an inferred type, so annotated
+   * names should be single-purpose in their scope. Unmatched entries are reported, so stale anchors
+   * surface instead of rotting.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param dataflow The analysis's dataflow graph, gaining the seeded variables as needed.
+   * @param init The initial tensor-type seeding map.
+   * @param initOrigins The initial origin seeding map.
+   */
+  private void seedTypeAnnotationSidecarEntries(
+      PropagationCallGraphBuilder builder,
+      Graph<PointsToSetVariable> dataflow,
+      Map<PointsToSetVariable, Set<TensorType>> init,
+      Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins) {
+    List<TypeAnnotationSidecar.Entry> entries = TypeAnnotationSidecar.load(this.sidecarSearchPath);
+    for (TypeAnnotationSidecar.Entry entry : entries) {
+      String target =
+          "script "
+              + entry.module().replace('/', '.')
+              + (entry.function().isEmpty() ? "" : "." + entry.function())
+              + ".do()LRoot;";
+      boolean matched = false;
+      for (CGNode node : builder.getCallGraph()) {
+        if (!node.getMethod().getSignature().equals(target)) continue;
+        IR ir = node.getIR();
+        if (ir == null) continue;
+        SSAInstruction[] instructions = ir.getInstructions();
+        Set<Integer> valueNumbers = new LinkedHashSet<>();
+        for (int i = 0; i < instructions.length; i++) {
+          SSAInstruction instruction = instructions[i];
+          if (instruction == null) continue;
+          for (int d = 0; d < instruction.getNumberOfDefs(); d++) {
+            int def = instruction.getDef(d);
+            String[] names = ir.getLocalNames(i, def);
+            if (names == null) continue;
+            for (String name : names)
+              if (entry.variable().equals(name)) {
+                valueNumbers.add(def);
+                break;
+              }
+          }
+        }
+        for (int vn : valueNumbers) {
+          PointerKey pk =
+              builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(node, vn);
+          if (builder.getPropagationSystem().isImplicit(pk)) {
+            LOGGER.warning(
+                "Type annotation "
+                    + entry.anchor()
+                    + " addresses an implicit pointer key; not applied (wala/ML#370).");
+            continue;
+          }
+          PointsToSetVariable var = builder.getPropagationSystem().findOrCreatePointsToSet(pk);
+          matched = true;
+          Set<TensorType> inferred = init.get(var);
+          if (inferred != null && !inferred.isEmpty()) {
+            if (!inferred.equals(Set.of(entry.type())))
+              LOGGER.warning(
+                  "Type annotation "
+                      + entry.anchor()
+                      + " = "
+                      + entry.type()
+                      + " conflicts with the inferred "
+                      + inferred
+                      + "; the annotation is not applied (wala/ML#370).");
+            continue; // Fill-only: inference wins wherever it has a type.
+          }
+          if (!dataflow.containsNode(var)) dataflow.addNode(var);
+          init.put(var, HashSetFactory.make(Set.of(entry.type())));
+          initOrigins.put(var, EnumSet.of(TensorOrigin.ANNOTATION));
+          LOGGER.fine(
+              () ->
+                  "Applied type annotation "
+                      + entry.anchor()
+                      + " = "
+                      + entry.type()
+                      + " at "
+                      + describe(var.getPointerKey())
+                      + " (wala/ML#370).");
+        }
+      }
+      if (!matched)
+        LOGGER.warning(
+            "Type annotation "
+                + entry.anchor()
+                + " matched no analyzed binding; check the module path and names (wala/ML#370).");
+    }
   }
 
   @Override
@@ -1448,6 +1551,8 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // `tf.compat.v1.placeholder` is a TensorFlow API (wala/ML#724).
         initOrigins.put(e.getKey(), EnumSet.of(TensorOrigin.TENSORFLOW));
       }
+
+      this.seedTypeAnnotationSidecarEntries(builder, dataflow, init, initOrigins);
 
       // wala/ML#509: recognize `x.set_shape(s)` via IR scanning rather than call-graph dispatch on
       // the `Ltensorflow/functions/set_shape` synthetic class. The legacy dispatch path requires

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TypeAnnotationSidecar.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TypeAnnotationSidecar.java
@@ -36,7 +36,9 @@ import org.json.JSONObject;
  * annotated binding. {@code dtype} and {@code shape} are each optional (an absent axis stays
  * unknown). The shape vocabulary is the dimension string: whitespace-separated integers ({@code
  * NumericDim}) or names ({@code SymbolicDim}); {@code "..."} alone declares an unknown rank; the
- * empty string declares rank 0.
+ * empty string declares rank 0. The optional {@code attribution} string cites the evidence that the
+ * value is content-dependent (e.g., a data-set reference or an issue link); it is echoed in every
+ * report about the entry so the audit trail travels with the fact.
  *
  * <p>Consumption semantics live in {@link PythonTensorAnalysisEngine}: fill-only (an entry seeds
  * only where inference has no type), check-and-report on conflicts, and a dedicated {@link
@@ -62,8 +64,11 @@ public class TypeAnnotationSidecar {
    * @param function The dotted qualified function name within the module; empty for module level.
    * @param variable The source-level name of the annotated binding.
    * @param type The declared tensor type (unknown axes per the entry's omissions).
+   * @param attribution The citation for why the value is content-dependent; empty when the entry
+   *     supplies none.
    */
-  public record Entry(String module, String function, String variable, TensorType type) {
+  public record Entry(
+      String module, String function, String variable, TensorType type, String attribution) {
 
     /**
      * Renders the entry's program-point anchor for logs and reports.
@@ -72,6 +77,16 @@ public class TypeAnnotationSidecar {
      */
     public String anchor() {
       return this.module() + ":" + this.function() + ":" + this.variable();
+    }
+
+    /**
+     * Renders the entry's attribution for logs and reports.
+     *
+     * @return The attribution as a parenthesized suffix, or the empty string when the entry
+     *     supplies none.
+     */
+    public String attributionSuffix() {
+      return this.attribution().isEmpty() ? "" : " (attributed: " + this.attribution() + ")";
     }
   }
 
@@ -181,7 +196,12 @@ public class TypeAnnotationSidecar {
         return null;
       }
     }
-    return new Entry(module, function, variable, new TensorType(dtype, dims));
+    return new Entry(
+        module,
+        function,
+        variable,
+        new TensorType(dtype, dims),
+        object.optString("attribution", ""));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TypeAnnotationSidecar.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TypeAnnotationSidecar.java
@@ -1,0 +1,210 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Loader for per-project type-annotation sidecar files (wala/ML#370): user-supplied shape/dtype
+ * facts for tensor values whose types are content-dependent (opaque reads such as {@code
+ * pickle.load} or {@code np.load}) and therefore unreachable by static inference. The sidecar
+ * leaves the analyzed program untouched (no imports, no restructuring, no runtime dependency), can
+ * address any named binding including tuple-unpack targets, and is toggleable per run.
+ *
+ * <p>A sidecar is a JSON file named {@value #SIDECAR_FILE_NAME} at a Python-path root (or the file
+ * named by the {@value #SIDECAR_FILE_PROPERTY} system property), of the form:
+ *
+ * <pre>{@code
+ * { "types": [ { "module": "datas/loader.py", "function": "Planetoid.load",
+ *                "variable": "allx", "dtype": "float32", "shape": "1708 3703" } ] }
+ * }</pre>
+ *
+ * <p>{@code module} is the root-relative script path; {@code function} is the dotted qualified name
+ * within the module, empty for module level; {@code variable} is the source-level name of the
+ * annotated binding. {@code dtype} and {@code shape} are each optional (an absent axis stays
+ * unknown). The shape vocabulary is the dimension string: whitespace-separated integers ({@code
+ * NumericDim}) or names ({@code SymbolicDim}); {@code "..."} alone declares an unknown rank; the
+ * empty string declares rank 0.
+ *
+ * <p>Consumption semantics live in {@link PythonTensorAnalysisEngine}: fill-only (an entry seeds
+ * only where inference has no type), check-and-report on conflicts, and a dedicated {@link
+ * com.ibm.wala.cast.python.ml.types.TensorOrigin#ANNOTATION} provenance, so annotations can extend
+ * the analysis but never silently change or mask what it computes.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TypeAnnotationSidecar {
+
+  private static final Logger LOGGER = Logger.getLogger(TypeAnnotationSidecar.class.getName());
+
+  /** The sidecar file name searched for at each Python-path root. */
+  public static final String SIDECAR_FILE_NAME = "ariadne-types.json";
+
+  /** System property naming an explicit sidecar file, overriding the path search. */
+  public static final String SIDECAR_FILE_PROPERTY = "ariadne.typeAnnotations.file";
+
+  /**
+   * One sidecar entry: a user-supplied type fact for a named binding.
+   *
+   * @param module The root-relative script path (e.g. {@code datas/loader.py}).
+   * @param function The dotted qualified function name within the module; empty for module level.
+   * @param variable The source-level name of the annotated binding.
+   * @param type The declared tensor type (unknown axes per the entry's omissions).
+   */
+  public record Entry(String module, String function, String variable, TensorType type) {
+
+    /**
+     * Renders the entry's program-point anchor for logs and reports.
+     *
+     * @return The {@code module:function:variable} anchor.
+     */
+    public String anchor() {
+      return this.module() + ":" + this.function() + ":" + this.variable();
+    }
+  }
+
+  private TypeAnnotationSidecar() {}
+
+  /**
+   * Loads every sidecar entry visible to an analysis: the file named by {@value
+   * #SIDECAR_FILE_PROPERTY} when set, else {@value #SIDECAR_FILE_NAME} at each given Python-path
+   * root. A malformed file or entry is reported and skipped rather than aborting the analysis.
+   *
+   * @param pythonPath The Python-path roots to search.
+   * @return The parsed entries, empty when no sidecar exists.
+   */
+  public static List<Entry> load(List<File> pythonPath) {
+    List<File> candidates = new ArrayList<>();
+    String explicit = System.getProperty(SIDECAR_FILE_PROPERTY);
+    if (explicit != null) candidates.add(new File(explicit));
+    else if (pythonPath != null)
+      for (File root : pythonPath) candidates.add(new File(root, SIDECAR_FILE_NAME));
+
+    List<Entry> ret = new ArrayList<>();
+    for (File candidate : candidates) {
+      try {
+        String content = readCandidate(candidate);
+        LOGGER.fine(
+            () ->
+                "Type-annotation sidecar candidate " + candidate + ": " + (content != null) + ".");
+        if (content == null) continue;
+        JSONObject sidecar = new JSONObject(content);
+        JSONArray types = sidecar.optJSONArray("types");
+        if (types == null) {
+          LOGGER.warning("Type-annotation sidecar " + candidate + " has no types array; skipped.");
+          continue;
+        }
+        for (int i = 0; i < types.length(); i++) {
+          Entry entry = parseEntry(types.getJSONObject(i), candidate);
+          if (entry != null) ret.add(entry);
+        }
+      } catch (IOException | JSONException e) {
+        LOGGER.warning("Unreadable type-annotation sidecar " + candidate + ": " + e + "; skipped.");
+      }
+    }
+    LOGGER.fine(() -> "Loaded " + ret.size() + " type-annotation sidecar entries.");
+    return ret;
+  }
+
+  /**
+   * Reads a sidecar candidate's content: directly for an ordinary file, and through a {@code jar:}
+   * URL when the Python-path root is a packaged resource (the in-suite harness resolves fixture
+   * projects from the test-data jar).
+   *
+   * @param candidate The candidate sidecar file.
+   * @return The file content, or {@code null} when the candidate does not exist.
+   * @throws IOException On a read error of an existing candidate.
+   */
+  private static String readCandidate(File candidate) throws IOException {
+    if (candidate.isFile()) return Files.readString(candidate.toPath());
+    String path = candidate.getPath();
+    if (path.contains(".jar!")) {
+      String spec = "jar:" + (path.startsWith("file:") ? path : "file:" + path);
+      try (java.io.InputStream in = java.net.URI.create(spec).toURL().openStream()) {
+        return new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+      } catch (IOException e) {
+        return null; // No such jar entry.
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parses one sidecar entry, reporting and skipping malformed ones.
+   *
+   * @param object The entry's JSON object.
+   * @param file The sidecar file, for reports.
+   * @return The entry, or {@code null} when malformed.
+   */
+  private static Entry parseEntry(JSONObject object, File file) {
+    String module = object.optString("module", "");
+    String variable = object.optString("variable", "");
+    if (module.isEmpty() || variable.isEmpty()) {
+      LOGGER.warning(
+          "Type-annotation entry in " + file + " lacks module or variable: " + object + ".");
+      return null;
+    }
+    String function = object.optString("function", "");
+    String dtypeName = object.has("dtype") ? object.getString("dtype") : null;
+    DType dtype = DType.UNKNOWN;
+    if (dtypeName != null) {
+      try {
+        dtype = DType.valueOf(dtypeName.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        LOGGER.warning(
+            "Type-annotation entry in " + file + " names unknown dtype " + dtypeName + ".");
+        return null;
+      }
+    }
+    List<Dimension<?>> dims = null;
+    if (object.has("shape")) {
+      dims = parseDimensions(object.getString("shape"));
+      if (dims == null && !"...".equals(object.getString("shape").trim())) {
+        LOGGER.warning(
+            "Type-annotation entry in "
+                + file
+                + " has an unparseable shape "
+                + object.getString("shape")
+                + ".");
+        return null;
+      }
+    }
+    return new Entry(module, function, variable, new TensorType(dtype, dims));
+  }
+
+  /**
+   * Parses a dimension string into dimensions: whitespace-separated integers ({@link NumericDim})
+   * or names ({@link SymbolicDim}); {@code "..."} alone means unknown rank; the empty string means
+   * rank 0.
+   *
+   * @param shape The dimension string.
+   * @return The dimensions, or {@code null} for unknown rank.
+   */
+  private static List<Dimension<?>> parseDimensions(String shape) {
+    String trimmed = shape.trim();
+    if ("...".equals(trimmed)) return null;
+    List<Dimension<?>> dims = new ArrayList<>();
+    if (trimmed.isEmpty()) return dims;
+    for (String token : trimmed.split("\\s+")) {
+      try {
+        dims.add(new NumericDim(Integer.parseInt(token)));
+      } catch (NumberFormatException e) {
+        if (!token.matches("[A-Za-z_][A-Za-z0-9_]*")) return null;
+        dims.add(new SymbolicDim(token));
+      }
+    }
+    return dims;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorOrigin.java
@@ -26,6 +26,13 @@ package com.ibm.wala.cast.python.ml.types;
  */
 public enum TensorOrigin {
 
+  /**
+   * The value's type was supplied by a user annotation (a sidecar entry, wala/ML#370) rather than
+   * inferred. Annotation seeding is fill-only: it applies only where inference has no type, so this
+   * origin marks exactly the evidence that rests on user-supplied facts.
+   */
+  ANNOTATION,
+
   /** The value is an ndarray produced by a numpy operation. */
   NUMPY,
 

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -1,0 +1,18 @@
+{
+  "types": [
+    {
+      "module": "driver.py",
+      "function": "",
+      "variable": "x",
+      "dtype": "float32",
+      "shape": "4 3"
+    },
+    {
+      "module": "driver_conflict.py",
+      "function": "",
+      "variable": "y",
+      "dtype": "float32",
+      "shape": "5 5"
+    }
+  ]
+}

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -13,6 +13,33 @@
       "variable": "y",
       "dtype": "float32",
       "shape": "5 5"
+    },
+    {
+      "module": "driver.py",
+      "function": "",
+      "variable": "no_such_binding",
+      "dtype": "float32",
+      "shape": "1"
+    },
+    {
+      "module": "driver.py",
+      "function": "",
+      "dtype": "float32",
+      "shape": "2"
+    },
+    {
+      "module": "driver.py",
+      "function": "",
+      "variable": "x2",
+      "dtype": "complex999",
+      "shape": "3"
+    },
+    {
+      "module": "driver.py",
+      "function": "",
+      "variable": "x3",
+      "dtype": "float32",
+      "shape": "4 $!"
     }
   ]
 }

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -5,14 +5,16 @@
       "function": "",
       "variable": "x",
       "dtype": "float32",
-      "shape": "4 3"
+      "shape": "4 3",
+      "attribution": "fixture: np.load of an array saved in the same script"
     },
     {
       "module": "driver_conflict.py",
       "function": "",
       "variable": "y",
       "dtype": "float32",
-      "shape": "5 5"
+      "shape": "5 5",
+      "attribution": "fixture: deliberately wrong to exercise the conflict report"
     },
     {
       "module": "driver.py",

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver.py
@@ -1,0 +1,18 @@
+# Test the type-annotation sidecar (wala/ML#370): `np.load` is an opaque, content-dependent read
+# the analysis cannot type; the sidecar supplies the type without touching this program.
+
+import os
+
+import numpy as np
+
+
+def consume(x):
+    pass
+
+
+np.save("sidecar_tmp.npy", np.ones((4, 3), dtype=np.float32))
+x = np.load("sidecar_tmp.npy")
+assert x.shape == (4, 3)
+assert x.dtype == np.float32
+consume(x)
+os.remove("sidecar_tmp.npy")

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_conflict.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_conflict.py
@@ -1,0 +1,14 @@
+# Companion to driver.py (wala/ML#370): the sidecar's claim about `y` disagrees with what the
+# analysis infers, so the annotation is reported and NOT applied; inference wins.
+
+import tensorflow as tf
+
+
+def consume(y):
+    pass
+
+
+y = tf.ones((2, 2))
+assert y.shape == (2, 2)
+assert y.dtype == tf.float32
+consume(y)


### PR DESCRIPTION
Advances wala/ML#370 (V1, per the mechanism decision on the issue).

A per-project `ariadne-types.json` sidecar supplies shape/dtype facts for tensor values whose types live in data the analysis cannot read (`np.load`, `pickle.load`, `tf.io.read_file`), addressing any named binding, including tuple-unpack targets, without modifying the analyzed program. Entries anchor by module path, function qualified name, and source-level variable name; the dimension vocabulary is a string of integers, symbolic names, or `...` for unknown rank; discovery searches the Python-path roots (jar-aware for packaged fixture projects) with a system-property override. An optional `attribution` string per entry cites the evidence that the value is content-dependent and is echoed in every report about the entry, so the audit trail travels with the fact.

The interaction semantics keep annotations from masking modeling gaps: seeding is **fill-only** (an entry seeds a binding only where inference produced no type), conflicts are **reported and not applied** (inference wins wherever it has a type), unmatched entries are reported so stale anchors surface, and every applied seed carries the new `TensorOrigin.ANNOTATION`, so evidence resting on user-supplied facts stays auditable downstream. Both directions carry distilled guards: `testTypeAnnotationSidecarFillsOpaqueLoad` pins the `(4, 3) float32` fill through an opaque `np.load`, and `testTypeAnnotationSidecarDoesNotOverrideInference` pins a disagreeing annotation losing to the inferred `(2, 2)`.

Consumer witness (probe build): with no sidecars configured, the six-subject reference populations are byte-identical to the baseline, so the mechanism is provably inert when unconfigured. The per-subject annotation worklist (attributing each unresolved parameter to a content-dependent source or a modeling gap before any annotation is written) follows separately on ponder-lab/Python-Subjects#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
