### PR TITLE
Decline the `np.array` dtype feed when an explicit `dtype` argument is unresolvable

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -14,6 +14,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_4_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_8_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_INT64;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.util.Util.addPytestEntrypoints;
@@ -754,6 +755,30 @@ public class TestMisc extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_INT64)));
+  }
+
+  /**
+   * The feed's decline leg (<a href="https://github.com/wala/ML/issues/774">wala/ML#774</a>): an
+   * explicit {@code dtype} argument overrides the source's dtype at runtime, so when a caller
+   * passes one the dtype resolution cannot map, the feed must decline and the result stays soundly
+   * both-axes-unknown rather than borrowing the operand's {@code int64}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarFeedDeclinesOnDtypeArgument()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_feed.py"},
+        "driver_feed.py",
+        "consume2",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -12,6 +12,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuild
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
@@ -21,8 +22,10 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -67,15 +70,25 @@ public class NpArray extends TensorGenerator {
    * both anchor shapes; the caller-argument edges in the assignment graph deliver the operand's
    * state there.
    *
+   * <p>The feed models only the preservation case: an explicit {@code dtype} argument overrides the
+   * source's dtype at runtime, so when a caller passes one that the dtype resolution could not map,
+   * borrowing the operand's dtype would fabricate evidence, and no feed is declared (<a
+   * href="https://github.com/wala/ML/issues/774">wala/ML#774</a>; the result stays soundly {@code
+   * UNKNOWN}). The passing is detected syntactically at the caller invokes, which is decisive
+   * regardless of whether the argument's own points-to evidence survives.
+   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
-   * @return The {@code DTYPE_ONLY} feed from {@code x}, or {@code null} for an unlocatable
-   *     argument.
+   * @return The {@code DTYPE_ONLY} feed from {@code x}, or {@code null} for an unlocatable argument
+   *     or an explicit-but-unresolvable {@code dtype} argument.
    */
   @Override
   protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
     int sourceVn = getArgumentValueNumber(0);
     if (sourceVn <= 0) return null;
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    int dtypeVn = getArgumentValueNumber(1);
+    if (dtypeVn > 0 && getDTypes(builder, dtypeVn).isEmpty() && this.isDtypeArgumentPassed(builder))
+      return null;
     PointerKey argument = pa.getHeapModel().getPointerKeyForLocal(this.getNode(), sourceVn);
     List<PointerKey> operands = new ArrayList<>();
     operands.add(argument);
@@ -113,6 +126,24 @@ public class NpArray extends TensorGenerator {
       }
     }
     return new TypeFeed(TypeFeedKind.DTYPE_ONLY, operands);
+  }
+
+  /**
+   * Determines whether any caller invoke supplies a {@code dtype} argument, positionally (a second
+   * positional argument beyond {@code x}) or by keyword (wala/ML#774).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the callers.
+   * @return {@code true} iff some caller passes a {@code dtype} argument.
+   */
+  private boolean isDtypeArgumentPassed(PropagationCallGraphBuilder builder) {
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, this.getNode())) {
+      if (!(callerInvoke.snd instanceof PythonInvokeInstruction)) continue;
+      PythonInvokeInstruction invoke = (PythonInvokeInstruction) callerInvoke.snd;
+      if (invoke.getNumberOfPositionalParameters() >= 3 || invoke.getKeywords().contains("dtype"))
+        return true;
+    }
+    return false;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_feed.py
@@ -18,6 +18,10 @@ def consume(m):
     pass
 
 
+def consume2(b):
+    pass
+
+
 np.save("sidecar_feed_tmp.npy", np.ones((4, 3), dtype=np.int64))
 batch_data = []
 for _ in range(2):
@@ -25,4 +29,10 @@ for _ in range(2):
 m = np.array(batch_data)
 assert m.dtype == np.int64
 consume(m)
+# An explicit dtype argument overrides the source's dtype at runtime, so when it is statically
+# unresolvable the feed must decline rather than borrow the operand's dtype (wala/ML#774).
+dt = np.load("sidecar_feed_tmp.npy").dtype
+b = np.array(batch_data, dtype=dt)
+assert b.dtype == np.int64
+consume2(b)
 os.remove("sidecar_feed_tmp.npy")


### PR DESCRIPTION
Closes wala/ML#774.

The wala/ML#772 dtype feed models `np.array`'s preservation semantics, but preservation only holds when no explicit `dtype` argument is supplied: a passed `dtype` overrides the source's dtype at runtime, so when it is statically unresolvable, borrowing the operand's dtype fabricates evidence. The 0.52.56 release smoke caught the witness through the evidence-baseline protocol (wala/ML#767): two `input_mask` parameter rows moved from the truthful `UNKNOWN[TOP]` to `FLOAT64[TOP]`, the `np.zeros` operand's float64 fed through `np.array(mask, dtype=np.bool)`, whose runtime dtype is bool.

`NpArray.getTypeFeed` now declines to declare a feed when the dtype resolution comes up empty AND a caller invoke syntactically passes a `dtype` argument (a second positional argument or the `dtype` keyword, checked at the caller invokes, which is decisive regardless of whether the argument's points-to evidence survives). The result stays soundly both-axes-unknown. The `dtype`-argument modeling itself (`np.bool` and friends) is separate work that, once done, tightens such rows correctly.

Guards: `testTypeAnnotationSidecarFeedDeclinesOnDtypeArgument` (new leg in `sidecar_proj/driver_feed.py`: an opaque `dtype` from a loaded array's attribute; the result observes both-axes-unknown, not the operand's `int64`) alongside the unchanged through-leg `testTypeAnnotationSidecarFeedsThroughNpArray`. The release-day smoke re-run against this fix is the disposition for the blocked baseline diff: the rows return to their prior values and the baseline stays unfolded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
