### PR TITLE
Guard the inter-procedural builtin dtype token flow

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1328,6 +1328,49 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The inter-procedural builtin dtype token (the NLPGNN graph-reader pattern, wala/ML#775): the
+   * builtin {@code int} flows as an argument into a reader helper whose {@code dtype} parameter
+   * reaches {@code np.array}, resolving through the call edge, and the subtraction preserves the
+   * declared dtype through the elementwise broadcast.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testInterproceduralDtypeToken()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dtype_token_flow.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 3))));
+  }
+
+  /**
+   * The two-hop corpus form of {@link #testInterproceduralDtypeToken()}: the token forwards through
+   * {@code Loader.read_file} into {@code read_raw_text}, whose comprehension-built rows feed {@code
+   * np.array} with the forwarded {@code dtype}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testInterproceduralDtypeToken2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dtype_token_flow.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
    * The {@code tf.bool} dtype token (<a
    * href="https://github.com/wala/ML/issues/793">wala/ML#793</a>): an explicit {@code
    * dtype=tf.bool} on an allocator resolves to the boolean dtype rather than falling to the float32

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dtype_token_flow.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dtype_token_flow.py
@@ -1,0 +1,37 @@
+# The inter-procedural builtin dtype token (the NLPGNN graph-reader pattern): the builtin
+# `int` flows as an argument into a reader helper whose `dtype` parameter reaches `np.array`,
+# and the declaration must resolve through the call edge.
+import numpy as np
+
+
+def consume(a):
+    pass
+
+
+def read_raw(src, dtype=None):
+    return np.array(src, dtype=dtype)
+
+
+def consume2(b):
+    pass
+
+
+class Loader:
+    def read_file(self, src, dtype=None):
+        return self.read_raw_text(src, seq=",", dtype=dtype)
+
+    def read_raw_text(self, src, seq=None, start=0, end=None, dtype=None):
+        rows = [[dtype(x) for x in line.split(seq)[start:end]] for line in src]
+        return np.array(rows, dtype=dtype)
+
+
+edge_index = read_raw([1, 2, 3], dtype=int) - 1
+assert edge_index.dtype == np.int64
+assert edge_index.shape == (3,)
+consume(edge_index)
+
+loader = Loader()
+batch = loader.read_file(["1,2", "3,4"], dtype=int) - 1
+assert batch.dtype == np.int64
+assert batch.shape == (2, 2)  # statically content-dependent
+consume2(batch)


### PR DESCRIPTION
Test-only regression guards for the graph-reader pattern, narrowing the wala/ML#796 diagnosis: the builtin `int` dtype token resolves through a single call edge into `np.array` (composing `(3,) int64` through the trailing subtraction) and through the two-hop `read_file`/`read_raw_text` forwarding with comprehension-built rows, where the dtype survives both hops and the shape is honestly `⊤` from content-dependent string splits. With these flows proven, the corpus's pure-unknown reader rows must be blocked by a delta the issue enumerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX