### PR TITLE
Model `np.eye` as an identity-matrix allocator

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1324,6 +1324,42 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The {@code np.eye} identity-matrix allocator (<a
+   * href="https://github.com/wala/ML/issues/797">wala/ML#797</a>): shape from the constant {@code
+   * N} argument, dtype the NumPy {@code float64} default.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpEye()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_eye.py", "consume", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_64, 3, 3))));
+  }
+
+  /**
+   * The one-hot fancy-indexing idiom over the {@code np.eye} allocation (<a
+   * href="https://github.com/wala/ML/issues/797">wala/ML#797</a>): the row-select subscript
+   * inherits the base array's {@code float64} dtype.
+   *
+   * <p>TODO: The pinned {@code (3,)} shape is the scalar-index row-select result; the length-4 list
+   * index actually selects four rows, so the runtime shape is {@code (4, 3)}. Flip when <a
+   * href="https://github.com/wala/ML/issues/798">wala/ML#798</a> lands.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpEyeOneHot()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_eye.py", "consume2", 1, 1, Map.of(2, Set.of(TensorType.of(FLOAT_64, 3))));
+  }
+
+  /**
    * The {@code np.uint8} token companion of {@link #testNdarrayConstructor()} on the {@code
    * np.zeros} allocator.
    *

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -29,6 +29,8 @@
         <putfield class="LRoot" field="zeros" fieldType="LRoot" ref="x" value="zeros_fn"/>
         <new def="reshape_fn" class="Lnumpy/reshape"/>
         <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape_fn"/>
+        <new def="eye_fn" class="Lnumpy/eye"/>
+        <putfield class="LRoot" field="eye" fieldType="LRoot" ref="x" value="eye_fn"/>
         <return value="x"/>
       </method>
     </class>
@@ -73,6 +75,18 @@
       <!-- Modeled as a class-per-function (same pattern as `array`) so that `np.zeros` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned ndarray takes its shape from arg 0 (a shape tuple) and its dtype from the `dtype` argument; see `NpZeros`. -->
       <class name="zeros" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self shape dtype">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.eye.html -->
+      <!-- Modeled as a class-per-function (same pattern as `zeros`) so that `np.eye` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. The returned identity matrix takes its shape from the `n`/`m` arguments and its dtype from the `dtype` argument (float64 default); the `k` diagonal offset does not affect the type. See `NpEye`; wala/ML#797. -->
+      <class name="eye" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self n m k dtype">
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpEye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpEye.java
@@ -1,0 +1,105 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code np.eye(N, M=None, k=0, dtype=float64)}: an identity matrix of shape ({@code
+ * N}, {@code M} or {@code N}). Unlike {@code tf.eye}, there is no {@code batch_shape}, the {@code
+ * k} diagonal offset does not affect the type, and the unspecified {@code dtype} default is NumPy's
+ * {@code float64} rather than {@code float32}. The corpus idiom is one-hot encoding via fancy
+ * indexing, {@code np.eye(n)[labels]}. See <a
+ * href="https://github.com/wala/ML/issues/797">wala/ML#797</a>.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpEye extends EyeBase {
+
+  private static final Logger LOGGER = getLogger(NpEye.class.getName());
+
+  protected enum Parameters {
+    N,
+    M,
+    K,
+    DTYPE;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public NpEye(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpEye(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected String getNumRowsParameterName() {
+    return Parameters.N.getName();
+  }
+
+  @Override
+  protected String getNumColumnsParameterName() {
+    return Parameters.M.getName();
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return Parameters.DTYPE.getIndex();
+  }
+
+  protected String getDTypeParameterName() {
+    return Parameters.DTYPE.getName();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>NumPy defaults to {@code float64} when no {@code dtype} argument is supplied.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} for the analysis.
+   * @return A singleton set containing the default NumPy dtype, {@code float64}.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    LOGGER.fine(
+        () ->
+            "No dtype specified for source: "
+                + describe(this.getSource())
+                + ". Using NumPy default dtype of: "
+                + FLOAT64
+                + ".");
+
+    return EnumSet.of(FLOAT64);
+  }
+
+  /**
+   * Returns the producing library of the modeled value: an {@code np.eye(...)} call, so the value
+   * is an ndarray (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpEye.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpEye.java
@@ -66,6 +66,7 @@ public class NpEye extends EyeBase {
     return Parameters.DTYPE.getIndex();
   }
 
+  @Override
   protected String getDTypeParameterName() {
     return Parameters.DTYPE.getName();
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -7585,6 +7585,8 @@ public abstract class TensorGenerator {
       // The `np.ndarray(shape, dtype, ...)` constructor shares the `zeros` typing contract
       // (wala/ML#775).
       return new NpZeros(node);
+    } else if (type.equals(NumpyTypes.EYE.getDeclaringClass())) {
+      return new NpEye(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
       return new SparseMatrixDot(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_TODENSE.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1707,6 +1707,7 @@ public class TensorGeneratorFactory {
     // (wala/ML#775).
     else if (isType(calledFunction, NumpyTypes.NDARRAY_CONSTRUCTOR.getDeclaringClass()))
       return new NpZeros(source);
+    else if (isType(calledFunction, NumpyTypes.EYE.getDeclaringClass())) return new NpEye(source);
     else if (isType(calledFunction, NumpyTypes.RESHAPE.getDeclaringClass()))
       return new NpReshape(source);
     else if (isType(calledFunction, DATASET_FROM_TENSOR_SLICES_TYPE))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -93,6 +93,15 @@ public class NumpyTypes extends PythonTypes {
 
   private static final String NDARRAY_CONSTRUCTOR_SIGNATURE = "numpy.ndarray()";
 
+  /** https://numpy.org/doc/stable/reference/generated/numpy.eye.html */
+  public static final MethodReference EYE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/eye")),
+          AstMethodReference.fnSelector);
+
+  private static final String EYE_SIGNATURE = "numpy.eye()";
+
   /** https://numpy.org/doc/stable/reference/generated/numpy.reshape.html */
   public static final MethodReference RESHAPE =
       MethodReference.findOrCreate(
@@ -130,6 +139,7 @@ public class NumpyTypes extends PythonTypes {
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(NDARRAY_CONSTRUCTOR.getDeclaringClass(), NDARRAY_CONSTRUCTOR_SIGNATURE),
+          Map.entry(EYE.getDeclaringClass(), EYE_SIGNATURE),
           Map.entry(RESHAPE.getDeclaringClass(), RESHAPE_SIGNATURE),
           Map.entry(RESHAPE_METHOD.getDeclaringClass(), RESHAPE_METHOD_SIGNATURE),
           Map.entry(ASTYPE.getDeclaringClass(), ASTYPE_SIGNATURE));

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_eye.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_eye.py
@@ -1,0 +1,23 @@
+# The `np.eye` identity-matrix allocator and its one-hot fancy-indexing idiom (wala/ML#797):
+# the allocation types (N, N) float64, and the row-select subscript inherits the dtype.
+import numpy as np
+
+
+def consume(e):
+    pass
+
+
+def consume2(o):
+    pass
+
+
+eye = np.eye(3)
+assert eye.shape == (3, 3)
+assert eye.dtype == np.float64
+consume(eye)
+
+labels = [0, 2, 1, 2]
+one_hot = np.eye(3)[labels]
+assert one_hot.shape == (4, 3)
+assert one_hot.dtype == np.float64
+consume2(one_hot)


### PR DESCRIPTION
Localized by the 0.52.65 release smoke at NLPGNN's one-hot encoding sites: `np.eye` was unmodeled, so `np.eye(len(set(labels)))[labels]` was dtype-unknown. The `eye` class follows the `zeros` class-per-function pattern in `numpy.xml`, registered in both dispatch tables. `NpEye` extends `EyeBase` rather than `Eye`: `tf.eye`'s third argument is `batch_shape` while `np.eye`'s is the type-irrelevant `k` diagonal offset, and the unspecified dtype default is NumPy's `float64`.

- `testNpEye` pins the direct allocation at `{(3,3) float64}` (constant `N`, defaulted dtype).
- `testNpEyeOneHot` shows the fancy-indexed one-hot inheriting `float64` through the existing subscript machinery; its shape is pinned as observed (`(3,)`, the scalar-index row-select result) with a TODO for wala/ML#798, which tracks array-index shape semantics.

Closes wala/ML#797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoqNGum9YcBd81MuypTWwX