### PR TITLE
Store comprehension elements under the append-contents property

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -215,6 +215,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_2_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 3);
 
+  protected static final TensorType TENSOR_6_1_FLOAT32 = TensorType.of(FLOAT_32, 6, 1);
+
   protected static final TensorType TENSOR_1_1_3_2_FLOAT32 = TensorType.of(FLOAT_32, 1, 1, 3, 2);
 
   protected static final TensorType TENSOR_2_3_1_FLOAT32 = TensorType.of(FLOAT_32, 2, 3, 1);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -786,20 +786,17 @@ public class TestMisc extends AbstractTensorTest {
    * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>): the annotated opaque read is
    * conditionally slice-reassigned inside its method, collected by a list comprehension in a second
    * method, and batched through {@code np.array} behind a method-call boundary. The comprehension
-   * trampoline's reflected element write is invisible to container-element dataflow consumers, so
-   * the {@code int64} dies at the comprehension hop and the parameter observes {@code {? of
-   * unknown}}.
-   *
-   * <p>TODO: Flip to a plain positive test when <a
-   * href="https://github.com/wala/ML/issues/773">wala/ML#773</a> gives comprehension element writes
-   * an enumerable channel.
+   * trampoline stores each element under the append-contents property (<a
+   * href="https://github.com/wala/ML/issues/773">wala/ML#773</a>), so container-element consumers
+   * observe comprehension-built elements like append-built ones and the annotated {@code int64}
+   * arrives at the parameter.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testTypeAnnotationSidecarFeedsThroughLoaderChain()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -21,6 +21,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_6_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_28_28_UINT8;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_6_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_6_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_6_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_6_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
@@ -418,15 +419,11 @@ public class TestShapeOps extends AbstractTensorTest {
   /**
    * Indexed dispatch over a comprehension-built sublayer list (wala/ML#661 shape 3, wala/ML#694):
    * {@code self.sub_layers = [Inner() for _ in range(n)]} dispatched through {@code
-   * self.sub_layers[i](out)} in a loop. {@code Inner.call} returns a distinctly-shaped {@code (6,
-   * 1)} tensor, so a working dispatch would flow {@code (6, 1)} to {@code consume}. The analysis
-   * instead reports the pre-loop input's {@code (2, 3)} (carried by the loop phi): the
-   * comprehension-built indexed call materializes no callee, so the sub-layer forward result never
-   * reaches the sink.
-   *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/694">wala/ML#694</a>): once the
-   * comprehension-built indexed dispatch materializes its callee, tighten the assertion to the
-   * precise {@code (6, 1)} shape (the Python runtime shape).
+   * self.sub_layers[i](out)} in a loop. The comprehension trampoline stores its elements under the
+   * append-contents property (<a href="https://github.com/wala/ML/issues/773">wala/ML#773</a>), so
+   * the indexed call materializes {@code Inner.call} and the sub-layer's distinctly-shaped {@code
+   * (6, 1)} forward result (the Python runtime shape) reaches {@code consume}; the pre-loop input's
+   * {@code (2, 3)} rides along in the union through the loop phi.
    *
    * @throws ClassHierarchyException if the class hierarchy cannot be built.
    * @throws IllegalArgumentException if the input fixture is malformed.
@@ -436,12 +433,20 @@ public class TestShapeOps extends AbstractTensorTest {
   @Test
   public void testIndexedComprehensionLayerListCall()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    // TODO(wala/ML#694): observed-but-imprecise (2, 3); the runtime shape is (6, 1).
-    test("tf2_test_layer_list_compr.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+    test(
+        "tf2_test_layer_list_compr.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_3_FLOAT32, TENSOR_6_1_FLOAT32)));
   }
 
   /**
-   * Probes wala/ML#661's indexed sub-layer call shape ({@code self.container[i](x)}).
+   * Probes wala/ML#661's indexed sub-layer call shape ({@code self.container[i](x)}). The
+   * comprehension-built {@code inner_layers} dispatch materializes {@code Inner.call} (<a
+   * href="https://github.com/wala/ML/issues/773">wala/ML#773</a>); the runtime {@code (4, 4)}
+   * matmul result is present, alongside an unknown-shape member from the matmul over the loop-phi's
+   * union.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -451,7 +456,12 @@ public class TestShapeOps extends AbstractTensorTest {
   @Test
   public void testIndexedLayerCall()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_indexed_layer_call.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_4_4_FLOAT32)));
+    test(
+        "tf2_test_indexed_layer_call.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_4_FLOAT32, TENSOR_UNKNOWN_SHAPE_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonComprehensionTrampolines.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/PythonComprehensionTrampolines.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ipa.summaries;
 
 import com.ibm.wala.cast.loader.DynamicCallSiteReference;
+import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ir.PythonLanguage;
 import com.ibm.wala.cast.python.ssa.PythonInvokeInstruction;
 import com.ibm.wala.cast.python.types.PythonTypes;
@@ -11,6 +12,7 @@ import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
+import com.ibm.wala.ssa.ConstantValue;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
@@ -80,6 +82,18 @@ public class PythonComprehensionTrampolines implements MethodTargetSelector {
         x.addStatement(new PythonInvokeInstruction(s, r, v++, ss, args, keywordParams));
 
         x.addStatement(PythonLanguage.Python.instructionFactory().PropertyWrite(idx++, 2, ofv, r));
+
+        // The reflected write above keys the element by the input iterable's field, which an
+        // opaque input cannot enumerate; also store the element under the append-contents
+        // property, the same durable channel `xs.append(v)` uses, so container-element consumers
+        // (value iteration, subscript reads, element feeds) observe comprehension-built elements
+        // exactly like append-built ones (wala/ML#773).
+        int contentsKey = v++;
+        x.addConstant(
+            contentsKey,
+            new ConstantValue(PythonSSAPropagationCallGraphBuilder.LIST_APPEND_CONTENTS_FIELD));
+        x.addStatement(
+            PythonLanguage.Python.instructionFactory().PropertyWrite(idx++, 2, contentsKey, r));
 
         x.addStatement(
             PythonLanguage.Python.instructionFactory().ReturnInstruction(idx++, 2, false));


### PR DESCRIPTION
Closes wala/ML#773. Advances wala/ML#694 (the confirmed comprehension-built class; the `extend`/`insert`/`+=` and dict-keyed classes remain with the issue).

`PythonComprehensionTrampolines` stored each mapped element only through a reflected `PropertyWrite` whose member comes from `EachElementGet` over the input iterable, so an opaque input (e.g. a `random.sample` result) enumerates nothing and the elements land nowhere: value iteration, subscript reads, and container-element feeds all observe an empty container, and an indexed dispatch over a comprehension-built layer list materializes no callee.

The trampoline now additionally stores each element under the `__list_append_contents__` synthetic property, the same durable channel `xs.append(v)` uses, whose read-side dual ponder-lab/ML#533 already installed. Comprehension-built containers thereby behave like append-built ones for every container-element consumer, with one write added to the synthesized body.

Effects, all pinned:

- `testTypeAnnotationSidecarFeedsThroughLoaderChain` flips from issue-blocked to a positive guard: the faithful loader shape (opaque read, conditional slice reassignment, comprehension collection, `np.array` batch behind a method boundary) now delivers the annotated `int64` to the consumer.
- `testIndexedComprehensionLayerListCall` improves onto its recorded TODO: the comprehension-built indexed dispatch materializes `Inner.call`, and the runtime `(6, 1)` sub-layer result reaches the sink (the pre-loop `(2, 3)` rides along through the loop phi's union). The TODO is retired.
- `testIndexedLayerCall` likewise gains the materialized dispatch; the runtime `(4, 4)` is present alongside an unknown-shape member from the matmul over the loop-phi union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
