### PR TITLE
Pin multi-member subscript results against the receiver leak

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.python.ml.test.tensorflow.v2;
 
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.FLOAT_32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.INT_32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_16_UINT8;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_3_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_28_28_1_FLOAT32;
@@ -333,6 +334,110 @@ public class TestShapeOps extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TENSOR_4_6_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of a trailing integer index with no following slice (wala/ML#813). {@code
+   * x[:, 0]} over a {@code (4, 5)} tensor drops the last axis entirely: {@code (4,)}. This differs
+   * from {@link #testSubscriptMultidimIndex} in that the indexed axis is the last one, so the
+   * subscript has no trailing slice component to mark the axes it keeps.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testColumnSliceRankConstant()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_column_slice_rank.py",
+        "consume_const_col",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of a trailing integer index applied to a batched dataset element
+   * (wala/ML#813), which is how such a column arrives in practice. {@code batch[:, 0]} over a
+   * {@code (2, 5)} batch leaves rank 1.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testColumnSliceRankBatched()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_column_slice_rank.py",
+        "consume_batch_col",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_FLOAT32)));
+  }
+
+  /**
+   * Pins the shape of a dict-valued padded batch before any column is taken (wala/ML#813). The
+   * value declared with {@code padded_shapes={"h_r": [None]}} is rank 2: the batch axis, and the
+   * padded axis that {@code None} leaves dynamic. The union carries the full batch alongside its
+   * partial-batch sibling, the same pairing as {@link TestCorpusFixtures#testGpt2GetLossVendored}.
+   * {@code drop_remainder=True} makes the partial batch unreachable here, which is the separate
+   * concern of wala/ML#812.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDictColumnSliceRow()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dict_column_slice.py",
+        "consume_row",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(INT_32, asList(new NumericDim(2), DynamicDim.INSTANCE)),
+                new TensorType(INT_32, asList(new SymbolicDim("?"), DynamicDim.INSTANCE)))));
+  }
+
+  /**
+   * Pins the rank of a column indexed out of a dict-valued padded batch (wala/ML#813). {@code
+   * data["h_r"][:, 0]} drops the last axis, so every member of the column's union is rank 1, each
+   * one the batch axis of the corresponding member in {@link #testDictColumnSliceRow}.
+   *
+   * <p>The generator computed those rank-1 members all along; what leaked was the receiver. The
+   * reroute that blocks a container's shape from reaching its subscript result used to install its
+   * pin only for a single-member result, so a subscript resolving to one member per calling context
+   * went unpinned and carried its rank-2 container alongside itself. Over-ranking is the more
+   * damaging direction: a rank-1 argument is not a subtype of a rank-2 specification, so a
+   * signature written from the leaked union rejects every call the function actually receives,
+   * where a signature that is merely too loose still admits them all.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testDictColumnSliceColumn()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_dict_column_slice.py",
+        "consume_col",
+        1,
+        1,
+        Map.of(
+            2,
+            Set.of(
+                new TensorType(INT_32, asList(new NumericDim(2))),
+                new TensorType(INT_32, asList(new SymbolicDim("?"))))));
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -389,7 +389,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
   private static IKilldallFramework<PointsToSetVariable, TensorVariable> createProblem(
       Graph<PointsToSetVariable> G,
       Map<PointsToSetVariable, Set<TensorType>> reshapeNodes,
-      Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, Set<TensorType>> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
       Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,
@@ -448,9 +448,9 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
           }
 
           final class SetShapeOp extends UnaryOperator<TensorVariable> {
-            private final TensorType setShapeTo;
+            private final Set<TensorType> setShapeTo;
 
-            public SetShapeOp(TensorType reshapeTo) {
+            public SetShapeOp(Set<TensorType> reshapeTo) {
               this.setShapeTo = reshapeTo;
             }
 
@@ -462,10 +462,15 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               // previous `add`-only semantics caused the cast result's Cast-generator-seeded
               // `(?, dtype)` to leak into the post-set_shape state alongside the asserted shape.
               // Clear-then-add mirrors `DropOp`'s clear-state pattern with CHANGED_AND_FIXED.
+              //
+              // The pinned value is a SET rather than a single type (wala/ML#813): a subscript
+              // result routed here legitimately carries one member per calling context, and
+              // restricting the pin to singletons left multi-member results unpinned, which is
+              // exactly the leak the reroute exists to block.
               boolean changed = false;
-              if (!(lhs.state.size() == 1 && lhs.state.contains(setShapeTo))) {
+              if (!lhs.state.equals(setShapeTo)) {
                 lhs.state.clear();
-                lhs.state.add(setShapeTo);
+                lhs.state.addAll(setShapeTo);
                 changed = true;
               }
               // Pinning replaces the SHAPE, not the provenance: the destination's value is still
@@ -1052,7 +1057,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, Set<TensorType>> init,
       Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
       Map<PointsToSetVariable, Set<TensorType>> reshapeTypes,
-      Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, Set<TensorType>> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
       Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,
@@ -1095,7 +1100,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Map<PointsToSetVariable, Set<TensorType>> init,
       Map<PointsToSetVariable, Set<TensorOrigin>> initOrigins,
       Map<PointsToSetVariable, Set<TensorType>> reshapeTypes,
-      Map<PointsToSetVariable, TensorType> set_shapes,
+      Map<PointsToSetVariable, Set<TensorType>> set_shapes,
       Map<PointsToSetVariable, List<Dimension<?>>> refinements,
       Map<PointsToSetVariable, FeedPlan> typeFeeds,
       Map<PointsToSetVariable, Set<PointsToSetVariable>> armSuppressions,

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -1473,11 +1473,13 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
    * guard for this filtering.
    *
    * @param builder The propagation call graph builder.
-   * @return Map from receiver {@link PointsToSetVariable} to the asserted {@link TensorType}.
+   * @return Map from receiver {@link PointsToSetVariable} to the asserted {@link TensorType}, as a
+   *     singleton set: an assertion pins exactly one shape, while the same pin mechanism carries
+   *     multi-member sets for the subscript reroute (wala/ML#813).
    */
-  private Map<PointsToSetVariable, TensorType> getSetShapeCallsSyntactic(
+  private Map<PointsToSetVariable, Set<TensorType>> getSetShapeCallsSyntactic(
       PropagationCallGraphBuilder builder) {
-    Map<PointsToSetVariable, TensorType> targets = HashMapFactory.make();
+    Map<PointsToSetVariable, Set<TensorType>> targets = HashMapFactory.make();
     for (CGNode caller : builder.getCallGraph()) {
       IR ir = caller.getIR();
       if (ir == null) continue;
@@ -1544,7 +1546,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         if (builder.getPropagationSystem().isImplicit(receiverKey)) continue;
         targets.put(
             builder.getPropagationSystem().findOrCreatePointsToSet(receiverKey),
-            TensorType.shapeArg(caller, call.getUse(1), builder));
+            Collections.singleton(TensorType.shapeArg(caller, call.getUse(1), builder)));
       }
     }
     return targets;
@@ -1826,7 +1828,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       // the `Ltensorflow/functions/set_shape` synthetic class. The legacy dispatch path requires
       // the receiver to have the `set_shape` attribute attached (via FixedLenFeature.do's
       // <putfield>) and breaks when the cast pass_through alias is removed.
-      Map<PointsToSetVariable, TensorType> setCalls = getSetShapeCallsSyntactic(builder);
+      Map<PointsToSetVariable, Set<TensorType>> setCalls = getSetShapeCallsSyntactic(builder);
 
       // wala/ML#509: `set_shape` is a user-supplied OVERRIDE of any per-op-generator init seed on
       // the receiver. Remove receivers from `init` so the SetShapeOp edge transfer is the sole
@@ -1852,10 +1854,23 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
         if (!(generator instanceof SliceBuiltinOperation)
             && !(generator instanceof NdarraySubscriptOperation)) continue;
         Set<TensorType> types = init.get(src);
-        if (types == null || types.size() != 1) continue;
-        TensorType onlyType = types.iterator().next();
-        if (onlyType.getDims() == null) continue;
-        setCalls.put(src, onlyType);
+        if (types == null || types.isEmpty()) continue;
+        // Every member must carry dimensions. A ⊤-shape member says nothing about the subscript's
+        // result, so pinning a set containing one would assert "the receiver's shape does not flow
+        // here" while offering no replacement, and the destination is better served by whatever the
+        // predecessors contribute.
+        boolean allRanked = true;
+        for (TensorType type : types) if (type.getDims() == null) allRanked = false;
+        if (!allRanked) continue;
+        // Pin the whole set, not just a singleton (wala/ML#813). A subscript evaluated in several
+        // calling contexts legitimately resolves to one member per context — `x[:, 0]` over a
+        // padded batch yields both the concrete-batch and the unresolved-batch column — and
+        // requiring a singleton left exactly those results unpinned. The receiver's pre-subscript
+        // shape then leaked back in through the assignment graph, so a rank-1 column carried its
+        // rank-2 container alongside it, and a signature written from that union OVER-RANKS the
+        // parameter: a rank-1 argument is not a subtype of a rank-2 specification, so the signature
+        // rejects every call the function actually receives.
+        setCalls.put(src, types);
       }
 
       // A shape-constraining consumer proves operand shapes its call alone fixes: an einsum

--- a/com.ibm.wala.cast.python.test/data/tf2_test_column_slice_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_column_slice_rank.py
@@ -1,0 +1,30 @@
+import tensorflow as tf
+
+
+def consume_const_col(c):
+    pass
+
+
+def consume_batch_col(c):
+    pass
+
+
+# A trailing integer index with no following slice: `x[:, 0]` over a rank-2
+# receiver drops the last axis entirely, leaving rank 1.
+x = tf.ones((4, 5), dtype=tf.float32)
+assert x.shape == (4, 5) and x.dtype == tf.float32
+
+const_col = x[:, 0]
+assert const_col.shape == (4,) and const_col.dtype == tf.float32
+consume_const_col(const_col)
+
+# The same pattern against a batched dataset element, which is how the column
+# arrives in practice: the batch axis is unknown, the indexed axis is gone.
+rows = tf.data.Dataset.from_tensor_slices(tf.ones((6, 5), dtype=tf.float32))
+batched = rows.batch(2)
+
+for batch in batched:
+    assert batch.shape == (2, 5) and batch.dtype == tf.float32
+    batch_col = batch[:, 0]
+    assert batch_col.shape == (2,) and batch_col.dtype == tf.float32
+    consume_batch_col(batch_col)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_dict_column_slice.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_dict_column_slice.py
@@ -1,0 +1,31 @@
+import tensorflow as tf
+
+
+def consume_col(c):
+    pass
+
+
+def consume_row(r):
+    pass
+
+
+def generator():
+    for x in [[1, 2, 3], [4, 5, 6]]:
+        yield {"h_r": x, "t": x}
+
+
+# A dict-valued dataset whose values are padded to a batch: `h_r` is rank 2.
+ds = tf.data.Dataset.from_generator(
+    generator=generator, output_types={"h_r": tf.int32, "t": tf.int32}
+)
+ds = ds.padded_batch(2, padded_shapes={"h_r": [None], "t": [None]}, drop_remainder=True)
+
+for data in ds:
+    row = data["h_r"]
+    assert row.shape == (2, 3) and row.dtype == tf.int32
+    consume_row(row)
+
+    # Indexing a column out of the dict value drops the last axis: rank 2 -> rank 1.
+    col = row[:, 0]
+    assert col.shape == (2,) and col.dtype == tf.int32
+    consume_col(col)


### PR DESCRIPTION
Fixes wala/ML#813.

## What Was Wrong

`SliceBuiltinOperation` computed the column correctly all along. With logging on, it matches the subscript and produces rank-1 members:

```
Matched multi-dim subscript [SLICE, INDEX] -> [[D:Constant,2], [D:Symbolic,?]]
```

What leaked was the receiver. The reroute in `PythonTensorAnalysisEngine` that stops a container's shape from reaching its subscript result installed its pin only when the result had exactly one member. A subscript that resolves to one member per calling context went unpinned, and the container's rank-2 shape flowed back in through the assignment graph.

That explains why the defect tracks batching rather than subscripting. A plain `x[:, 0]` resolves to a single member and was always pinned; a batched pipeline splits into the full batch and its partial-batch sibling, so it was not.

## Why Over-Ranking Matters More Than Looseness

A rank-1 argument is not a subtype of a rank-2 specification. A signature written from the leaked union rejects every call the function actually receives, while one that is merely too loose still admits them all.

## The Change

`set_shapes` and `SetShapeOp` now carry a set of types rather than a single one, with `set_shape` assertions passing a singleton. The reroute pins only when every member is ranked: a set carrying an unknown-rank member would assert that the receiver does not flow here while offering nothing in its place.

## Testing

Both fixtures run to completion under `python3.10` with their assertions, and the assertions mirror the JUnit expectations.

`tf2_test_column_slice_rank.py` covers the plain and batched cases. Both passed before this change, which bounds the blast radius: the subscript arithmetic was never at fault.

`tf2_test_dict_column_slice.py` is the reproduction, a dict-valued padded batch with a column indexed out of it. Before:

```
consume_col  {(2,Dynamic) int32, (?,Dynamic) int32, (?) int32, (2) int32}
```

After:

```
consume_col  {(?) int32, (2) int32}
```

The column's expected union keeps its partial-batch member, the same pairing documented on `testGpt2GetLossVendored`. `drop_remainder=True` making that member unreachable is wala/ML#812, not this change.

Full module suite: 1190 tests, 0 failures, 3 skipped.
