### PR TITLE
Refine `⊤` and partially-unknown inferred types with sidecar annotations

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -681,4 +681,52 @@ public class TestMisc extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 2, 2))));
   }
+
+  /**
+   * Axis-level refinement of a top placeholder (<a
+   * href="https://github.com/wala/ML/issues/771">wala/ML#771</a>): inference holds a
+   * both-axes-unknown member for {@code tf.constant} of an opaque {@code np.load}, and the sidecar
+   * fills both axes rather than being declined as a conflict.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarRefinesTopInference()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_refine.py"},
+        "driver_refine.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 3))));
+  }
+
+  /**
+   * Axis-level refinement of a partially-known member (<a
+   * href="https://github.com/wala/ML/issues/771">wala/ML#771</a>): inference knows {@code
+   * tf.zeros}' float32 dtype but not its opaque extent; a shape-only sidecar entry fills the dims
+   * axis, and the omitted dtype axis does not conflict with the definite inferred one.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarRefinesPartialShape()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_refine.py"},
+        "driver_refine.py",
+        "consume2",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 3))));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -274,7 +274,11 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           matched = true;
           Set<TensorType> inferred = init.get(var);
           if (inferred != null && !inferred.isEmpty()) {
-            if (!inferred.equals(Set.of(entry.type())))
+            // Fill-only, per axis (wala/ML#771): the annotation refines exactly the axes where
+            // inference holds no information; a definite inferred axis wins, and a definite
+            // disagreement is reported rather than applied.
+            Set<TensorType> merged = mergeAnnotationIntoInferredTypes(inferred, entry.type());
+            if (merged == null) {
               LOGGER.warning(
                   "Type annotation "
                       + entry.anchor()
@@ -285,7 +289,28 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                       + "; the annotation is not applied (wala/ML#370)"
                       + entry.attributionSuffix()
                       + ".");
-            continue; // Fill-only: inference wins wherever it has a type.
+              continue;
+            }
+            if (merged == inferred) continue; // The annotation adds no information.
+            init.put(var, HashSetFactory.make(merged));
+            EnumSet<TensorOrigin> origins = EnumSet.of(TensorOrigin.ANNOTATION);
+            Set<TensorOrigin> priorOrigins = initOrigins.get(var);
+            if (priorOrigins != null) origins.addAll(priorOrigins);
+            initOrigins.put(var, origins);
+            LOGGER.fine(
+                () ->
+                    "Refined the inferred "
+                        + inferred
+                        + " with type annotation "
+                        + entry.anchor()
+                        + " = "
+                        + entry.type()
+                        + " at "
+                        + describe(var.getPointerKey())
+                        + " (wala/ML#771)"
+                        + entry.attributionSuffix()
+                        + ".");
+            continue;
           }
           if (!dataflow.containsNode(var)) dataflow.addNode(var);
           init.put(var, HashSetFactory.make(Set.of(entry.type())));
@@ -309,6 +334,37 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
                 + entry.anchor()
                 + " matched no analyzed binding; check the module path and names (wala/ML#370).");
     }
+  }
+
+  /**
+   * Merges a sidecar annotation into an inferred type set axis-by-axis (wala/ML#771). For each
+   * inferred member, the annotation fills the dtype only where the member's is {@link
+   * DType#UNKNOWN} and the dims only where the member's are unknown ({@code null}); a definite
+   * inferred axis is kept, and a definite inferred axis that disagrees with a definite annotation
+   * axis is a conflict.
+   *
+   * @param inferred The inferred members at the annotated binding.
+   * @param annotation The annotation's declared type.
+   * @return The merged members; {@code inferred} itself (same reference) when the annotation adds
+   *     no information; or {@code null} on an axis conflict.
+   */
+  private static Set<TensorType> mergeAnnotationIntoInferredTypes(
+      Set<TensorType> inferred, TensorType annotation) {
+    Set<TensorType> merged = HashSetFactory.make();
+    boolean changed = false;
+    for (TensorType member : inferred) {
+      DType dtype = member.getDType();
+      if (dtype == DType.UNKNOWN) dtype = annotation.getDType();
+      else if (annotation.getDType() != DType.UNKNOWN && annotation.getDType() != dtype)
+        return null;
+      List<Dimension<?>> dims = member.getDims();
+      if (dims == null) dims = annotation.getDims();
+      else if (annotation.getDims() != null && !annotation.getDims().equals(dims)) return null;
+      TensorType mergedMember = TensorType.of(dtype, dims, member.layout());
+      changed |= !mergedMember.equals(member);
+      merged.add(mergedMember);
+    }
+    return changed ? merged : inferred;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -17,6 +17,21 @@
       "attribution": "fixture: deliberately wrong to exercise the conflict report"
     },
     {
+      "module": "driver_refine.py",
+      "function": "",
+      "variable": "t",
+      "dtype": "float32",
+      "shape": "4 3",
+      "attribution": "fixture: tf.constant of an opaque np.load; inference holds a top placeholder"
+    },
+    {
+      "module": "driver_refine.py",
+      "function": "",
+      "variable": "z",
+      "shape": "4 3",
+      "attribution": "fixture: tf.zeros of an opaque extent; inference knows the dtype, the sidecar fills the shape"
+    },
+    {
       "module": "driver.py",
       "function": "",
       "variable": "no_such_binding",

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_refine.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_refine.py
@@ -1,0 +1,30 @@
+# Axis-level refinement fixture (wala/ML#771): values inference types only partially. The
+# sidecar fills exactly the unknown axes: both axes of `t` (a top placeholder from `tf.constant`
+# of an opaque read) and only the shape of `z` (whose float32 dtype inference already knows).
+
+import os
+
+import numpy as np
+import tensorflow as tf
+
+
+def consume(t):
+    pass
+
+
+def consume2(z):
+    pass
+
+
+np.save("sidecar_refine_tmp.npy", np.ones((4, 3), dtype=np.float32))
+raw = np.load("sidecar_refine_tmp.npy")
+t = tf.constant(raw)
+assert t.shape == (4, 3)
+assert t.dtype == tf.float32
+consume(t)
+dims = raw.shape
+z = tf.zeros(dims)
+assert z.shape == (4, 3)
+assert z.dtype == tf.float32
+consume2(z)
+os.remove("sidecar_refine_tmp.npy")


### PR DESCRIPTION
Closes wala/ML#771.

The wala/ML#370 V1 sidecar declined an annotation whenever inference held any type at the anchor, including the both-axes-unknown placeholder; the configured verification run on the pickle-loading subject produced the witness verbatim (`{? of int64}` declined against `[{? of unknown}]`). The mechanism therefore could not serve exactly the case it was built for whenever the opaque read surfaces as a top tensor rather than no tensor.

Seeding is now fill-only per axis (`mergeAnnotationIntoInferredTypes`): for each inferred member, the annotation fills the dtype only where the member's is `UNKNOWN` and the dims only where the member's are unknown; a definite inferred axis is kept; a definite disagreement on either axis remains a reported, unapplied conflict; and a merge that adds nothing is a no-op. An applied refinement adds `ANNOTATION` to the destination's origins alongside the existing ones, since the resulting evidence rests on both sources. The member's storage layout is preserved.

The `sidecar_proj/driver_refine.py` fixture pins both refinement directions, confirmed to exercise the merge path (not the plain fill) by the seeding logs:

- `testTypeAnnotationSidecarRefinesTopInference`: `tf.constant` of an opaque `np.load` infers `[{? of unknown}]` (the witness state), and the sidecar fills both axes to `(4, 3) float32`.
- `testTypeAnnotationSidecarRefinesPartialShape`: `tf.zeros` of an opaque extent infers `[{? of float32}]`; a shape-only entry fills the dims axis, and the omitted dtype axis does not conflict with the definite inferred one.

The existing fill and conflict guards are unchanged and still pass: the conflict leg now declines through the per-axis check (definite `(2, 2)` vs declared `(5, 5)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
