### PR TITLE
Guard declared `from_generator` element shapes across the transformation chain

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -874,6 +874,76 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * Both axes declared at the {@code from_generator} source (<a
+   * href="https://github.com/wala/ML/issues/776">wala/ML#776</a>): {@code output_types} fixes the
+   * element dtype and {@code output_shapes} the element shape, and both declarations survive the
+   * {@code shuffle}/{@code prefetch} pass-through chain to the iterated element. The shape-axis
+   * companion of {@link #testDatasetWindowedChain()}, whose source declares no shapes and so
+   * degrades that axis to ⊤.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDatasetFromGeneratorDeclaredShapes()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_from_generator_shapes.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2))));
+  }
+
+  /**
+   * The keyword form of {@link #testDatasetFromGeneratorDeclaredShapes()}: {@code output_shapes}
+   * passed by keyword rather than positionally.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDatasetFromGeneratorDeclaredShapes2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_from_generator_shapes2.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 2))));
+  }
+
+  /**
+   * The {@code tf.TensorShape} literal form of {@link #testDatasetFromGeneratorDeclaredShapes()}:
+   * the declared shape is wrapped in a {@code TensorShape} constructor rather than a plain tuple.
+   * {@code tf.TensorShape} is unmodeled, so the argument is present but unparseable and the shape
+   * axis soundly degrades to ⊤ ({@code {? of int32}}) instead of composing {@code (2,)}.
+   *
+   * <p>TODO: Flip to expect {@code TensorType.of(INT_32, 2)} when <a
+   * href="https://github.com/wala/ML/issues/789">wala/ML#789</a> parses {@code TensorShape}
+   * constructor literals in shape arguments.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDatasetFromGeneratorDeclaredShapes3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_from_generator_shapes3.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_32, null))));
+  }
+
+  /**
    * The corpus loader-chain shape (<a
    * href="https://github.com/wala/ML/issues/776">wala/ML#776</a>): {@code from_generator} with a
    * declared element dtype, then {@code .shuffle(...).prefetch(...).window(n)}. {@code window}

--- a/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes.py
@@ -1,0 +1,22 @@
+# `tf.data.Dataset.from_generator` with BOTH axes declared (wala/ML#776): `output_types`
+# fixes the element dtype and `output_shapes` the element shape, so the declaration must
+# survive the pass-through combinator chain to the iterated value on both axes.
+import numpy as np
+import tensorflow as tf
+
+
+def gen():
+    for i in range(4):
+        yield np.array([i, i + 1])
+
+
+def consume(a):
+    pass
+
+
+ds = tf.data.Dataset.from_generator(gen, tf.int32, (2,))
+ds = ds.shuffle(4).prefetch(tf.data.experimental.AUTOTUNE)
+for a in ds:
+    assert a.dtype == tf.int32
+    assert a.shape == (2,)
+    consume(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes2.py
@@ -1,0 +1,22 @@
+# The keyword form of `tf2_test_from_generator_shapes.py` (wala/ML#776): `output_shapes`
+# passed by keyword rather than positionally; the declaration must survive the chain the same
+# way.
+import numpy as np
+import tensorflow as tf
+
+
+def gen():
+    for i in range(4):
+        yield np.array([i, i + 1])
+
+
+def consume(a):
+    pass
+
+
+ds = tf.data.Dataset.from_generator(gen, tf.int32, output_shapes=(2,))
+ds = ds.shuffle(4).prefetch(tf.data.experimental.AUTOTUNE)
+for a in ds:
+    assert a.dtype == tf.int32
+    assert a.shape == (2,)
+    consume(a)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_from_generator_shapes3.py
@@ -1,0 +1,21 @@
+# The `tf.TensorShape` literal form of `tf2_test_from_generator_shapes.py` (wala/ML#776):
+# the declared shape is wrapped in a `TensorShape` constructor rather than a plain tuple.
+import numpy as np
+import tensorflow as tf
+
+
+def gen():
+    for i in range(4):
+        yield np.array([i, i + 1])
+
+
+def consume(a):
+    pass
+
+
+ds = tf.data.Dataset.from_generator(gen, tf.int32, output_shapes=tf.TensorShape([2]))
+ds = ds.shuffle(4).prefetch(tf.data.experimental.AUTOTUNE)
+for a in ds:
+    assert a.dtype == tf.int32
+    assert a.shape == (2,)
+    consume(a)


### PR DESCRIPTION
Test-only follow-up to ponder-lab/ML#699 answering whether a declared element shape survives the pass-through chain the way the declared dtype does. Advances wala/ML#776.

Three fixtures cover the declaration forms: the positional tuple (`from_generator(gen, tf.int32, (2,))`) and keyword tuple (`output_shapes=(2,)`) both compose the iterated element as `(2,)` `int32` through `shuffle`/`prefetch`, pinned as positive guards. The `tf.TensorShape([2])` literal form is unmodeled, so the argument is present but unparseable and the shape axis soundly degrades to `⊤`; that observation is pinned with a TODO until wala/ML#789 parses `TensorShape` constructor literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX