### PR TITLE
Floor an all-unknown shape union at `⊤` in every read mode

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -735,13 +735,14 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    * @throws IOException On I/O error reading the test file.
    *     <p>The local count excludes the slice-constructor objects under the multi-dim subscript,
    *     pinned non-tensor since wala/ML#732 (all-constant bounds) and wala/ML#787 (the dynamic
-   *     {@code inputs.shape[1]} bound); the subscript result stays typed. The {@code tf.add} return
-   *     is currently uncounted: its only typing was cross-caller leakage through the shared {@code
-   *     slice} builtin frame, which the wala/ML#787 pin cuts, and its own generator seed is ⊥
-   *     because the untyped subscript operand annihilates the typed one.
-   *     <p>TODO: Expect a fourth local ({@code tf.add}'s {@code (2, 50, 64)} float32 return) when
-   *     <a href="https://github.com/wala/ML/issues/790">wala/ML#790</a> stops a ⊥ operand from
-   *     annihilating the resolved one.
+   *     {@code inputs.shape[1]} bound); the subscript result stays typed. The fourth local is the
+   *     {@code tf.add} return at {@code {? of float32}}: its shape operand (the subscript result)
+   *     floors at ⊤ under wala/ML#788 and the elementwise seed composes honestly, where before
+   *     wala/ML#787 the same union arrived via cross-caller leakage through the shared {@code
+   *     slice} builtin frame.
+   *     <p>TODO: Expect {@code (2, 50, 64)} float32 for the {@code tf.add} return when <a
+   *     href="https://github.com/wala/ML/issues/790">wala/ML#790</a> broadcasts a resolved operand
+   *     shape past an unknown one instead of degrading to ⊤.
    */
   @Test
   public void testMusicTransformerPositionEmbedding()
@@ -756,7 +757,7 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         "DynamicPositionEmbedding.call",
         "musictx_proj",
         1,
-        3,
+        4,
         Map.of(3, Set.of(TensorType.of(FLOAT_32, 2, 50, 64))));
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3550,6 +3550,7 @@ public abstract class TensorGenerator {
     }
 
     boolean hasUnknown = false;
+    boolean sawUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
     WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
@@ -3604,6 +3605,7 @@ public abstract class TensorGenerator {
               // An unresolvable element makes the union incomplete: mark the remainder and keep
               // collecting the resolvable members (wala/ML#718).
               if (exact) hasUnknown = true;
+              sawUnknown = true;
               continue;
             }
 
@@ -3654,6 +3656,7 @@ public abstract class TensorGenerator {
           if (fromTensor.hasUnknown() || fromTensor.isBottom()) {
             if (exact) hasUnknown = true; // The union is incomplete, wala/ML#718.
           }
+          sawUnknown |= fromTensor.hasUnknown();
           ret.addAll(fromTensor.members());
         }
       } else if (getAllocationSiteInNode(valueIK) != null) {
@@ -3677,6 +3680,7 @@ public abstract class TensorGenerator {
             ret.addAll(generatorShapes.members());
             if (exact && generatorShapes.hasUnknown())
               hasUnknown = true; // Incomplete union, wala/ML#718.
+            sawUnknown |= generatorShapes.hasUnknown();
             if (replay) {
               TensorGenerator dispatched = generator;
               LOGGER.fine(
@@ -3710,7 +3714,26 @@ public abstract class TensorGenerator {
         throw new IllegalStateException("Unknown value type: " + valueIK.getClass() + ".");
       }
 
-    return new ShapeResult(ret, hasUnknown);
+    return finishShapeResult(ret, hasUnknown, sawUnknown);
+  }
+
+  /**
+   * Finalizes a shape resolution over a member union: when no members resolved but an unknown
+   * remainder was sighted, the value is a tensor of unknown shape (⊤), not a non-tensor (⊥). In the
+   * default (non-exact) mode the per-member unknown flags drop from the result (the resolvable
+   * subset contract, wala/ML#718), which without this floor collapses an all-unknown union to ⊥ and
+   * silently drops the value from downstream analysis (wala/ML#788).
+   *
+   * @param members The resolvable shape members collected over the union.
+   * @param hasUnknown Whether the result carries an unknown remainder under the current mode.
+   * @param sawUnknown Whether any union member resolved to an unknown remainder, regardless of
+   *     mode.
+   * @return The finalized resolution result.
+   */
+  private static ShapeResult finishShapeResult(
+      Set<List<Dimension<?>>> members, boolean hasUnknown, boolean sawUnknown) {
+    if (members.isEmpty() && (hasUnknown || sawUnknown)) return ShapeResult.unknown();
+    return new ShapeResult(members, hasUnknown);
   }
 
   /**
@@ -3779,6 +3802,7 @@ public abstract class TensorGenerator {
       boolean exact,
       boolean applyRecursionGuards) {
     boolean hasUnknown = false;
+    boolean sawUnknown = false;
     Set<List<Dimension<?>>> ret = HashSetFactory.make();
     CGNode readDataNode = asin.getNode();
     WorklistTypeResolver activeEngine = WorklistTypeResolver.active(builder);
@@ -3818,6 +3842,7 @@ public abstract class TensorGenerator {
           ret.addAll(delegatedShapes.members());
           if (exact && delegatedShapes.hasUnknown())
             hasUnknown = true; // Incomplete union, wala/ML#718.
+          sawUnknown |= delegatedShapes.hasUnknown();
           if (replay) {
             TensorGenerator manual = generator;
             LOGGER.fine(
@@ -3860,6 +3885,7 @@ public abstract class TensorGenerator {
             ret.addAll(delegatedShapes.members());
             if (exact && delegatedShapes.hasUnknown())
               hasUnknown = true; // Incomplete union, wala/ML#718.
+            sawUnknown |= delegatedShapes.hasUnknown();
             if (replay) {
               TensorGenerator dispatched = generator;
               LOGGER.fine(
@@ -3882,7 +3908,7 @@ public abstract class TensorGenerator {
           }
         }
       }
-      return new ShapeResult(ret, hasUnknown);
+      return finishShapeResult(ret, hasUnknown, sawUnknown);
     }
 
     // 1. read_data is called by the operation's 'do' method; the call-graph edges identify the
@@ -3918,7 +3944,10 @@ public abstract class TensorGenerator {
           LOGGER.fine("Delegating shape inference to: " + generator);
           Set<List<Dimension<?>>> delegatedShapes = generator.getShapes(builder);
           if (delegatedShapes != null) ret.addAll(delegatedShapes);
-          else if (exact) hasUnknown = true; // Incomplete union, wala/ML#718.
+          else {
+            if (exact) hasUnknown = true; // Incomplete union, wala/ML#718.
+            sawUnknown = true;
+          }
           if (replay) {
             TensorGenerator dispatched = generator;
             LOGGER.fine(
@@ -3939,7 +3968,7 @@ public abstract class TensorGenerator {
         }
       }
     }
-    return new ShapeResult(ret, hasUnknown);
+    return finishShapeResult(ret, hasUnknown, sawUnknown);
   }
 
   /**


### PR DESCRIPTION
The general repair behind the wala/ML#776 dataset-side floor. Closes wala/ML#788.

The default-mode reads kept the unknown remainder only under `exact` (the wala/ML#718 resolvable-subset contract), so a union in which no member resolved but unknown evidence was sighted flattened from `⊤` ("tensor, shape unknown") to `⊥` ("not a tensor"), and the composed `⊥` memoized down every producer-delegation chain: one unresolved hop deleted the whole chain, and a `⊥` shape annihilated a resolved dtype on the other axis. `finishShapeResult` now floors an empty-member result with a sighted unknown at the fully unknown tensor in both modes; the partial-subset contract is untouched when members exist, so the wala/ML#716 precision behavior for genuinely partial unions is unchanged.

Landing this required wala/ML#787 first: values whose non-tensor classification silently relied on the accidental flattening (the dynamic-bound slice objects) would otherwise resurface as spurious tensor rows. With those pins structural, the full suite passes, and the MusicTransformer `tf.add` return recovers as an honestly composed `{? of float32}`: the floored subscript operand no longer annihilates the elementwise seed, replacing the cross-caller leak the pin cut. wala/ML#790 now tracks tightening that `⊤` shape by broadcasting the resolved operand past the unknown one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX