### PR TITLE
Resolve numpy dtype tokens passed as `dtype=` arguments

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -307,8 +307,8 @@ public class TestConstructors extends AbstractTensorTest {
    * and <a href="https://github.com/wala/ML/issues/775">wala/ML#775</a>): {@code np.zeros} feeds
    * {@code np.array} with an explicit {@code np.bool_} dtype, which overrides the source's dtype at
    * runtime. The wala/ML#774 decline correctly refused to borrow the operand's float64 while the
-   * token was unresolvable; with the {@code bool_} token modeled, the declared dtype resolves and
-   * the result reads boolean with the shape still unresolved.
+   * token was unresolvable; with the {@code bool_} token modeled and the scalar shape-argument form
+   * parsed ({@code np.zeros(5)} allocates rank 1), both axes resolve exactly.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -323,7 +323,7 @@ public class TestConstructors extends AbstractTensorTest {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(BOOL, null))));
+        Map.of(2, Set.of(TensorType.of(BOOL, 5))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -303,11 +303,12 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
-   * The corpus metrics-mask shape (<a
-   * href="https://github.com/wala/ML/issues/774">wala/ML#774</a>): {@code np.zeros} feeds {@code
-   * np.array} with an explicit but statically-unresolvable dtype, which overrides the source's
-   * dtype at runtime, so the operand feed declines and the result's dtype stays unknown rather than
-   * borrowing the operand's float64. The shape is likewise unresolved at present.
+   * The corpus metrics-mask shape (<a href="https://github.com/wala/ML/issues/774">wala/ML#774</a>
+   * and <a href="https://github.com/wala/ML/issues/775">wala/ML#775</a>): {@code np.zeros} feeds
+   * {@code np.array} with an explicit {@code np.bool_} dtype, which overrides the source's dtype at
+   * runtime. The wala/ML#774 decline correctly refused to borrow the operand's float64 while the
+   * token was unresolvable; with the {@code bool_} token modeled, the declared dtype resolves and
+   * the result reads boolean with the shape still unresolved.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -322,7 +323,7 @@ public class TestConstructors extends AbstractTensorTest {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(new TensorType(UNKNOWN, null))));
+        Map.of(2, Set.of(new TensorType(BOOL, null))));
   }
 
   /**
@@ -1263,6 +1264,67 @@ public class TestConstructors extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TensorType.of(FLOAT_32, 5, 3))));
+  }
+
+  /**
+   * The numpy dtype-token witnesses of <a
+   * href="https://github.com/wala/ML/issues/775">wala/ML#775</a>: the {@code np.ndarray}
+   * constructor resolves its {@code np.int32} token through the {@code zeros} typing contract.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNdarrayConstructor()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_dtype_tokens.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_32, 3))));
+  }
+
+  /**
+   * The builtin-token companion of {@link #testNdarrayConstructor()}: {@code np.array(...,
+   * dtype=int)}, where numpy promotes the Python builtin to int64.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpArrayBuiltinIntDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_dtype_tokens.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 2, 2))));
+  }
+
+  /**
+   * The {@code np.uint8} token companion of {@link #testNdarrayConstructor()} on the {@code
+   * np.zeros} allocator.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpZerosUint8()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_dtype_tokens.py",
+        "consume3",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(UINT_8, 2))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -13,6 +13,14 @@
         <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32"/>
         <new def="int64" class="Ltensorflow/dtypes/DType"/>
         <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64"/>
+        <new def="uint8" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="x" value="uint8"/>
+        <new def="bool" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="bool" fieldType="LRoot" ref="x" value="bool"/>
+        <new def="bool_" class="Ltensorflow/dtypes/DType"/>
+        <putfield class="LRoot" field="bool_" fieldType="LRoot" ref="x" value="bool_"/>
+        <new def="ndarray_fn" class="Lnumpy/ndarray_constructor"/>
+        <putfield class="LRoot" field="ndarray" fieldType="LRoot" ref="x" value="ndarray_fn"/>
         <new def="array_fn" class="Lnumpy/array"/>
         <putfield class="LRoot" field="array" fieldType="LRoot" ref="x" value="array_fn"/>
         <new def="ones_fn" class="Lnumpy/ones"/>
@@ -25,6 +33,18 @@
       </method>
     </class>
     <package name="numpy">
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html -->
+      <!-- The `np.ndarray(shape, dtype, ...)` constructor: an uninitialized array of the given shape and dtype, so the typing model is the `zeros` allocator's (shape from arg 0, dtype from the `dtype` argument) and the dispatch reuses `NpZeros`. wala/ML#775. -->
+      <class name="ndarray_constructor" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self shape dtype buffer">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
       <!-- https://numpy.org/doc/stable/reference/generated/numpy.array.html -->
       <!-- Modeled as a class-per-function so that `np.array` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray preserves shape from arg 0 and takes dtype from arg 1; see `NpArray`. -->
       <class name="array" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -177,12 +177,7 @@ public class NpArray extends TensorGenerator {
     // multi-strategy resolver: the callee-frame parameter's points-to set is empty on a
     // return-value anchoring, and the caller walk recovers the keyword (wala/ML#775).
     OrdinalSet<InstanceKey> dtypePTS = getArgumentPointsToSet(builder, 1, "dtype");
-    LOGGER.fine(
-        () ->
-            "DTYPE-ARG-PROBE size="
-                + (dtypePTS == null ? "null" : dtypePTS.size())
-                + " members="
-                + describe(dtypePTS));
+    LOGGER.fine(() -> "Resolved dtype argument points-to set: " + describe(dtypePTS) + ".");
     if (dtypePTS != null && !dtypePTS.isEmpty()) {
       Set<DType> dTypes = getDTypesFromDTypeArgument(builder, dtypePTS);
       if (!dTypes.isEmpty()) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -171,9 +171,20 @@ public class NpArray extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    int dtypeVn = getArgumentValueNumber(1);
-    if (dtypeVn > 0) {
-      Set<DType> dTypes = getDTypes(builder, dtypeVn);
+    // The explicit `dtype` argument is a token (`np.int32`, the builtin `int`), not a value whose
+    // dtype the value walk could compute (that walk deliberately ignores `DType` allocations), so
+    // it resolves through the dtype-argument token resolver, with the argument located by the
+    // multi-strategy resolver: the callee-frame parameter's points-to set is empty on a
+    // return-value anchoring, and the caller walk recovers the keyword (wala/ML#775).
+    OrdinalSet<InstanceKey> dtypePTS = getArgumentPointsToSet(builder, 1, "dtype");
+    LOGGER.fine(
+        () ->
+            "DTYPE-ARG-PROBE size="
+                + (dtypePTS == null ? "null" : dtypePTS.size())
+                + " members="
+                + describe(dtypePTS));
+    if (dtypePTS != null && !dtypePTS.isEmpty()) {
+      Set<DType> dTypes = getDTypesFromDTypeArgument(builder, dtypePTS);
       if (!dTypes.isEmpty()) {
         return dTypes;
       }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3989,6 +3989,22 @@ public abstract class TensorGenerator {
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     for (InstanceKey instanceKey : pointsToSet) {
+      // Python builtin type objects passed as dtype tokens (`np.array(x, dtype=int)`): numpy
+      // promotes the builtins to its 64-bit defaults on 64-bit platforms, and `bool` maps to the
+      // boolean dtype (wala/ML#775). Checked before the allocation-site extraction below, which
+      // throws for the builtin's `ConcreteTypeKey`.
+      String builtinTypeName = instanceKey.concreteType().getReference().getName().toString();
+      if (builtinTypeName.equals("Lwala/builtin/int")) {
+        ret.add(DType.INT64);
+        continue;
+      } else if (builtinTypeName.equals("Lwala/builtin/float")) {
+        ret.add(DType.FLOAT64);
+        continue;
+      } else if (builtinTypeName.equals("Lwala/builtin/bool")) {
+        ret.add(DType.BOOL);
+        continue;
+      }
+
       AllocationSiteInNode asin = getAllocationSiteInNode(instanceKey);
       if (asin == null && !(instanceKey instanceof ConstantKey)) continue;
       // First, check for `None`.
@@ -7548,6 +7564,10 @@ public abstract class TensorGenerator {
     } else if (type.equals(NumpyTypes.ONES.getDeclaringClass())) {
       return new NpOnes(node);
     } else if (type.equals(NumpyTypes.ZEROS.getDeclaringClass())) {
+      return new NpZeros(node);
+    } else if (type.equals(NumpyTypes.NDARRAY_CONSTRUCTOR.getDeclaringClass())) {
+      // The `np.ndarray(shape, dtype, ...)` constructor shares the `zeros` typing contract
+      // (wala/ML#775).
       return new NpZeros(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
       return new SparseMatrixDot(node);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -484,6 +484,17 @@ public abstract class TensorGenerator {
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     for (InstanceKey instanceKey : pointsToSet) {
+      // A bare integer shape denotes rank 1 (`np.zeros(5)` allocates shape `(5,)`); the shape
+      // parameter of the numpy and TensorFlow allocators accepts an int or a sequence, and the
+      // container arms below only cover the sequence forms (wala/ML#775).
+      if (instanceKey instanceof ConstantKey) {
+        Object constantValue = ((ConstantKey<?>) instanceKey).getValue();
+        if (constantValue instanceof Number) {
+          ret.add(List.of(new NumericDim(((Number) constantValue).intValue())));
+          continue;
+        }
+      }
+
       AllocationSiteInNode asin = getAllocationSiteInNode(instanceKey);
       if (asin == null) continue;
       TypeReference reference = asin.concreteType().getReference();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1702,6 +1702,11 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, NumpyTypes.ONES.getDeclaringClass())) return new NpOnes(source);
     else if (isType(calledFunction, NumpyTypes.ZEROS.getDeclaringClass()))
       return new NpZeros(source);
+    // `np.ndarray(shape, dtype, ...)` is an uninitialized allocation with the `zeros` typing
+    // contract (shape from arg 0, dtype from the `dtype` argument), so it reuses `NpZeros`
+    // (wala/ML#775).
+    else if (isType(calledFunction, NumpyTypes.NDARRAY_CONSTRUCTOR.getDeclaringClass()))
+      return new NpZeros(source);
     else if (isType(calledFunction, NumpyTypes.RESHAPE.getDeclaringClass()))
       return new NpReshape(source);
     else if (isType(calledFunction, DATASET_FROM_TENSOR_SLICES_TYPE))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/WorklistTypeResolver.java
@@ -748,7 +748,17 @@ final class WorklistTypeResolver {
     } catch (IllegalArgumentException e) {
       // Demand-driven callers catch this variously; under the engine the conservative reading is
       // an unknown value of the query's kind.
-      LOGGER.log(Level.FINE, e, () -> "Worklist transfer IAE for " + key + "; treating as ⊤.");
+      LOGGER.log(
+          Level.FINE,
+          e,
+          () ->
+              "Worklist transfer IAE for "
+                  + key
+                  + " ("
+                  + e.getMessage()
+                  + " at "
+                  + e.getStackTrace()[0]
+                  + "); treating as ⊤.");
       result = this.shapeKinds.get(key) ? ShapeResult.unknown() : EnumSet.of(DType.UNKNOWN);
     } finally {
       this.evaluating.pop();

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -84,6 +84,15 @@ public class NumpyTypes extends PythonTypes {
 
   private static final String ONES_SIGNATURE = "numpy.ones()";
 
+  /** https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html */
+  public static final MethodReference NDARRAY_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/ndarray_constructor")),
+          AstMethodReference.fnSelector);
+
+  private static final String NDARRAY_CONSTRUCTOR_SIGNATURE = "numpy.ndarray()";
+
   /** https://numpy.org/doc/stable/reference/generated/numpy.reshape.html */
   public static final MethodReference RESHAPE =
       MethodReference.findOrCreate(
@@ -120,6 +129,7 @@ public class NumpyTypes extends PythonTypes {
           Map.entry(ARRAY.getDeclaringClass(), ARRAY_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
+          Map.entry(NDARRAY_CONSTRUCTOR.getDeclaringClass(), NDARRAY_CONSTRUCTOR_SIGNATURE),
           Map.entry(RESHAPE.getDeclaringClass(), RESHAPE_SIGNATURE),
           Map.entry(RESHAPE_METHOD.getDeclaringClass(), RESHAPE_METHOD_SIGNATURE),
           Map.entry(ASTYPE.getDeclaringClass(), ASTYPE_SIGNATURE));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -2358,6 +2358,15 @@ public class TensorFlowTypes extends PythonTypes {
       FieldReference.findOrCreate(
           PythonTypes.Root, findOrCreateAsciiAtom(BOOL.name().toLowerCase(Locale.ROOT)), D_TYPE);
 
+  /**
+   * The {@code bool_} dtype token: numpy's modern spelling ({@code np.bool_}). Lives in this map
+   * because the dtype-argument resolver iterates these entries against both the TensorFlow and
+   * numpy owner objects; no TensorFlow field carries the name, so it can only match on the numpy
+   * side.
+   */
+  public static final FieldReference BOOL_ALIAS_FIELD =
+      FieldReference.findOrCreate(PythonTypes.Root, findOrCreateAsciiAtom("bool_"), D_TYPE);
+
   /** A mapping from a field reference to its associated {@link DType}, if any. */
   public static final Map<FieldReference, DType> FIELD_REFERENCE_TO_DTYPE =
       Map.ofEntries(
@@ -2367,6 +2376,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(INT_64, INT64),
           Map.entry(UINT_8, UINT8),
           Map.entry(BOOL_FIELD, BOOL),
+          Map.entry(BOOL_ALIAS_FIELD, BOOL),
           Map.entry(COMPLEX_64, COMPLEX64),
           Map.entry(COMPLEX_128, COMPLEX128),
           Map.entry(STRING, DType.STRING));

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_dtype_tokens.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_dtype_tokens.py
@@ -1,0 +1,32 @@
+# The numpy dtype-token witnesses of wala/ML#775: the `np.ndarray` constructor with an
+# `np.int32` token, `np.array` with the Python builtin `int` (which numpy promotes to int64),
+# and an allocator with the `np.uint8` token.
+import numpy as np
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+def consume3(c):
+    pass
+
+
+a = np.ndarray(shape=(3,), dtype=np.int32)
+assert a.dtype == np.int32
+assert a.shape == (3,)
+consume(a)
+
+b = np.array([[1, 2], [3, 4]], dtype=int)
+assert b.dtype == np.int64
+assert b.shape == (2, 2)
+consume2(b)
+
+c = np.zeros((2,), dtype=np.uint8)
+assert c.dtype == np.uint8
+assert c.shape == (2,)
+consume3(c)


### PR DESCRIPTION
Closes wala/ML#775.

Four pieces cover the issue's three witnesses. The numpy import block gains the `uint8`, `bool`, and `bool_` tokens, with the `bool_` alias entry in the field-to-dtype map (the map lives on the TensorFlow side because the resolver iterates it against both owner objects). The `np.ndarray(shape, dtype, ...)` constructor is modeled with the `zeros` typing contract, reusing `NpZeros` in both dispatch anchorings. Python builtin type objects (`dtype=int`/`float`/`bool`) map to numpy's promoted dtypes (`int64`/`float64`/`bool`) in the token resolver, checked before the allocation-site extraction, which throws for their `ConcreteTypeKey` representations. And `NpArray` routes its explicit `dtype` argument through the token resolver via the multi-strategy argument lookup, since the value walk it previously used deliberately ignores `DType` allocations, so its dtype literal path had never worked.

The wala/ML#774 mask guard flips to its resolved state: the declared `np.bool_` reads boolean rather than declining to unknown, and the fixtures pin `np.ndarray` at `{(3,) int32}`, the builtin at `{(2, 2) int64}`, and the allocator token at `{(2,) uint8}`. A small diagnostic rides along: the worklist's swallowed-transfer-exception log now includes the message and origin frame, which is what located the `ConcreteTypeKey` throw.

The in-vivo acceptance is the next release smoke on the NLPGNN rows the issue catalogs: the `read_raw_text`-fed `edge_index`/`batch` parameters (`dtype=int`), the word2vec skip-gram tensors (`np.ndarray` with `np.int32`), and the `sample_mask` results (`np.array(mask, dtype=np.bool)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX