### PR TITLE
Key the `list_files` manual dispatch on its allocating class

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -1732,9 +1732,7 @@ public class TestDatasets extends AbstractTensorTest {
   /**
    * The Pix2Pix corpus form of {@link #testListFilesMapCallbackParameter()}: an intervening {@code
    * shuffle} before a {@code map} with {@code num_parallel_calls}; the element type must survive
-   * the chain hop into the callback (wala/ML#801 residual probe).
-   *
-   * <p>TODO: Flip to a positive guard when the shuffle-hop element delegation lands (<a
+   * the chain hop into the callback (<a
    * href="https://github.com/wala/ML/issues/802">wala/ML#802</a>).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
@@ -1742,7 +1740,7 @@ public class TestDatasets extends AbstractTensorTest {
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testListFilesShuffleMapCallbackParameter()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -7726,7 +7726,11 @@ public abstract class TensorGenerator {
       return new TextLineDatasetGenerator(node);
     } else if (type.equals(TensorFlowTypes.TFRECORD_DATASET_TYPE)) {
       return new TFRecordDatasetGenerator(node);
-    } else if (type.equals(TensorFlowTypes.LIST_FILES_DATASET_TYPE)) {
+    } else if (type.equals(TensorFlowTypes.DATASET_LIST_FILES_TYPE)
+        || type.equals(TensorFlowTypes.LIST_FILES_DATASET_TYPE)) {
+      // The allocating class for a `list_files` result is the function class
+      // `Ltensorflow/data/Dataset/list_files`, not the distinct allocation class the summary
+      // makes; the node-based dispatch keys on the former (wala/ML#802).
       return new ListFilesDatasetGenerator(node);
     } else if (type.equals(TensorFlowTypes.DATASET_RANDOM_TYPE)) {
       return new DatasetRandomGenerator(node);


### PR DESCRIPTION
Closes wala/ML#802.

The node-based manual table dispatches on the allocating synthetic's class, which for a `list_files` result is the function class `Ltensorflow/data/Dataset/list_files` rather than the distinct `ListFilesDataset` allocation class; the wala/ML#801 arm matched only the latter, so the direct `map` form worked (source-side dispatch) while any chain hop (the Pix2Pix `shuffle`) starved. One-branch fix; `testListFilesShuffleMapCallbackParameter` flips positive. Suite: 1183/0 under the CI logging config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY