### PR TITLE
Divert nested-binop operand evaluations through the engine

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -661,7 +661,11 @@ public class ElementWiseOperation extends TensorGenerator {
    */
   private Set<List<Dimension<?>>> getOperandShapes(PropagationCallGraphBuilder builder, int vn) {
     ElementWiseOperation nested = getNestedForBinop(builder, vn);
-    if (nested != null) return nested.getDefaultShapes(builder);
+    // The nested evaluation diverts through the engine's memoized generator eval (wala/ML#790): a
+    // direct getDefaultShapes call is an engine-invisible transfer whose result depends on the
+    // evaluation schedule (the wala/ML#753 class), invisible to re-evaluation when the operand's
+    // value later grows.
+    if (nested != null) return memoizedShapeResult(builder, nested).toLegacy();
     if (isScalarLiteral(builder, vn)) {
       return singleton(emptyList());
     }
@@ -673,7 +677,8 @@ public class ElementWiseOperation extends TensorGenerator {
   /** Dtype counterpart of {@link #getOperandShapes(PropagationCallGraphBuilder, int)}. */
   private Set<DType> getOperandDTypes(PropagationCallGraphBuilder builder, int vn) {
     ElementWiseOperation nested = getNestedForBinop(builder, vn);
-    if (nested != null) return nested.getDefaultDTypes(builder);
+    // Diverted like the shape counterpart (wala/ML#790).
+    if (nested != null) return memoizedDTypes(builder, nested);
     return this.getDTypes(builder, vn);
   }
 


### PR DESCRIPTION
Advances wala/ML#790.

The nested `ElementWiseOperation` bypass (the wala/ML#739 chain handling) called `getDefaultShapes`/`getDefaultDTypes` directly, an engine-invisible transfer with no recorded dependency edges: a nested operand chain's value could neither reschedule its readers on growth nor participate in bottom promotion, the anti-pattern class the wala/ML#753 localization named. Both reads now divert through the memoized generator evaluations. Behavior-preserving: the full suite passes under both the FINEST and CI logging configurations.

The wala/ML#790 rescue itself stays on the held draft (ponder-lab/ML#707), now blocked by wala/ML#795: even fully gated, its baked operand members inherit the transformer anchors' pre-existing configuration-schedule sensitivity, so the rescue cannot pin stably until that substrate issue is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX