### PR TITLE
Pin the scalar `tf.Variable` broadcast gap

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -1698,4 +1698,32 @@ public class TestElementwiseOps extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TensorType.of(UINT_8, 2, 2, 3))));
   }
+
+  /**
+   * Test a {@code W * x + b} chain whose {@code W} and {@code b} are scalar {@code tf.Variable}s.
+   * The runtime truth is {@code float32 (3,)}, but the {@code tf.Variable} allocation never reaches
+   * the {@code W} operand's points-to walk, and the one-sided broadcast rule discards the resolved
+   * {@code [3]} because the opaque co-operand is not structurally a scalar expression. Mirrors the
+   * TensorFlow-Examples linear-regression rows whose concrete member degraded to ⊤ at 0.52.73, when
+   * the wala/ML#796 null-skip removed the fabricated scalar member the broadcast had been riding.
+   *
+   * <p>TODO: Flip to a positive guard when <a
+   * href="https://github.com/wala/ML/issues/804">wala/ML#804</a> lands (scalar {@code tf.Variable}
+   * operands recognized by the one-sided elementwise broadcast).
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testScalarVariableBroadcast()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_scalar_variable_broadcast.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.test/data/tf2_test_scalar_variable_broadcast.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_scalar_variable_broadcast.py
@@ -1,0 +1,27 @@
+# Test https://github.com/wala/ML/issues/796: a scalar `tf.Variable` operand whose points-to set
+# carries only analysis-substrate null constants must broadcast as the rank-0 identity instead of
+# annihilating the elementwise composition (the `tf.matmul(x, W) + b` bias-slot regression caught
+# by the 0.52.73 release smoke on TensorFlow-Examples).
+
+import numpy as np
+import tensorflow as tf
+
+rng = np.random
+
+W = tf.Variable(rng.randn(), name="weight")
+b = tf.Variable(rng.randn(), name="bias")
+
+
+def linear_regression(x):
+    return W * x + b
+
+
+def consume(y_pred):
+    pass
+
+
+X = np.array([1.0, 2.0, 3.0])
+pred = linear_regression(X)
+assert pred.shape == (3,)
+assert pred.dtype == tf.float32
+consume(pred)


### PR DESCRIPTION
Adds the pinned witness for wala/ML#804: a `W * x + b` chain over scalar `tf.Variable`s whose runtime truth is `float32 (3,)` infers `{? of unknown}`, because the `tf.Variable` allocation never reaches the `W` operand's points-to walk and the one-sided broadcast rule requires the opaque co-operand to be structurally a scalar expression. The fixture mirrors the TensorFlow-Examples linear-regression rows whose concrete member degraded to honest ⊤ at 0.52.73. Test-only; suite 1186/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY