### PR TITLE
Compute `tf.gather`'s output shape instead of passing the table through

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -213,6 +213,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_4_3_FLOAT32 = TensorType.of(FLOAT_32, 4, 3);
 
+  protected static final TensorType TENSOR_2_256_8_FLOAT32 = TensorType.of(FLOAT_32, 2, 256, 8);
+
   protected static final TensorType TENSOR_2_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 3);
 
   protected static final TensorType TENSOR_6_1_FLOAT32 = TensorType.of(FLOAT_32, 6, 1);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_3_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_28_28_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_1_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_256_8_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_1_FLOAT32;
@@ -1340,5 +1341,50 @@ public class TestShapeOps extends AbstractTensorTest {
   public void testAttrGuardDispatch2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_attr_guard2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of {@code tf.gather} at its default axis (wala/ML#815). Gathering rows of
+   * a {@code (5000, 8)} table with {@code (2, 256)} indices yields {@code (2, 256, 8)}: the
+   * indices' shape indexes the result and each entry is a row of the table.
+   *
+   * <p>The operation was previously modeled as a pass-through, which reported the table's own
+   * shape. That is a rank error rather than an imprecision, so a signature written from it rejects
+   * every call.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGatherRank()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_gathered",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testGatherRank} through the Keras backend alias (wala/ML#815), which is
+   * the form the corpus uses.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testBackendGatherRank()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_backend_gathered",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1387,4 +1387,25 @@ public class TestShapeOps extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
   }
+
+  /**
+   * Checks that a gathered value composes as an operand rather than only as a sink argument
+   * (wala/ML#815). The elementwise consumer reads the gather result's shape and dtype, so the
+   * lookup's rank has to survive one hop past the call that produced it.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGatherRankThroughElementwiseConsumer()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_scaled",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -597,8 +597,9 @@
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="tile"/>
         <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through"/>
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="gather" class="Ltensorflow/functions/gather"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="gather"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="gather"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd -->
         <new def="gather_nd" class="Ltensorflow/functions/gather_nd"/>
         <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="x" value="gather_nd"/>
@@ -870,7 +871,7 @@
         <putfield class="LRoot" field="cast" fieldType="LRoot" ref="backend" value="cast"/>
         <putfield class="LRoot" field="equal" fieldType="LRoot" ref="backend" value="equal"/>
         <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="backend" value="one_hot"/>
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="backend" value="pass_through"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="backend" value="gather"/>
         <putfield class="LRoot" field="dropout" fieldType="LRoot" ref="backend" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
         <new def="expand_dims" class="Ltensorflow/functions/expand_dims"/>
@@ -2094,6 +2095,13 @@
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self shape lam dtype seed name">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="x"/>
+        </method>
+      </class>
+      <class name="gather" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather. Allocates its result rather than passing `params` through: a gather returns the selected slices, whose shape is `indices.shape + params.shape[1:]`, not the table itself (wala/ML#815). -->
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self params indices validate_indices axis batch_dims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="gather_nd" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gather.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gather.java
@@ -1,0 +1,38 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.gather} at its default axis. Output dtype is inherited from the {@code
+ * params} argument, and output shape is {@code indices.shape + params.shape[1:]}: each index
+ * selects a full slice along the first axis, so the leading {@code indices.shape} indexes the
+ * result and the trailing {@code params.shape[1:]} is the selected slice.
+ *
+ * <p>That is the same computation {@link EmbeddingLookup} performs, because {@code
+ * tf.nn.embedding_lookup} is a gather along the first axis; this subclass exists to give the two
+ * APIs distinct dispatch while sharing one rule rather than two that can drift apart.
+ *
+ * <p>Modeled previously as a pass-through, which returned the table's own type. A subject reading
+ * {@code K.gather(self.embeddings, inputs)} therefore typed the result as the {@code (vocab,
+ * model_dim)} table rather than the {@code (batch, sequence, model_dim)} lookup, which is a rank
+ * error rather than an imprecision, and a signature written from it rejects every call. See
+ * wala/ML#815.
+ *
+ * <p>Scope: the default first-axis gather. A non-default {@code axis} or a non-zero {@code
+ * batch_dims} rearranges the result differently, and is left to the inherited behavior rather than
+ * answered wrongly.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/gather">tf.gather</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Gather extends EmbeddingLookup {
+
+  public Gather(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Gather(CGNode node) {
+    super(node);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -102,6 +102,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_ROW_STARTS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWIDS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER_ND;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GLOBAL_AVERAGE_POOLING_1D_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
@@ -592,6 +593,8 @@ public class TensorGeneratorFactory {
       return anchor.makeGenerator(ImageAugmentation::new, ImageAugmentation::new);
     if (isType(type, FLATTEN.getDeclaringClass()))
       return anchor.makeGenerator(Flatten::new, Flatten::new);
+    if (isType(type, GATHER.getDeclaringClass()))
+      return anchor.makeGenerator(Gather::new, Gather::new);
     if (isType(type, GATHER_ND.getDeclaringClass()))
       return anchor.makeGenerator(GatherNd::new, GatherNd::new);
     if (isType(type, IDENTITY.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1285,6 +1285,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EMBEDDING_LOOKUP_SIGNATURE = "tf.nn.embedding_lookup()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/gather. */
+  public static final MethodReference GATHER =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/gather")),
+          AstMethodReference.fnSelector);
+
+  private static final String GATHER_SIGNATURE = "tf.gather()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gather_nd. */
   public static final MethodReference GATHER_ND =
       MethodReference.findOrCreate(
@@ -2229,6 +2238,7 @@ public class TensorFlowTypes extends PythonTypes {
               TENSOR_SCATTER_ND_UPDATE.getDeclaringClass(), TENSOR_SCATTER_ND_UPDATE_SIGNATURE),
           Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),
           Map.entry(EMBEDDING_LOOKUP.getDeclaringClass(), EMBEDDING_LOOKUP_SIGNATURE),
+          Map.entry(GATHER.getDeclaringClass(), GATHER_SIGNATURE),
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(SLICE.getDeclaringClass(), SLICE_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+from tensorflow.keras import backend as K
+
+
+def consume_gathered(g):
+    pass
+
+
+def consume_backend_gathered(b):
+    pass
+
+
+# `tf.gather` selects whole slices along the first axis, so the result is indexed by the
+# indices' shape with each entry a row of the table. It is NOT the table's own shape, which
+# is what a pass-through model would report.
+table = tf.ones((5000, 8), dtype=tf.float32)
+indices = tf.ones((2, 256), dtype=tf.int32)
+
+gathered = tf.gather(table, indices)
+assert gathered.shape == (2, 256, 8) and gathered.dtype == tf.float32
+consume_gathered(gathered)
+
+# The Keras backend alias reaches the same operation, which is the form the corpus uses.
+backend_gathered = K.gather(table, indices)
+assert backend_gathered.shape == (2, 256, 8) and backend_gathered.dtype == tf.float32
+consume_backend_gathered(backend_gathered)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
@@ -10,6 +10,10 @@ def consume_backend_gathered(b):
     pass
 
 
+def consume_scaled(s):
+    pass
+
+
 # `tf.gather` selects whole slices along the first axis, so the result is indexed by the
 # indices' shape with each entry a row of the table. It is NOT the table's own shape, which
 # is what a pass-through model would report.
@@ -24,3 +28,10 @@ consume_gathered(gathered)
 backend_gathered = K.gather(table, indices)
 assert backend_gathered.shape == (2, 256, 8) and backend_gathered.dtype == tf.float32
 consume_backend_gathered(backend_gathered)
+
+# Consuming the result as an operand rather than as a sink argument: the elementwise
+# operation reads the gathered shape, so the lookup's rank has to survive one hop past the
+# call that produced it.
+scaled = gathered * 2.0
+assert scaled.shape == (2, 256, 8) and scaled.dtype == tf.float32
+consume_scaled(scaled)


### PR DESCRIPTION
Fixes wala/ML#815.

## The Cause

`tf.gather` was modeled as `pass_through`, so it returned its `params` argument's type. A subject reading

```python
embeddings = K.gather(self.embeddings, inputs)
```

therefore typed the result as the embedding table itself, `(vocab, model_dim)`, rather than the lookup, `(batch, sequence, model_dim)`. That explains the "table-like extents" the issue reports: `(5000, 8)` is the table, and `5000` is the vocabulary size.

Three wirings carried the pass-through: `tf.gather`, `array_ops.gather`, and the Keras backend alias, which is the form the subject uses.

## Why It Matters More Than Imprecision

An argument of a different rank is not a subtype of the specification, so a signature written from this rejects every call the function receives, in the same way as wala/ML#813 though by a different route.

## The Fix Reuses An Existing Rule

`tf.nn.embedding_lookup` already computes `ids.shape + params.shape[1:]`, because an embedding lookup **is** a gather along the first axis. `Gather` therefore subclasses `EmbeddingLookup` rather than restating the arithmetic in a second place that can drift from the first.

Scoped to the default first-axis gather. A non-default `axis` or a non-zero `batch_dims` rearranges the result differently and is left to the inherited behavior rather than answered wrongly, which the class says explicitly.

## A Note On The Model

Rewiring the field alone was not enough: with `<new>` and the `putfield` but no synthetic class body, the call produced nothing and the parameter stopped being tensor-typed at all. The `do()` method with `<new>` and `<return>` is what makes an allocating model yield a tensor, following `gather_nd` exactly.

## Testing

Two fixtures, both run to completion under `python3.10` with their assertions, which the JUnit expectations mirror: the direct call and the Keras backend alias, since real code commonly reaches it through the latter.

Full module suite: 1195 tests, 0 failures, 3 skipped.

## Provenance

Found by comparing emitted signatures against argument types observed at run time, and reproduced through a second driver before being filed.

