### PR TITLE
Model the `tf.bool` dtype token

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -13,6 +13,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_0_0_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_INT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_BOOL;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_3_FLOAT32;
@@ -1262,5 +1263,22 @@ public class TestConstructors extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 5, 3))));
+  }
+
+  /**
+   * The {@code tf.bool} dtype token (<a
+   * href="https://github.com/wala/ML/issues/793">wala/ML#793</a>): an explicit {@code
+   * dtype=tf.bool} on an allocator resolves to the boolean dtype rather than falling to the float32
+   * default, completing the import block's token inventory against the dtype lattice.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testZerosBoolMask()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_bool_mask.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
   }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -746,6 +746,9 @@
         <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64"/>
         <putfield class="LRoot" field="float64" fieldType="LRoot" ref="dtypes" value="float64"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#int32 -->
+        <new def="bool" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="bool" fieldType="LRoot" ref="x" value="bool"/>
+        <putfield class="LRoot" field="bool" fieldType="LRoot" ref="dtypes" value="bool"/>
         <new def="uint8" class="Ltensorflow/dtypes/DType"/>
         <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="x" value="uint8"/>
         <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="dtypes" value="uint8"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.cast.python.ml.types;
 
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX128;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.COMPLEX64;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
@@ -2347,6 +2348,16 @@ public class TensorFlowTypes extends PythonTypes {
           findOrCreateAsciiAtom(COMPLEX128.name().toLowerCase(Locale.ROOT)),
           D_TYPE);
 
+  /**
+   * Represents the TensorFlow bool data type.
+   *
+   * @see <a href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dtypes#bool">
+   *     TensorFlow bool DType</a>.
+   */
+  public static final FieldReference BOOL_FIELD =
+      FieldReference.findOrCreate(
+          PythonTypes.Root, findOrCreateAsciiAtom(BOOL.name().toLowerCase(Locale.ROOT)), D_TYPE);
+
   /** A mapping from a field reference to its associated {@link DType}, if any. */
   public static final Map<FieldReference, DType> FIELD_REFERENCE_TO_DTYPE =
       Map.ofEntries(
@@ -2355,6 +2366,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(INT_32, INT32),
           Map.entry(INT_64, INT64),
           Map.entry(UINT_8, UINT8),
+          Map.entry(BOOL_FIELD, BOOL),
           Map.entry(COMPLEX_64, COMPLEX64),
           Map.entry(COMPLEX_128, COMPLEX128),
           Map.entry(STRING, DType.STRING));

--- a/com.ibm.wala.cast.python.test/data/tf2_test_bool_mask.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_bool_mask.py
@@ -1,0 +1,13 @@
+# The `tf.bool` dtype token (wala/ML#793): an explicit `dtype=tf.bool` on an allocator must
+# resolve to the boolean dtype rather than falling to the float32 default.
+import tensorflow as tf
+
+
+def consume(m):
+    pass
+
+
+mask = tf.zeros((2, 2), dtype=tf.bool)
+assert mask.dtype == tf.bool
+assert mask.shape == (2, 2)
+consume(mask)


### PR DESCRIPTION
Closes wala/ML#793.

Completes the import block's `DType` token inventory against the dtype lattice, the second gap of the wala/ML#792 audit: the `bool` token allocation plus the `BOOL_FIELD` entry in the field-to-dtype map. The two halves were separately missing, so an explicit `dtype=tf.bool` first resolved to nothing (float32 default) and, with the token alone, to the unknown dtype; with both, the `tf.zeros((2, 2), dtype=tf.bool)` mask fixture pins `{(2, 2) bool}`. The remaining lattice members all have tokens and map entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX