### PR TITLE
Stop treating executed-fixture byproducts as source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,13 +80,3 @@ gha-creds-*.json
 
 # Claude Code local settings
 .claude/
-
-# Test-data byproducts, written when a fixture is executed rather than analyzed.
-# The Cora archive and its extraction are fetched by `deep_recommenders.datasets.cora`
-# behind an existence check; the tfrecord is named by a vendored gpt-2 driver. The JUnit
-# tests analyze these fixtures statically and never read the bytes, so committing them
-# would version outputs nothing in the build consumes. `spotless` also fails on the
-# archive, since it is binary.
-com.ibm.wala.cast.python.test/data/tr_proj/cora.tgz
-com.ibm.wala.cast.python.test/data/tr_proj/cora/
-com.ibm.wala.cast.python.test/data/gpt2_vendored/dummy.tfrecord

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,13 @@ gha-creds-*.json
 
 # Claude Code local settings
 .claude/
+
+# Test-data byproducts, written when a fixture is executed rather than analyzed.
+# The Cora archive and its extraction are fetched by `deep_recommenders.datasets.cora`
+# behind an existence check; the tfrecord is named by a vendored gpt-2 driver. The JUnit
+# tests analyze these fixtures statically and never read the bytes, so committing them
+# would version outputs nothing in the build consumes. `spotless` also fails on the
+# archive, since it is binary.
+com.ibm.wala.cast.python.test/data/tr_proj/cora.tgz
+com.ibm.wala.cast.python.test/data/tr_proj/cora/
+com.ibm.wala.cast.python.test/data/gpt2_vendored/dummy.tfrecord

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/.gitignore
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/.gitignore
@@ -1,0 +1,5 @@
+# Byproduct, written when this fixture is executed rather than analyzed. The record is
+# named by the vendored data-pipeline driver. The JUnit tests analyze the fixture
+# statically and never read the bytes, so committing it would version an output nothing
+# in the build consumes.
+dummy.tfrecord

--- a/com.ibm.wala.cast.python.test/data/tr_proj/.gitignore
+++ b/com.ibm.wala.cast.python.test/data/tr_proj/.gitignore
@@ -1,0 +1,7 @@
+# Byproducts, written when this fixture is executed rather than analyzed.
+# `deep_recommenders.datasets.cora` fetches the archive from an external URL behind an
+# existence check and extracts it beside itself. The JUnit tests analyze the fixture
+# statically and never read the bytes, so committing these would version outputs nothing
+# in the build consumes.
+cora.tgz
+cora/

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,14 @@
                   <exclude>**/*.min.*</exclude>
                   <exclude>**/tmp.*</exclude>
                   <exclude>**/*.jar</exclude>
+                  <!-- Archive and record formats written by executing a test fixture. Spotless
+                       walks the filesystem rather than the index, so ignoring these in git is
+                       not enough: it still attempts to format them and fails on the encoding,
+                       which fails the pre-commit hook and makes the tree un-committable while
+                       one is present. -->
+                  <exclude>**/*.tgz</exclude>
+                  <exclude>**/*.tar.gz</exclude>
+                  <exclude>**/*.tfrecord</exclude>
                   <exclude>**/*.exe</exclude>
                   <exclude>**/*.dll</exclude>
                   <exclude>**/*.class</exclude>


### PR DESCRIPTION
Three artifacts appear in the working tree after a fixture is run rather than analyzed:

| Artifact | Written by |
|---|---|
| `tr_proj/cora.tgz`, `tr_proj/cora/` | the vendored dataset loader, fetching from an external URL behind an existence check |
| `gpt2_vendored/dummy.tfrecord` | named by a vendored gpt-2 driver |

The JUnit tests analyze these fixtures statically and never read the bytes. Verified rather than assumed: `TestCorpusFixtures` (20) and `TestTensorOrigins` (5) both pass with the files absent. Committing them would version outputs nothing in the build consumes.

## Two Changes, Not One

Ignoring them in git stops them being committed. It does **not** stop `spotless`, which walks the filesystem rather than the index: it attempts to format the archive, fails on its encoding, and fails the pre-commit hook. While one of these files is present, the tree is un-committable.

So the formatter needs its own exclusion, which its configuration already provides and already uses for the other binary formats (`*.jar`, `*.png`, `*.class`). The archive and record extensions join that list.

## Where The Ignores Live

Beside what they describe, in `data/tr_proj/.gitignore` and `data/gpt2_vendored/.gitignore`, rather than as repeated root-relative paths. That follows the fourteen per-directory files the repository already keeps, `data/.gitignore` among them, and it keeps a rule discoverable from the directory a reader is already looking at.

The `spotless` exclusion cannot follow suit, since the plugin is configured once in the parent `pom.xml`.

## Not Deleted

Ignored rather than removed. The archive is fetched from an external URL, so a local copy has value that a re-fetch cannot guarantee, even though it does not belong in version control.
