### PR TITLE
Model the shape-and-dtype-preserving `tf.image` augmentation ops

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -27,7 +27,9 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_RAGGED_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_INT32_UNKNOWN_SHAPE;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_NONE_32_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.UINT_8;
 
+import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
@@ -1649,5 +1651,51 @@ public class TestElementwiseOps extends AbstractTensorTest {
   public void testParamDefault()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_param_default.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT32)));
+  }
+
+  /**
+   * The shape-and-dtype-preserving {@code tf.image} augmentation chain (<a
+   * href="https://github.com/wala/ML/issues/792">wala/ML#792</a>): {@code adjust_brightness},
+   * {@code random_flip_left_right}, {@code adjust_contrast}, {@code adjust_saturation}, and {@code
+   * adjust_hue} each pass the image argument's shape and dtype through, so the {@code (4, 5, 3)}
+   * uint8 constant survives all five hops.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testImageAugmentationChain()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_image_augmentation.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(UINT_8, 4, 5, 3))));
+  }
+
+  /**
+   * The cropped companion of {@link #testImageAugmentationChain()}: the image passes through a
+   * {@code tf.slice} hop into {@code adjust_brightness}, matching the corpus augmentation chain's
+   * crop-then-adjust structure. With constant extents the sliced shape computes exactly
+   * (wala/ML#569); the corpus's dynamically sized crop rides the same dtype path with the shape
+   * axis at ⊤ instead.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testImageAugmentationCroppedChain()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_image_augmentation.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(UINT_8, 2, 2, 3))));
   }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -497,6 +497,26 @@
         <new def="extract_patches" class="Ltensorflow/functions/image/extract_patches"/>
         <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="image" value="extract_patches"/>
         <putfield class="LRoot" field="extract_patches" fieldType="LRoot" ref="array_ops" value="extract_patches"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/random_flip_left_right -->
+        <new def="random_flip_left_right" class="Ltensorflow/functions/image/random_flip_left_right"/>
+        <putfield class="LRoot" field="random_flip_left_right" fieldType="LRoot" ref="image" value="random_flip_left_right"/>
+        <putfield class="LRoot" field="random_flip_left_right" fieldType="LRoot" ref="image_ops_impl" value="random_flip_left_right"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_contrast -->
+        <new def="adjust_contrast" class="Ltensorflow/functions/image/adjust_contrast"/>
+        <putfield class="LRoot" field="adjust_contrast" fieldType="LRoot" ref="image" value="adjust_contrast"/>
+        <putfield class="LRoot" field="adjust_contrast" fieldType="LRoot" ref="image_ops_impl" value="adjust_contrast"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_brightness -->
+        <new def="adjust_brightness" class="Ltensorflow/functions/image/adjust_brightness"/>
+        <putfield class="LRoot" field="adjust_brightness" fieldType="LRoot" ref="image" value="adjust_brightness"/>
+        <putfield class="LRoot" field="adjust_brightness" fieldType="LRoot" ref="image_ops_impl" value="adjust_brightness"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_saturation -->
+        <new def="adjust_saturation" class="Ltensorflow/functions/image/adjust_saturation"/>
+        <putfield class="LRoot" field="adjust_saturation" fieldType="LRoot" ref="image" value="adjust_saturation"/>
+        <putfield class="LRoot" field="adjust_saturation" fieldType="LRoot" ref="image_ops_impl" value="adjust_saturation"/>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_hue -->
+        <new def="adjust_hue" class="Ltensorflow/functions/image/adjust_hue"/>
+        <putfield class="LRoot" field="adjust_hue" fieldType="LRoot" ref="image" value="adjust_hue"/>
+        <putfield class="LRoot" field="adjust_hue" fieldType="LRoot" ref="image_ops_impl" value="adjust_hue"/>
         <new def="zeros" class="Ltensorflow/functions/zeros"/>
         <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros"/>
         <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="array_ops" value="zeros"/>
@@ -726,6 +746,9 @@
         <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64"/>
         <putfield class="LRoot" field="float64" fieldType="LRoot" ref="dtypes" value="float64"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#int32 -->
+        <new def="uint8" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="x" value="uint8"/>
+        <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="dtypes" value="uint8"/>
         <new def="int32" class="Ltensorflow/dtypes/DType"/>
         <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32"/>
         <putfield class="LRoot" field="int32" fieldType="LRoot" ref="dtypes" value="int32"/>
@@ -2329,6 +2352,42 @@
       <class name="extract_patches" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self images sizes strides rates padding name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <!-- The five shape-and-dtype-preserving augmentation ops below share the `ImageAugmentation` generator (wala/ML#792): each returns a fresh tensor of the same shape and type as its image argument, so the model is a direct `<new>`+`<return>` and the generator passes both axes through from arg 0. -->
+      <class name="random_flip_left_right" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/random_flip_left_right -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self image seed">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="adjust_contrast" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_contrast -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self images contrast_factor">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="adjust_brightness" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_brightness -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self image delta">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="adjust_saturation" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_saturation -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self image saturation_factor name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
+        </method>
+      </class>
+      <class name="adjust_hue" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/adjust_hue -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self image delta name">
           <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="res"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImageAugmentation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ImageAugmentation.java
@@ -1,0 +1,45 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * A generator for the shape-and-dtype-preserving {@code tf.image} augmentation ops ({@code
+ * random_flip_left_right} and the {@code adjust_contrast}/{@code adjust_brightness}/{@code
+ * adjust_saturation}/{@code adjust_hue} family): each returns a fresh tensor of the same shape and
+ * dtype as its image argument, with every other argument a scalar. One class serves all five op
+ * types, the {@link ElementWiseOperation} precedent for a shared generator over several dispatch
+ * keys. See wala/ML#792.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ImageAugmentation extends PassThroughUnaryTensorGenerator {
+
+  /**
+   * Constructs a new {@code ImageAugmentation}.
+   *
+   * @param source The {@link PointsToSetVariable} whose defining instruction is the invoke.
+   */
+  public ImageAugmentation(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs a new {@code ImageAugmentation}.
+   *
+   * @param node The synthetic {@link CGNode} allocating the result.
+   */
+  public ImageAugmentation(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected int getInputParameterPosition() {
+    return 0;
+  }
+
+  @Override
+  protected String getInputParameterName() {
+    return "image";
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -8,6 +8,10 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ACOSH;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD_WEIGHT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJOINT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJUST_BRIGHTNESS;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJUST_CONTRAST;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJUST_HUE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADJUST_SATURATION;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMAX;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARGMIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ARRAY_OPS_RESHAPE;
@@ -141,6 +145,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.POISSON_OP;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.POW;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RAGGED_CONSTANT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RAGGED_RANGE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANDOM_FLIP_LEFT_RIGHT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANDOM_NORMAL_INIT_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANGE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.RANK;
@@ -573,6 +578,12 @@ public class TensorGeneratorFactory {
       return anchor.makeGenerator(DiagPart::new, DiagPart::new);
     if (isType(type, EXTRACT_PATCHES.getDeclaringClass()))
       return anchor.makeGenerator(ExtractPatches::new, ExtractPatches::new);
+    if (isType(type, RANDOM_FLIP_LEFT_RIGHT.getDeclaringClass())
+        || isType(type, ADJUST_CONTRAST.getDeclaringClass())
+        || isType(type, ADJUST_BRIGHTNESS.getDeclaringClass())
+        || isType(type, ADJUST_SATURATION.getDeclaringClass())
+        || isType(type, ADJUST_HUE.getDeclaringClass()))
+      return anchor.makeGenerator(ImageAugmentation::new, ImageAugmentation::new);
     if (isType(type, FLATTEN.getDeclaringClass()))
       return anchor.makeGenerator(Flatten::new, Flatten::new);
     if (isType(type, GATHER_ND.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1279,6 +1279,57 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EXTRACT_PATCHES_SIGNATURE = "tf.image.extract_patches()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/image/random_flip_left_right. */
+  public static final MethodReference RANDOM_FLIP_LEFT_RIGHT =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/random_flip_left_right")),
+          AstMethodReference.fnSelector);
+
+  private static final String RANDOM_FLIP_LEFT_RIGHT_SIGNATURE =
+      "tf.image.random_flip_left_right()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/image/adjust_contrast. */
+  public static final MethodReference ADJUST_CONTRAST =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/adjust_contrast")),
+          AstMethodReference.fnSelector);
+
+  private static final String ADJUST_CONTRAST_SIGNATURE = "tf.image.adjust_contrast()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/image/adjust_brightness. */
+  public static final MethodReference ADJUST_BRIGHTNESS =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/adjust_brightness")),
+          AstMethodReference.fnSelector);
+
+  private static final String ADJUST_BRIGHTNESS_SIGNATURE = "tf.image.adjust_brightness()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/image/adjust_saturation. */
+  public static final MethodReference ADJUST_SATURATION =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/adjust_saturation")),
+          AstMethodReference.fnSelector);
+
+  private static final String ADJUST_SATURATION_SIGNATURE = "tf.image.adjust_saturation()";
+
+  /** https://www.tensorflow.org/api_docs/python/tf/image/adjust_hue. */
+  public static final MethodReference ADJUST_HUE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/functions/image/adjust_hue")),
+          AstMethodReference.fnSelector);
+
+  private static final String ADJUST_HUE_SIGNATURE = "tf.image.adjust_hue()";
+
   // Tier-A math ops (continued, wala/ML#422). Most are shape and dtype passthrough on their primary
   // tensor argument (named `x` for most unary ops; `features` for `softplus` / `softsign`). The
   // binary ops `atan2` / `maximum` / `minimum` are the exception: they're routed through
@@ -2118,6 +2169,11 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(SQUEEZE.getDeclaringClass(), SQUEEZE_SIGNATURE),
           Map.entry(SPLIT.getDeclaringClass(), SPLIT_SIGNATURE),
           Map.entry(EXTRACT_PATCHES.getDeclaringClass(), EXTRACT_PATCHES_SIGNATURE),
+          Map.entry(RANDOM_FLIP_LEFT_RIGHT.getDeclaringClass(), RANDOM_FLIP_LEFT_RIGHT_SIGNATURE),
+          Map.entry(ADJUST_CONTRAST.getDeclaringClass(), ADJUST_CONTRAST_SIGNATURE),
+          Map.entry(ADJUST_BRIGHTNESS.getDeclaringClass(), ADJUST_BRIGHTNESS_SIGNATURE),
+          Map.entry(ADJUST_SATURATION.getDeclaringClass(), ADJUST_SATURATION_SIGNATURE),
+          Map.entry(ADJUST_HUE.getDeclaringClass(), ADJUST_HUE_SIGNATURE),
           Map.entry(TAN.getDeclaringClass(), TAN_SIGNATURE),
           Map.entry(ASIN.getDeclaringClass(), ASIN_SIGNATURE),
           Map.entry(ATAN.getDeclaringClass(), ATAN_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_image_augmentation.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_image_augmentation.py
@@ -1,0 +1,32 @@
+# The shape-and-dtype-preserving `tf.image` augmentation ops (wala/ML#792), mirroring the
+# corpus augmentation chain: each op returns a tensor of the same shape and dtype as its
+# image argument, and the dtype must also survive a hop whose shape is honestly unknown
+# (`tf.slice` with runtime extents).
+import tensorflow as tf
+
+
+def consume(x):
+    pass
+
+
+def consume2(x):
+    pass
+
+
+img = tf.zeros((4, 5, 3), dtype=tf.uint8)
+
+a = tf.image.adjust_brightness(img, delta=0.1)
+a = tf.image.random_flip_left_right(a)
+a = tf.image.adjust_contrast(a, contrast_factor=1.2)
+a = tf.image.adjust_saturation(a, saturation_factor=1.1)
+a = tf.image.adjust_hue(a, delta=0.02)
+assert a.dtype == tf.uint8
+assert a.shape == (4, 5, 3)
+consume(a)
+
+begin = tf.constant([0, 0, 0])
+size = tf.constant([2, 2, 3])
+cropped = tf.slice(img, begin, size)
+b = tf.image.adjust_brightness(cropped, delta=0.1)
+assert b.dtype == tf.uint8
+consume2(b)


### PR DESCRIPTION
Closes wala/ML#792.

The residual-⊤ hunt on the TensorFlow-Examples baselines traced the `UNKNOWN[TOP]` union member on the `random_hue`/`random_saturation`/`random_brightness` parameters to the augmentation-chain context, where the dtype died at five unmodeled ops. This models `tf.image.random_flip_left_right` and the `adjust_contrast`/`adjust_brightness`/`adjust_saturation`/`adjust_hue` family as `<new>`+`<return>` classes served by one shared `ImageAugmentation` pass-through generator (both dispatch anchorings via the shared table), each documented as returning a tensor of the same shape and type as its image argument.

The unit also surfaced and fixes a second gap the fixture tripped: the import block had no `tf.uint8` `DType` token, so an explicit `dtype=tf.uint8` on any allocator resolved to nothing and fell to the float32 default. With both pieces, the fixture's uint8 image survives the full five-hop chain exactly, and the cropped variant carries the dtype through a `tf.slice` hop whose constant extents also compute the sliced shape.

The in-vivo acceptance is the next release smoke: the three TensorFlow-Examples unions should tighten from `UINT8[...] | UNKNOWN[TOP]` toward all-`UINT8` members, letting the consumer pin the concrete dtype with an honest wildcard shape for the dynamically cropped context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX