### PR TITLE
Accept only a single dtype from the `np.array` content chain

### DIFF
--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpArray.java
@@ -200,12 +200,21 @@ public class NpArray extends TensorGenerator {
                     ? engine.read(key, transfer, false)
                     : engine.demand(key, transfer, false));
       }
-      if (viaChain != null
-          && !viaChain.isEmpty()
-          && !(viaChain.size() == 1 && viaChain.contains(DType.UNKNOWN))) {
+      // Only a SINGLE resolved dtype is content evidence. `np.array` promotes heterogeneous
+      // content to one dtype rather than producing a union, so a multi-dtype chain result cannot
+      // describe the content's element type: in the corpus it means the walk reached a container
+      // of mixed constants (an object catalog or a keyword map, one dtype per Java constant kind)
+      // and widened edge-weight parameters to a `STRING`-bearing union (wala/ML#806).
+      if (viaChain != null && viaChain.size() == 1 && !viaChain.contains(DType.UNKNOWN)) {
         LOGGER.fine(() -> "Recovered " + viaChain + " via the content argument's SSA chain.");
         return viaChain;
       }
+      if (viaChain != null && viaChain.size() > 1)
+        LOGGER.fine(
+            () ->
+                "Discarding the content argument's multi-dtype chain result as non-evidence: "
+                    + viaChain
+                    + ".");
     }
 
     return Set.of(DType.UNKNOWN);


### PR DESCRIPTION
Fixes wala/ML#806.

The chain fallback added in ponder-lab/ML#722 took whatever dtype set the content argument's SSA walk returned. `np.array` promotes heterogeneous content to one dtype rather than producing a union, so a multi-dtype result cannot describe the content's element type. In the corpus it meant the walk had reached a container of mixed constants, one dtype per Java constant kind, which widened eight NLPGNN edge-weight parameters to a union carrying `STRING` and `BOOL`. Those parameters are numeric at runtime, so the members were wrong-definite.

The fallback now accepts only an unambiguous single resolved dtype and logs what it discards.

Bisected against the corpus, one candidate at a time, with three innocent suspects restored along the way (the element-read object continuation, the bottom-seed feed registration, and the local-name definer scan each left the widening fully intact). With this gate the `STRING` and `BOOL` members disappear from every affected row, while the release's genuine gains hold: two NLPGNN functions newly hybridizable, the message functions gaining inferred parameter types, and roughly twenty parameters shedding their `UNKNOWN` twins.

Suite: 1186/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY