### PR TITLE
Pin the `shuffle`-hop element-type loss

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1730,6 +1730,30 @@ public class TestDatasets extends AbstractTensorTest {
   }
 
   /**
+   * The Pix2Pix corpus form of {@link #testListFilesMapCallbackParameter()}: an intervening {@code
+   * shuffle} before a {@code map} with {@code num_parallel_calls}; the element type must survive
+   * the chain hop into the callback (wala/ML#801 residual probe).
+   *
+   * <p>TODO: Flip to a positive guard when the shuffle-hop element delegation lands (<a
+   * href="https://github.com/wala/ML/issues/802">wala/ML#802</a>).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testListFilesShuffleMapCallbackParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_list_files_shuffle_map.py",
+        "load_image_train",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_STRING)));
+  }
+
+  /**
    * The map-callback direction of {@link #testListFilesIterationElementType()} (the Pix2Pix {@code
    * load(image_file)} corpus form).
    *

--- a/com.ibm.wala.cast.python.test/data/tf2_test_list_files_shuffle_map.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_list_files_shuffle_map.py
@@ -1,0 +1,26 @@
+# The Pix2Pix corpus form (wala/ML#801 residual probe): list_files -> shuffle -> map with
+# num_parallel_calls; the element type must survive the shuffle hop into the callback.
+import os
+import tempfile
+
+import tensorflow as tf
+
+folder = tempfile.mkdtemp()
+for name in ("a.txt", "b.txt"):
+    with open(os.path.join(folder, name), "w") as handle:
+        handle.write("x")
+
+
+def load_image_train(image_file):
+    assert image_file.dtype == tf.string
+    assert image_file.shape.rank == 0
+    return tf.strings.length(image_file)
+
+
+train_dataset = tf.data.Dataset.list_files(os.path.join(folder, "*.txt"))
+train_dataset = train_dataset.shuffle(400)
+train_dataset = train_dataset.map(
+    load_image_train, num_parallel_calls=tf.data.experimental.AUTOTUNE
+)
+for length in train_dataset:
+    assert length.dtype == tf.int32


### PR DESCRIPTION
Advances wala/ML#802: the Pix2Pix corpus form (`list_files` then `shuffle` then `map` with `num_parallel_calls`) reproduced in-suite as `tf2_test_list_files_shuffle_map.py`, with `testListFilesShuffleMapCallbackParameter` the expected-failure pin carrying the flip condition. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY