### PR TITLE
Type an integral array divided by a float literal as `float64`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -502,6 +502,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_4_5_FLOAT64 = TensorType.of(FLOAT_64, 4, 5);
 
+  protected static final TensorType TENSOR_4_5_COMPLEX64 = TensorType.of(COMPLEX_64, 4, 5);
+
   protected static final TensorType TENSOR_1_28_28_1_FLOAT32 =
       TensorType.of(FLOAT_32, 1, 28, 28, 1);
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -500,6 +500,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_4_5_FLOAT32 = TensorType.of(FLOAT_32, 4, 5);
 
+  protected static final TensorType TENSOR_4_5_FLOAT64 = TensorType.of(FLOAT_64, 4, 5);
+
   protected static final TensorType TENSOR_1_28_28_1_FLOAT32 =
       TensorType.of(FLOAT_32, 1, 28, 28, 1);
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -18,6 +18,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_4_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_RAGGED_RAGGED_INT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_COMPLEX64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_FLOAT32;
@@ -1769,5 +1770,33 @@ public class TestElementwiseOps extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testNumpyIntegerDividedByFloatLiteral} for a complex operand
+   * (wala/ML#814). A complex array keeps its own dtype, so the rule is that an integral operand
+   * widens to {@code float64} while every other numeric operand keeps itself. Testing
+   * floating-point-ness rather than numeric-ness here would send complex operands to the {@code
+   * float32} fallback and lose the imaginary part.
+   *
+   * <p>TODO: Flip to a plain {@code @Test} when <a
+   * href="https://github.com/wala/ML/issues/816">wala/ML#816</a> lands. The promotion rule here is
+   * already correct for complex operands; the operand never arrives as one, because {@code
+   * np.zeros(..., dtype=np.complex64)} is itself typed {@code float64}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testNumpyComplexDividedByFloatLiteral()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_numpy_float_division.py",
+        "consume_complex_scaled",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_COMPLEX64)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -18,6 +18,8 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_4_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_3_RAGGED_RAGGED_INT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_INT32;
@@ -1725,5 +1727,47 @@ public class TestElementwiseOps extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TENSOR_3_FLOAT32)));
+  }
+
+  /**
+   * Pins the dtype of an integral NumPy array divided by a Python float (wala/ML#814). NumPy
+   * promotes to {@code float64}, because a Python float is a double. The previous rule answered
+   * {@code float32} for every float-literal operand, citing this very idiom.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNumpyIntegerDividedByFloatLiteral()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_numpy_float_division.py",
+        "consume_int_scaled",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT64)));
+  }
+
+  /**
+   * Companion to {@link #testNumpyIntegerDividedByFloatLiteral} (wala/ML#814): a {@code float32}
+   * array keeps {@code float32} under the same operation, so the rule is not "a float literal makes
+   * the result {@code float64}" either. The operand's own dtype decides.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNumpyFloat32DividedByFloatLiteral()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_numpy_float_division.py",
+        "consume_float_scaled",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
   }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -630,7 +630,11 @@ public class ElementWiseOperation extends TensorGenerator {
     Set<DType> ret = EnumSet.noneOf(DType.class);
     for (DType operandDType : operandDTypes)
       if (operandDType.isIntegral()) ret.add(DType.FLOAT64);
-      else if (operandDType.isFloatingPoint()) ret.add(operandDType);
+      // Numeric but not integral means floating-point or complex, and both keep their own
+      // dtype: `complex64 / 255.0` is `complex64`, verified alongside the cases above. Testing
+      // `isFloatingPoint` here instead would send complex operands to the `float32` fallback,
+      // which contradicts this method's own contract and loses the imaginary part.
+      else if (operandDType.isNumeric()) ret.add(operandDType);
       else ret.add(DType.FLOAT32);
     return ret;
   }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/ElementWiseOperation.java
@@ -575,20 +575,15 @@ public class ElementWiseOperation extends TensorGenerator {
     LOGGER.fine("ElementWiseOperation getDefaultDTypes xVn: " + xVn + ", yVn: " + yVn);
     if (xVn <= 0) return EnumSet.of(DType.UNKNOWN);
 
-    // Type promotion for scalar-literal operands: NumPy/TF rules promote `int_tensor op
-    // float_literal` to float32 (e.g., `x_train.astype(uint8) / 255.0` → float32). Check for
-    // literals BEFORE calling getOperandDTypes to avoid short-circuiting via exception on
-    // an implicit-PK operand (see wala/WALA#1889).
+    // Type promotion for scalar-literal operands. Check for literals BEFORE calling
+    // getOperandDTypes on the literal's own value number, to avoid short-circuiting via
+    // exception on an implicit-PK operand (see wala/WALA#1889).
     CGNode node = this.getNode();
     if (yVn > 0 && isFloatLiteralVn(node, yVn)) {
-      LOGGER.fine(
-          "ElementWiseOperation getDefaultDTypes: promoting to FLOAT32 (y is float literal)");
-      return EnumSet.of(DType.FLOAT32);
+      return promoteWithFloatLiteral(builder, xVn);
     }
     if (isFloatLiteralVn(node, xVn)) {
-      LOGGER.fine(
-          "ElementWiseOperation getDefaultDTypes: promoting to FLOAT32 (x is float literal)");
-      return EnumSet.of(DType.FLOAT32);
+      return promoteWithFloatLiteral(builder, yVn);
     }
 
     Set<DType> xDTypes = this.getOperandDTypes(builder, xVn);
@@ -600,6 +595,44 @@ public class ElementWiseOperation extends TensorGenerator {
     // identification across the chain even though every step is demonstrably a tensor producer.
     if (xDTypes == null || xDTypes.isEmpty()) return EnumSet.of(DType.UNKNOWN);
     return xDTypes;
+  }
+
+  /**
+   * Computes the dtype of an element-wise result whose other operand is a Python float literal.
+   *
+   * <p>The previous rule promoted every such result to {@code float32}, citing {@code
+   * x_train.astype(uint8) / 255.0}. That is the wrong answer for exactly that expression. NumPy
+   * promotes an integral array combined with a Python float to {@code float64}, because a Python
+   * float is a double; a {@code float32} array keeps {@code float32}. TensorFlow does not promote
+   * at all, and raises when an integral tensor meets a float literal. So the only combination of an
+   * integral operand with a float literal that can execute is NumPy's, and its result is {@code
+   * float64} (wala/ML#814).
+   *
+   * <p>A floating-point or complex operand keeps its own dtype, which is correct for both
+   * libraries. An operand that does not resolve, or that is neither numeric nor floating-point,
+   * keeps the previous {@code float32} answer rather than degrading, so this narrows a wrong result
+   * without widening an unknown one.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @param operandVn The value number of the operand that is not the float literal.
+   * @return The dtypes of the result.
+   */
+  private Set<DType> promoteWithFloatLiteral(PropagationCallGraphBuilder builder, int operandVn) {
+    Set<DType> operandDTypes = operandVn > 0 ? this.getOperandDTypes(builder, operandVn) : null;
+    LOGGER.fine(
+        () ->
+            "ElementWiseOperation getDefaultDTypes: float literal beside operand vn="
+                + operandVn
+                + " dtypes="
+                + operandDTypes);
+    if (operandDTypes == null || operandDTypes.isEmpty()) return EnumSet.of(DType.FLOAT32);
+
+    Set<DType> ret = EnumSet.noneOf(DType.class);
+    for (DType operandDType : operandDTypes)
+      if (operandDType.isIntegral()) ret.add(DType.FLOAT64);
+      else if (operandDType.isFloatingPoint()) ret.add(operandDType);
+      else ret.add(DType.FLOAT32);
+    return ret;
   }
 
   /**

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -67,6 +67,36 @@ public class TensorFlowTypes extends PythonTypes {
       this.precision = precision;
     }
 
+    /**
+     * Whether this is a numeric dtype, i.e. one arithmetic can widen and narrow.
+     *
+     * @return {@code true} iff this dtype is numeric.
+     */
+    public boolean isNumeric() {
+      return this.numeric;
+    }
+
+    /**
+     * Whether this is a floating-point dtype, as opposed to an integral or non-numeric one.
+     *
+     * @return {@code true} iff this dtype is floating-point.
+     */
+    public boolean isFloatingPoint() {
+      return this.floatingPoint;
+    }
+
+    /**
+     * Whether this is an integral dtype, i.e. numeric but neither floating-point nor complex.
+     * Promotion rules distinguish these from floating-point dtypes, since an integral operand
+     * combined with a floating-point one widens to the floating-point type while a floating-point
+     * operand keeps its own precision.
+     *
+     * @return {@code true} iff this dtype is integral.
+     */
+    public boolean isIntegral() {
+      return this.numeric && !this.floatingPoint && !this.complex;
+    }
+
     public boolean canConvertTo(DType other) {
       if (other == null) return false;
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_numpy_float_division.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_numpy_float_division.py
@@ -22,3 +22,16 @@ y = np.zeros((4, 5), dtype=np.float32)
 float_scaled = y / 255.0
 assert float_scaled.dtype == np.float32 and float_scaled.shape == (4, 5)
 consume_float_scaled(float_scaled)
+
+
+def consume_complex_scaled(c):
+    pass
+
+
+# A complex array keeps its own dtype too, so the rule is "an integral operand widens to
+# float64, every other numeric operand keeps itself" rather than anything about the literal.
+z = np.zeros((4, 5), dtype=np.complex64)
+
+complex_scaled = z / 255.0
+assert complex_scaled.dtype == np.complex64 and complex_scaled.shape == (4, 5)
+consume_complex_scaled(complex_scaled)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_numpy_float_division.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_numpy_float_division.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def consume_int_scaled(s):
+    pass
+
+
+def consume_float_scaled(f):
+    pass
+
+
+# NumPy promotes an integer array divided by a Python float to float64, not float32.
+# This is the ubiquitous image-normalization idiom.
+x = np.zeros((4, 5), dtype=np.uint8)
+scaled = x / 255.0
+assert scaled.dtype == np.float64 and scaled.shape == (4, 5)
+consume_int_scaled(scaled)
+
+# A float32 array keeps float32 under the same operation, so the promotion is not
+# "any float literal makes the result float64" either.
+y = np.zeros((4, 5), dtype=np.float32)
+float_scaled = y / 255.0
+assert float_scaled.dtype == np.float32 and float_scaled.shape == (4, 5)
+consume_float_scaled(float_scaled)


### PR DESCRIPTION
Fixes wala/ML#814.

The rule promoted every float-literal operand to `float32`, and its own comment cited `x_train.astype(uint8) / 255.0` as the example. That expression is `float64`.

## What The Libraries Actually Do

Measured on TensorFlow 2.9.3 and NumPy 1.23.4 rather than taken from documentation:

```
numpy   uint8   / 255.0  ->  float64
numpy   int32   / 255.0  ->  float64
numpy   float32 / 255.0  ->  float32
tf      float32 / 255.0  ->  float32
tf      int32   / 255.0  ->  TypeError
```

## Why Origin Is Not Needed

I expected this to require consulting whether the operand came from NumPy or TensorFlow. The last row removes that need. An integral operand meeting a float literal raises under TensorFlow, so the only combination that can execute is NumPy's, and NumPy's answer is `float64` because a Python float is a double.

A floating-point operand keeps its own dtype, which is correct for both libraries. So the result follows from the operand, not from the literal.

## The Change

The literal branch now resolves the other operand, which it previously had no reason to. Integral becomes `float64`, floating-point keeps its own dtype, and an operand that does not resolve keeps the former `float32`. That narrows a wrong answer without widening an unknown one.

`DType` gains `isNumeric`, `isFloatingPoint` and `isIntegral`. The flags already existed but were private, and an enumerated list of integral dtypes would go stale the next time one is added.

## Testing

Two fixtures, both run to completion under `python3.10` with their assertions, which are mirrored in the JUnit expectations. The `float32` companion is deliberate: it is the guard against over-correcting to "any float literal yields `float64`."

Full module suite: 1192 tests, 0 failures, 3 skipped.

## Provenance

Found by comparing emitted signatures against argument types observed at run time, and reproduced in two subjects with different datasets before being filed. A wrong dtype is the damaging kind: a specification declaring `float32` does not coerce a `float64` argument, it rejects the call, so this affected every call to four parameters.
