### PR TITLE
Fill an `Unresolved` axis from a concrete annotated size

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -733,6 +733,58 @@ public class TestMisc extends AbstractTensorTest {
   }
 
   /**
+   * An inferred {@code Unresolved} axis accepts a concrete annotated size (<a
+   * href="https://github.com/wala/ML/issues/800">wala/ML#800</a>): the {@code np.unique} inverse
+   * infers {@code [Unresolved] int64}, and {@code Unresolved} asserts precisely that the length is
+   * a fixed runtime integer the analysis could not compute, which is the fact the annotation
+   * supplies (the wala/ML#721 criterion).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarFillsUnresolvedAxis()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_unresolved.py"},
+        "driver_unresolved.py",
+        "consume",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TensorType.of(INT_64, 4))));
+  }
+
+  /**
+   * The kept-conflict direction of {@link #testTypeAnnotationSidecarFillsUnresolvedAxis()}: a
+   * {@code Dynamic} axis carries runtime-{@code None} evidence a concrete annotated size would
+   * contradict, so the annotation is reported as a conflict and not applied, and the inferred type
+   * stands (<a href="https://github.com/wala/ML/issues/800">wala/ML#800</a>). The {@code (None, 3)}
+   * pin is the ceiling, not a concession: a batch-size-less {@code tf.keras.Input}'s runtime static
+   * shape is {@code [None, 3]} (the fixture asserts it), so {@code Dynamic} is the faithful
+   * representation per the wala/ML#721 criterion and any concrete batch axis here would be wrong.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTypeAnnotationSidecarKeepsDynamicConflict()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        new String[] {"sidecar_proj/driver_unresolved.py"},
+        "driver_unresolved.py",
+        "consume2",
+        "sidecar_proj",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_NONE_3_FLOAT32)));
+  }
+
+  /**
    * Feed-through of an annotation across an {@code np.array} boundary (<a
    * href="https://github.com/wala/ML/issues/772">wala/ML#772</a>): the sidecar types an opaque
    * {@code np.load} inside a helper, and the {@code int64} dtype reaches the {@code np.array}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -81,9 +81,11 @@ import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -297,6 +299,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
             Set<TensorOrigin> priorOrigins = initOrigins.get(var);
             if (priorOrigins != null) origins.addAll(priorOrigins);
             initOrigins.put(var, origins);
+            mergeAnnotationIntoUpstreamSeeds(
+                dataflow,
+                init,
+                initOrigins,
+                var,
+                entry.type(),
+                entry.anchor(),
+                entry.attributionSuffix());
             LOGGER.fine(
                 () ->
                     "Refined the inferred "
@@ -315,6 +325,14 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
           if (!dataflow.containsNode(var)) dataflow.addNode(var);
           init.put(var, HashSetFactory.make(Set.of(entry.type())));
           initOrigins.put(var, EnumSet.of(TensorOrigin.ANNOTATION));
+          mergeAnnotationIntoUpstreamSeeds(
+              dataflow,
+              init,
+              initOrigins,
+              var,
+              entry.type(),
+              entry.anchor(),
+              entry.attributionSuffix());
           LOGGER.fine(
               () ->
                   "Applied type annotation "
@@ -359,12 +377,129 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         return null;
       List<Dimension<?>> dims = member.getDims();
       if (dims == null) dims = annotation.getDims();
-      else if (annotation.getDims() != null && !annotation.getDims().equals(dims)) return null;
+      else if (annotation.getDims() != null) {
+        dims = mergeAnnotationDims(dims, annotation.getDims());
+        if (dims == null) return null;
+      }
       TensorType mergedMember = TensorType.of(dtype, dims, member.layout());
       changed |= !mergedMember.equals(member);
       merged.add(mergedMember);
     }
     return changed ? merged : inferred;
+  }
+
+  /**
+   * Merges a matched annotation into the seeded values dataflow-upstream of the matched binding
+   * (wala/ML#800). The at-binding merge alone cannot hold: the analysis state unions monotonically,
+   * so a producer seed flowing into the annotated binding re-unions its unmerged member (an {@code
+   * Unresolved}-axis twin of the filled member) into every downstream consumer, and the
+   * whole-function signature consensus then re-wildcards the filled axis. Walking the dataflow
+   * predecessors and applying the same fill-only merge at the first seed on each path removes the
+   * twin at its source; a seed that conflicts is reported and left untouched (the fill-only
+   * doctrine per seed), and the walk never descends past a seed, so sibling outputs of a shared
+   * producer (e.g. the other {@code np.unique} slots) are never reached.
+   *
+   * @param dataflow The dataflow graph whose predecessor edges are walked.
+   * @param init The seed map to merge into.
+   * @param initOrigins The seed-origin map to stamp.
+   * @param var The matched binding's variable.
+   * @param annotation The annotation's type.
+   * @param anchor The annotation's anchor, for logging.
+   * @param attributionSuffix The annotation's attribution suffix, for logging.
+   */
+  private static void mergeAnnotationIntoUpstreamSeeds(
+      Graph<PointsToSetVariable> dataflow,
+      Map<PointsToSetVariable, Set<TensorType>> init,
+      Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
+      PointsToSetVariable var,
+      TensorType annotation,
+      String anchor,
+      String attributionSuffix) {
+    if (!dataflow.containsNode(var)) return;
+    Deque<PointsToSetVariable> work = new ArrayDeque<>();
+    Set<PointsToSetVariable> visited = HashSetFactory.make();
+    work.add(var);
+    visited.add(var);
+    while (!work.isEmpty()) {
+      PointsToSetVariable v = work.poll();
+      for (Iterator<PointsToSetVariable> it = dataflow.getPredNodes(v); it.hasNext(); ) {
+        PointsToSetVariable pred = it.next();
+        if (!visited.add(pred)) continue;
+        Set<TensorType> seed = init.get(pred);
+        if (seed == null || seed.isEmpty()) {
+          // An unseeded pass-through: keep walking, under a cap that bounds pathological graphs.
+          if (visited.size() < UPSTREAM_ANNOTATION_MERGE_CAP) work.add(pred);
+          continue;
+        }
+        Set<TensorType> merged = mergeAnnotationIntoInferredTypes(seed, annotation);
+        if (merged == null) {
+          LOGGER.warning(
+              "Type annotation "
+                  + anchor
+                  + " = "
+                  + annotation
+                  + " conflicts with the upstream seed "
+                  + seed
+                  + " at "
+                  + describe(pred.getPointerKey())
+                  + "; the seed is not refined (wala/ML#800)"
+                  + attributionSuffix
+                  + ".");
+          continue; // Stop this path at the conflicting seed.
+        }
+        if (merged != seed) {
+          init.put(pred, HashSetFactory.make(merged));
+          EnumSet<TensorOrigin> origins = EnumSet.of(TensorOrigin.ANNOTATION);
+          Set<TensorOrigin> priorOrigins = initOrigins.get(pred);
+          if (priorOrigins != null) origins.addAll(priorOrigins);
+          initOrigins.put(pred, origins);
+          LOGGER.fine(
+              () ->
+                  "Refined the upstream seed "
+                      + seed
+                      + " with type annotation "
+                      + anchor
+                      + " = "
+                      + annotation
+                      + " at "
+                      + describe(pred.getPointerKey())
+                      + " (wala/ML#800)"
+                      + attributionSuffix
+                      + ".");
+        }
+        // A seed terminates the walk on this path either way.
+      }
+    }
+  }
+
+  /** Visit cap for {@link #mergeAnnotationIntoUpstreamSeeds}'s predecessor walk. */
+  private static final int UPSTREAM_ANNOTATION_MERGE_CAP = 64;
+
+  /**
+   * Merges an annotation's dims into an inferred member's dims per axis (wala/ML#800). An axis
+   * agrees when equal; an inferred {@link UnresolvedDim} accepts the annotation's {@link
+   * NumericDim}, since {@code Unresolved} asserts precisely that the size is a fixed runtime
+   * integer the analysis could not compute, which is the fact the annotation supplies (the
+   * wala/ML#721 criterion). Every other disagreement conflicts: a {@link TensorType.DynamicDim}
+   * carries runtime-{@code None} evidence a concrete size would contradict, and numeric or symbolic
+   * disagreements are definite-vs-definite.
+   *
+   * @param inferred The inferred member's dims.
+   * @param annotated The annotation's dims.
+   * @return The merged dims, or {@code null} on a rank or axis conflict.
+   */
+  private static List<Dimension<?>> mergeAnnotationDims(
+      List<Dimension<?>> inferred, List<Dimension<?>> annotated) {
+    if (inferred.size() != annotated.size()) return null;
+    List<Dimension<?>> out = new ArrayList<>(inferred.size());
+    for (int i = 0; i < inferred.size(); i++) {
+      Dimension<?> inf = inferred.get(i);
+      Dimension<?> ann = annotated.get(i);
+      if (inf.equals(ann)) out.add(inf);
+      else if (inf instanceof UnresolvedDim && ann instanceof NumericDim) out.add(ann);
+      else return null;
+    }
+    return out;
   }
 
   @Override

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/ariadne-types.json
@@ -72,6 +72,22 @@
       "variable": "x3",
       "dtype": "float32",
       "shape": "4 $!"
+    },
+    {
+      "module": "driver_unresolved.py",
+      "function": "",
+      "variable": "inv",
+      "dtype": "int64",
+      "shape": "4",
+      "attribution": "fixture: the concrete length of the np.unique inverse, the fixed runtime integer its Unresolved axis asserts is uncomputable"
+    },
+    {
+      "module": "driver_unresolved.py",
+      "function": "",
+      "variable": "batch",
+      "dtype": "float32",
+      "shape": "8 3",
+      "attribution": "fixture: deliberately concrete against the Dynamic batch axis to exercise the kept conflict"
     }
   ]
 }

--- a/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_unresolved.py
+++ b/com.ibm.wala.cast.python.test/data/sidecar_proj/driver_unresolved.py
@@ -1,0 +1,25 @@
+# The wala/ML#800 pair: an inferred Unresolved axis accepts a concrete annotated size (the
+# annotation supplies exactly the fixed runtime integer Unresolved asserts the analysis could
+# not compute), while a Dynamic axis keeps conflicting (it carries runtime-None evidence a
+# concrete size would contradict).
+import numpy as np
+import tensorflow as tf
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+labels = np.array([3, 1, 3, 2], dtype=int)
+_, _, inv = np.unique(labels, return_index=True, return_inverse=True)
+assert inv.dtype == np.int64
+assert inv.shape == (4,)
+consume(inv)
+
+batch = tf.keras.Input(shape=(3,))
+assert batch.shape.as_list() == [None, 3]
+consume2(batch)


### PR DESCRIPTION
Closes wala/ML#800.

The annotation-merge shape arm now goes per axis: an inferred `UnresolvedDim` accepts the annotation's `NumericDim`, since `Unresolved` asserts precisely that the size is a fixed runtime integer the analysis could not compute, which is the fact the annotation supplies (the wala/ML#721 criterion). A `Dynamic` axis carries runtime-None evidence and keeps conflicting, as do numeric and symbolic disagreements and rank mismatches.

A matched annotation also merges into the seeded values dataflow-upstream of the matched binding (first seed per path, fill-validated per seed, conflicts reported and left untouched): the at-binding merge alone cannot hold under the monotone state union, because the unmerged producer seed re-unions an `Unresolved`-axis twin into every consumer and the whole-function signature consensus re-wildcards the filled axis. The walk never descends past a seed, so sibling outputs of a shared producer (the other `np.unique` slots) are never touched.

Witnesses: `testTypeAnnotationSidecarFillsUnresolvedAxis` (the `np.unique` inverse fills to `{(4,) int64}`) and `testTypeAnnotationSidecarKeepsDynamicConflict` (a batch-size-less `tf.keras.Input` stays `(None, 3)`, the at-ceiling pin per wala/ML#721). Suite: 1178/0 under the CI logging config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY