### PR TITLE
Extend the SSA-chain walkers across closures, callees, generators, and parameters

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -1538,11 +1538,17 @@ public class TestConstructors extends AbstractTensorTest {
    * the sampling generator's tuple yield and for-loop unpack, and the merge-time {@code np.array}
    * rebase with {@code tf.concat} to reach the model-call parameters.
    *
-   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands: the merge-side {@code
-   * np.array(item)} receives yield-delivered elements whose points-to sets carry only analysis
-   * substrate (the generator-protocol nulls and a self-referential list union), so its content walk
-   * and the downstream {@code tf.concat} feed compose from unknown state; the sampling generator's
-   * yield/unpack element plumbing is the remaining path.
+   * <p>The wala/ML#796 chain work types every merge-side {@code np.array} and the batch-side {@code
+   * tf.concat} as {@code int64}. What remains is the {@code edge_index} concat, whose elements pass
+   * through the arithmetic comprehension {@code w + strips[i]}: that binary operation is swept as a
+   * dataflow source but declines {@code ElementWiseOperation} dispatch, because the
+   * operand-evidence gate requires points-to evidence (correctly, since it is what keeps integer
+   * arithmetic and list concatenation from being typed as tensors, wala/ML#653) and neither operand
+   * has any, their producers minting no allocation site at all.
+   *
+   * <p>TODO: Flip to a positive guard when <a
+   * href="https://github.com/wala/ML/issues/805">wala/ML#805</a> lands (binary-operator results
+   * mint no {@code InstanceKey}), which supplies exactly the operand evidence the gate looks for.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
@@ -1565,7 +1571,8 @@ public class TestConstructors extends AbstractTensorTest {
    * unmodeled ndarray {@code tolist} method from the generator-yield/unpack and merge-rebase hops
    * (<a href="https://github.com/wala/ML/issues/796">wala/ML#796</a>).
    *
-   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
+   * <p>TODO: Flip to a positive guard when <a
+   * href="https://github.com/wala/ML/issues/805">wala/ML#805</a> lands; see {@link
    * #testReaderChainMergedDtype()}.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
@@ -1648,12 +1655,7 @@ public class TestConstructors extends AbstractTensorTest {
         Map.of(2, Set.of(new TensorType(INT_64, null))));
   }
 
-  /**
-   * See {@link #testReaderChainProbeUnpacked()}.
-   *
-   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
-   * #testReaderChainMergedDtype()}.
-   */
+  /** See {@link #testReaderChainProbeUnpacked()}. */
   @Test
   public void testReaderChainProbeListed()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -1665,12 +1667,7 @@ public class TestConstructors extends AbstractTensorTest {
         Map.of(2, Set.of(new TensorType(INT_64, null))));
   }
 
-  /**
-   * See {@link #testReaderChainProbeUnpacked()}.
-   *
-   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
-   * #testReaderChainMergedDtype()}.
-   */
+  /** See {@link #testReaderChainProbeUnpacked()}. */
   @Test
   public void testReaderChainProbeDynamic()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -1682,12 +1679,7 @@ public class TestConstructors extends AbstractTensorTest {
         Map.of(2, Set.of(new TensorType(INT_64, null))));
   }
 
-  /**
-   * See {@link #testReaderChainProbeUnpacked()}.
-   *
-   * <p>TODO: Flip to a positive guard when the last wala/ML#796 hop lands; see {@link
-   * #testReaderChainMergedDtype()}.
-   */
+  /** See {@link #testReaderChainProbeUnpacked()}. */
   @Test
   public void testReaderChainProbeRearrayed()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
@@ -26,7 +26,6 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_8_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_784_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_FLOAT32;
-import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 import static com.ibm.wala.cast.python.util.Util.addPytestEntrypoints;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -367,10 +366,10 @@ public class TestModelCall extends AbstractTensorTest {
    * accuracy}'s {@code y_pred} parameter. This test runs at k-CFA depth 4 (wala/ML#379) so {@code
    * NeuralNet.call} is analyzed per caller and its layer-output ({@code pred}) no longer collapses
    * the training shape into the test context (wala/ML#530); value 2 is therefore the per-context
-   * union {@code {(256, 10) float32, ? float32}}. The test-context contribution is ⊤ shape because
-   * the {@code x_test} chain resolves to a rank-preserving but shape-unknown tensor by the time it
-   * reaches {@code NeuralNet.call}'s first {@code Dense} operand; closing that gap would narrow the
-   * ⊤ to {@code (10000, 10)} (orthogonal to #358/#530).
+   * union {@code {(256, 10) float32, (10000, 10) float32}}. The test-context member narrowed from ⊤
+   * shape when the SSA-chain walkers gained the parameter-to-caller-argument arm (wala/ML#796),
+   * which resolves the {@code x_test} chain through {@code NeuralNet.call}'s first {@code Dense}
+   * operand.
    */
   @Test
   public void testNeuralNetwork4()
@@ -389,12 +388,11 @@ public class TestModelCall extends AbstractTensorTest {
         Map.of(
             2,
             // Per-context union: training call site `accuracy(pred, batch_y)` gives `(256, 10)`;
-            // the test-set call site `accuracy(pred, y_test)` resolves to ⊤ shape because the
-            // `x_test` chain is shape-unknown by the time it reaches `NeuralNet.call`'s first
-            // `Dense` operand. With the depth-4 context separation (wala/ML#530), `argmax`'s result
-            // no longer leaks the training shape into the test context. TODO: the test-context ⊤
-            // should narrow to `(10000, 10)` once the `x_test` shape gap is closed.
-            Set.of(TENSOR_256_10_FLOAT32, TENSOR_UNKNOWN_SHAPE_FLOAT32),
+            // the test-set call site `accuracy(pred, y_test)` gives `(10000, 10)`: the walkers'
+            // parameter-to-caller-argument arm (wala/ML#796) resolves the `x_test` chain that
+            // previously floored the test context to ⊤ shape. With the depth-4 context separation
+            // (wala/ML#530), `argmax`'s result does not leak the training shape across contexts.
+            Set.of(TENSOR_256_10_FLOAT32, TENSOR_10000_10_FLOAT32),
             3,
             Set.of(TENSOR_256_UINT8, TENSOR_10000_UINT8)));
   }

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -44,6 +44,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -56,6 +58,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -68,6 +72,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -80,6 +86,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -92,6 +100,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -125,6 +135,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -136,6 +148,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -148,6 +162,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -163,6 +179,8 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -174,11 +192,23 @@
           <new def="ret" class="Lnumpy/ndarray"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
         </method>
       </class>
+      <!-- https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html -->
+      <!-- `x.tolist()` returns the array's elements as a nested Python list. The result is a distinct allocation (`tolist_result`, not `Lnumpy/ndarray`) so producer delegation dispatches `TolistOperation` (dtype and shape recovered from the receiver) without conflating the value with a real ndarray; the downstream `np.array(list)` rebase reads through it. wala/ML#796. -->
+      <class name="tolist" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self ndarray">
+          <new def="ret" class="Lnumpy/ndarray/tolist_result"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- Allocation-only marker class for `tolist` results; no method body (same pattern as `ndarray`). -->
+      <class name="tolist_result" allocatable="true"></class>
     </package>
   </classloader>
 </summary-spec>

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -3743,6 +3743,8 @@
           <!-- Populate ndarray method fields so `x_train.astype(...)` / `x_train.reshape(...)` calls resolve via class-type dispatch (mirrors the Dataset-method pattern). -->
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3753,6 +3755,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3763,6 +3767,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/mnist/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3773,6 +3779,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/mnist/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3809,6 +3817,8 @@
           <!-- Populate ndarray method fields so `x_train.astype(...)` / `x_train.reshape(...)` calls resolve via class-type dispatch (mirrors the mnist/Dataset-method pattern). -->
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3819,6 +3829,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3829,6 +3841,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar10/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3839,6 +3853,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar10/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3874,6 +3890,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3884,6 +3902,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3894,6 +3914,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3904,6 +3926,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3939,6 +3963,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3949,6 +3975,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3959,6 +3987,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -3969,6 +3999,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4004,6 +4036,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4014,6 +4048,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4024,6 +4060,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4034,6 +4072,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4069,6 +4109,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4079,6 +4121,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4089,6 +4133,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4099,6 +4145,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4134,6 +4182,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4144,6 +4194,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_train"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4154,6 +4206,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
@@ -4164,6 +4218,8 @@
           <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_test"/>
           <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
           <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -148,6 +148,7 @@ public class NpArray extends TensorGenerator {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
     // The explicit `dtype` argument is a token (`np.int32`, the builtin `int`), not a value whose
     // dtype the value walk could compute (that walk deliberately ignores `DType` allocations), so
@@ -181,8 +182,24 @@ public class NpArray extends TensorGenerator {
       // producers are only reachable syntactically, the reader-chain merge frames): fall back to
       // the SSA-chain walk, whose lexical, phi, tuple-peel, and parameter arms recover the
       // producing array's dtype interprocedurally. `np.array` preserves an array-typed content's
-      // dtype, so the recovered dtype is the result's. wala/ML#796.
-      Set<DType> viaChain = getDTypesOrSSAChain(builder, getNode(), sourceVn);
+      // dtype, so the recovered dtype is the result's. The walk is routed through the engine so
+      // the transfer is schedule-visible: a seed-time evaluation that runs before the upstream
+      // generators exist re-evaluates when the values it read grow, instead of memoizing the
+      // unknown forever (the wala/ML#753 class; `readElementShapes` is the precedent).
+      // wala/ML#796.
+      WorklistTypeResolver engine = WorklistTypeResolver.active(builder);
+      Set<DType> viaChain;
+      if (engine == null) viaChain = getDTypesOrSSAChain(builder, getNode(), sourceVn);
+      else {
+        Object key = Pair.make("nparray-content-chain", pk);
+        java.util.function.Supplier<Object> transfer =
+            () -> getDTypesOrSSAChain(builder, getNode(), sourceVn);
+        viaChain =
+            (Set<DType>)
+                (engine.isEvaluating()
+                    ? engine.read(key, transfer, true)
+                    : engine.demand(key, transfer, true));
+      }
       if (viaChain != null
           && !viaChain.isEmpty()
           && !(viaChain.size() == 1 && viaChain.contains(DType.UNKNOWN))) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -172,9 +172,22 @@ public class NpArray extends TensorGenerator {
       PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(getNode(), sourceVn);
       OrdinalSet<InstanceKey> sourcePTS = pa.getPointsToSet(pk);
       Set<DType> inferred = numpyPromotedDTypes(builder, sourcePTS);
-      if (!inferred.isEmpty()) {
-        LOGGER.fine(() -> "NpArray.getDefaultDTypes: inferred " + inferred + " from sourceVn.");
+      if (!inferred.isEmpty() && !(inferred.size() == 1 && inferred.contains(DType.UNKNOWN))) {
+        LOGGER.fine(() -> "Inferred " + inferred + " from the content argument's leaves.");
         return inferred;
+      }
+
+      // The content's leaves resolve to nothing or only the ⊤ floor (e.g. a rebased element whose
+      // producers are only reachable syntactically, the reader-chain merge frames): fall back to
+      // the SSA-chain walk, whose lexical, phi, tuple-peel, and parameter arms recover the
+      // producing array's dtype interprocedurally. `np.array` preserves an array-typed content's
+      // dtype, so the recovered dtype is the result's. wala/ML#796.
+      Set<DType> viaChain = getDTypesOrSSAChain(builder, getNode(), sourceVn);
+      if (viaChain != null
+          && !viaChain.isEmpty()
+          && !(viaChain.size() == 1 && viaChain.contains(DType.UNKNOWN))) {
+        LOGGER.fine(() -> "Recovered " + viaChain + " via the content argument's SSA chain.");
+        return viaChain;
       }
     }
 

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -197,8 +197,8 @@ public class NpArray extends TensorGenerator {
         viaChain =
             (Set<DType>)
                 (engine.isEvaluating()
-                    ? engine.read(key, transfer, true)
-                    : engine.demand(key, transfer, true));
+                    ? engine.read(key, transfer, false)
+                    : engine.demand(key, transfer, false));
       }
       if (viaChain != null
           && !viaChain.isEmpty()

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1912,11 +1912,18 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         // vendored Conv1d and gather probes are wala/ML#682's witnesses for wholesale
         // suppression). DTYPE_ONLY declares no operand→result shape relation, so proven-dtype
         // seeds under it stay untouched.
-        if (types == null || types.isEmpty()) continue;
+        if (types == null) continue;
         boolean anyProvenDType = types.stream().anyMatch(t -> t.getDType() != DType.UNKNOWN);
         boolean anyTopShape = types.stream().anyMatch(t -> t.getDims() == null);
         TensorTypeAnalysis.FeedMode mode;
-        if (!anyProvenDType)
+        if (types.isEmpty())
+          // A ⊥ seed (nothing provable at evaluation time) still registers its declared feed:
+          // operand evidence arriving during the fixpoint replaces the empty state, or the
+          // variable stays ⊥ exactly as before. Without this, a schedule artifact at seed time
+          // permanently excludes the variable from the feed channel (the merge-frame binops of
+          // wala/ML#796, whose operand states only exist after the reader generators evaluate).
+          mode = TensorTypeAnalysis.FeedMode.REPLACE;
+        else if (!anyProvenDType)
           mode =
               types.size() == 1 && anyTopShape
                   ? TensorTypeAnalysis.FeedMode.REPLACE
@@ -2320,7 +2327,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       if (generator == null) return null;
 
       Set<TensorType> tensorTypes = generator.getTensorTypes(builder);
-      LOGGER.fine(() -> "Found tensor types: " + tensorTypes + ".");
+      LOGGER.fine(() -> "Found tensor types: " + tensorTypes + " for " + describe(source) + ".");
 
       if (tensorTypes != null && tensorTypes.stream().anyMatch(t -> t.getDims() == null))
         LOGGER.fine(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3175,13 +3175,75 @@ public abstract class TensorGenerator {
    */
   private static Set<Pair<CGNode, Integer>> findCalleeTupleFieldStores(
       PropagationCallGraphBuilder builder, CGNode node, PythonPropertyRead propRead) {
-    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
     SymbolTable symbolTable = node.getIR().getSymbolTable();
     int memberVn = propRead.getMemberRef();
-    if (!symbolTable.isConstant(memberVn)) return ret;
+    if (!symbolTable.isConstant(memberVn)) return HashSetFactory.make();
     String fieldName = String.valueOf(symbolTable.getConstantValue(memberVn));
     SSAInstruction objDef = node.getDU().getDef(propRead.getObjectRef());
-    if (!(objDef instanceof SSAAbstractInvokeInstruction call)) return ret;
+    if (!(objDef instanceof SSAAbstractInvokeInstruction call)) {
+      // The object is a parameter: the tuple was built in a frame reachable only through the
+      // CALLERS' actuals, so hop the object out and peel the same field against each actual's
+      // producing invoke (`edge_index, batch = data` inside a callee whose caller passes
+      // `load(...)`'s result). wala/ML#796.
+      Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+      int objVn = propRead.getObjectRef();
+      if (objDef == null)
+        for (Pair<CGNode, Integer> producerSite : producingInvokeSites(builder, node, objVn, 0)) {
+          SSAInstruction producerDef = producerSite.fst.getDU().getDef(producerSite.snd);
+          if (producerDef instanceof SSAAbstractInvokeInstruction producer)
+            ret.addAll(calleeTupleFieldStoresOf(builder, producerSite.fst, producer, fieldName));
+        }
+      return ret;
+    }
+    return calleeTupleFieldStoresOf(builder, node, call, fieldName);
+  }
+
+  /**
+   * Resolves a parameter's producing sites through the caller chain (bounded): the (frame, value
+   * number) pairs whose definitions are actual instructions rather than parameters. A trampoline
+   * caller's actual is itself a parameter, so the resolution recurses until a real definition or
+   * the depth bound. wala/ML#796.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The frame holding the parameter.
+   * @param vn The parameter's value number.
+   * @param depth The current recursion depth; resolution stops at 8.
+   * @return The (frame, value number) pairs with non-parameter definitions.
+   */
+  private static Set<Pair<CGNode, Integer>> producingInvokeSites(
+      PropagationCallGraphBuilder builder, CGNode node, int vn, int depth) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    if (depth > 8 || node.getIR() == null) return ret;
+    if (vn > node.getIR().getSymbolTable().getNumberOfParameters()) return ret;
+    for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+        getCallerInvokes(builder, node)) {
+      int useIdx = vn - 1;
+      if (useIdx < 0 || useIdx >= callerInvoke.snd.getNumberOfUses()) continue;
+      int actualVn = callerInvoke.snd.getUse(useIdx);
+      SSAInstruction actualDef = callerInvoke.fst.getDU().getDef(actualVn);
+      if (actualDef == null)
+        ret.addAll(producingInvokeSites(builder, callerInvoke.fst, actualVn, depth + 1));
+      else ret.add(Pair.make(callerInvoke.fst, actualVn));
+    }
+    return ret;
+  }
+
+  /**
+   * Core of {@code findCalleeTupleFieldStores}: peel the given field from the return-tuples of the
+   * invoke's user-body callees (trampoline-expanded, bounded).
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The CG node whose IR contains {@code call}.
+   * @param call The invoke producing the tuple.
+   * @param fieldName The read field's name.
+   * @return The (callee node, stored value number) pairs.
+   */
+  private static Set<Pair<CGNode, Integer>> calleeTupleFieldStoresOf(
+      PropagationCallGraphBuilder builder,
+      CGNode node,
+      SSAAbstractInvokeInstruction call,
+      String fieldName) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
     // Method dispatch interposes synthetic trampolines between the invoke and the user body;
     // expand through them (bounded) to the AstMethod callees that hold the tuple.
     Deque<CGNode> work = new ArrayDeque<>();
@@ -3202,14 +3264,13 @@ public abstract class TensorGenerator {
     }
     LOGGER.fine(
         () ->
-            "findCalleeTupleFieldStores: field="
+            "Peeling field "
                 + fieldName
-                + " bodies="
+                + " from "
                 + bodies.size()
-                + " for "
-                + propRead
-                + " in "
-                + describe(node));
+                + " callee body(ies) in "
+                + describe(node)
+                + ".");
     for (CGNode callee : bodies) {
       IR calleeIr = callee.getIR();
       if (calleeIr == null) continue;
@@ -3235,6 +3296,92 @@ public abstract class TensorGenerator {
         }
       }
     }
+    return ret;
+  }
+
+  /**
+   * The generator-yield counterpart of {@code findCalleeTupleFieldStores} (wala/ML#796): a {@code
+   * for x, y in gen(...)} unpack reads a constant tuple field off a loop element that is a DYNAMIC
+   * member read over the generator call's result, so the invoke sits one property-read further out
+   * than the direct-call peel expects. A {@code yield a, b} lowers to a tuple allocation stored
+   * into the generator function object's {@code __content__} field; this peel expands the generator
+   * call's callees through trampolines, collects the {@code __content__}-stored tuples, and returns
+   * the (generator frame, value number) pairs stored under the read's field on those tuples.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The CG node whose IR contains {@code propRead}.
+   * @param propRead The constant-member tuple-field read over the loop element.
+   * @return The (generator node, stored value number) pairs; empty if the structure does not match.
+   */
+  private static Set<Pair<CGNode, Integer>> findGeneratorYieldTupleStores(
+      PropagationCallGraphBuilder builder, CGNode node, PythonPropertyRead propRead) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    SymbolTable symbolTable = node.getIR().getSymbolTable();
+    int memberVn = propRead.getMemberRef();
+    if (!symbolTable.isConstant(memberVn)) return ret;
+    String fieldName = String.valueOf(symbolTable.getConstantValue(memberVn));
+    SSAInstruction objDef = node.getDU().getDef(propRead.getObjectRef());
+    if (!(objDef instanceof PythonPropertyRead elementRead)) return ret;
+    // The element read's member is the loop-carried iteration key, deliberately not required to
+    // be constant.
+    SSAInstruction genDef = node.getDU().getDef(elementRead.getObjectRef());
+    if (!(genDef instanceof SSAAbstractInvokeInstruction call)) return ret;
+    Deque<CGNode> work = new ArrayDeque<>();
+    Set<CGNode> seen = HashSetFactory.make();
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, call.getCallSite()))
+      if (seen.add(callee)) work.add(callee);
+    Set<CGNode> bodies = HashSetFactory.make();
+    while (!work.isEmpty() && seen.size() < 32) {
+      CGNode callee = work.poll();
+      if (callee.getMethod() instanceof AstMethod) {
+        bodies.add(callee);
+        continue;
+      }
+      for (Iterator<CGNode> it = builder.getCallGraph().getSuccNodes(callee); it.hasNext(); ) {
+        CGNode next = it.next();
+        if (seen.add(next)) work.add(next);
+      }
+    }
+    for (CGNode gen : bodies) {
+      IR genIr = gen.getIR();
+      if (genIr == null) continue;
+      SymbolTable genSymbols = genIr.getSymbolTable();
+      for (SSAInstruction instruction : genIr.getInstructions()) {
+        int yieldedVn = -1;
+        if (instruction instanceof SSAPutInstruction put
+            && !put.isStatic()
+            && "__content__".equals(put.getDeclaredField().getName().toString()))
+          yieldedVn = put.getVal();
+        else if (instruction instanceof AstPropertyWrite write
+            && genSymbols.isConstant(write.getMemberRef())
+            && "__content__"
+                .equals(String.valueOf(genSymbols.getConstantValue(write.getMemberRef()))))
+          yieldedVn = write.getValue();
+        if (yieldedVn <= 0) continue;
+        for (SSAInstruction store : genIr.getInstructions()) {
+          if (store instanceof SSAPutInstruction put2
+              && !put2.isStatic()
+              && put2.getRef() == yieldedVn
+              && fieldName.equals(put2.getDeclaredField().getName().toString()))
+            ret.add(Pair.make(gen, put2.getVal()));
+          else if (store instanceof AstPropertyWrite write2 && write2.getObjectRef() == yieldedVn) {
+            int storeMemberVn = write2.getMemberRef();
+            if (genSymbols.isConstant(storeMemberVn)
+                && fieldName.equals(String.valueOf(genSymbols.getConstantValue(storeMemberVn))))
+              ret.add(Pair.make(gen, write2.getValue()));
+          }
+        }
+      }
+    }
+    LOGGER.fine(
+        () ->
+            "Resolved "
+                + ret.size()
+                + " generator-yield store(s) for field "
+                + fieldName
+                + " in "
+                + describe(node)
+                + ".");
     return ret;
   }
 
@@ -3365,6 +3512,17 @@ public abstract class TensorGenerator {
         }
         Set<List<Dimension<?>>> chain = shapesFromSSAChain(builder, store.fst, store.snd, visited);
         if (chain != null && !chain.isEmpty()) return chain;
+      }
+      // The generator-yield peel; see the dtype walker's arm. wala/ML#796.
+      for (Pair<CGNode, Integer> store : findGeneratorYieldTupleStores(builder, node, propRead)) {
+        try {
+          Set<List<Dimension<?>>> viaPts = getShapes(builder, store.fst, store.snd);
+          if (viaPts != null && !viaPts.isEmpty()) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the generator-frame chain walk
+        }
+        Set<List<Dimension<?>>> chain2 = shapesFromSSAChain(builder, store.fst, store.snd, visited);
+        if (chain2 != null && !chain2.isEmpty()) return chain2;
       }
       return null;
     }
@@ -3577,6 +3735,25 @@ public abstract class TensorGenerator {
         Set<DType> chain = dtypesFromSSAChain(builder, store.fst, store.snd, visited);
         if (chain != null && !chain.isEmpty()) return chain;
       }
+      // The generator-yield peel: `for x, y in gen(...)` reads the yielded tuples' fields.
+      for (Pair<CGNode, Integer> store : findGeneratorYieldTupleStores(builder, node, propRead)) {
+        try {
+          Set<DType> viaPts = getDTypes(builder, store.fst, store.snd);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the generator-frame chain walk
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, store.fst, store.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      // An element read whose member is not a constant (a loop-carried index) reads a homogeneous
+      // container position: the element's dtype is whatever array producer the CONTAINER's chain
+      // bottoms out at, so continue on the object. Constant-member reads already peeled above and
+      // must not fall through here, since a heterogeneous tuple's fields differ. wala/ML#796.
+      if (!node.getIR().getSymbolTable().isConstant(propRead.getMemberRef()))
+        return dtypesFromSSAChain(builder, node, propRead.getObjectRef(), visited);
       return null;
     }
 
@@ -3714,7 +3891,64 @@ public abstract class TensorGenerator {
       }
       return dtypesFromSSAChain(builder, node, inputVn, visited);
     }
+
+    // Generic callee-return continuation: for a user-body callee (an AstMethod, reached through
+    // synthetic trampolines), the invoke result's dtype is the callee's returned value's — chain
+    // into each return in the callee frame. Comprehension calls return the per-item value, so
+    // this is how a chain crosses `xs = [f(x) for x in ...]` producers. wala/ML#796.
+    for (Pair<CGNode, Integer> returned : calleeReturnedValues(builder, node, call)) {
+      try {
+        Set<DType> viaPts = getDTypes(builder, returned.fst, returned.snd);
+        if (viaPts != null
+            && !viaPts.isEmpty()
+            && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+      } catch (IllegalArgumentException e) {
+        // fall through to the callee-frame chain walk
+      }
+      Set<DType> chain = dtypesFromSSAChain(builder, returned.fst, returned.snd, visited);
+      if (chain != null && !chain.isEmpty()) return chain;
+    }
     return null;
+  }
+
+  /**
+   * Expands an invoke's callees through synthetic trampolines (bounded) to user bodies and returns
+   * the (callee frame, returned value number) pairs of their return instructions. The generic
+   * interprocedural continuation for the SSA-chain walkers' invoke arms. wala/ML#796.
+   *
+   * @param builder The propagation call graph builder.
+   * @param node The CG node whose IR contains {@code call}.
+   * @param call The invoke whose callee returns are wanted.
+   * @return The (callee node, returned value number) pairs; empty if no user body resolves.
+   */
+  private static Set<Pair<CGNode, Integer>> calleeReturnedValues(
+      PropagationCallGraphBuilder builder, CGNode node, SSAAbstractInvokeInstruction call) {
+    Set<Pair<CGNode, Integer>> ret = HashSetFactory.make();
+    Deque<CGNode> work = new ArrayDeque<>();
+    Set<CGNode> seen = HashSetFactory.make();
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, call.getCallSite()))
+      if (seen.add(callee)) work.add(callee);
+    Set<CGNode> bodies = HashSetFactory.make();
+    while (!work.isEmpty() && seen.size() < 32) {
+      CGNode callee = work.poll();
+      if (callee.getMethod() instanceof AstMethod) {
+        bodies.add(callee);
+        continue;
+      }
+      for (Iterator<CGNode> it = builder.getCallGraph().getSuccNodes(callee); it.hasNext(); ) {
+        CGNode next = it.next();
+        if (seen.add(next)) work.add(next);
+      }
+    }
+    for (CGNode callee : bodies) {
+      IR calleeIr = callee.getIR();
+      if (calleeIr == null) continue;
+      for (SSAInstruction instruction : calleeIr.getInstructions())
+        if (instruction instanceof SSAReturnInstruction returnInstruction
+            && returnInstruction.getResult() > 0)
+          ret.add(Pair.make(callee, returnInstruction.getResult()));
+    }
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3272,7 +3272,40 @@ public abstract class TensorGenerator {
           ret.add(Pair.make(lpk.getNode(), lpk.getValueNumber()));
       }
     }
-    LOGGER.fine(() -> "lexicalDefiners: vn=" + vn + " in " + describe(node) + " -> " + ret.size());
+    // The funarg's local predecessor is the variable's merged EXIT state (an SSA phi whose arms
+    // are the substrate null default and post-rebinding values), which loses the capture-time
+    // write: `xs = [f(x) for ...]` rebinds `xs` to a value built FROM the capture, so the phi's
+    // only real arm is self-referential and the cycle guard rightly kills it. Recover the
+    // individual writes by scanning each definer frame's `AstLexicalWrite`s for the same
+    // variable name and adding their written values as definers. wala/ML#796.
+    SSAInstruction readDef = node.getDU().getDef(vn);
+    if (readDef instanceof AstLexicalRead read && read.getAccessCount() > 0) {
+      String name = read.getAccess(0).getName().fst;
+      Set<CGNode> definerNodes = HashSetFactory.make();
+      for (Pair<CGNode, Integer> d : ret) definerNodes.add(d.fst);
+      for (CGNode definer : definerNodes) {
+        IR ir = definer.getIR();
+        if (ir == null) continue;
+        SSAInstruction[] insts = ir.getInstructions();
+        for (int i = 0; i < insts.length; i++) {
+          SSAInstruction inst = insts[i];
+          if (inst == null || !inst.hasDef()) continue;
+          int d = inst.getDef();
+          String[] names = ir.getLocalNames(i, d);
+          if (names == null) continue;
+          for (String nm : names) if (name.equals(nm)) ret.add(Pair.make(definer, d));
+        }
+      }
+    }
+    LOGGER.fine(
+        () ->
+            "Resolved "
+                + ret.size()
+                + " lexical definer(s) for vn="
+                + vn
+                + " in "
+                + describe(node)
+                + ".");
     return ret;
   }
 
@@ -3351,6 +3384,30 @@ public abstract class TensorGenerator {
         if (chain != null && !chain.isEmpty()) return chain;
       }
       return null;
+    }
+
+    // A multiply-written local (e.g. a variable rebound after a comprehension) reaches the walk
+    // as the phi over its writes; union the arms, skipping null-constant substrate uses. The
+    // per-frame visited set breaks loop-carried self-reference. wala/ML#796.
+    if (def instanceof SSAPhiInstruction) {
+      SymbolTable st = node.getIR() == null ? null : node.getIR().getSymbolTable();
+      Set<List<Dimension<?>>> union = HashSetFactory.make();
+      for (int i = 0; i < def.getNumberOfUses(); i++) {
+        int use = def.getUse(i);
+        if (use <= 0 || (st != null && st.isNullConstant(use))) continue;
+        try {
+          Set<List<Dimension<?>>> viaPts = getShapes(builder, node, use);
+          if (viaPts != null && !viaPts.isEmpty()) {
+            union.addAll(viaPts);
+            continue;
+          }
+        } catch (IllegalArgumentException e) {
+          // fall through to the chain walk on this arm
+        }
+        Set<List<Dimension<?>>> chain = shapesFromSSAChain(builder, node, use, visited);
+        if (chain != null) union.addAll(chain);
+      }
+      return union.isEmpty() ? null : union;
     }
 
     if (!(def instanceof SSAAbstractInvokeInstruction)) return null;
