### PR TITLE
Type `TFRecordDataset` and `Dataset.list_files` elements as 0-D string tensors

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1673,6 +1673,78 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * A {@code tf.data.TFRecordDataset}'s iterated elements are 0-D string tensors (one serialized
+   * record each), the {@link TextLineDatasetGenerator}-family intrinsic element type for the
+   * string-truth corpus rows (gpt-2 and deep_recommenders record parsers).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTFRecordDatasetIterationElementType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_tfrecord_string_elements.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
+  /**
+   * The map-callback direction of {@link #testTFRecordDatasetIterationElementType()}: {@code
+   * dataset.map(parse_example)} types the callback's parameter as the dataset's 0-D string element
+   * (the gpt-2 {@code parse_example(serialized_example)} corpus form).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testTFRecordDatasetMapCallbackParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_tfrecord_string_elements.py",
+        "parse_example",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
+  /**
+   * A {@code tf.data.Dataset.list_files} dataset's iterated elements are 0-D filename-string
+   * tensors, keyed on the distinct {@code ListFilesDataset} allocation its summary now makes.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testListFilesIterationElementType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_list_files_map.py", "consume", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
+  /**
+   * The map-callback direction of {@link #testListFilesIterationElementType()} (the Pix2Pix {@code
+   * load(image_file)} corpus form).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testListFilesMapCallbackParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_list_files_map.py", "load", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
+  /**
    * Regression guard for wala/ML#655: a {@code tf.io.FixedLenFeature} value, parsed by {@code
    * tf.io.parse_single_example} and read back through a dict subscript, types as a dense tensor
    * whose shape comes from the feature's {@code dims} argument and whose dtype comes from its

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -2762,6 +2762,8 @@
           <return value="it"/>
         </method>
       </class>
+      <!-- The distinct allocation class for `list_files` results (the wala/ML#618 treatment); deliberately body-less, a `<new>` target only, like `numpy/ndarray`. Its elements are 0-D filename-string tensors; see `ListFilesDatasetGenerator`. -->
+      <class name="ListFilesDataset" allocatable="true"></class>
       <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset. A fresh chainable dataset per call site (parallel to TextLineDataset); its elements are serialized records, typically consumed by a `map(parse_*)` that derives its own types. The chain-method fields are bound on the new instance so `tf.data.TFRecordDataset(...).map(...).padded_batch(...)` chains resolve. wala/ML#618. -->
       <class name="TFRecordDataset" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self filenames compression_type buffer_size num_parallel_reads name">
@@ -3324,8 +3326,9 @@
       </class>
       <class name="list_files" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#list_files -->
+        <!-- Allocates the distinct `ListFilesDataset` class (not the generic `Dataset`) so producer delegation can recover the filename-string element type; the wala/ML#618 distinct-class treatment. See `ListFilesDatasetGenerator`. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self file_pattern shuffle seed name">
-          <new def="x" class="Ltensorflow/data/Dataset"/>
+          <new def="x" class="Ltensorflow/data/ListFilesDataset"/>
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. The duplication is structural to how the Python loader's instance-attribute dispatch works in this XML modeling: non-dunder instance attributes (`shuffle`, `batch`, `repeat`, …) must be attached *per-instance* via `<putfield>`, not inherited from a class-level definition (the loader handles only dunder methods that way; see wala/ML#509's day-2 finding for the parallel set_shape case). Centralising into a shared helper doesn't dissolve the duplication: even with a single helper method, the helper's `<new>` allocations would alias across callers and chained `dataset.shuffle(...).batch(...)` would lose distinctness because each step's field-target allocations would be shared with prior steps. Verified empirically — stripping the block from `shuffle.do` alone produced 19 test failures under the current 2-CFA-for-TF setup (wala/ML#549 spike). The previous version of this comment cited "1-CFA context sensitivity limits"; the engine actually applies 2-CFA to TF callees per `PythonTensorAnalysisEngine.getCallGraphBuilder`, so depth-of-context wasn't the actual blocker. -->
           <new def="rd_shuffle" class="Ltensorflow/data/shuffle"/>
           <putfield class="LRoot" field="shuffle" fieldType="LRoot" ref="x" value="rd_shuffle"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ListFilesDatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ListFilesDatasetGenerator.java
@@ -1,0 +1,46 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator for tensors produced by iterating a {@code tf.data.Dataset.list_files} dataset. Each
+ * iteration element is a 0-D scalar string tensor (one matched filename per element), typically
+ * consumed by a {@code map(load_*)} callback whose parameter therefore types as {@code {[]
+ * string}}. See <a
+ * href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#list_files">tf.data.Dataset.list_files</a>.
+ *
+ * <p>Same intrinsic-element-type trick as {@link TextLineDatasetGenerator} (wala/ML#452), keyed on
+ * the distinct {@code ListFilesDataset} allocation the summary makes (the wala/ML#618 treatment).
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class ListFilesDatasetGenerator extends DatasetGenerator {
+
+  public ListFilesDatasetGenerator(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public ListFilesDatasetGenerator(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    ret.add(Collections.emptyList());
+    return ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return Set.of(DType.STRING);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TFRecordDatasetGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TFRecordDatasetGenerator.java
@@ -1,0 +1,46 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator for tensors produced by iterating a {@code tf.data.TFRecordDataset}. Each iteration
+ * element is a 0-D scalar string tensor (one serialized record per element), typically consumed by
+ * a {@code map(parse_*)} callback whose parameter therefore types as {@code {[] string}}. See <a
+ * href="https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/TFRecordDataset">tf.data.TFRecordDataset</a>.
+ *
+ * <p>Same intrinsic-element-type trick as {@link TextLineDatasetGenerator} (wala/ML#452): the
+ * per-record element type is a property of the API, with no upstream tensor-allocation chain to
+ * peel.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TFRecordDatasetGenerator extends DatasetGenerator {
+
+  public TFRecordDatasetGenerator(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public TFRecordDatasetGenerator(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> ret = HashSetFactory.make();
+    ret.add(Collections.emptyList());
+    return ret;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return Set.of(DType.STRING);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -7724,6 +7724,10 @@ public abstract class TensorGenerator {
       return new DatasetRangeGenerator(node);
     } else if (type.equals(TensorFlowTypes.TEXT_LINE_DATASET_TYPE)) {
       return new TextLineDatasetGenerator(node);
+    } else if (type.equals(TensorFlowTypes.TFRECORD_DATASET_TYPE)) {
+      return new TFRecordDatasetGenerator(node);
+    } else if (type.equals(TensorFlowTypes.LIST_FILES_DATASET_TYPE)) {
+      return new ListFilesDatasetGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_RANDOM_TYPE)) {
       return new DatasetRandomGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_BATCH_TYPE)) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -52,6 +52,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FILTER_T
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_GENERATOR_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_TENSORS_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_FROM_TENSOR_SLICES_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_LIST_FILES_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_MAP_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_PADDED_BATCH_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DATASET_PREFETCH_TYPE;
@@ -116,6 +117,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LEAKY_RELU;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LESS_EQUAL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LINSPACE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LIST_FILES_DATASET_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG1P;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.LOG_SOFTMAX;
@@ -194,6 +196,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSORDOT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TENSOR_SCATTER_ND_UPDATE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TEXT_LINE_DATASET_TYPE;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TFRECORD_DATASET_TYPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TF_RESHAPE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TILE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.TOP_K;
@@ -1728,6 +1731,11 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, DATASET_RANGE_TYPE)) return new DatasetRangeGenerator(source);
     else if (isType(calledFunction, TEXT_LINE_DATASET_TYPE))
       return new TextLineDatasetGenerator(source);
+    else if (isType(calledFunction, TFRECORD_DATASET_TYPE))
+      return new TFRecordDatasetGenerator(source);
+    else if (isType(calledFunction, DATASET_LIST_FILES_TYPE)
+        || isType(calledFunction, LIST_FILES_DATASET_TYPE))
+      return new ListFilesDatasetGenerator(source);
     else if (isType(calledFunction, DATASET_RANDOM_TYPE)) return new DatasetRandomGenerator(source);
     else if (isType(calledFunction, DATASET_FROM_GENERATOR_TYPE))
       return new DatasetFromGeneratorGenerator(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -362,6 +362,29 @@ public class TensorFlowTypes extends PythonTypes {
 
   public static final String TEXT_LINE_DATASET_SIGNATURE = "tf.data.TextLineDataset()";
 
+  /** Serialized-record elements are 0-D string tensors; see {@code TFRecordDatasetGenerator}. */
+  public static final TypeReference TFRECORD_DATASET_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/data/TFRecordDataset"));
+
+  public static final String TFRECORD_DATASET_SIGNATURE = "tf.data.TFRecordDataset()";
+
+  /** The {@code tf.data.Dataset.list_files} function class, for source-side dispatch. */
+  public static final TypeReference DATASET_LIST_FILES_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/data/Dataset/list_files"));
+
+  public static final String DATASET_LIST_FILES_SIGNATURE = "tf.data.Dataset.list_files()";
+
+  /**
+   * The dataset allocated by {@code list_files}' summary, distinct from the generic {@code Dataset}
+   * so producer delegation can recover its filename-string element type (the wala/ML#618
+   * distinct-class treatment); see {@code ListFilesDatasetGenerator}.
+   */
+  public static final TypeReference LIST_FILES_DATASET_TYPE =
+      TypeReference.findOrCreate(
+          pythonLoader, TypeName.findOrCreate("Ltensorflow/data/ListFilesDataset"));
+
   public static final TypeReference DATASET_FROM_TENSOR_SLICES_TYPE =
       TypeReference.findOrCreate(
           pythonLoader, TypeName.findOrCreate("Ltensorflow/data/Dataset/from_tensor_slices"));
@@ -2067,6 +2090,9 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(DATASET_FROM_TENSOR_SLICES_TYPE, DATASET_FROM_TENSOR_SLICES_SIGNATURE),
           Map.entry(DATASET_RANGE_TYPE, DATASET_RANGE_SIGNATURE),
           Map.entry(TEXT_LINE_DATASET_TYPE, TEXT_LINE_DATASET_SIGNATURE),
+          Map.entry(TFRECORD_DATASET_TYPE, TFRECORD_DATASET_SIGNATURE),
+          Map.entry(DATASET_LIST_FILES_TYPE, DATASET_LIST_FILES_SIGNATURE),
+          Map.entry(LIST_FILES_DATASET_TYPE, DATASET_LIST_FILES_SIGNATURE),
           Map.entry(IMAGE_DATA_GENERATOR_FLOW_FROM_DIRECTORY_TYPE, FLOW_FROM_DIRECTORY_SIGNATURE),
           Map.entry(DATASET_FROM_GENERATOR_TYPE, DATASET_FROM_GENERATOR_SIGNATURE),
           Map.entry(DATASET_FROM_TENSORS_TYPE, DATASET_FROM_TENSORS_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_files_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_files_map.py
@@ -23,6 +23,8 @@ def consume(a):
 
 dataset = tf.data.Dataset.list_files(os.path.join(folder, "*.txt"))
 mapped = dataset.map(load)
+for length in mapped:
+    assert length.dtype == tf.int32
 for element in dataset:
     assert element.dtype == tf.string
     assert element.shape.rank == 0

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_files_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_files_map.py
@@ -1,0 +1,29 @@
+# A tf.data.Dataset.list_files dataset's elements are 0-D filename-string tensors, so a map
+# callback's parameter types as {[] string} (the Pix2Pix load(image_file) corpus form).
+import os
+import tempfile
+
+import tensorflow as tf
+
+folder = tempfile.mkdtemp()
+for name in ("a.txt", "b.txt"):
+    with open(os.path.join(folder, name), "w") as handle:
+        handle.write("x")
+
+
+def load(image_file):
+    assert image_file.dtype == tf.string
+    assert image_file.shape.rank == 0
+    return tf.strings.length(image_file)
+
+
+def consume(a):
+    pass
+
+
+dataset = tf.data.Dataset.list_files(os.path.join(folder, "*.txt"))
+mapped = dataset.map(load)
+for element in dataset:
+    assert element.dtype == tf.string
+    assert element.shape.rank == 0
+    consume(element)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_string_elements.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_string_elements.py
@@ -25,6 +25,8 @@ with tempfile.TemporaryDirectory() as tmp:
 
     dataset = tf.data.TFRecordDataset(record_path)
     mapped = dataset.map(parse_example)
+    for length in mapped:
+        assert length.dtype == tf.int32
     for element in dataset:
         assert element.dtype == tf.string
         assert element.shape.rank == 0

--- a/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_string_elements.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_tfrecord_string_elements.py
@@ -1,0 +1,31 @@
+# A TFRecordDataset's elements are 0-D string tensors (one serialized record each): the map
+# callback's parameter and the iterated element both type as {[] string} (the gpt-2
+# parse_example(serialized_example) corpus form).
+import os
+import tempfile
+
+import tensorflow as tf
+
+
+def parse_example(serialized_example):
+    assert serialized_example.dtype == tf.string
+    assert serialized_example.shape.rank == 0
+    return tf.strings.length(serialized_example)
+
+
+def consume(a):
+    pass
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    record_path = os.path.join(tmp, "sample.tfrecord")
+    with tf.io.TFRecordWriter(record_path) as writer:
+        writer.write(b"payload-0")
+        writer.write(b"payload-1")
+
+    dataset = tf.data.TFRecordDataset(record_path)
+    mapped = dataset.map(parse_example)
+    for element in dataset:
+        assert element.dtype == tf.string
+        assert element.shape.rank == 0
+        consume(element)


### PR DESCRIPTION
Closes wala/ML#801.

`TextLineDatasetGenerator`-family generators for both APIs (element shape `[]`, dtype `STRING`; the wala/ML#452 intrinsic-element-type treatment), registered in both dispatch tables. The `list_files` summary now allocates a distinct `ListFilesDataset` class instead of the generic `Dataset` (the wala/ML#618 treatment) so producer delegation can key on it.

Witnesses: iteration and map-callback directions for each dataset (`testTFRecordDatasetIterationElementType`/`MapCallbackParameter`, `testListFilesIterationElementType`/`MapCallbackParameter`), all pinning `{[] string}`, with the TextLine guard unchanged. The corpus acceptance is the four named rows (gpt-2 `parse_example`, deep_recommenders `_parse_example`, Pix2Pix `load`/`load_image_train`) leaving UNKNOWN_DTYPE. The `glob.glob` feeder stays wala/ML#782 and the parse-output typing stays wala/ML#645. Suite: 1182/0 under the CI logging config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY