### PR TITLE
Add the lexical-read hop and cross-frame tuple peel to the SSA-chain walkers

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1609,6 +1609,32 @@ public class TestConstructors extends AbstractTensorTest {
         Map.of(2, Set.of(new TensorType(INT_64, null))));
   }
 
+  /**
+   * The lexical-hop witness (wala/ML#796): a dynamic-bound slice consumed inside the comprehension
+   * itself, whose receiver is a lexical read of the enclosing frame's unpacked reader result; the
+   * SSA-chain walkers must cross both the closure boundary and the callee tuple to recover the
+   * dtype.
+   *
+   * <p>TODO: Flip to a positive guard when the remaining wala/ML#796 residuals land (the reader
+   * shape walk's spurious scalar member and the consume-side dtype drop; see the issue's diagnosis
+   * comments).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testReaderChainProbeLexicalSlice()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_reader_chain3.py",
+        "consume_lexical_slice",
+        1,
+        1,
+        Map.of(2, Set.of(new TensorType(INT_64, null))));
+  }
+
   /** See {@link #testReaderChainProbeUnpacked()}. */
   @Test
   public void testReaderChainProbeSliced()

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1538,10 +1538,11 @@ public class TestConstructors extends AbstractTensorTest {
    * the sampling generator's tuple yield and for-loop unpack, and the merge-time {@code np.array}
    * rebase with {@code tf.concat} to reach the model-call parameters.
    *
-   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
-   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>): the slice receiver's lexical
-   * read is invisible to the SSA-chain walkers, and the reader tuple's cross-frame unpack defeats
-   * the same-frame tuple peel, so the merge-side feeds compose from unknown states.
+   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands: the merge-side {@code
+   * np.array(item)} receives yield-delivered elements whose points-to sets carry only analysis
+   * substrate (the generator-protocol nulls and a self-referential list union), so its content walk
+   * and the downstream {@code tf.concat} feed compose from unknown state; the sampling generator's
+   * yield/unpack element plumbing is the remaining path.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1564,8 +1565,8 @@ public class TestConstructors extends AbstractTensorTest {
    * unmodeled ndarray {@code tolist} method from the generator-yield/unpack and merge-rebase hops
    * (<a href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
    *
-   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
-   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
+   * #testReaderChainMergedDtype()}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1624,7 +1625,7 @@ public class TestConstructors extends AbstractTensorTest {
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testReaderChainProbeLexicalSlice()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1650,10 +1651,10 @@ public class TestConstructors extends AbstractTensorTest {
   /**
    * See {@link #testReaderChainProbeUnpacked()}.
    *
-   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
-   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
+   * #testReaderChainMergedDtype()}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testReaderChainProbeListed()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1667,10 +1668,10 @@ public class TestConstructors extends AbstractTensorTest {
   /**
    * See {@link #testReaderChainProbeUnpacked()}.
    *
-   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
-   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
+   * #testReaderChainMergedDtype()}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testReaderChainProbeDynamic()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1684,10 +1685,10 @@ public class TestConstructors extends AbstractTensorTest {
   /**
    * See {@link #testReaderChainProbeUnpacked()}.
    *
-   * <p>TODO: Flip to a positive guard when the remaining chain hops land (<a
-   * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
+   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
+   * #testReaderChainMergedDtype()}.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testReaderChainProbeRearrayed()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gamma.java
@@ -106,8 +106,12 @@ public class Gamma extends TensorTypeAllocator {
         this.getArgumentPointsToSet(
             builder, this.getBetaParameterPosition(), this.getBetaParameterName());
 
-    // If there is no beta parameter.
-    if (betaPointsToSet == null || betaPointsToSet.isEmpty())
+    // If there is no beta parameter. An explicit `beta=None` reaches here as a points-to set of
+    // null constants; that is the same absent case (`tf.random.gamma` then defaults beta to 1,
+    // whose scalar shape broadcasts away), not a value whose shape participates in the
+    // composition. Route it to the no-beta arm rather than letting the null-skipping shape walk
+    // return an empty beta-shape set that annihilates the whole product. wala/ML#796.
+    if (betaPointsToSet == null || betaPointsToSet.isEmpty() || allNullConstants(betaPointsToSet))
       // return shape `tf.concat([shape, tf.shape(alpha)], axis=0)`.
       shapes.forEach(
           shape -> {
@@ -121,6 +125,9 @@ public class Gamma extends TensorTypeAllocator {
     else { // There is a beta parameter.
       // return shape `tf.concat([shape, tf.shape(alpha + beta)], axis=0)`.
       Set<List<Dimension<?>>> betaShapes = this.getShapesOfValue(builder, betaPointsToSet);
+
+      // beta's shape is part of the output rank; ⊤ if unresolvable, matching alpha. wala/ML#611.
+      if (betaShapes == null || betaShapes.isEmpty()) return null;
 
       shapes.forEach(
           shape -> {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -30,6 +30,9 @@ import static com.ibm.wala.core.util.strings.Atom.findOrCreateAsciiAtom;
 import static java.util.Collections.emptyList;
 
 import com.ibm.wala.cast.ipa.callgraph.AstPointerKeyFactory;
+import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
+import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
+import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.ir.ssa.CAstBinaryOp;
 import com.ibm.wala.cast.ir.ssa.CAstUnaryOp;
 import com.ibm.wala.cast.loader.AstMethod;
@@ -89,6 +92,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -3158,6 +3162,121 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Cross-frame counterpart of {@code findTupleFieldStore} (wala/ML#796): when a tuple-unpack
+   * read's object was produced by an invoke, the tuple and its field stores live in the callee's
+   * frame; find the callee returns whose results are tuple allocations and the store into the
+   * read's field on each, yielding (callee, stored value number) pairs the SSA-chain walkers
+   * continue in.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The reading node.
+   * @param propRead The tuple-unpack property read.
+   * @return The (callee node, stored value number) pairs; empty if none resolve.
+   */
+  private static Set<Pair<CGNode, Integer>> findCalleeTupleFieldStores(
+      PropagationCallGraphBuilder builder, CGNode node, PythonPropertyRead propRead) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    SymbolTable symbolTable = node.getIR().getSymbolTable();
+    int memberVn = propRead.getMemberRef();
+    if (!symbolTable.isConstant(memberVn)) return ret;
+    String fieldName = String.valueOf(symbolTable.getConstantValue(memberVn));
+    SSAInstruction objDef = node.getDU().getDef(propRead.getObjectRef());
+    if (!(objDef instanceof SSAAbstractInvokeInstruction call)) return ret;
+    // Method dispatch interposes synthetic trampolines between the invoke and the user body;
+    // expand through them (bounded) to the AstMethod callees that hold the tuple.
+    Deque<CGNode> work = new ArrayDeque<>();
+    Set<CGNode> seen = HashSetFactory.make();
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, call.getCallSite()))
+      if (seen.add(callee)) work.add(callee);
+    Set<CGNode> bodies = HashSetFactory.make();
+    while (!work.isEmpty() && seen.size() < 32) {
+      CGNode callee = work.poll();
+      if (callee.getMethod() instanceof AstMethod) {
+        bodies.add(callee);
+        continue;
+      }
+      for (Iterator<CGNode> it = builder.getCallGraph().getSuccNodes(callee); it.hasNext(); ) {
+        CGNode next = it.next();
+        if (seen.add(next)) work.add(next);
+      }
+    }
+    LOGGER.fine(
+        () ->
+            "findCalleeTupleFieldStores: field="
+                + fieldName
+                + " bodies="
+                + bodies.size()
+                + " for "
+                + propRead
+                + " in "
+                + describe(node));
+    for (CGNode callee : bodies) {
+      IR calleeIr = callee.getIR();
+      if (calleeIr == null) continue;
+      for (SSAInstruction instruction : calleeIr.getInstructions()) {
+        if (!(instruction instanceof SSAReturnInstruction returnInstruction)
+            || returnInstruction.getResult() <= 0) continue;
+        SSAInstruction returnDef = callee.getDU().getDef(returnInstruction.getResult());
+        if (!(returnDef instanceof SSANewInstruction)) continue;
+        int allocVn = returnInstruction.getResult();
+        for (SSAInstruction store : calleeIr.getInstructions()) {
+          if (store instanceof SSAPutInstruction put
+              && !put.isStatic()
+              && put.getRef() == allocVn
+              && fieldName.equals(put.getDeclaredField().getName().toString()))
+            ret.add(Pair.make(callee, put.getVal()));
+          else if (store instanceof AstPropertyWrite write && write.getObjectRef() == allocVn) {
+            int storeMemberVn = write.getMemberRef();
+            SymbolTable calleeSymbols = calleeIr.getSymbolTable();
+            if (calleeSymbols.isConstant(storeMemberVn)
+                && fieldName.equals(String.valueOf(calleeSymbols.getConstantValue(storeMemberVn))))
+              ret.add(Pair.make(callee, write.getValue()));
+          }
+        }
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * Resolves the frames defining a lexically-read variable: the two-hop predecessor walk in the
+   * propagation graph from the read's pointer key to the {@link AstLexicalWrite} writers' local
+   * keys (the {@code PythonTurtleAnalysisEngine} recipe), yielding the (definer node, value number)
+   * pairs the SSA-chain walkers continue in. Comprehension bodies read their enclosing frame's
+   * locals this way, which previously dead-ended both walkers (wala/ML#796).
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The reading node.
+   * @param vn The lexical read's definition value number.
+   * @return The definer (node, value number) pairs; empty if none resolve.
+   */
+  private static Set<Pair<CGNode, Integer>> lexicalDefiners(
+      PropagationCallGraphBuilder builder, CGNode node, int vn) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    PointerKey pk = builder.getPointerKeyForLocal(node, vn);
+    if (builder.getPropagationSystem().isImplicit(pk)) return ret;
+    PointsToSetVariable av = builder.getPropagationSystem().findOrCreatePointsToSet(pk);
+    Graph<PointsToSetVariable> flow =
+        builder.getPropagationSystem().getFlowGraphIncludingImplicitConstraints();
+    if (!flow.containsNode(av)) return ret;
+    for (Iterator<PointsToSetVariable> outer = flow.getPredNodes(av); outer.hasNext(); ) {
+      PointsToSetVariable p = outer.next();
+      // The read's immediate predecessor is the upward-funarg key linking the closure to its
+      // enclosing frame; its own predecessors are the defining locals. An explicit
+      // AstLexicalWrite use is not required: a comprehension's closure capture flows through the
+      // funarg key by direct constraint, so the funarg hop itself is the discriminator.
+      if (!p.getPointerKey().getClass().getSimpleName().contains("UpwardFunarg")) continue;
+      for (Iterator<PointsToSetVariable> inner = flow.getPredNodes(p); inner.hasNext(); ) {
+        PointsToSetVariable pp = inner.next();
+        if (pp.getPointerKey() instanceof LocalPointerKey lpk)
+          ret.add(Pair.make(lpk.getNode(), lpk.getValueNumber()));
+      }
+    }
+    LOGGER.fine(() -> "lexicalDefiners: vn=" + vn + " in " + describe(node) + " -> " + ret.size());
+    return ret;
+  }
+
+  /**
    * Recursive worker for {@link #shapesFromSSAChain(PropagationCallGraphBuilder, CGNode, int)}.
    *
    * @param builder The propagation call graph builder used to resolve callees.
@@ -3169,8 +3288,11 @@ public abstract class TensorGenerator {
    *     has already visited {@code vn} on this walk (cycle guard).
    */
   private Set<List<Dimension<?>>> shapesFromSSAChain(
-      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<Integer> visited) {
-    if (!visited.add(vn)) return null; // cycle guard
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int vn,
+      Set<Pair<CGNode, Integer>> visited) {
+    if (!visited.add(Pair.make(node, vn))) return null; // cycle guard (per-frame, wala/ML#796)
     SSAInstruction def = node.getDU().getDef(vn);
     LOGGER.fine(
         () ->
@@ -3198,6 +3320,35 @@ public abstract class TensorGenerator {
           // fall through
         }
         return shapesFromSSAChain(builder, node, storedVn, visited);
+      }
+      // The tuple was built in a callee (a cross-frame unpack, wala/ML#796); continue at the
+      // callee-side field stores.
+      for (Pair<CGNode, Integer> store : findCalleeTupleFieldStores(builder, node, propRead)) {
+        try {
+          Set<List<Dimension<?>>> viaPts = getShapes(builder, store.fst, store.snd);
+          if (viaPts != null && !viaPts.isEmpty()) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the callee-frame chain walk
+        }
+        Set<List<Dimension<?>>> chain = shapesFromSSAChain(builder, store.fst, store.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      return null;
+    }
+
+    // A comprehension body reads its enclosing frame's locals lexically; continue the walk in
+    // the definer frame(s) (wala/ML#796).
+    if (def instanceof AstLexicalRead) {
+      for (Pair<CGNode, Integer> definer : lexicalDefiners(builder, node, vn)) {
+        try {
+          Set<List<Dimension<?>>> viaPts = getShapes(builder, definer.fst, definer.snd);
+          if (viaPts != null && !viaPts.isEmpty()) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the definer-frame chain walk
+        }
+        Set<List<Dimension<?>>> chain =
+            shapesFromSSAChain(builder, definer.fst, definer.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
       }
       return null;
     }
@@ -3311,8 +3462,11 @@ public abstract class TensorGenerator {
    *     has already visited {@code vn} on this walk (cycle guard).
    */
   private Set<DType> dtypesFromSSAChain(
-      PropagationCallGraphBuilder builder, CGNode node, int vn, Set<Integer> visited) {
-    if (!visited.add(vn)) return null;
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      int vn,
+      Set<Pair<CGNode, Integer>> visited) {
+    if (!visited.add(Pair.make(node, vn))) return null; // cycle guard (per-frame, wala/ML#796)
     SSAInstruction def = node.getDU().getDef(vn);
 
     if (def instanceof PythonPropertyRead) {
@@ -3326,6 +3480,19 @@ public abstract class TensorGenerator {
           // fall through
         }
         return dtypesFromSSAChain(builder, node, storedVn, visited);
+      }
+      // The cross-frame unpack counterpart; see shapesFromSSAChain (wala/ML#796).
+      for (Pair<CGNode, Integer> store : findCalleeTupleFieldStores(builder, node, propRead)) {
+        try {
+          Set<DType> viaPts = getDTypes(builder, store.fst, store.snd);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the callee-frame chain walk
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, store.fst, store.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
       }
       return null;
     }
@@ -3341,6 +3508,24 @@ public abstract class TensorGenerator {
       }
       // Otherwise take the first operand's dtype.
       return dtypesFromSSAChain(builder, node, xVn, visited);
+    }
+
+    // A comprehension body reads its enclosing frame's locals lexically; continue the walk in
+    // the definer frame(s) (wala/ML#796).
+    if (def instanceof AstLexicalRead) {
+      for (Pair<CGNode, Integer> definer : lexicalDefiners(builder, node, vn)) {
+        try {
+          Set<DType> viaPts = getDTypes(builder, definer.fst, definer.snd);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the definer-frame chain walk
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, definer.fst, definer.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      return null;
     }
 
     if (!(def instanceof SSAAbstractInvokeInstruction)) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3725,6 +3725,26 @@ public abstract class TensorGenerator {
   }
 
   /**
+   * Returns whether every member of the given points-to set is a {@code null} {@link ConstantKey},
+   * i.e., the value is statically an explicit Python {@code None}. Consumers of optional arguments
+   * use this to treat an explicit {@code None} the same as an omitted argument, since the shape and
+   * dtype walks deliberately produce nothing for {@code null} constants (wala/ML#796) and composing
+   * with the resulting empty set would annihilate the composition.
+   *
+   * @param pointsToSet The {@link OrdinalSet} of {@link InstanceKey}s to examine.
+   * @return {@code true} iff {@code pointsToSet} is non-empty and every member is a {@code null}
+   *     constant.
+   */
+  protected static boolean allNullConstants(OrdinalSet<InstanceKey> pointsToSet) {
+    if (pointsToSet == null || pointsToSet.isEmpty()) return false;
+
+    for (InstanceKey ik : pointsToSet)
+      if (!(ik instanceof ConstantKey) || ((ConstantKey<?>) ik).getValue() != null) return false;
+
+    return true;
+  }
+
+  /**
    * Record-carrying core of {@link #getShapesOfValue(PropagationCallGraphBuilder, OrdinalSet,
    * boolean)} (wala/ML#718): in exact mode, a member whose shapes do not resolve marks the unknown
    * remainder and the resolvable members keep collecting, so a partially resolvable points-to union
@@ -3758,8 +3778,16 @@ public abstract class TensorGenerator {
     boolean replay = activeEngine != null && activeEngine.isReplaying();
 
     for (InstanceKey valueIK : valuePointsToSet)
-      if (valueIK instanceof ConstantKey) ret.add(emptyList()); // Scalar value.
-      else if (valueIK instanceof AllocationSiteInNode) {
+      if (valueIK instanceof ConstantKey) {
+        // A null constant is analysis substrate (loop-carried phi defaults, the generator
+        // iteration protocol) or an explicit `None` argument, never a scalar value; typing it as
+        // shape [] fabricates a scalar member the downstream pass-throughs then propagate (the
+        // shape twin of the dtype walk's null skip, wala/ML#796). A consumer of an *optional*
+        // argument must treat an all-null points-to set as an absent argument rather than
+        // composing with the resulting empty set (see `Gamma.getShapes` and
+        // `allNullConstants(OrdinalSet)`).
+        if (((ConstantKey<?>) valueIK).getValue() != null) ret.add(emptyList()); // Scalar value.
+      } else if (valueIK instanceof AllocationSiteInNode) {
         AllocationSiteInNode asin = getAllocationSiteInNode(valueIK);
         TypeReference reference = asin.concreteType().getReference();
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain3.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_reader_chain3.py
@@ -25,6 +25,10 @@ def consume_rearrayed(e):
     pass
 
 
+def consume_lexical_slice(f):
+    pass
+
+
 class Loader:
     def read_file(self, src, dtype=None):
         rows = [[dtype(x) for x in line.split(",")] for line in src]
@@ -45,6 +49,7 @@ assert sliced.dtype == np.int64
 consume_sliced(sliced)
 
 value = [(0, 1), (1, 2)]
+probed = [consume_lexical_slice(edge_index[se[0] : se[1]]) for se in value]
 listed = [edge_index[se[0] : se[1]] for se in value]
 assert listed[0].dtype == np.int64
 consume_listed(listed[0])


### PR DESCRIPTION
Advances wala/ML#796.

Two increments:

1. The SSA-chain walkers cross closure boundaries (the upward-funarg predecessor walk to the defining frame's locals; comprehension captures flow by direct constraint, so the funarg hop itself is the discriminator) and callee tuple builds (return-tuple field stores in both `SSAPutInstruction` and `AstPropertyWrite` forms, targets expanded through synthetic trampolines), with per-frame visited keys.
2. The shape walk's scalar arm skips `null` constants, the shape twin of the dtype walk's null skip: a `null` points-to member is analysis substrate or an explicit `None`, and typing it as shape `[]` fabricated a scalar member that pass-throughs propagated. `Gamma` treats an all-`null` optional `beta` as an absent argument via the new `allNullConstants` helper so the composition does not annihilate.

Together these flip four reader-chain probes to positive guards (`testReaderChainProbeListed`, `Dynamic`, `Rearrayed`, `LexicalSlice`), all now inferring `{? of int64}`. The remaining hop is the merge-side `np.array` over yield-delivered elements whose points-to sets carry only analysis substrate; `testReaderChainMergedDtype`/`2` stay pinned with a TODO naming it.

Suite: 1185/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY