### PR TITLE
Guard the corpus metrics-mask row against dtype fabrication

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -302,6 +302,29 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The corpus metrics-mask shape (<a
+   * href="https://github.com/wala/ML/issues/774">wala/ML#774</a>): {@code np.zeros} feeds {@code
+   * np.array} with an explicit but statically-unresolvable dtype, which overrides the source's
+   * dtype at runtime, so the operand feed declines and the result's dtype stays unknown rather than
+   * borrowing the operand's float64. The shape is likewise unresolved at present.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpArrayUnresolvableDtypeMask()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_nparray_bool_mask.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(UNKNOWN, null))));
+  }
+
+  /**
    * Regression guard for <a href="https://github.com/wala/ML/issues/598">wala/ML#598</a>: the
    * {@code tf.constant}-wrapped {@code numpy.array} form also propagates to the callee parameter.
    * It currently types to {@code ⊤} unknown, coarser than the bare form's {@code (3,)} because

--- a/com.ibm.wala.cast.python.test/data/tf2_test_nparray_bool_mask.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_nparray_bool_mask.py
@@ -1,0 +1,15 @@
+# The metrics-mask shape from the corpus (wala/ML#774): `np.zeros` feeds `np.array` with an
+# explicit but statically-unresolvable dtype, which overrides the source's dtype at runtime; the
+# result's dtype must stay unknown rather than borrowing the operand's float64.
+import numpy as np
+
+
+def consume(m):
+    pass
+
+
+mask = np.zeros(5)
+m = np.array(mask, dtype=np.bool_)
+assert m.dtype == np.bool_
+assert m.shape == (5,)
+consume(m)


### PR DESCRIPTION
Pins wala/ML#774's class at row shape in the always-on layer: the corpus metrics-mask chain (`np.zeros` into `np.array(mask, dtype=<unresolvable>)`) observes `{? of unknown}` at the consumer, the sound verdict when an explicit dtype argument cannot be mapped. This is the vendored counterpart of the release-smoke rows that caught the 0.52.56 fabrication; the fixture runs to completion under python3.10 and asserts the runtime bool dtype. When wala/ML#775 resolves numpy dtype tokens, this pin moves to the truthful `BOOL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX