### PR TITLE
Model `float` and `bool` as builtin functions

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1308,6 +1308,22 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The {@code bool} sibling of {@link #testNpArrayBuiltinIntDtype()} (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>): the builtin resolves through the
+   * front-end's builtin-function table like {@code int} and {@code float}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpArrayBuiltinBoolDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_builtin_bool.py", "consume", 1, 1, Map.of(2, Set.of(TensorType.of(BOOL, 3))));
+  }
+
+  /**
    * The {@code np.uint8} token companion of {@link #testNdarrayConstructor()} on the {@code
    * np.zeros} allocator.
    *
@@ -1368,6 +1384,46 @@ public class TestConstructors extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * The three-hop corpus form of the graph-reader pattern (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>): {@code read_data} calls the
+   * shared reader with mixed {@code int} and {@code float} tokens over a real file read.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testInterproceduralDtypeToken3()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dtype_token_flow2.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * The float side of {@link #testInterproceduralDtypeToken3()}'s mixed call sites.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testInterproceduralDtypeToken4()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dtype_token_flow2.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(FLOAT_64, null))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dtype_token_flow2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dtype_token_flow2.py
@@ -1,0 +1,47 @@
+# The three-hop corpus form of the graph-reader pattern (wala/ML#796): `read_data` calls
+# `read_file` with mixed dtype tokens (`int` for indices, `float` for attributes), forwarding
+# through `read_raw_text` over a real file read, so the reader is context-shared between the
+# two declarations.
+import os
+import tempfile
+
+import numpy as np
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+class Loader:
+    def read_file(self, folder, name, dtype=None):
+        return self.read_raw_text(
+            os.path.join(folder, name + ".txt"), seq=",", dtype=dtype
+        )
+
+    def read_raw_text(self, path, seq=None, start=0, end=None, dtype=None):
+        with open(path, "r") as rf:
+            src = rf.read().split("\n")[:-1]
+        rows = [[dtype(x) for x in line.split(seq)[start:end]] for line in src]
+        return np.array(rows, dtype=dtype)
+
+    def read_data(self, folder):
+        edge_index = self.read_file(folder, "A", dtype=int) - 1
+        node_attributes = self.read_file(folder, "attrs", dtype=float)
+        return edge_index, node_attributes
+
+
+folder = tempfile.mkdtemp()
+with open(os.path.join(folder, "A.txt"), "w") as f:
+    f.write("1,2\n2,3\n")
+with open(os.path.join(folder, "attrs.txt"), "w") as f:
+    f.write("0.5,1.5\n2.5,3.5\n")
+
+edges, attrs = Loader().read_data(folder)
+assert edges.dtype == np.int64
+assert attrs.dtype == np.float64
+consume(edges)
+consume2(attrs)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_builtin_bool.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_builtin_bool.py
@@ -1,0 +1,13 @@
+# The `bool` builtin as a dtype token (wala/ML#796): like `int` and `float`, the builtin
+# resolves to a dtype through the front-end's builtin-function table.
+import numpy as np
+
+
+def consume(m):
+    pass
+
+
+mask = np.array([True, False, True], dtype=bool)
+assert mask.dtype == np.bool_
+assert mask.shape == (3,)
+consume(mask)

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -476,6 +476,10 @@ public class BuiltinFunctions {
     //		builtinFunctions.put("enumerate", Either.forLeft(PythonTypes.enumerate));
     builtinFunctions.put("enumerate", Either.forRight(2));
     builtinFunctions.put("int", Either.forLeft(TypeReference.Int));
+    // https://docs.python.org/3/library/functions.html#float
+    builtinFunctions.put("float", Either.forLeft(TypeReference.Double));
+    // https://docs.python.org/3/library/functions.html#bool
+    builtinFunctions.put("bool", Either.forLeft(TypeReference.Boolean));
     builtinFunctions.put("round", Either.forLeft(TypeReference.Int));
     builtinFunctions.put("len", Either.forLeft(TypeReference.Int));
     builtinFunctions.put("list", Either.forLeft(PythonTypes.list));


### PR DESCRIPTION
The front-end's builtin-function table modeled `int` but not `float` or `bool`. A `dtype=float` argument therefore read an unmodeled global whose points-to set was empty in every calling context, and the dtype-token resolver's `Lwala/builtin/float` and `Lwala/builtin/bool` arms were unreachable. The failure was never inter-procedural: hop count, token forwarding, and mixed call sites all resolve once the token exists.

- `tf2_test_dtype_token_flow2.py` vendors the three-hop mixed-token reader pattern over real file reads; `testInterproceduralDtypeToken3`/`testInterproceduralDtypeToken4` pin `{? of int64}` and `{? of float64}`, the shape staying honestly unknown for content-dependent row splits.
- `tf2_test_np_builtin_bool.py` exercises the previously dead `bool` arm; `testNpArrayBuiltinBoolDtype` pins `{(3,) bool}`.

Advances wala/ML#796: the reproduced float-side loss is fixed in-suite; the release smoke adjudicates the corpus reader rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX
