### PR TITLE
Model `window` as an element-preserving dataset and floor unresolved dataset element types at `⊤`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -876,20 +876,17 @@ public class TestDatasets extends AbstractTensorTest {
   /**
    * The corpus loader-chain shape (<a
    * href="https://github.com/wala/ML/issues/776">wala/ML#776</a>): {@code from_generator} with a
-   * declared element dtype, then {@code .shuffle(...).prefetch(...).window(n)}. {@code window} is
-   * unmodeled (it yields datasets of datasets), so the declared dtype currently dies at the
-   * combinator and the doubly-iterated element observes nothing.
-   *
-   * <p>TODO: Flip to a positive test when <a
-   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a> models {@code window} and the
-   * declaration survives the chain.
+   * declared element dtype, then {@code .shuffle(...).prefetch(...).window(n)}. {@code window}
+   * yields datasets of datasets, modeled level-collapsed as an element-preserving transform; the
+   * declared dtype survives the combinator chain to the doubly-iterated element, whose shape is
+   * unknown (⊤) since {@code from_generator} declares no {@code output_shapes}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testDatasetWindowedChain()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2680,6 +2680,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
         <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
@@ -2717,6 +2719,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
         <method name="__iter__" descriptor="()LRoot;" numArgs="1" paramNames="self">
@@ -2754,6 +2758,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2786,6 +2792,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2817,6 +2825,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2849,6 +2859,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2881,6 +2893,42 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
+          <return value="x"/>
+        </method>
+      </class>
+      <class name="window" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#window (wala/ML#776). Level-collapsed model: the runtime yields windows (sub-datasets) whose own iteration yields the source elements; this model returns an element-preserving Dataset, so the generic pass-through dataset generator delegates element types to the source and the two-level iteration observes the source element types. -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self size shift stride drop_remainder name">
+          <new def="x" class="Ltensorflow/data/Dataset"/>
+          <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance* via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>` allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
+          <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
+          <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>
+          <new def="rd_batch" class="Ltensorflow/data/batch"/>
+          <putfield class="LRoot" field="batch" fieldType="LRoot" ref="x" value="rd_batch"/>
+          <new def="rd_padded_batch" class="Ltensorflow/data/padded_batch"/>
+          <putfield class="LRoot" field="padded_batch" fieldType="LRoot" ref="x" value="rd_padded_batch"/>
+          <new def="rd_repeat" class="Ltensorflow/data/repeat"/>
+          <putfield class="LRoot" field="repeat" fieldType="LRoot" ref="x" value="rd_repeat"/>
+          <new def="rd_prefetch" class="Ltensorflow/data/prefetch"/>
+          <putfield class="LRoot" field="prefetch" fieldType="LRoot" ref="x" value="rd_prefetch"/>
+          <new def="rd_with_options" class="Ltensorflow/data/with_options"/>
+          <putfield class="LRoot" field="with_options" fieldType="LRoot" ref="x" value="rd_with_options"/>
+          <new def="rd_take" class="Ltensorflow/data/take"/>
+          <putfield class="LRoot" field="take" fieldType="LRoot" ref="x" value="rd_take"/>
+          <new def="rd_map" class="Ltensorflow/data/map"/>
+          <putfield class="LRoot" field="map" fieldType="LRoot" ref="x" value="rd_map"/>
+          <new def="rd_filter" class="Ltensorflow/data/filter"/>
+          <putfield class="LRoot" field="filter" fieldType="LRoot" ref="x" value="rd_filter"/>
+          <new def="rd_concatenate" class="Ltensorflow/data/concatenate"/>
+          <putfield class="LRoot" field="concatenate" fieldType="LRoot" ref="x" value="rd_concatenate"/>
+          <new def="rd_reduce" class="Ltensorflow/data/reduce"/>
+          <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
+          <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
+          <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2913,6 +2961,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2945,6 +2995,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -2980,6 +3032,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3012,6 +3066,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3044,6 +3100,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3082,6 +3140,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3117,6 +3177,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3149,6 +3211,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3181,6 +3245,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3213,6 +3279,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3245,6 +3313,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3277,6 +3347,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3309,6 +3381,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <!-- FIXME: This could return tuples of tensors. See https://github.com/wala/ML/issues/165. -->
           <return value="x"/>
         </method>
@@ -3342,6 +3416,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>
@@ -3374,6 +3450,8 @@
           <putfield class="LRoot" field="reduce" fieldType="LRoot" ref="x" value="rd_reduce"/>
           <new def="rd_enumerate" class="Ltensorflow/data/enumerate"/>
           <putfield class="LRoot" field="enumerate" fieldType="LRoot" ref="x" value="rd_enumerate"/>
+          <new def="rd_window" class="Ltensorflow/data/window"/>
+          <putfield class="LRoot" field="window" fieldType="LRoot" ref="x" value="rd_window"/>
           <return value="x"/>
         </method>
       </class>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DatasetGenerator.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.client;
 
+import static com.ibm.wala.cast.python.types.PythonTypes.DO_METHOD_NAME;
 import static com.ibm.wala.cast.python.util.Util.findDefinition;
 import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 
@@ -72,9 +73,38 @@ public class DatasetGenerator extends TensorGenerator implements TupleElementPro
     OrdinalSet<InstanceKey> receiverPTS =
         this.getArgumentPointsToSet(builder, RECEIVER_PARAMETER_POSITION, SELF);
     if (receiverPTS != null && !receiverPTS.isEmpty()) {
-      return this.getShapesOfValue(builder, receiverPTS);
+      Set<List<Dimension<?>>> shapes = this.getShapesOfValue(builder, receiverPTS);
+      // An API-produced dataset receiver's elements are tensors by construction, so an empty
+      // resolution here means the upstream element shape did not resolve, not that the elements
+      // are non-tensors. The default-mode delegation walk flattens an all-unknown union to ⊥ (the
+      // wala/ML#718 resolvable-subset contract keeps the unknown remainder only in exact mode),
+      // which without this floor kills the whole transformation chain at its first unresolved
+      // hop: ⊥ shapes compose with any resolved dtype to no types at all (wala/ML#776). The
+      // modeled-producer gate keeps a receiver with no synthetic-`do` allocation (e.g. the
+      // import-block `Dataset` singleton reached by the illegal direct construction in
+      // `tf2_test_dataset3.py`) at ⊥.
+      if ((shapes == null || shapes.isEmpty()) && hasModeledProducer(receiverPTS)) return null;
+      return shapes;
     }
     return null;
+  }
+
+  /**
+   * Returns whether any member of the given points-to set is allocated in a synthetic {@code do}
+   * method, i.e., was produced by a modeled dataset API rather than reached some other way (such as
+   * the import-block class singleton).
+   *
+   * @param pointsToSet The receiver's points-to set.
+   * @return {@code true} iff some member's allocation node is a {@code do} method.
+   */
+  private static boolean hasModeledProducer(OrdinalSet<InstanceKey> pointsToSet) {
+    for (InstanceKey ik : pointsToSet) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin != null && asin.getNode().getMethod().getName().toString().equals(DO_METHOD_NAME)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -83,7 +113,13 @@ public class DatasetGenerator extends TensorGenerator implements TupleElementPro
     OrdinalSet<InstanceKey> receiverPTS =
         this.getArgumentPointsToSet(builder, RECEIVER_PARAMETER_POSITION, SELF);
     if (receiverPTS != null && !receiverPTS.isEmpty()) {
-      return this.getDTypesOfValue(builder, receiverPTS);
+      Set<DType> dTypes = this.getDTypesOfValue(builder, receiverPTS);
+      // The dtype counterpart of the shape floor above: ⊥ on one axis must pair with ⊥ on the
+      // other, so an unresolved element dtype degrades to UNKNOWN (⊤) rather than emptying the
+      // set, under the same modeled-producer gate (wala/ML#776).
+      if ((dTypes == null || dTypes.isEmpty()) && hasModeledProducer(receiverPTS))
+        return EnumSet.of(DType.UNKNOWN);
+      return dTypes == null ? EnumSet.of(DType.UNKNOWN) : dTypes;
     }
     return EnumSet.of(DType.UNKNOWN);
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -58,6 +58,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_REPEAT_T
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_SAMPLE_FROM_DATASETS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_SHUFFLE_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_TAKE_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_WINDOW_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_WITH_OPTIONS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_ZIP_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DENSE_CALL;
@@ -1715,6 +1716,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, DATASET_SAMPLE_FROM_DATASETS_TYPE))
       return new DatasetSampleFromDatasetsGenerator(source);
     else if (isType(calledFunction, DATASET_SHUFFLE_TYPE)
+        || isType(calledFunction, DATASET_WINDOW_TYPE)
         || isType(calledFunction, DATASET_MAP_TYPE)
         || isType(calledFunction, DATASET_REPEAT_TYPE)
         || isType(calledFunction, DATASET_PREFETCH_TYPE)

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -222,6 +222,11 @@ public class TensorFlowTypes extends PythonTypes {
 
   public static final String DATASET_PREFETCH_SIGNATURE = "tf.data.Dataset.prefetch()";
 
+  public static final TypeReference DATASET_WINDOW_TYPE =
+      TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Ltensorflow/data/window"));
+
+  public static final String DATASET_WINDOW_SIGNATURE = "tf.data.Dataset.window()";
+
   public static final TypeReference DATASET_TAKE_TYPE =
       TypeReference.findOrCreate(pythonLoader, TypeName.findOrCreate("Ltensorflow/data/take"));
 
@@ -1991,6 +1996,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(DATASET_MAP_TYPE, DATASET_MAP_SIGNATURE),
           Map.entry(DATASET_REPEAT_TYPE, DATASET_REPEAT_SIGNATURE),
           Map.entry(DATASET_PREFETCH_TYPE, DATASET_PREFETCH_SIGNATURE),
+          Map.entry(DATASET_WINDOW_TYPE, DATASET_WINDOW_SIGNATURE),
           Map.entry(DATASET_TAKE_TYPE, DATASET_TAKE_SIGNATURE),
           Map.entry(DATASET_WITH_OPTIONS_TYPE, DATASET_WITH_OPTIONS_SIGNATURE),
           Map.entry(DATASET_CONCATENATE_TYPE, DATASET_CONCATENATE_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dataset_window.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dataset_window.py
@@ -14,6 +14,10 @@ def consume(w):
     pass
 
 
+def consume_outer(w):
+    pass
+
+
 ds = (
     tf.data.Dataset.from_generator(gen, tf.int32)
     .shuffle(4)
@@ -21,6 +25,7 @@ ds = (
     .window(2)
 )
 for w in ds:
+    consume_outer(w)
     for e in w:
         assert e.dtype == tf.int32
         consume(e)


### PR DESCRIPTION
Models `tf.data.Dataset.window` and repairs the transformation-chain type flow it exposed. Advances wala/ML#776.

**`window` Surface**

A `window` synthetic class in `tensorflow.xml` (an element-preserving pass-through cloned from `prefetch`, level-collapsed: a windowed dataset's sub-dataset elements are approximated by the base element type), the `rd_window` field in every dataset block, `DATASET_WINDOW_TYPE` plus its signature entry, and the factory pass-through arm. The two-level fixture `tf2_test_dataset_window.py` iterates `from_generator(gen, tf.int32).shuffle(4).prefetch(...).window(2)` at both levels.

**Chain Repair**

The surface alone was insufficient: the default-mode delegation walk flattens an all-unknown producer union to `⊥` (the wala/ML#718 resolvable-subset contract keeps the unknown remainder only in exact mode), so the declared `int32` dtype died at the first hop even though it resolved: `⊥` shapes composed with the resolved dtype to no types at all, and the composed `⊥` memoized down the chain. `DatasetGenerator.getDefaultShapes`/`getDefaultDTypes` now degrade an empty receiver-element resolution to `⊤` (`null` shapes, `UNKNOWN` dtype), gated on the receiver having a modeled producer (a member allocated in a synthetic `do` method). Every transformation hop re-enters `DatasetGenerator`, so the chain repairs per hop; the gate keeps the deliberately illegal direct construction in `tf2_test_dataset3.py` (an import-block singleton receiver) at `⊥`.

With both pieces, `consume` in the fixture observes `{? of int32}` through the full chain and `testDatasetWindowedChain` flips to a positive guard. The general (engine-level) floor is tracked separately as wala/ML#788, blocked by wala/ML#787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