@@ -3436,7 +3493,7 @@ public abstract class TensorGenerator {
    * them recover the underlying dtype, even when an op is unmodeled. See wala/ML#602.
    */
   private static final Set<String> DTYPE_PRESERVING_OP_NAMES =
-      Set.of("reshape", "pad", "expand_dims", "squeeze", "transpose", "identity");
+      Set.of("reshape", "pad", "expand_dims", "squeeze", "transpose", "identity", "tolist");
 
   /**
    * Dtype counterpart to {@link #shapesFromSSAChain(PropagationCallGraphBuilder, CGNode, int)}.
@@ -3526,6 +3583,32 @@ public abstract class TensorGenerator {
         if (chain != null && !chain.isEmpty()) return chain;
       }
       return null;
+    }
+
+    // The dtype twin of the shape walker's phi arm: union over the writes of a multiply-written
+    // local, skipping null-constant substrate uses; the per-frame visited set breaks loop-carried
+    // self-reference. wala/ML#796.
+    if (def instanceof SSAPhiInstruction) {
+      SymbolTable st = node.getIR() == null ? null : node.getIR().getSymbolTable();
+      Set<DType> union = EnumSet.noneOf(DType.class);
+      for (int i = 0; i < def.getNumberOfUses(); i++) {
+        int use = def.getUse(i);
+        if (use <= 0 || (st != null && st.isNullConstant(use))) continue;
+        try {
+          Set<DType> viaPts = getDTypes(builder, node, use);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) {
+            union.addAll(viaPts);
+            continue;
+          }
+        } catch (IllegalArgumentException e) {
+          // fall through to the chain walk on this arm
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, node, use, visited);
+        if (chain != null) union.addAll(chain);
+      }
+      return union.isEmpty() ? null : union;
     }
 
     if (!(def instanceof SSAAbstractInvokeInstruction)) return null;
@@ -7899,6 +7982,10 @@ public abstract class TensorGenerator {
       return new NpUniqueValues(node);
     } else if (type.equals(NumpyTypes.UNIQUE_INDICES.getDeclaringClass())) {
       return new NpUniqueIndices(node);
+    } else if (type.equals(NumpyTypes.TOLIST.getDeclaringClass())) {
+      // Producer delegation for `tolist_result` allocations: dtype and shape recover from the
+      // receiver (wala/ML#796).
+      return new TolistOperation(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_DOT.getDeclaringClass())) {
       return new SparseMatrixDot(node);
     } else if (type.equals(ScipyTypes.SPARSE_MATRIX_TODENSE.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3190,8 +3190,22 @@ public abstract class TensorGenerator {
       if (objDef == null)
         for (Pair<CGNode, Integer> producerSite : producingInvokeSites(builder, node, objVn, 0)) {
           SSAInstruction producerDef = producerSite.fst.getDU().getDef(producerSite.snd);
-          if (producerDef instanceof SSAAbstractInvokeInstruction producer)
-            ret.addAll(calleeTupleFieldStoresOf(builder, producerSite.fst, producer, fieldName));
+          if (producerDef instanceof SSAAbstractInvokeInstruction producer) {
+            // The enumerate peel: field #1 of an enumerate element is the iterated container's
+            // element, so the continuation is the enumerate ARGUMENT in the producing frame.
+            // Field #0 is the integer index (the wala/ML#409 drop) and gets no continuation.
+            SSAInstruction producerFn =
+                producer.getNumberOfUses() < 2
+                    ? null
+                    : producerSite.fst.getDU().getDef(producer.getUse(0));
+            if ("1".equals(fieldName)
+                && producerFn instanceof AstLexicalRead lexRead
+                && lexRead.getAccessCount() > 0
+                && "enumerate".equals(lexRead.getAccess(0).getName().fst))
+              ret.add(Pair.make(producerSite.fst, producer.getUse(1)));
+            else
+              ret.addAll(calleeTupleFieldStoresOf(builder, producerSite.fst, producer, fieldName));
+          }
         }
       return ret;
     }
@@ -3297,6 +3311,34 @@ public abstract class TensorGenerator {
       }
     }
     return ret;
+  }
+
+  /**
+   * The {@code enumerate} peel (wala/ML#796): {@code for i, x in enumerate(xs)} reads field {@code
+   * #1} of the enumerate tuples, whose values are exactly the elements of {@code xs} — so the walk
+   * continues on the {@code enumerate} ARGUMENT. Field {@code #0} is the integer index (the
+   * wala/ML#409 drop) and must not continue. Matches a constant-member read over a dynamic element
+   * read over an invoke whose function is the lexical builtin {@code enumerate}.
+   *
+   * @param node The CG node whose IR contains {@code propRead}.
+   * @param propRead The constant-member tuple-field read over the loop element.
+   * @return The {@code xs} argument's value number, or {@code -1} when the structure does not match
+   *     or the field is not {@code 1}.
+   */
+  private static int enumerateArgumentVn(CGNode node, PythonPropertyRead propRead) {
+    SymbolTable symbolTable = node.getIR().getSymbolTable();
+    int memberVn = propRead.getMemberRef();
+    if (!symbolTable.isConstant(memberVn)) return -1;
+    if (!"1".equals(String.valueOf(symbolTable.getConstantValue(memberVn)))) return -1;
+    SSAInstruction objDef = node.getDU().getDef(propRead.getObjectRef());
+    if (!(objDef instanceof PythonPropertyRead elementRead)) return -1;
+    SSAInstruction iterDef = node.getDU().getDef(elementRead.getObjectRef());
+    if (!(iterDef instanceof SSAAbstractInvokeInstruction call) || call.getNumberOfUses() < 2)
+      return -1;
+    SSAInstruction funcDef = node.getDU().getDef(call.getUse(0));
+    if (!(funcDef instanceof AstLexicalRead read) || read.getAccessCount() == 0) return -1;
+    if (!"enumerate".equals(read.getAccess(0).getName().fst)) return -1;
+    return call.getUse(1);
   }
 
   /**
@@ -3746,6 +3788,20 @@ public abstract class TensorGenerator {
           // fall through to the generator-frame chain walk
         }
         Set<DType> chain = dtypesFromSSAChain(builder, store.fst, store.snd, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      // The enumerate peel: field #1 of an enumerate element is the iterated container's element.
+      int enumArgVn = enumerateArgumentVn(node, propRead);
+      if (enumArgVn > 0) {
+        try {
+          Set<DType> viaPts = getDTypes(builder, node, enumArgVn);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the chain walk on the argument
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, node, enumArgVn, visited);
         if (chain != null && !chain.isEmpty()) return chain;
       }
       // An element read whose member is not a constant (a loop-carried index) reads a homogeneous

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -3410,6 +3410,32 @@ public abstract class TensorGenerator {
       return union.isEmpty() ? null : union;
     }
 
+    // A function parameter has no defining instruction (DefUse is intraprocedural); continue the
+    // walk on the corresponding actual argument in each caller frame. Value numbers v1..vN are
+    // the parameters and use index vn-1 pairs the caller-side actual with the callee-side formal
+    // (use 0 holds the callee function object for v1). A trampoline caller's actual is itself a
+    // parameter, so interposed dispatch hops compose by recursion. wala/ML#796.
+    if (def == null
+        && node.getIR() != null
+        && vn <= node.getIR().getSymbolTable().getNumberOfParameters()) {
+      for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+          getCallerInvokes(builder, node)) {
+        int useIdx = vn - 1;
+        if (useIdx < 0 || useIdx >= callerInvoke.snd.getNumberOfUses()) continue;
+        int actualVn = callerInvoke.snd.getUse(useIdx);
+        try {
+          Set<List<Dimension<?>>> viaPts = getShapes(builder, callerInvoke.fst, actualVn);
+          if (viaPts != null && !viaPts.isEmpty()) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the caller-frame chain walk
+        }
+        Set<List<Dimension<?>>> chain =
+            shapesFromSSAChain(builder, callerInvoke.fst, actualVn, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      return null;
+    }
+
     if (!(def instanceof SSAAbstractInvokeInstruction)) return null;
     SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) def;
     for (CGNode callee : builder.getCallGraph().getPossibleTargets(node, call.getCallSite())) {
@@ -3609,6 +3635,30 @@ public abstract class TensorGenerator {
         if (chain != null) union.addAll(chain);
       }
       return union.isEmpty() ? null : union;
+    }
+
+    // The dtype twin of the shape walker's parameter arm: continue on each caller's actual
+    // argument (use index vn-1); trampoline hops compose by recursion. wala/ML#796.
+    if (def == null
+        && node.getIR() != null
+        && vn <= node.getIR().getSymbolTable().getNumberOfParameters()) {
+      for (Pair<CGNode, SSAAbstractInvokeInstruction> callerInvoke :
+          getCallerInvokes(builder, node)) {
+        int useIdx = vn - 1;
+        if (useIdx < 0 || useIdx >= callerInvoke.snd.getNumberOfUses()) continue;
+        int actualVn = callerInvoke.snd.getUse(useIdx);
+        try {
+          Set<DType> viaPts = getDTypes(builder, callerInvoke.fst, actualVn);
+          if (viaPts != null
+              && !viaPts.isEmpty()
+              && !(viaPts.size() == 1 && viaPts.contains(UNKNOWN))) return viaPts;
+        } catch (IllegalArgumentException e) {
+          // fall through to the caller-frame chain walk
+        }
+        Set<DType> chain = dtypesFromSSAChain(builder, callerInvoke.fst, actualVn, visited);
+        if (chain != null && !chain.isEmpty()) return chain;
+      }
+      return null;
     }
 
     if (!(def instanceof SSAAbstractInvokeInstruction)) return null;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -4,6 +4,7 @@ import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.ASTYPE_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.NumpyTypes.RESHAPE_METHOD;
+import static com.ibm.wala.cast.python.ml.types.NumpyTypes.TOLIST_METHOD_NAME;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ACOSH;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.ADD_WEIGHT;
@@ -302,6 +303,8 @@ public class TensorGeneratorFactory {
       PROPERTY_NAME_GENERATORS =
           Map.ofEntries(
               entry(ASTYPE_METHOD_NAME, AstypeOperation::new),
+              // `x.tolist()` on slice results and other unsummarized property reads (wala/ML#796).
+              entry(TOLIST_METHOD_NAME, TolistOperation::new),
               // wala/ML#449: `tf.random.truncated_normal(...)` doesn't reach the per-class
               // `isType` checks because `calledFunction` resolves to generic `LCodeBody`
               // rather than the specific `TRUNCATED_NORMAL`/`TRUNCATED_NORMAL_OP` class.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TolistOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TolistOperation.java
@@ -1,0 +1,155 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for {@code ndarray.tolist()}: the receiver's elements as a nested Python list, so both
+ * dtype and shape recover from the receiver. The runtime list of Python scalars erases the NumPy
+ * dtype, but the downstream {@code np.array(list)} rebase re-derives exactly the receiver's element
+ * type, so preserving it through the {@code tolist_result} allocation is the faithful reading for
+ * the reader chains this models. See <a
+ * href="https://github.com/wala/ML/issues/796">wala/ML#796</a>.
+ *
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class TolistOperation extends TensorGenerator {
+
+  private static final Logger LOGGER = Logger.getLogger(TolistOperation.class.getName());
+
+  /**
+   * Parameter positions and keyword names for the {@code numpy/ndarray/tolist} synthetic. Ordinals
+   * match the position in {@code numpy.xml}'s {@code paramNames} after the implicit {@code self}
+   * receiver.
+   */
+  protected enum Parameters {
+    /** The receiver array whose elements are listed; its dtype and shape are preserved. */
+    NDARRAY;
+
+    /**
+     * Lowercase keyword name used in argument-resolution helpers.
+     *
+     * @return The lowercased enum name (e.g. {@code "ndarray"}).
+     */
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Positional index of this parameter, excluding the implicit {@code self} receiver.
+     *
+     * @return The zero-based positional index.
+     */
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public TolistOperation(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public TolistOperation(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    // Source anchor: resolve the receiver's value number in the caller frame first, since the
+    // multi-strategy walk there covers producers (slice results, lexical reads) whose points-to
+    // sets alone do not resolve.
+    int receiverVn = getReceiverVn();
+    if (this.source != null && receiverVn > 0) {
+      try {
+        Set<List<Dimension<?>>> shapes = getShapesOrSSAChain(builder, getNode(), receiverVn);
+        if (shapes != null && !shapes.isEmpty()) return shapes;
+      } catch (IllegalArgumentException e) {
+        // Fall through to the caller-aware points-to path.
+      }
+    }
+    OrdinalSet<InstanceKey> receiverPts =
+        getArgumentPointsToSet(
+            builder, Parameters.NDARRAY.getIndex(), Parameters.NDARRAY.getName());
+    Set<List<Dimension<?>>> preserved = getShapesOfValue(builder, receiverPts);
+    // ⊤ (unknown shape) when the receiver does not resolve: the value is still list-shaped like
+    // its receiver, never ⊥.
+    return preserved == null || preserved.isEmpty() ? null : preserved;
+  }
+
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    // See getDefaultShapes on the anchor split.
+    int receiverVn = getReceiverVn();
+    if (this.source != null && receiverVn > 0) {
+      try {
+        Set<DType> dTypes = getDTypesOrSSAChain(builder, getNode(), receiverVn);
+        LOGGER.fine(
+            () -> "Resolved tolist receiver dtypes via the caller-frame chain: " + dTypes + ".");
+        if (dTypes != null && !dTypes.isEmpty() && !dTypes.equals(EnumSet.of(DType.UNKNOWN)))
+          return dTypes;
+      } catch (IllegalArgumentException e) {
+        // Fall through to the caller-aware points-to path.
+      }
+    }
+    OrdinalSet<InstanceKey> receiverPts =
+        getArgumentPointsToSet(
+            builder, Parameters.NDARRAY.getIndex(), Parameters.NDARRAY.getName());
+    Set<DType> preserved = getDTypesOfValue(builder, receiverPts);
+    return preserved == null || preserved.isEmpty() ? EnumSet.of(DType.UNKNOWN) : preserved;
+  }
+
+  /**
+   * Returns the receiver's value number in the anchoring frame for a source-based instance: the
+   * {@code x} of {@code x.tolist()}, read from the {@link PythonPropertyRead} that def'd the
+   * invoke's function object. Returns {@code -1} for a manual anchor or when the structure does not
+   * match; callers then use the caller-aware points-to path.
+   *
+   * @return The receiver's value number, or {@code -1} when unavailable.
+   */
+  private int getReceiverVn() {
+    com.ibm.wala.cast.python.ssa.PythonInvokeInstruction call = getInvokeInstruction();
+    if (call != null) {
+      int funcVn = call.getUse(0);
+      com.ibm.wala.ssa.SSAInstruction funcDef = getNode().getDU().getDef(funcVn);
+      if (funcDef instanceof com.ibm.wala.cast.python.ssa.PythonPropertyRead)
+        return ((com.ibm.wala.cast.python.ssa.PythonPropertyRead) funcDef).getObjectRef();
+    }
+    return -1;
+  }
+
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -159,6 +159,27 @@ public class NumpyTypes extends PythonTypes {
 
   private static final String ASTYPE_SIGNATURE = "numpy.ndarray.astype()";
 
+  /** Method name used in {@code numpy.xml} for {@link #TOLIST}. */
+  public static final String TOLIST_METHOD_NAME = "tolist";
+
+  /** https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html */
+  public static final MethodReference TOLIST =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/ndarray/tolist")),
+          AstMethodReference.fnSelector);
+
+  private static final String TOLIST_SIGNATURE = "numpy.ndarray.tolist()";
+
+  /**
+   * The allocation-only marker class for {@link #TOLIST} results: a distinct class rather than
+   * {@code Lnumpy/ndarray} so producer delegation dispatches {@code TolistOperation} without
+   * conflating the value with a real ndarray. wala/ML#796.
+   */
+  public static final TypeReference TOLIST_RESULT =
+      TypeReference.findOrCreate(
+          PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/ndarray/tolist_result"));
+
   /** A mapping from a {@link TypeReference} to its associated NumPy signature. */
   public static final Map<TypeReference, String> TYPE_REFERENCE_TO_SIGNATURE =
       Map.ofEntries(
@@ -172,7 +193,8 @@ public class NumpyTypes extends PythonTypes {
           Map.entry(UNIQUE_INDICES.getDeclaringClass(), UNIQUE_INDICES_SIGNATURE),
           Map.entry(RESHAPE.getDeclaringClass(), RESHAPE_SIGNATURE),
           Map.entry(RESHAPE_METHOD.getDeclaringClass(), RESHAPE_METHOD_SIGNATURE),
-          Map.entry(ASTYPE.getDeclaringClass(), ASTYPE_SIGNATURE));
+          Map.entry(ASTYPE.getDeclaringClass(), ASTYPE_SIGNATURE),
+          Map.entry(TOLIST.getDeclaringClass(), TOLIST_SIGNATURE));
 
   public static final FieldReference FLOAT_32 =
       FieldReference.findOrCreate(


### PR DESCRIPTION
Advances wala/ML#796 by building out the interprocedural reach of the SSA-chain walkers, and closes the investigation by localizing what remains.

## Modeling

`ndarray.tolist` joins the modeling surface: a `numpy.xml` synthetic allocating a distinct `tolist_result` marker, `tolist_fn` field populations at every ndarray-producing site, a `TolistOperation` generator preserving the receiver's dtype and shape, registration in both dispatch tables, and membership in the dtype-preserving op names.

## Walker Arms

- Phi arms union over a multiply-written local's writes, skipping null-constant substrate, with the per-frame visited set breaking the self-referential rebinding cycle.
- `lexicalDefiners` recovers the capture-time write: the upward-funarg predecessor is the variable's merged exit phi, so definer frames are scanned for defs whose local names match the read's variable (captures flow by direct constraint, so no `AstLexicalWrite` exists).
- A parameter arm continues on each caller's actual argument, since `DefUse` is intraprocedural; trampoline hops compose by recursion.
- Element reads continue on the container when the member is not constant; `np.array` falls back to the chain walk on its content argument.
- `findGeneratorYieldTupleStores` peels `for x, y in gen(...)` unpacks through the yielded tuples' `__content__` stores; `calleeReturnedValues` gives the invoke arms a generic callee-return continuation; the tuple peel gains a param-object hop.
- The `enumerate` peel continues on the iterated argument for field 1 (field 0 is the integer index, the wala/ML#409 drop).
- The `NpArray` content-chain walk is engine-routed so a seed-time evaluation re-evaluates when the values it read grow, and bottom-seeded sources still register their declared feed.

## Effect

The reader-chain fixture types the whole topology as `{? of int64}`: every merge-side `np.array` and the batch-side `tf.concat`, end to end. `testNeuralNetwork4`'s test-context member tightened from top shape to `(10000, 10)`, exactly the narrowing its Javadoc predicted.

The `edge_index` concat remains open, and the pins now name the real blocker: its elements pass through `w + strips[i]`, a binary operation that is swept as a dataflow source but declines dispatch because the operand-evidence gate requires points-to evidence and neither operand has any, their producers minting no allocation site. That gate is correct as written (it is what keeps integer arithmetic and list concatenation from being typed as tensors, wala/ML#653), so the fix belongs in wala/ML#805.

Suite: 1186/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY