### PR TITLE
Feed `np.array` results the source argument's dataflow dtype

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -419,6 +419,9 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
   /** A {@code float32} tensor whose shape cannot be statically inferred. */
   protected static final TensorType TENSOR_UNKNOWN_SHAPE_FLOAT32 = new TensorType(FLOAT_32, null);
 
+  /** An {@code int64} tensor whose shape cannot be statically inferred. */
+  protected static final TensorType TENSOR_UNKNOWN_SHAPE_INT64 = new TensorType(INT_64, null);
+
   /** Fully-⊤ tensor type: unknown shape and unknown dtype. */
   protected static final TensorType TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE =
       new TensorType(UNKNOWN, null);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -44,7 +44,6 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_NONE_NONE_STRING;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNRESOLVED_UNRESOLVED_FLOAT32;
-import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.UNKNOWN;
 import static java.util.Arrays.asList;
 
 import com.ibm.wala.cast.python.ml.client.Constant;
@@ -282,12 +281,14 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
-   * Companion to {@link #testNpArrayBareParam()} for the non-literal-source floor of <a
+   * Companion to {@link #testNpArrayBareParam()} for the non-literal source of <a
    * href="https://github.com/wala/ML/issues/626">wala/ML#626</a>: when {@code x} is itself an
-   * {@code np.ndarray} rather than a Python literal, numpy preserves the source's dtype, which the
-   * walk does not model, so the dtype floors to ⊤. The nested-array {@code (2,)} shape now
-   * propagates through the outer {@code np.array} via the producer registration (wala/ML#625); the
-   * dtype residue stays with wala/ML#626.
+   * {@code np.ndarray} rather than a Python literal, numpy preserves the source's dtype. The
+   * nested-array {@code (2,)} shape propagates through the outer {@code np.array} via the producer
+   * registration (wala/ML#625), and the preserved {@code int64} dtype arrives through {@code
+   * NpArray}'s dtype feed from the source argument's dataflow state (<a
+   * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>), lifting the former ⊤-dtype
+   * floor.
    */
   @Test
   public void testNpArrayArraySource()
@@ -297,7 +298,7 @@ public class TestConstructors extends AbstractTensorTest {
         "f",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(UNKNOWN, asList(new NumericDim(2))))));
+        Map.of(2, Set.of(new TensorType(INT_64, asList(new NumericDim(2))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -13,6 +13,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_32_28_28_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_4_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_8_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_INT64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.util.Util.addPytestEntrypoints;
@@ -728,5 +729,30 @@ public class TestMisc extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 4, 3))));
+  }
+
+  /**
+   * Feed-through of an annotation across an {@code np.array} boundary (<a
+   * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>): the sidecar types an opaque
+   * {@code np.load} inside a helper, and the {@code int64} dtype reaches the {@code np.array}
+   * result through {@code NpArray}'s dtype feed rather than dying at the generator-seeded boundary.
+   * The result's shape stays unknown: the {@code DTYPE_ONLY} feed borrows only the dtype.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarFeedsThroughNpArray()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_feed.py"},
+        "driver_feed.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_INT64)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -755,4 +755,35 @@ public class TestMisc extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_INT64)));
   }
+
+  /**
+   * The faithful loader shape for {@link #testTypeAnnotationSidecarFeedsThroughNpArray()} (<a
+   * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>): the annotated opaque read is
+   * conditionally slice-reassigned inside its method, collected by a list comprehension in a second
+   * method, and batched through {@code np.array} behind a method-call boundary. The comprehension
+   * trampoline's reflected element write is invisible to container-element dataflow consumers, so
+   * the {@code int64} dies at the comprehension hop and the parameter observes {@code {? of
+   * unknown}}.
+   *
+   * <p>TODO: Flip to a plain positive test when <a
+   * href="https://github.com/wala/ML/issues/773">wala/ML#773</a> gives comprehension element writes
+   * an enumerable channel.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testTypeAnnotationSidecarFeedsThroughLoaderChain()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_feed2.py"},
+        "driver_feed2.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_INT64)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -375,12 +375,16 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param operands The feeding operand variables, in operand order.
    * @param seedMembers The suppressed seed's retained members for the fill modes; empty for {@link
    *     FeedMode#REPLACE}.
+   * @param seedOrigins The suppressed seed's origins, stamped on the fed result: the producing
+   *     library is the modeled operation's, whatever produced the operand (wala/ML#724,
+   *     wala/ML#772).
    */
   public record FeedPlan(
       TensorGenerator.TypeFeedKind kind,
       FeedMode mode,
       List<PointsToSetVariable> operands,
-      Set<TensorType> seedMembers) {}
+      Set<TensorType> seedMembers,
+      Set<TensorOrigin> seedOrigins) {}
 
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
@@ -645,9 +649,15 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
                   }
                   break;
               }
-              // The fed result is a TensorFlow op's product regardless of what produced the
-              // operand (wala/ML#724).
-              if (changed) changed |= lhs.origins.add(TensorOrigin.TENSORFLOW);
+              // The fed result carries the modeled operation's own origins regardless of what
+              // produced the operand (wala/ML#724, wala/ML#772), plus the operand's ANNOTATION
+              // marker when present: evidence resting on user-supplied facts stays auditable
+              // through feeds (wala/ML#370).
+              if (changed) {
+                changed |= lhs.origins.addAll(this.plan.seedOrigins());
+                if (rhs.origins.contains(TensorOrigin.ANNOTATION))
+                  changed |= lhs.origins.add(TensorOrigin.ANNOTATION);
+              }
               return changed ? CHANGED : NOT_CHANGED;
             }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -8,6 +8,7 @@ import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -23,6 +24,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -73,9 +75,44 @@ public class NpArray extends TensorGenerator {
   protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
     int sourceVn = getArgumentValueNumber(0);
     if (sourceVn <= 0) return null;
-    PointerKey operand =
-        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(this.getNode(), sourceVn);
-    return new TypeFeed(TypeFeedKind.DTYPE_ONLY, List.of(operand));
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    PointerKey argument = pa.getHeapModel().getPointerKeyForLocal(this.getNode(), sourceVn);
+    List<PointerKey> operands = new ArrayList<>();
+    operands.add(argument);
+    // The argument is often a container of the actual values (an append-built or literal batch
+    // list), whose own variable carries no dataflow state: the element state lives in the
+    // container's field keys. Add the append-contents key and the cataloged subscript keys of
+    // each list/tuple allocation so element evidence feeds too.
+    for (InstanceKey ik : pa.getPointsToSet(argument)) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin == null) continue;
+      TypeReference reference = asin.concreteType().getReference();
+      if (!reference.equals(list) && !reference.equals(tuple)) continue;
+      FieldReference contents =
+          FieldReference.findOrCreate(
+              Root,
+              findOrCreateAsciiAtom(
+                  PythonSSAPropagationCallGraphBuilder.LIST_APPEND_CONTENTS_FIELD),
+              Root);
+      IField contentsField = builder.getClassHierarchy().resolveField(contents);
+      if (contentsField != null)
+        operands.add(builder.getPointerKeyForInstanceField(asin, contentsField));
+      OrdinalSet<InstanceKey> catalogPTS =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      for (InstanceKey catalogIK : catalogPTS) {
+        if (!(catalogIK instanceof ConstantKey)) continue;
+        Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
+        if (fieldIndex == null) continue;
+        FieldReference subscript =
+            FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldIndex.toString()), Root);
+        IField subscriptField = builder.getClassHierarchy().resolveField(subscript);
+        if (subscriptField != null)
+          operands.add(builder.getPointerKeyForInstanceField(asin, subscriptField));
+      }
+    }
+    return new TypeFeed(TypeFeedKind.DTYPE_ONLY, operands);
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -53,6 +53,31 @@ public class NpArray extends TensorGenerator {
     super(node);
   }
 
+  /**
+   * Declares a dtype feed from the source argument ({@code x}) (<a
+   * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>): {@code numpy.array} preserves an
+   * array-like input's element dtype, so when this generator's own resolution floors at {@code
+   * UNKNOWN} (an opaque, content-dependent {@code x}), dtype evidence that lives only in {@code
+   * TensorTypeAnalysis} dataflow state at the argument (e.g. a type-annotation seed, <a
+   * href="https://github.com/wala/ML/issues/370">wala/ML#370</a>) still reaches the result. The
+   * operand key pairs {@link #getArgumentValueNumber(int)}'s value number with {@link #getNode()}'s
+   * own frame, the same pairing this generator's shape and dtype reads use, so it is consistent for
+   * both anchor shapes; the caller-argument edges in the assignment graph deliver the operand's
+   * state there.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The {@code DTYPE_ONLY} feed from {@code x}, or {@code null} for an unlocatable
+   *     argument.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    int sourceVn = getArgumentValueNumber(0);
+    if (sourceVn <= 0) return null;
+    PointerKey operand =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(this.getNode(), sourceVn);
+    return new TypeFeed(TypeFeedKind.DTYPE_ONLY, List.of(operand));
+  }
+
   @Override
   protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
     int sourceVn = getArgumentValueNumber(0);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1744,15 +1744,16 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           if (!dataflow.containsNode(operand)) dataflow.addNode(operand);
           if (!dataflow.hasEdge(operand, src)) dataflow.addEdge(operand, src);
         }
+        Set<TensorOrigin> origins = initOrigins.get(src);
         typeFeeds.put(
             src,
             new TensorTypeAnalysis.FeedPlan(
                 feed.kind(),
                 mode,
                 feedSources,
-                mode == TensorTypeAnalysis.FeedMode.REPLACE ? Collections.emptySet() : types));
+                mode == TensorTypeAnalysis.FeedMode.REPLACE ? Collections.emptySet() : types,
+                origins != null ? origins : generator.getOrigins(builder)));
         suppressedSeeds.put(src, types);
-        Set<TensorOrigin> origins = initOrigins.get(src);
         if (origins != null) suppressedOrigins.put(src, origins);
         init.remove(src);
         initOrigins.remove(src);

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -25,6 +25,13 @@
       "attribution": "fixture: opaque np.load inside a helper; the dtype must reach the np.array result through the feed"
     },
     {
+      "module": "driver_feed2.py",
+      "function": "Data._get_seq",
+      "variable": "data",
+      "dtype": "int64",
+      "attribution": "fixture: opaque np.load conditionally slice-reassigned, comprehension-collected, batched via np.array"
+    },
+    {
       "module": "driver_refine.py",
       "function": "",
       "variable": "t",

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -17,6 +17,14 @@
       "attribution": "fixture: deliberately wrong to exercise the conflict report"
     },
     {
+      "module": "driver_feed.py",
+      "function": "get_seq",
+      "variable": "data",
+      "dtype": "int64",
+      "shape": "4 3",
+      "attribution": "fixture: opaque np.load inside a helper; the dtype must reach the np.array result through the feed"
+    },
+    {
       "module": "driver_refine.py",
       "function": "",
       "variable": "t",

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
@@ -1,6 +1,8 @@
 # Feed-through fixture (wala/ML#772): a sidecar annotation on an opaque read reaches an
 # `np.array` result through the dtype feed. Mirrors the loader shape that motivated the issue:
-# an opaque per-item read returned from a helper, batched through `np.array`.
+# an opaque per-item read returned from a helper, accumulated in a list, batched through
+# `np.array`. The list hop matters: the argument's own variable carries no dataflow state, so
+# the feed must read the container's element keys.
 
 import os
 
@@ -17,7 +19,9 @@ def consume(m):
 
 
 np.save("sidecar_feed_tmp.npy", np.ones((4, 3), dtype=np.int64))
-batch_data = get_seq()
+batch_data = []
+for _ in range(2):
+    batch_data.append(get_seq())
 m = np.array(batch_data)
 assert m.dtype == np.int64
 consume(m)

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
@@ -1,0 +1,24 @@
+# Feed-through fixture (wala/ML#772): a sidecar annotation on an opaque read reaches an
+# `np.array` result through the dtype feed. Mirrors the loader shape that motivated the issue:
+# an opaque per-item read returned from a helper, batched through `np.array`.
+
+import os
+
+import numpy as np
+
+
+def get_seq():
+    data = np.load("sidecar_feed_tmp.npy")
+    return data
+
+
+def consume(m):
+    pass
+
+
+np.save("sidecar_feed_tmp.npy", np.ones((4, 3), dtype=np.int64))
+batch_data = get_seq()
+m = np.array(batch_data)
+assert m.dtype == np.int64
+consume(m)
+os.remove("sidecar_feed_tmp.npy")

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed2.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed2.py
@@ -1,0 +1,41 @@
+# Faithful loader-shape fixture (wala/ML#772): the annotated opaque read is conditionally
+# reassigned through a slice inside its method, collected by a list comprehension in another
+# method, and batched through `np.array`. Mirrors the in-vivo chain the plain append fixture
+# (driver_feed.py) simplifies away.
+
+import os
+import random
+
+import numpy as np
+
+
+class Data:
+    def __init__(self, files):
+        self.files = files
+
+    def _get_seq(self, fname, max_length=None):
+        data = np.load(fname)
+        if max_length is not None:
+            if max_length <= len(data):
+                start = random.randrange(0, len(data) - max_length)
+                data = data[start : start + max_length]
+            else:
+                data = np.append(data, 0)
+        return data
+
+    def batch(self, batch_size, length):
+        batch_files = random.sample(self.files, k=batch_size)
+        batch_data = [self._get_seq(file, length) for file in batch_files]
+        return np.array(batch_data)
+
+
+def consume(m):
+    pass
+
+
+np.save("sidecar_feed2_tmp.npy", np.arange(8, dtype=np.int64))
+d = Data(["sidecar_feed2_tmp.npy", "sidecar_feed2_tmp.npy"])
+m = d.batch(2, 4)
+assert m.dtype == np.int64
+consume(m)
+os.remove("sidecar_feed2_tmp.npy")


### PR DESCRIPTION
Closes wala/ML#772.

`NpArray` resolved its result dtype only from the explicit `dtype` argument or the PTS literal-promotion walk (wala/ML#626), flooring at `UNKNOWN` for opaque sources, and declared no type feed, so dtype evidence living only in `TensorTypeAnalysis` dataflow state at the argument never reached the result. The wala/ML#771 verification arc produced the witness: a sidecar annotation applies at a pickle-loaded value, propagates along assignment edges, and dies at the `np.array` boundary because the result's seed is generator-computed and feed-less.

Changes:

- **`NpArray.getTypeFeed`** declares a `DTYPE_ONLY` feed from the source argument (`x`): `numpy.array` preserves an array-like input's element dtype, so borrowing the operand's dataflow dtype is the operation's actual semantics. The operand key pairs the argument value number with the anchor node's own frame, the same pairing the generator's existing shape and dtype reads use, so it is consistent for both anchor shapes.
- **Container element keys feed too**: the argument is often a list of the actual values (an append-built batch list) whose own variable carries no dataflow state, so the feed also includes each list/tuple allocation's `__list_append_contents__` key and its cataloged subscript keys.
- **`FeedPlan` carries `seedOrigins`**, and `TypeFeedOp` stamps those instead of the previously hard-coded `TENSORFLOW` (the latent issue noted when wala/ML#736 landed, which a NumPy feed would have made live by mispainting NumPy values with a TensorFlow origin). The suppressed seed's origins are captured at the plan's construction site, falling back to the generator's declared origins; an operand carrying `ANNOTATION` additionally propagates that marker, so evidence resting on user-supplied facts stays auditable through feeds (wala/ML#370). The origin pins (`TestTensorOrigins`) pass unchanged.

Guards:

- `testTypeAnnotationSidecarFeedsThroughNpArray` (new, `sidecar_proj/driver_feed.py`): a sidecar-typed opaque read inside a helper, accumulated through an explicit `append` loop, reaches the `np.array` result as `{? of int64}` through the feed; the seeding logs confirm the `REPLACE`/`DTYPE_ONLY` installation.
- `testTypeAnnotationSidecarFeedsThroughLoaderChain` (new, issue-blocked, `sidecar_proj/driver_feed2.py`): the faithful loader shape (conditional slice reassignment, list *comprehension*, method boundary) still loses the dtype, because the comprehension trampoline's reflected element write is invisible to container-element dataflow consumers. Pinned as `@Test(expected = AssertionError.class)` with a TODO on wala/ML#773, which that finding spawned.
- `testNpArrayArraySource` (pin moved): the wala/ML#626 non-literal-source dtype floor is lifted; `np.array` of an `np.ndarray` source now types `int64 (2,)` per numpy's preserve-the-source-dtype semantics (runtime-confirmed), where it previously floored at ⊤ dtype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
