### PR TITLE
Broadcast a resolved operand past a non-scalar opaque one as a partial result

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -453,7 +453,16 @@ public class TestCorpusFixtures extends AbstractTensorTest {
                         new NumericDim(8),
                         new NumericDim(100),
                         UnresolvedDim.INSTANCE,
-                        UnresolvedDim.INSTANCE))),
+                        UnresolvedDim.INSTANCE)),
+                // The wala/ML#790 rescue members: a one-sided broadcast whose legacy result was ⊥
+                // now stands its resolved operand's shapes as partial members, so the union gains
+                // the resolvable subset of those operands (including a constant operand's scalar
+                // member) beside the compositions above.
+                new TensorType(FLOAT_32, asList()),
+                new TensorType(FLOAT_32, asList(UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE)),
+                new TensorType(
+                    FLOAT_32,
+                    asList(new NumericDim(8), UnresolvedDim.INSTANCE, UnresolvedDim.INSTANCE))),
             3,
             Set.of(
                 new TensorType(
@@ -1019,7 +1028,7 @@ public class TestCorpusFixtures extends AbstractTensorTest {
         "MusicTransformer.__prepare_train_data",
         "musictransformer_proj",
         2,
-        5,
+        6,
         Map.of(
             2,
             Set.of(TENSOR_UNKNOWN_SHAPE_UNKNOWN_DTYPE),

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestCorpusFixtures.java
@@ -740,9 +740,10 @@ public class TestCorpusFixtures extends AbstractTensorTest {
    *     floors at ⊤ under wala/ML#788 and the elementwise seed composes honestly, where before
    *     wala/ML#787 the same union arrived via cross-caller leakage through the shared {@code
    *     slice} builtin frame.
-   *     <p>TODO: Expect {@code (2, 50, 64)} float32 for the {@code tf.add} return when <a
-   *     href="https://github.com/wala/ML/issues/790">wala/ML#790</a> broadcasts a resolved operand
-   *     shape past an unknown one instead of degrading to ⊤.
+   *     <p>Under <a href="https://github.com/wala/ML/issues/790">wala/ML#790</a> the {@code tf.add}
+   *     return additionally carries the concrete {@code (2, 50, 64)} member: the elementwise
+   *     broadcast emits the resolved operand's shapes as partial-result members with the unknown
+   *     remainder covering a rank-dominating opaque side, so the union reads both.
    */
   @Test
   public void testMusicTransformerPositionEmbedding()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMathOps.java
@@ -74,7 +74,7 @@ public class TestMathOps extends AbstractTensorTest {
   @Test
   public void testTopPLogits()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test("tf2_test_top_p_logits.py", "top_p_logits", 1, 12, Map.of(2, Set.of(TENSOR_1_5_FLOAT32)));
+    test("tf2_test_top_p_logits.py", "top_p_logits", 1, 13, Map.of(2, Set.of(TENSOR_1_5_FLOAT32)));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -278,6 +278,13 @@ public class ElementWiseOperation extends TensorGenerator {
       ShapeResult legacy = ShapeResult.fromLegacy(this.getDefaultShapes(builder));
       if (!legacy.isBottom()) return legacy;
       if (!isObservationFinal(builder)) return legacy;
+      LOGGER.fine(
+          () ->
+              "One-sided broadcast rescue for "
+                  + describe(this.getSource())
+                  + ": members "
+                  + resolved
+                  + ".");
       return new ShapeResult(resolved, true);
     }
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
@@ -675,7 +682,11 @@ public class ElementWiseOperation extends TensorGenerator {
    */
   private Set<List<Dimension<?>>> getOperandShapes(PropagationCallGraphBuilder builder, int vn) {
     ElementWiseOperation nested = getNestedForBinop(builder, vn);
-    if (nested != null) return nested.getDefaultShapes(builder);
+    // The nested evaluation diverts through the engine's memoized generator eval (wala/ML#790): a
+    // direct getDefaultShapes call is an engine-invisible transfer whose result depends on the
+    // evaluation schedule (the wala/ML#753 class), so consumers that bake operand members (the
+    // one-sided broadcast rescue) would bake schedule-dependent content.
+    if (nested != null) return memoizedShapeResult(builder, nested).toLegacy();
     if (isScalarLiteral(builder, vn)) {
       return singleton(emptyList());
     }
@@ -687,7 +698,8 @@ public class ElementWiseOperation extends TensorGenerator {
   /** Dtype counterpart of {@link #getOperandShapes(PropagationCallGraphBuilder, int)}. */
   private Set<DType> getOperandDTypes(PropagationCallGraphBuilder builder, int vn) {
     ElementWiseOperation nested = getNestedForBinop(builder, vn);
-    if (nested != null) return nested.getDefaultDTypes(builder);
+    // Diverted like the shape counterpart (wala/ML#790).
+    if (nested != null) return memoizedDTypes(builder, nested);
     return this.getDTypes(builder, vn);
   }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -268,8 +268,16 @@ public class ElementWiseOperation extends TensorGenerator {
       // A non-scalar opaque co-operand can dominate the broadcast when its rank exceeds the
       // resolved side's, so the resolved shapes stand as members with the unknown remainder
       // marking those possibilities (wala/ML#790): the default view reads the same-shape
-      // elementwise case, and exact readers keep the remainder. The legacy path annihilated the
-      // resolved evidence entirely.
+      // elementwise case, and exact readers keep the remainder. Two gates keep the rescue
+      // deterministic and additive. It applies only where the legacy path annihilates the result
+      // outright, since a legacy result with members feeds downstream walks (the transformer
+      // reshape chains) whose real multi-rank members the partial's members would displace. And
+      // it fires only on a provably final observation: one operand's emptiness during an interim
+      // read is exactly the non-monotone-fallback-arm hazard (wala/ML#753), so a possibly-interim
+      // sighting defers to the settlement pass (wala/ML#758), mirroring the Concat memberless arm.
+      ShapeResult legacy = ShapeResult.fromLegacy(this.getDefaultShapes(builder));
+      if (!legacy.isBottom()) return legacy;
+      if (!isObservationFinal(builder)) return legacy;
       return new ShapeResult(resolved, true);
     }
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -265,6 +265,12 @@ public class ElementWiseOperation extends TensorGenerator {
       int opaqueVn = xHas ? yVn : xVn;
       if (resolved.stream().anyMatch(dims -> !dims.isEmpty())
           && isScalarExpression(builder, opaqueVn)) return ShapeResult.of(resolved);
+      // A non-scalar opaque co-operand can dominate the broadcast when its rank exceeds the
+      // resolved side's, so the resolved shapes stand as members with the unknown remainder
+      // marking those possibilities (wala/ML#790): the default view reads the same-shape
+      // elementwise case, and exact readers keep the remainder. The legacy path annihilated the
+      // resolved evidence entirely.
+      return new ShapeResult(resolved, true);
     }
     return ShapeResult.fromLegacy(this.getDefaultShapes(builder));
   }


### PR DESCRIPTION
Draft on a blocked disposition. Advances wala/ML#790.

The elementwise one-sided arm previously kept the resolved operand's shapes only when the opaque co-operand was provably a scalar expression; otherwise the legacy path annihilated the resolved evidence. This emits the resolved shapes as partial-result members with the unknown remainder covering the rank-dominating possibilities, the designed use of the wala/ML#718 record. The MusicTransformer witness delivers: the `tf.add` return's union gains the concrete `(2, 50, 64)` member beside the honest remainder.

**Why draft:** the full suite shows 4 shifts, and the NLPGNN transformer anchors (the wala/ML#753-sensitive family) move non-monotonically: `testNlpgnnFullDense3dInput`'s union loses its rank-4 `(8, ?, ?, ?)` member while gaining a scalar `[]` and two lower-rank members, and the einsum anchor shifts similarly. A vanished member is a blocked loss under the evidence protocol until traced: the partial's members now feed downstream broadcasts that previously saw `⊥`, so compositions changed shape rather than purely widening. The trace of where the rank-4 member went, and whether the scalar member is a constant-operand artifact the partial should filter, is the remaining work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX