### PR TITLE
Harden the reader-chain dtype path and feed `tf.concat` from element states

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1463,6 +1463,147 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The NLPGNN TUDataset downstream chain (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>): a typed reader output must
+   * survive load-time slicing comprehensions with {@code tolist()}, the tuple return and unpack,
+   * the sampling generator's tuple yield and for-loop unpack, and the merge-time {@code np.array}
+   * rebase with {@code tf.concat} to reach the model-call parameters.
+   *
+   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>): the slice receiver's lexical
+   * read is invisible to the SSA-chain walkers, and the reader tuple's cross-frame unpack defeats
+   * the same-frame tuple peel, so the merge-side feeds compose from unknown states.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainMergedDtype()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain.py",
+        "consume_merged",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * {@link #testReaderChainMergedDtype()} with the {@code tolist()} hop removed, isolating the
+   * unmodeled ndarray {@code tolist} method from the generator-yield/unpack and merge-rebase hops
+   * (<a href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   *
+   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainMergedDtype2()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain2.py",
+        "consume_merged",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * Staged probes for the {@code wala/ML#796} downstream chain (see {@code
+   * tf2_test_reader_chain3.py}): each probe observes the reader's {@code int64} one hop deeper.
+   * Diagnostic scaffolding while the chain lands; the pins localize where the dtype state stops
+   * flowing. The unpacked and sliced probes pass and guard the working hops; the listed, dynamic,
+   * and rearrayed probes are expected failures pinning the frontier.
+   *
+   * <p>TODO: Flip the expected-failure probes to positive guards when the remaining chain hops land
+   * (<a href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testReaderChainProbeUnpacked()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_unpacked",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /** See {@link #testReaderChainProbeUnpacked()}. */
+  @Test
+  public void testReaderChainProbeSliced()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_sliced",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * See {@link #testReaderChainProbeUnpacked()}.
+   *
+   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainProbeListed()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_listed",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * See {@link #testReaderChainProbeUnpacked()}.
+   *
+   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainProbeDynamic()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_dynamic",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
+   * See {@link #testReaderChainProbeUnpacked()}.
+   *
+   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
+   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainProbeRearrayed()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_rearrayed",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
+  /**
    * The {@code tf.bool} dtype token (<a
    * href="https://github.com/wala/ML/issues/793">wala/ML#793</a>): an explicit {@code
    * dtype=tf.bool} on an allocator resolves to the boolean dtype rather than falling to the float32

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Concat.java
@@ -156,6 +156,29 @@ public class Concat extends TensorGenerator {
     return ret;
   }
 
+  /**
+   * Declares a dtype feed over the {@code values} list's element keys. The elements' dtypes often
+   * exist only in dataflow state (e.g. seeded binary-op results whose points-to sets are empty, the
+   * NLPGNN merge chain of wala/ML#796), so the seed-time resolution of {@link
+   * #getDefaultDTypes(PropagationCallGraphBuilder)} starves while the state-side evidence is
+   * complete; the feed composes the result's dtype from the element states instead.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The dtype feed over the {@code values} argument and its container element keys, or
+   *     {@code null} when the argument cannot be located.
+   */
+  @Override
+  protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
+    int valuesVn = getArgumentValueNumber(Parameters.VALUES.getIndex());
+    if (valuesVn <= 0) return null;
+    PointerKey argument =
+        builder.getPointerAnalysis().getHeapModel().getPointerKeyForLocal(this.getNode(), valuesVn);
+    List<PointerKey> operands = new ArrayList<>();
+    operands.add(argument);
+    addContainerElementOperands(builder, argument, operands);
+    return new TypeFeed(TypeFeedKind.DTYPE_ONLY, operands);
+  }
+
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     OrdinalSet<InstanceKey> valuesPts =

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -252,7 +252,7 @@ public class NpArray extends TensorGenerator {
         else if (value instanceof Boolean) leaves.add(DType.BOOL);
         else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
         else if (value instanceof String) leaves.add(DType.STRING);
-        else if (value != null && "org.python.core.PyComplex".equals(value.getClass().getName()))
+        else if ("org.python.core.PyComplex".equals(value.getClass().getName()))
           // A Python complex literal, which the Jython front-end represents as a `PyComplex{@code .
           // Matched by class name to avoid a compile-time dependency on the Jython runtime.
           leaves.add(DType.COMPLEX128);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -8,7 +8,6 @@ import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
-import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorOrigin;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -29,6 +28,7 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -96,35 +96,7 @@ public class NpArray extends TensorGenerator {
     // list), whose own variable carries no dataflow state: the element state lives in the
     // container's field keys. Add the append-contents key and the cataloged subscript keys of
     // each list/tuple allocation so element evidence feeds too.
-    for (InstanceKey ik : pa.getPointsToSet(argument)) {
-      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-      if (asin == null) continue;
-      TypeReference reference = asin.concreteType().getReference();
-      if (!reference.equals(list) && !reference.equals(tuple)) continue;
-      FieldReference contents =
-          FieldReference.findOrCreate(
-              Root,
-              findOrCreateAsciiAtom(
-                  PythonSSAPropagationCallGraphBuilder.LIST_APPEND_CONTENTS_FIELD),
-              Root);
-      IField contentsField = builder.getClassHierarchy().resolveField(contents);
-      if (contentsField != null)
-        operands.add(builder.getPointerKeyForInstanceField(asin, contentsField));
-      OrdinalSet<InstanceKey> catalogPTS =
-          pa.getPointsToSet(
-              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
-                  .getPointerKeyForObjectCatalog(asin));
-      for (InstanceKey catalogIK : catalogPTS) {
-        if (!(catalogIK instanceof ConstantKey)) continue;
-        Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
-        if (fieldIndex == null) continue;
-        FieldReference subscript =
-            FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldIndex.toString()), Root);
-        IField subscriptField = builder.getClassHierarchy().resolveField(subscript);
-        if (subscriptField != null)
-          operands.add(builder.getPointerKeyForInstanceField(asin, subscriptField));
-      }
-    }
+    addContainerElementOperands(builder, argument, operands);
     return new TypeFeed(TypeFeedKind.DTYPE_ONLY, operands);
   }
 
@@ -218,9 +190,21 @@ public class NpArray extends TensorGenerator {
   private Set<DType> numpyPromotedDTypes(
       PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> sourcePTS) {
     if (sourcePTS == null || sourcePTS.isEmpty()) return Set.of();
+    LOGGER.fine(() -> "numpyPromotedDTypes: walking " + describe(sourcePTS) + ".");
 
     EnumSet<DType> leaves = EnumSet.noneOf(DType.class);
-    if (!collectNumpyLeaves(builder, sourcePTS, leaves)) return Set.of(DType.UNKNOWN);
+    if (!collectNumpyLeaves(builder, sourcePTS, leaves, new HashSet<>()))
+      return Set.of(DType.UNKNOWN);
+
+    // A single leaf kind needs no promotion: this covers dtype preservation from an existing
+    // array/tensor element (wala/ML#796), whose non-literal dtype (e.g. int32) the ladder below
+    // does not rank.
+    if (leaves.size() == 1) return EnumSet.copyOf(leaves);
+
+    // Promotion is modeled only over the literal leaf kinds; a mix involving a preserved
+    // non-literal dtype floors to ⊤ rather than mis-ranking.
+    if (!EnumSet.of(DType.STRING, DType.COMPLEX128, DType.FLOAT64, DType.INT64, DType.BOOL)
+        .containsAll(leaves)) return Set.of(DType.UNKNOWN);
 
     // Promotion order: a string array subsumes everything; otherwise widen numerically.
     if (leaves.contains(DType.STRING)) return Set.of(DType.STRING);
@@ -239,17 +223,31 @@ public class NpArray extends TensorGenerator {
    * @param pts The points-to set to walk.
    * @param leaves Accumulator for the leaf numpy base dtypes ({@code BOOL}, {@code INT64}, {@code
    *     FLOAT64}, {@code COMPLEX128}, {@code STRING}).
-   * @return {@code true} if every element was a literal scalar or a nested list/tuple of literals;
-   *     {@code false} if an element is not a promotable literal (e.g. an existing array/tensor), in
-   *     which case the caller floors to ⊤.
+   * @param visited The instance keys already descended through, guarding against points-to cycles
+   *     among container allocations (wala/ML#796).
+   * @return {@code true} if every element was a literal scalar, a nested list/tuple of literals, or
+   *     an existing array/tensor whose producer resolves a definite dtype (preservation,
+   *     wala/ML#796); {@code false} otherwise, in which case the caller floors to ⊤.
    */
   private boolean collectNumpyLeaves(
-      PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> pts, EnumSet<DType> leaves) {
+      PropagationCallGraphBuilder builder,
+      OrdinalSet<InstanceKey> pts,
+      EnumSet<DType> leaves,
+      Set<InstanceKey> visited) {
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
 
     for (InstanceKey ik : pts) {
+      if (!(ik instanceof ConstantKey) && !visited.add(ik)) continue;
       if (ik instanceof ConstantKey) {
         Object value = ((ConstantKey<?>) ik).getValue();
+        if (value == null) {
+          // A null constant next to real members is analysis substrate (loop-carried phi
+          // defaults, the generator iteration protocol), not element evidence; flooring on it
+          // would erase the sibling members' dtypes (wala/ML#796). A value that is only null
+          // collects nothing and degrades to ⊤ via the empty-leaves path.
+          LOGGER.fine(() -> "collectNumpyLeaves: skipping null constant.");
+          continue;
+        }
         if (value instanceof Float || value instanceof Double) leaves.add(DType.FLOAT64);
         else if (value instanceof Boolean) leaves.add(DType.BOOL);
         else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
@@ -258,16 +256,35 @@ public class NpArray extends TensorGenerator {
           // A Python complex literal, which the Jython front-end represents as a `PyComplex{@code .
           // Matched by class name to avoid a compile-time dependency on the Jython runtime.
           leaves.add(DType.COMPLEX128);
-        else return false; // Unrecognized scalar.
+        else {
+          LOGGER.fine(() -> "collectNumpyLeaves: unrecognized scalar " + value + "; flooring.");
+          return false; // Unrecognized scalar.
+        }
       } else {
         AllocationSiteInNode asin = getAllocationSiteInNode(ik);
-        if (asin == null) return false;
+        if (asin == null) {
+          LOGGER.fine(() -> "collectNumpyLeaves: no allocation site for " + ik + "; flooring.");
+          return false;
+        }
 
         TypeReference reference = asin.concreteType().getReference();
-        if (!reference.equals(list) && !reference.equals(tuple))
-          // An existing array/tensor (or other non-literal): numpy would preserve its dtype rather
-          // than promote, which this walk does not model. Floor to ⊤.
-          return false;
+        if (!reference.equals(list) && !reference.equals(tuple)) {
+          // An existing array/tensor: numpy preserves its dtype rather than promoting. Delegate
+          // to the producer for the preserved dtype; floor only when the producer cannot resolve
+          // one (wala/ML#796).
+          Set<DType> preserved = this.getDTypesFromTensor(builder, asin);
+          LOGGER.fine(
+              () ->
+                  "collectNumpyLeaves: producer of "
+                      + asin.concreteType().getReference().getName()
+                      + " preserved "
+                      + preserved
+                      + ".");
+          if (preserved == null || preserved.isEmpty() || preserved.contains(DType.UNKNOWN))
+            return false;
+          leaves.addAll(preserved);
+          continue;
+        }
 
         OrdinalSet<InstanceKey> catalogPTS =
             pa.getPointsToSet(
@@ -285,7 +302,7 @@ public class NpArray extends TensorGenerator {
 
           OrdinalSet<InstanceKey> fieldPTS =
               pa.getPointsToSet(builder.getPointerKeyForInstanceField(asin, f));
-          if (!collectNumpyLeaves(builder, fieldPTS, leaves)) return false;
+          if (!collectNumpyLeaves(builder, fieldPTS, leaves, visited)) return false;
         }
       }
     }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -45,6 +45,12 @@ import java.util.logging.Logger;
 public class NpArray extends TensorGenerator {
   private static final Logger LOGGER = Logger.getLogger(NpArray.class.getName());
 
+  /**
+   * The Jython runtime class representing a Python complex literal. Matched by name to avoid a
+   * compile-time dependency on the Jython runtime.
+   */
+  private static final String PYCOMPLEX_CLASS_NAME = "org.python.core.PyComplex";
+
   public NpArray(PointsToSetVariable source) {
     super(source);
   }
@@ -252,9 +258,8 @@ public class NpArray extends TensorGenerator {
         else if (value instanceof Boolean) leaves.add(DType.BOOL);
         else if (value instanceof Integer || value instanceof Long) leaves.add(DType.INT64);
         else if (value instanceof String) leaves.add(DType.STRING);
-        else if ("org.python.core.PyComplex".equals(value.getClass().getName()))
-          // A Python complex literal, which the Jython front-end represents as a `PyComplex{@code .
-          // Matched by class name to avoid a compile-time dependency on the Jython runtime.
+        else if (PYCOMPLEX_CLASS_NAME.equals(value.getClass().getName()))
+          // A Python complex literal, which the Jython front-end represents as a `PyComplex`.
           leaves.add(DType.COMPLEX128);
         else {
           LOGGER.fine(() -> "collectNumpyLeaves: unrecognized scalar " + value + "; flooring.");

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4509,6 +4509,24 @@ public abstract class TensorGenerator {
    */
   protected Set<DType> getDTypesOfValue(
       PropagationCallGraphBuilder builder, OrdinalSet<InstanceKey> valuePointsToSet) {
+    return getDTypesOfValue(builder, valuePointsToSet, new HashSet<>());
+  }
+
+  /**
+   * The recursive worker for {@link #getDTypesOfValue(PropagationCallGraphBuilder, OrdinalSet)},
+   * threading the set of already-visited instance keys through the container-element descent. A
+   * points-to cycle among container allocations (e.g. a loop-carried phi whose list elements reach
+   * the list itself) otherwise recurses without bound (wala/ML#796).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param valuePointsToSet The points-to set of the value from which the dtype will be derived.
+   * @param visited The instance keys already descended through in this resolution.
+   * @return A set of possible dtypes of the tensor returned by this generator.
+   */
+  private Set<DType> getDTypesOfValue(
+      PropagationCallGraphBuilder builder,
+      OrdinalSet<InstanceKey> valuePointsToSet,
+      Set<InstanceKey> visited) {
     if (valuePointsToSet == null || valuePointsToSet.isEmpty()) {
       LOGGER.fine(
           () ->
@@ -4522,6 +4540,7 @@ public abstract class TensorGenerator {
     PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
 
     for (InstanceKey valueIK : valuePointsToSet) {
+      if (valueIK instanceof AllocationSiteInNode && !visited.add(valueIK)) continue;
       if (valueIK instanceof ConstantKey) { // It's a scalar value.
         ConstantKey<?> constantKey = (ConstantKey<?>) valueIK;
         Object value = constantKey.getValue();
@@ -4620,7 +4639,8 @@ public abstract class TensorGenerator {
             LOGGER.fine(
                 "Points-to set for instance field: " + describe(instanceFieldPointsToSet) + ".");
 
-            Set<DType> fieldDTypes = this.getDTypesOfValue(builder, instanceFieldPointsToSet);
+            Set<DType> fieldDTypes =
+                this.getDTypesOfValue(builder, instanceFieldPointsToSet, visited);
             if (fieldDTypes != null) ret.addAll(fieldDTypes);
           }
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
@@ -4679,7 +4699,7 @@ public abstract class TensorGenerator {
     return ret;
   }
 
-  private Set<DType> getDTypesFromTensor(
+  protected Set<DType> getDTypesFromTensor(
       PropagationCallGraphBuilder builder, AllocationSiteInNode asin) {
     // Dtype counterpart of the producer-cycle handling in `getShapeResultFromTensor`
     // (wala/ML#718): the engine's bottom for an unconverged dtype read is the empty set rather
@@ -5003,6 +5023,51 @@ public abstract class TensorGenerator {
    */
   protected TypeFeed getTypeFeed(PropagationCallGraphBuilder builder) {
     return null;
+  }
+
+  /**
+   * Adds the container-element pointer keys of {@code argument}'s list/tuple allocations to {@code
+   * operands}: the append-contents key and the cataloged integer-subscript keys. A container-valued
+   * argument's own variable carries no dataflow state — the element state lives in the container's
+   * field keys — so a type feed over the argument must include them for element evidence to feed
+   * (wala/ML#772, wala/ML#796).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param argument The argument's pointer key.
+   * @param operands The operand list to extend.
+   */
+  protected void addContainerElementOperands(
+      PropagationCallGraphBuilder builder, PointerKey argument, List<PointerKey> operands) {
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    for (InstanceKey ik : pa.getPointsToSet(argument)) {
+      AllocationSiteInNode asin = getAllocationSiteInNode(ik);
+      if (asin == null) continue;
+      TypeReference reference = asin.concreteType().getReference();
+      if (!reference.equals(list) && !reference.equals(tuple)) continue;
+      FieldReference contents =
+          FieldReference.findOrCreate(
+              Root,
+              findOrCreateAsciiAtom(
+                  PythonSSAPropagationCallGraphBuilder.LIST_APPEND_CONTENTS_FIELD),
+              Root);
+      IField contentsField = builder.getClassHierarchy().resolveField(contents);
+      if (contentsField != null)
+        operands.add(builder.getPointerKeyForInstanceField(asin, contentsField));
+      OrdinalSet<InstanceKey> catalogPTS =
+          pa.getPointsToSet(
+              ((AstPointerKeyFactory) builder.getPointerKeyFactory())
+                  .getPointerKeyForObjectCatalog(asin));
+      for (InstanceKey catalogIK : catalogPTS) {
+        if (!(catalogIK instanceof ConstantKey)) continue;
+        Integer fieldIndex = getFieldIndex((ConstantKey<?>) catalogIK);
+        if (fieldIndex == null) continue;
+        FieldReference subscript =
+            FieldReference.findOrCreate(Root, findOrCreateAsciiAtom(fieldIndex.toString()), Root);
+        IField subscriptField = builder.getClassHierarchy().resolveField(subscript);
+        if (subscriptField != null)
+          operands.add(builder.getPointerKeyForInstanceField(asin, subscriptField));
+      }
+    }
   }
 
   protected PythonInvokeInstruction getInvokeInstruction() {
@@ -7159,6 +7224,23 @@ public abstract class TensorGenerator {
               found = true;
             }
           }
+          final int finalArgValNum = argValNum;
+          LOGGER.fine(
+              () ->
+                  "getArgumentPointsToSet: caller "
+                      + describe(caller)
+                      + " instr "
+                      + pyCallInstr
+                      + " argValNum="
+                      + finalArgValNum);
+        } else {
+          LOGGER.fine(
+              () ->
+                  "getArgumentPointsToSet: caller "
+                      + describe(caller)
+                      + " has non-Python invoke "
+                      + callInstr
+                      + "; skipped.");
         }
       }
 
@@ -7167,6 +7249,15 @@ public abstract class TensorGenerator {
       }
       // If we analyzed the call but couldn't find the argument, it likely wasn't provided.
       if (callAnalyzed) {
+        LOGGER.fine(
+            () ->
+                "getArgumentPointsToSet: caller analysis of "
+                    + describe(node)
+                    + " found no argument at pos="
+                    + paramPos
+                    + " name="
+                    + paramName
+                    + "; returning empty.");
         return OrdinalSet.empty();
       }
     }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain.py
@@ -1,0 +1,65 @@
+# The NLPGNN TUDataset downstream chain (wala/ML#796): a typed reader output must survive
+# load-time slicing comprehensions with `.tolist()`, the tuple return and unpack, the sampling
+# generator's tuple yield and for-loop unpack, and the merge-time `np.array` rebase with
+# `tf.concat` to reach the model-call parameters.
+import numpy as np
+import tensorflow as tf
+
+
+def consume_loaded(a):
+    pass
+
+
+def consume_sampled(b):
+    pass
+
+
+def consume_merged(c):
+    pass
+
+
+class Loader:
+    def read_file(self, src, dtype=None):
+        rows = [[dtype(x) for x in line.split(",")] for line in src]
+        return np.array(rows, dtype=dtype)
+
+    def read_data(self, src):
+        edge_index = self.read_file(src, dtype=int) - 1
+        batch = self.read_file(src, dtype=int) - 1
+        return edge_index, batch
+
+    def load(self, src):
+        edge_index, batch = self.read_data(src)
+        value = [(0, 1), (1, 2)]
+        edge_index = [edge_index[se[0] : se[1]].tolist() for se in value]
+        batch = [batch[se[0] : se[1]].tolist() for se in value]
+        return edge_index, batch
+
+    def sample(self, data):
+        edge_index, batch = data
+        for i in range(2):
+            nedge_index = [edge_index[j] for j in [i]]
+            nbatch = [batch[j] for j in [i]]
+            yield nedge_index, nbatch
+
+
+def merge(edge_index, batch):
+    lis_edge_index = [np.array(item) for item in edge_index]
+    lis_batch = [np.array(item) for item in batch]
+    strips = [0] + [i.size for i in lis_batch]
+    strips = np.cumsum(strips)
+    nlis_edge_index = [w + strips[i] for i, w in enumerate(lis_edge_index)]
+    edge_index = tf.concat(nlis_edge_index, 0)
+    batch = tf.concat(lis_batch, 0)
+    return edge_index, batch
+
+
+loader = Loader()
+train_data = loader.load(["1,2", "3,4", "5,6"])
+consume_loaded(train_data)
+for edge_index, batch in loader.sample(train_data):
+    consume_sampled(edge_index)
+    edge_index, batch = merge(edge_index, batch)
+    assert edge_index.dtype == tf.int64
+    assert batch.dtype == tf.int64
+    consume_merged(edge_index)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain2.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain2.py
@@ -1,0 +1,54 @@
+# The wala/ML#796 chain with the `.tolist()` hop removed: isolates whether the unmodeled
+# ndarray `tolist` method (vs. the generator yield/unpack or the merge rebase) is what kills
+# the reader dtype. Identical to tf2_test_reader_chain.py otherwise.
+import numpy as np
+import tensorflow as tf
+
+
+def consume_merged(c):
+    pass
+
+
+class Loader:
+    def read_file(self, src, dtype=None):
+        rows = [[dtype(x) for x in line.split(",")] for line in src]
+        return np.array(rows, dtype=dtype)
+
+    def read_data(self, src):
+        edge_index = self.read_file(src, dtype=int) - 1
+        batch = self.read_file(src, dtype=int) - 1
+        return edge_index, batch
+
+    def load(self, src):
+        edge_index, batch = self.read_data(src)
+        value = [(0, 1), (1, 2)]
+        edge_index = [edge_index[se[0] : se[1]] for se in value]
+        batch = [batch[se[0] : se[1]] for se in value]
+        return edge_index, batch
+
+    def sample(self, data):
+        edge_index, batch = data
+        for i in range(2):
+            nedge_index = [edge_index[j] for j in [i]]
+            nbatch = [batch[j] for j in [i]]
+            yield nedge_index, nbatch
+
+
+def merge(edge_index, batch):
+    lis_edge_index = [np.array(item) for item in edge_index]
+    lis_batch = [np.array(item) for item in batch]
+    strips = [0] + [i.size for i in lis_batch]
+    strips = np.cumsum(strips)
+    nlis_edge_index = [w + strips[i] for i, w in enumerate(lis_edge_index)]
+    edge_index = tf.concat(nlis_edge_index, 0)
+    batch = tf.concat(lis_batch, 0)
+    return edge_index, batch
+
+
+loader = Loader()
+train_data = loader.load(["1,2", "3,4", "5,6"])
+for edge_index, batch in loader.sample(train_data):
+    edge_index, batch = merge(edge_index, batch)
+    assert edge_index.dtype == tf.int64
+    assert batch.dtype == tf.int64
+    consume_merged(edge_index)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain3.py
@@ -1,0 +1,58 @@
+# Staged probes for the wala/ML#796 downstream chain: each consume observes the reader's
+# int64 one hop deeper (tuple unpack, slice application, comprehension list, dynamic
+# subscript, re-array), so a per-probe assertion localizes where the dtype state stops
+# flowing.
+import numpy as np
+
+
+def consume_unpacked(a):
+    pass
+
+
+def consume_sliced(b):
+    pass
+
+
+def consume_listed(c):
+    pass
+
+
+def consume_dynamic(d):
+    pass
+
+
+def consume_rearrayed(e):
+    pass
+
+
+class Loader:
+    def read_file(self, src, dtype=None):
+        rows = [[dtype(x) for x in line.split(",")] for line in src]
+        return np.array(rows, dtype=dtype)
+
+    def read_data(self, src):
+        edge_index = self.read_file(src, dtype=int) - 1
+        return edge_index, 0
+
+
+loader = Loader()
+edge_index, _zero = loader.read_data(["1,2", "3,4", "5,6"])
+assert edge_index.dtype == np.int64
+consume_unpacked(edge_index)
+
+sliced = edge_index[0:2]
+assert sliced.dtype == np.int64
+consume_sliced(sliced)
+
+value = [(0, 1), (1, 2)]
+listed = [edge_index[se[0] : se[1]] for se in value]
+assert listed[0].dtype == np.int64
+consume_listed(listed[0])
+
+for j in [0, 1]:
+    dyn = listed[j]
+    assert dyn.dtype == np.int64
+    consume_dynamic(dyn)
+    rearr = np.array(dyn)
+    assert rearr.dtype == np.int64
+    consume_rearrayed(rearr)


### PR DESCRIPTION
Advances wala/ML#796.

Reproduces the NLPGNN downstream chain in-suite and lands the proven half:

- Cycle guard in `TensorGenerator.getDTypesOfValue`'s container descent: a points-to cycle among container allocations overflowed the stack (surfaced by the probe fixtures); same guard in `NpArray.collectNumpyLeaves`.
- `NpArray` content walk: an existing array/tensor element now delegates to its producer for the preserved dtype instead of flooring to ⊤; a single preserved kind bypasses the literal promotion ladder so non-64-bit dtypes survive; a null constant next to real members no longer erases sibling evidence.
- `Concat` declares a `DTYPE_ONLY` type feed over the `values` list's element keys (the wala/ML#772 mechanism, via a shared `addContainerElementOperands` helper), so the concat result composes element dtypes from dataflow state where seed-time PTS resolution starves.
- Diagnostics: caller-analysis logging in `getArgumentPointsToSet`; walk logging in the content walk.

The staged probe family pins the chain per hop: binop/tuple-unpack and constant-bound slice hops are positive guards; the comprehension-lexical slice receiver, cross-frame tuple unpack, and merge-side composition remain expected-failure pins with TODOs (diagnosis on the issue). Suite: 1173/0 under the CI logging config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY