### PR TITLE
Model `np.unique` with per-output generators

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1360,6 +1360,75 @@ public class TestConstructors extends AbstractTensorTest {
   }
 
   /**
+   * The inverse output of {@code np.unique} (<a
+   * href="https://github.com/wala/ML/issues/799">wala/ML#799</a>): always {@code int64} regardless
+   * of the input dtype, rank 1 with a statically unresolvable length.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpUniqueInverse()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_unique.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, asList(UnresolvedDim.INSTANCE)))));
+  }
+
+  /**
+   * The values output of {@code np.unique} (<a
+   * href="https://github.com/wala/ML/issues/799">wala/ML#799</a>): dtype preserved from the input,
+   * rank 1 with a statically unresolvable length.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpUniqueValues()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_unique.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, asList(UnresolvedDim.INSTANCE)))));
+  }
+
+  /**
+   * The {@code TUDataset.read_data} two-branch label idiom (<a
+   * href="https://github.com/wala/ML/issues/799">wala/ML#799</a>): regression labels are float,
+   * classification labels are int densified through the unique inverse and a shape-preserving
+   * reshape; the union must carry both dtypes rather than collapsing to a wrong definite when the
+   * labels branch's producer is unmodeled.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpUniqueTwoBranchLabels()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_unique.py",
+        "consume3",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                TensorType.of(FLOAT_64, 2),
+                new TensorType(INT_64, asList(UnresolvedDim.INSTANCE)))));
+  }
+
+  /**
    * The {@code np.uint8} token companion of {@link #testNdarrayConstructor()} on the {@code
    * np.zeros} allocator.
    *

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -31,6 +31,8 @@
         <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="x" value="reshape_fn"/>
         <new def="eye_fn" class="Lnumpy/eye"/>
         <putfield class="LRoot" field="eye" fieldType="LRoot" ref="x" value="eye_fn"/>
+        <new def="unique_fn" class="Lnumpy/unique"/>
+        <putfield class="LRoot" field="unique" fieldType="LRoot" ref="x" value="unique_fn"/>
         <return value="x"/>
       </method>
     </class>
@@ -97,6 +99,48 @@
       </class>
       <!-- Must be declared `allocatable="true"` so that `<new class="Lnumpy/ndarray"/>` in the various array-producing `do()` methods (both here and in `tensorflow.xml`) resolves to a concrete `InstanceKey` in the heap model. Without this declaration, `HeapModel.getInstanceKeyForAllocation` returns `null`, `getInvariantContents` returns empty, and `visitReturn` never adds the iKey to the caller-side `PointerKey`. Same pattern as the wala/WALA#1889 fix for `tensorflow/python/ops/variables/Variable`. The class deliberately has no method body because it is only referenced as a `<new>` target, not invoked directly. -->
       <class name="ndarray" allocatable="true"></class>
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.unique.html -->
+      <!-- `np.unique(ar, return_index, return_inverse, return_counts, axis)` modeled as the flag form the corpus destructures: a tuple whose slot 0 is the unique values (dtype preserved from `ar`, flattened to rank 1) and whose slots 1-3 are the index, inverse, and counts outputs (positional indices, always int64 regardless of the input dtype). Each slot is produced by its own class (the `load_data` per-output pattern) so tuple-field reads dispatch per-slot generators; see `NpUniqueValues`/`NpUniqueIndices`. The flagless call's runtime result is the bare values array rather than a tuple; this model returns the tuple regardless, a deliberate approximation scoped to the destructuring form. wala/ML#799. -->
+      <class name="unique" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self ar return_index return_inverse return_counts axis">
+          <new def="values_fn" class="Lnumpy/unique_values"/>
+          <call class="Lnumpy/unique_values" name="do" type="virtual" def="values" descriptor="()LRoot;" arg0="values_fn" arg1="ar" numArgs="2"/>
+          <new def="index_fn" class="Lnumpy/unique_indices"/>
+          <call class="Lnumpy/unique_indices" name="do" type="virtual" def="index" descriptor="()LRoot;" arg0="index_fn" numArgs="1"/>
+          <new def="inverse_fn" class="Lnumpy/unique_indices"/>
+          <call class="Lnumpy/unique_indices" name="do" type="virtual" def="inverse" descriptor="()LRoot;" arg0="inverse_fn" numArgs="1"/>
+          <new def="counts_fn" class="Lnumpy/unique_indices"/>
+          <call class="Lnumpy/unique_indices" name="do" type="virtual" def="counts" descriptor="()LRoot;" arg0="counts_fn" numArgs="1"/>
+          <new def="ret" class="Ltuple"/>
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="values"/>
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="index"/>
+          <putfield class="LRoot" field="2" fieldType="LRoot" ref="ret" value="inverse"/>
+          <putfield class="LRoot" field="3" fieldType="LRoot" ref="ret" value="counts"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- Slot 0 of `np.unique`: the unique values, dtype preserved from `ar`, flattened to rank 1 with a statically unresolvable length. wala/ML#799. -->
+      <class name="unique_values" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self ar">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- Slots 1-3 of `np.unique`: the index, inverse, and counts outputs, always int64 (positional indices), rank 1 with a statically unresolvable length. wala/ML#799. -->
+      <class name="unique_indices" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
       <!-- https://numpy.org/doc/stable/reference/generated/numpy.reshape.html -->
       <!-- Function-form counterpart of `numpy/ndarray/reshape`: `np.reshape(x, shape)` rather than `x.reshape(shape)`. Modeled as a class-per-function so that `np.reshape` resolves to this class via a field lookup on the numpy module, and the invocation dispatches to its `do` method. Shape comes from arg 1 (target shape); dtype is preserved from arg 0 (input tensor); see `NpReshape`. -->
       <class name="reshape" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueIndices.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueIndices.java
@@ -1,0 +1,73 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT64;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for the index, inverse, and counts outputs of {@code np.unique} (slots 1&ndash;3 of the
+ * flag-form tuple): positional indices into (or occurrence counts over) the input, always {@code
+ * int64} regardless of the input dtype, rank 1 with a statically unresolvable length. The corpus
+ * idiom is label densification via the inverse output, {@code _, _, y = np.unique(y,
+ * return_index=True, return_inverse=True)}. See <a
+ * href="https://github.com/wala/ML/issues/799">wala/ML#799</a>.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpUniqueIndices extends TensorGenerator {
+
+  public NpUniqueIndices(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpUniqueIndices(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Rank 1; the length (the number of uniques, the input's size, or the count vector's length)
+    // is a fixed runtime integer the analysis cannot compute, so the axis is Unresolved rather
+    // than Dynamic (wala/ML#721).
+    return Set.of(List.of(UnresolvedDim.INSTANCE));
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(INT64);
+  }
+
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueValues.java
@@ -11,6 +11,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -22,6 +23,34 @@ import java.util.Set;
  * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
  */
 public class NpUniqueValues extends TensorGenerator {
+
+  /**
+   * Parameter positions and keyword names for the {@code numpy/unique_values} synthetic. Ordinals
+   * match the position in {@code numpy.xml}'s {@code paramNames} after the implicit {@code self}
+   * receiver.
+   */
+  protected enum Parameters {
+    /** The input array whose unique values are taken; its dtype is preserved. */
+    AR;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "ar"}).
+     */
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
 
   public NpUniqueValues(PointsToSetVariable source) {
     super(source);
@@ -40,7 +69,8 @@ public class NpUniqueValues extends TensorGenerator {
 
   @Override
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
-    OrdinalSet<InstanceKey> arPts = getArgumentPointsToSet(builder, 0, "ar");
+    OrdinalSet<InstanceKey> arPts =
+        getArgumentPointsToSet(builder, Parameters.AR.getIndex(), Parameters.AR.getName());
     Set<DType> preserved = getDTypesOfValue(builder, arPts);
     return preserved == null || preserved.isEmpty() ? EnumSet.of(DType.UNKNOWN) : preserved;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueValues.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpUniqueValues.java
@@ -1,0 +1,72 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Generator for the unique-values output of {@code np.unique} (slot 0 of the flag-form tuple): the
+ * sorted unique elements of the input, dtype preserved from {@code ar}, flattened to rank 1 with a
+ * statically unresolvable length. See <a
+ * href="https://github.com/wala/ML/issues/799">wala/ML#799</a>.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpUniqueValues extends TensorGenerator {
+
+  public NpUniqueValues(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpUniqueValues(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // `np.unique` flattens: rank 1, with the number of uniques a fixed runtime integer the
+    // analysis cannot compute, so the axis is Unresolved rather than Dynamic (wala/ML#721).
+    return Set.of(List.of(UnresolvedDim.INSTANCE));
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    OrdinalSet<InstanceKey> arPts = getArgumentPointsToSet(builder, 0, "ar");
+    Set<DType> preserved = getDTypesOfValue(builder, arPts);
+    return preserved == null || preserved.isEmpty() ? EnumSet.of(DType.UNKNOWN) : preserved;
+  }
+
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -7122,7 +7122,11 @@ public abstract class TensorGenerator {
           getCallerInvokes(builder, node)) {
         CGNode caller = callerInvoke.fst;
         SSAAbstractInvokeInstruction callInstr = callerInvoke.snd;
-        callAnalyzed = true;
+        // Only a Python invoke carries the positional/keyword structure this analysis reads; a
+        // synthetic summary `<call>` (a plain SSA invoke) binds its arguments straight onto the
+        // callee frame, so it must fall through to the callee-parameter fallback below rather
+        // than counting as an analyzed-but-argless caller (wala/ML#799).
+        if (callInstr instanceof PythonInvokeInstruction) callAnalyzed = true;
 
         if (callInstr instanceof PythonInvokeInstruction) {
           PythonInvokeInstruction pyCallInstr = (PythonInvokeInstruction) callInstr;
@@ -7587,6 +7591,10 @@ public abstract class TensorGenerator {
       return new NpZeros(node);
     } else if (type.equals(NumpyTypes.EYE.getDeclaringClass())) {
       return new NpEye(node);
+    } else if (type.equals(NumpyTypes.UNIQUE_VALUES.getDeclaringClass())) {
+      return new NpUniqueValues(node);
+    } else if (type.equals(NumpyTypes.UNIQUE_INDICES.getDeclaringClass())) {
+      return new NpUniqueIndices(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
       return new SparseMatrixDot(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_TODENSE.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -1708,6 +1708,10 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, NumpyTypes.NDARRAY_CONSTRUCTOR.getDeclaringClass()))
       return new NpZeros(source);
     else if (isType(calledFunction, NumpyTypes.EYE.getDeclaringClass())) return new NpEye(source);
+    else if (isType(calledFunction, NumpyTypes.UNIQUE_VALUES.getDeclaringClass()))
+      return new NpUniqueValues(source);
+    else if (isType(calledFunction, NumpyTypes.UNIQUE_INDICES.getDeclaringClass()))
+      return new NpUniqueIndices(source);
     else if (isType(calledFunction, NumpyTypes.RESHAPE.getDeclaringClass()))
       return new NpReshape(source);
     else if (isType(calledFunction, DATASET_FROM_TENSOR_SLICES_TYPE))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -102,6 +102,33 @@ public class NumpyTypes extends PythonTypes {
 
   private static final String EYE_SIGNATURE = "numpy.eye()";
 
+  /** https://numpy.org/doc/stable/reference/generated/numpy.unique.html */
+  public static final MethodReference UNIQUE =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/unique")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNIQUE_SIGNATURE = "numpy.unique()";
+
+  /** Slot 0 of {@link #UNIQUE}: the unique values, dtype preserved from the input. wala/ML#799. */
+  public static final MethodReference UNIQUE_VALUES =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/unique_values")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNIQUE_VALUES_SIGNATURE = "numpy.unique() values";
+
+  /** Slots 1-3 of {@link #UNIQUE}: index, inverse, and counts, always int64. wala/ML#799. */
+  public static final MethodReference UNIQUE_INDICES =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/unique_indices")),
+          AstMethodReference.fnSelector);
+
+  private static final String UNIQUE_INDICES_SIGNATURE = "numpy.unique() indices";
+
   /** https://numpy.org/doc/stable/reference/generated/numpy.reshape.html */
   public static final MethodReference RESHAPE =
       MethodReference.findOrCreate(
@@ -140,6 +167,9 @@ public class NumpyTypes extends PythonTypes {
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),
           Map.entry(NDARRAY_CONSTRUCTOR.getDeclaringClass(), NDARRAY_CONSTRUCTOR_SIGNATURE),
           Map.entry(EYE.getDeclaringClass(), EYE_SIGNATURE),
+          Map.entry(UNIQUE.getDeclaringClass(), UNIQUE_SIGNATURE),
+          Map.entry(UNIQUE_VALUES.getDeclaringClass(), UNIQUE_VALUES_SIGNATURE),
+          Map.entry(UNIQUE_INDICES.getDeclaringClass(), UNIQUE_INDICES_SIGNATURE),
           Map.entry(RESHAPE.getDeclaringClass(), RESHAPE_SIGNATURE),
           Map.entry(RESHAPE_METHOD.getDeclaringClass(), RESHAPE_METHOD_SIGNATURE),
           Map.entry(ASTYPE.getDeclaringClass(), ASTYPE_SIGNATURE));

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_unique.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_unique.py
@@ -1,0 +1,48 @@
+# `np.unique` in its flag form (wala/ML#799): the inverse output is always int64 regardless
+# of the input dtype, the values output preserves the input dtype, and the corpus's two-branch
+# label idiom must yield a dtype union rather than a wrong definite.
+import numpy as np
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+def consume3(c):
+    pass
+
+
+labels = np.array([3, 1, 3, 2], dtype=int)
+_, _, inv = np.unique(labels, return_index=True, return_inverse=True)
+assert inv.dtype == np.int64
+assert inv.shape == (4,)
+consume(inv)
+
+vals = np.unique(labels, return_index=True, return_inverse=True)[0]
+assert vals.dtype == np.int64
+assert vals.shape == (3,)
+consume2(vals)
+
+
+# The TUDataset.read_data two-branch idiom: regression labels are float, classification labels
+# are int densified through the unique inverse; the union must carry both.
+def read(flag):
+    if flag:
+        y = np.array([1.5, 2.5], dtype=float)
+    else:
+        y = np.array([3, 1, 3], dtype=int)
+        _, _, y = np.unique(y, return_index=True, return_inverse=True)
+        y = np.reshape(y, y.shape)
+    return y
+
+
+ya = read(True)
+assert ya.dtype == np.float64
+consume3(ya)
+yb = read(False)
+assert yb.dtype == np.int64
+consume3(yb)


### PR DESCRIPTION
Closes wala/ML#799.

Models the flag-form `np.unique` tuple with per-output producer classes (the `load_data` pattern): slot 0 (`NpUniqueValues`) preserves the input dtype; slots 1-3 (`NpUniqueIndices`: index, inverse, counts) are always int64 (positional indices); all rank 1 with a statically unresolvable length per the wala/ML#721 criterion. Registered in both dispatch tables.

Also fixes a cross-cutting argument-resolution gap the sub-calls surfaced: a synthetic summary `<call>` caller (a plain SSA invoke) counted as an analyzed-but-argless caller in `getArgumentPointsToSet`'s caller analysis, suppressing the callee-parameter fallback that is exactly where a summary call binds its arguments.

Witnesses: `testNpUniqueInverse` ({? int64 [Unresolved]}), `testNpUniqueValues` (dtype preserved), and `testNpUniqueTwoBranchLabels`, where the `TUDataset.read_data` two-branch label idiom now yields the honest {float64, int64} union instead of the wrong-definite float64 that conflicted with the recorded MUTAG sidecar entry. Suite: 1169/0 under the CI logging config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY