### PR TITLE
Pin the `from_generator` tuple-form and `window`-chain gaps

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -827,6 +827,83 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * The tuple-structured legacy {@code output_types} form of {@code tf.data.Dataset.from_generator}
+   * (<a href="https://github.com/wala/ML/issues/776">wala/ML#776</a>): the declared {@code
+   * (tf.int32, tf.float32)} statically determines each iterated component's dtype, regardless of
+   * the generator body's opacity. The dict-structured form (wala/ML#615) delivers, but the tuple
+   * form observes a scalar-shaped unknown-dtype element, so the declaration is currently lost.
+   *
+   * <p>TODO: Flip to a positive test when <a
+   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a> delivers the tuple-form
+   * per-component dtypes.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testDatasetFromGeneratorTupleTypes()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_from_generator.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_32, null))));
+  }
+
+  /**
+   * The second component of {@link #testDatasetFromGeneratorTupleTypes()}.
+   *
+   * <p>TODO: Flip to a positive test when <a
+   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a> delivers the tuple-form
+   * per-component dtypes.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testDatasetFromGeneratorTupleTypes2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_from_generator.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * The corpus loader-chain shape (<a
+   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a>): {@code from_generator} with a
+   * declared element dtype, then {@code .shuffle(...).prefetch(...).window(n)}. {@code window} is
+   * unmodeled (it yields datasets of datasets), so the declared dtype currently dies at the
+   * combinator and the doubly-iterated element observes nothing.
+   *
+   * <p>TODO: Flip to a positive test when <a
+   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a> models {@code window} and the
+   * declaration survives the chain.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testDatasetWindowedChain()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dataset_window.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_32, null))));
+  }
+
+  /**
    * Regression guard for wala/ML#506: {@code tf.data.Dataset.map(map_func)} types its elements from
    * {@code map_func}'s return, not the receiver's elements. {@code map_func} here ({@code double})
    * consumes its argument ({@code tf.cast(x, tf.int64)}), exercising both halves: the callback's

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_window.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_window.py
@@ -1,0 +1,26 @@
+# The corpus loader chain shape (wala/ML#776): `from_generator` with declared output types,
+# then `.shuffle(...).prefetch(...).window(n)`. `window` yields datasets of datasets; the
+# element dtype declaration must survive the combinator chain to reach the iterated values.
+import numpy as np
+import tensorflow as tf
+
+
+def gen():
+    for i in range(4):
+        yield np.array([i, i + 1])
+
+
+def consume(w):
+    pass
+
+
+ds = (
+    tf.data.Dataset.from_generator(gen, tf.int32)
+    .shuffle(4)
+    .prefetch(tf.data.experimental.AUTOTUNE)
+    .window(2)
+)
+for w in ds:
+    for e in w:
+        assert e.dtype == tf.int32
+        consume(e)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_from_generator.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_from_generator.py
@@ -1,0 +1,26 @@
+# `tf.data.Dataset.from_generator` declares its element dtypes in the `output_types` tuple
+# (wala/ML#776): the iterated values' dtypes are statically determined by the declaration,
+# regardless of the generator body's opacity.
+import numpy as np
+import tensorflow as tf
+
+
+def gen():
+    for i in range(3):
+        yield np.array([i, i + 1]), np.array([float(i)])
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+ds = tf.data.Dataset.from_generator(gen, (tf.int32, tf.float32))
+for a, b in ds:
+    assert a.dtype == tf.int32
+    assert b.dtype == tf.float32
+    consume(a)
+    consume2(b)


### PR DESCRIPTION
Advances wala/ML#776 with its in-suite reproduction, both layers pinned as issue-blocked guards: the tuple-structured `output_types` form loses its per-component dtype declaration even without combinators (the dict form of wala/ML#615 delivers, an asymmetry the fix can diff against), and the `.window(n)` combinator is unmodeled entirely, so the corpus loader chain dies at it regardless. Both fixtures run to completion under python3.10 and assert the runtime dtypes; the guards flip to positive as each layer lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX