### PR TITLE
Capture the destructured value before binding any target

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -213,6 +213,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_4_3_FLOAT32 = TensorType.of(FLOAT_32, 4, 3);
 
+  protected static final TensorType TENSOR_2_256_8_FLOAT32 = TensorType.of(FLOAT_32, 2, 256, 8);
+
   protected static final TensorType TENSOR_2_3_FLOAT32 = TensorType.of(FLOAT_32, 2, 3);
 
   protected static final TensorType TENSOR_6_1_FLOAT32 = TensorType.of(FLOAT_32, 6, 1);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -160,6 +160,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_3_28_28_UINT8 = TensorType.of(UINT_8, 3, 28, 28);
 
+  protected static final TensorType TENSOR_8_207_INT32 = TensorType.of(INT_32, 8, 207);
+
   protected static final TensorType TENSOR_1_2_INT32 = TensorType.of(INT_32, 1, 2);
 
   protected static final TensorType TENSOR_1_5_INT32 = TensorType.of(INT_32, 1, 5);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -2159,4 +2159,91 @@ public class TestDatasets extends AbstractTensorTest {
             4, Set.of(TENSOR_25000_OBJECT),
             5, Set.of(TENSOR_25000_INT64)));
   }
+
+  /**
+   * Two step methods handed out as a tuple of function values, destructured by the caller, and
+   * invoked indirectly, which is {@code gpt-2-tensorflow2.0}'s {@code Gpt2.fit} in miniature. The
+   * training arm's arguments type; this pins that they do.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPairedStepFunctionsTrainArm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_paired_step_functions.py",
+        "consume_train",
+        2,
+        2,
+        Map.of(2, Set.of(TENSOR_8_207_INT32), 3, Set.of(TENSOR_8_207_INT32)));
+  }
+
+  /**
+   * Companion to {@link #testPairedStepFunctionsTrainArm} for the testing arm, whose dataset is
+   * field 1 of a destructuring whose field 0 rebinds the parameter being destructured. The corpus
+   * shape of {@link #testRebindingDestructure}.
+   *
+   * <p>TODO: Blocked by wala/ML#819.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testPairedStepFunctionsTestArm()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_paired_step_functions.py",
+        "consume_test",
+        2,
+        2,
+        Map.of(2, Set.of(TENSOR_8_207_INT32), 3, Set.of(TENSOR_8_207_INT32)));
+  }
+
+  /**
+   * A destructuring assignment whose left-hand side does not mention the name being destructured.
+   * Both fields keep their types, which is the control for {@link #testRebindingDestructure}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPlainDestructureSecondField()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_rebinding_destructure.py",
+        "consume_plain_second",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
+  }
+
+  /**
+   * The same destructuring, except that field 0's target rebinds the very name on the right, which
+   * is {@code gpt-2-tensorflow2.0}'s {@code train_dataset, test_dataset = train_dataset}. Field 1
+   * loses its type.
+   *
+   * <p>TODO: Blocked by wala/ML#819.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testRebindingDestructure()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_rebinding_destructure.py",
+        "consume_rebound_second",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -2184,7 +2184,7 @@ public class TestDatasets extends AbstractTensorTest {
   /**
    * Companion to {@link #testPairedStepFunctionsTrainArm} for the testing arm, whose dataset is
    * field 1 of a destructuring whose field 0 rebinds the parameter being destructured. The corpus
-   * shape of {@link #testRebindingDestructure}.
+   * shape of {@link TestTupleBinding#testRebindingDestructure}.
    *
    * <p>TODO: Blocked by wala/ML#819.
    *
@@ -2202,48 +2202,5 @@ public class TestDatasets extends AbstractTensorTest {
         2,
         2,
         Map.of(2, Set.of(TENSOR_8_207_INT32), 3, Set.of(TENSOR_8_207_INT32)));
-  }
-
-  /**
-   * A destructuring assignment whose left-hand side does not mention the name being destructured.
-   * Both fields keep their types, which is the control for {@link #testRebindingDestructure}.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
-   */
-  @Test
-  public void testPlainDestructureSecondField()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_rebinding_destructure.py",
-        "consume_plain_second",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
-  }
-
-  /**
-   * The same destructuring, except that field 0's target rebinds the very name on the right, which
-   * is {@code gpt-2-tensorflow2.0}'s {@code train_dataset, test_dataset = train_dataset}. Field 1
-   * loses its type.
-   *
-   * <p>TODO: Blocked by wala/ML#819.
-   *
-   * @throws ClassHierarchyException On WALA class-hierarchy error.
-   * @throws IllegalArgumentException On illegal argument.
-   * @throws CancelException On analysis cancellation.
-   * @throws IOException On I/O error reading the test file.
-   */
-  @Test(expected = AssertionError.class)
-  public void testRebindingDestructure()
-      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    test(
-        "tf2_test_rebinding_destructure.py",
-        "consume_rebound_second",
-        1,
-        1,
-        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestDatasets.java
@@ -2193,7 +2193,7 @@ public class TestDatasets extends AbstractTensorTest {
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testPairedStepFunctionsTestArm()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -6,6 +6,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_3_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_28_28_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_1_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_256_8_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_1_FLOAT32;
@@ -1340,5 +1341,50 @@ public class TestShapeOps extends AbstractTensorTest {
   public void testAttrGuardDispatch2()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_attr_guard2.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_3_1_FLOAT32)));
+  }
+
+  /**
+   * Pins the output shape of {@code tf.gather} at its default axis (wala/ML#815). Gathering rows of
+   * a {@code (5000, 8)} table with {@code (2, 256)} indices yields {@code (2, 256, 8)}: the
+   * indices' shape indexes the result and each entry is a row of the table.
+   *
+   * <p>The operation was previously modeled as a pass-through, which reported the table's own
+   * shape. That is a rank error rather than an imprecision, so a signature written from it rejects
+   * every call.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGatherRank()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_gathered",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
+  }
+
+  /**
+   * Companion to {@link #testGatherRank} through the Keras backend alias (wala/ML#815), which is
+   * the form the corpus uses.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testBackendGatherRank()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_backend_gathered",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1387,4 +1387,25 @@ public class TestShapeOps extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
   }
+
+  /**
+   * Checks that a gathered value composes as an operand rather than only as a sink argument
+   * (wala/ML#815). The elementwise consumer reads the gather result's shape and dtype, so the
+   * lookup's rank has to survive one hop past the call that produced it.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testGatherRankThroughElementwiseConsumer()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_rank.py",
+        "consume_scaled",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestTupleBinding.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestTupleBinding.java
@@ -39,16 +39,15 @@ public class TestTupleBinding extends AbstractTensorTest {
   /**
    * The same destructuring, except that field 0's target rebinds the very name on the right, which
    * is {@code gpt-2-tensorflow2.0}'s {@code train_dataset, test_dataset = train_dataset}. Field 1
-   * loses its type.
-   *
-   * <p>TODO: Blocked by wala/ML#819.
+   * used to lose its type, because the read that followed the rebinding was re-pointed at field 0's
+   * result rather than at the tuple (wala/ML#819).
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testRebindingDestructure()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestTupleBinding.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestTupleBinding.java
@@ -1,0 +1,61 @@
+package com.ibm.wala.cast.python.ml.test.tensorflow.v2;
+
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_5_FLOAT32;
+
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Tests of how a tensor's type survives a binding form rather than an operation: tuple
+ * destructuring, and the names the targets take. Nothing here is about what a TensorFlow API
+ * computes, which is why it is not in a feature-area class for one.
+ */
+public class TestTupleBinding extends AbstractTensorTest {
+
+  /**
+   * A destructuring assignment whose left-hand side does not mention the name being destructured.
+   * Both fields keep their types, which is the control for {@link #testRebindingDestructure}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testPlainDestructureSecondField()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_rebinding_destructure.py",
+        "consume_plain_second",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
+  }
+
+  /**
+   * The same destructuring, except that field 0's target rebinds the very name on the right, which
+   * is {@code gpt-2-tensorflow2.0}'s {@code train_dataset, test_dataset = train_dataset}. Field 1
+   * loses its type.
+   *
+   * <p>TODO: Blocked by wala/ML#819.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testRebindingDestructure()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_rebinding_destructure.py",
+        "consume_rebound_second",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_4_5_FLOAT32)));
+  }
+}

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -597,8 +597,9 @@
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="tile"/>
         <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through"/>
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through"/>
+        <new def="gather" class="Ltensorflow/functions/gather"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="gather"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="gather"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd -->
         <new def="gather_nd" class="Ltensorflow/functions/gather_nd"/>
         <putfield class="LRoot" field="gather_nd" fieldType="LRoot" ref="x" value="gather_nd"/>
@@ -870,7 +871,7 @@
         <putfield class="LRoot" field="cast" fieldType="LRoot" ref="backend" value="cast"/>
         <putfield class="LRoot" field="equal" fieldType="LRoot" ref="backend" value="equal"/>
         <putfield class="LRoot" field="one_hot" fieldType="LRoot" ref="backend" value="one_hot"/>
-        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="backend" value="pass_through"/>
+        <putfield class="LRoot" field="gather" fieldType="LRoot" ref="backend" value="gather"/>
         <putfield class="LRoot" field="dropout" fieldType="LRoot" ref="backend" value="pass_through"/>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
         <new def="expand_dims" class="Ltensorflow/functions/expand_dims"/>
@@ -2094,6 +2095,13 @@
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self shape lam dtype seed name">
           <new def="x" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="x"/>
+        </method>
+      </class>
+      <class name="gather" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather. Allocates its result rather than passing `params` through: a gather returns the selected slices, whose shape is `indices.shape + params.shape[1:]`, not the table itself (wala/ML#815). -->
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self params indices validate_indices axis batch_dims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="res"/>
         </method>
       </class>
       <class name="gather_nd" allocatable="true">

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gather.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Gather.java
@@ -1,0 +1,38 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+
+/**
+ * Generator for {@code tf.gather} at its default axis. Output dtype is inherited from the {@code
+ * params} argument, and output shape is {@code indices.shape + params.shape[1:]}: each index
+ * selects a full slice along the first axis, so the leading {@code indices.shape} indexes the
+ * result and the trailing {@code params.shape[1:]} is the selected slice.
+ *
+ * <p>That is the same computation {@link EmbeddingLookup} performs, because {@code
+ * tf.nn.embedding_lookup} is a gather along the first axis; this subclass exists to give the two
+ * APIs distinct dispatch while sharing one rule rather than two that can drift apart.
+ *
+ * <p>Modeled previously as a pass-through, which returned the table's own type. A subject reading
+ * {@code K.gather(self.embeddings, inputs)} therefore typed the result as the {@code (vocab,
+ * model_dim)} table rather than the {@code (batch, sequence, model_dim)} lookup, which is a rank
+ * error rather than an imprecision, and a signature written from it rejects every call. See
+ * wala/ML#815.
+ *
+ * <p>Scope: the default first-axis gather. A non-default {@code axis} or a non-zero {@code
+ * batch_dims} rearranges the result differently, and is left to the inherited behavior rather than
+ * answered wrongly.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/gather">tf.gather</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Gather extends EmbeddingLookup {
+
+  public Gather(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public Gather(CGNode node) {
+    super(node);
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -102,6 +102,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_ROW_STARTS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.FROM_VALUE_ROWIDS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GAMMA_OP;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GATHER_ND;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GLOBAL_AVERAGE_POOLING_1D_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.GRADIENT;
@@ -592,6 +593,8 @@ public class TensorGeneratorFactory {
       return anchor.makeGenerator(ImageAugmentation::new, ImageAugmentation::new);
     if (isType(type, FLATTEN.getDeclaringClass()))
       return anchor.makeGenerator(Flatten::new, Flatten::new);
+    if (isType(type, GATHER.getDeclaringClass()))
+      return anchor.makeGenerator(Gather::new, Gather::new);
     if (isType(type, GATHER_ND.getDeclaringClass()))
       return anchor.makeGenerator(GatherNd::new, GatherNd::new);
     if (isType(type, IDENTITY.getDeclaringClass()))

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1285,6 +1285,15 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String EMBEDDING_LOOKUP_SIGNATURE = "tf.nn.embedding_lookup()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/gather. */
+  public static final MethodReference GATHER =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Ltensorflow/functions/gather")),
+          AstMethodReference.fnSelector);
+
+  private static final String GATHER_SIGNATURE = "tf.gather()";
+
   /** https://www.tensorflow.org/api_docs/python/tf/gather_nd. */
   public static final MethodReference GATHER_ND =
       MethodReference.findOrCreate(
@@ -2229,6 +2238,7 @@ public class TensorFlowTypes extends PythonTypes {
               TENSOR_SCATTER_ND_UPDATE.getDeclaringClass(), TENSOR_SCATTER_ND_UPDATE_SIGNATURE),
           Map.entry(SEQUENCE_MASK.getDeclaringClass(), SEQUENCE_MASK_SIGNATURE),
           Map.entry(EMBEDDING_LOOKUP.getDeclaringClass(), EMBEDDING_LOOKUP_SIGNATURE),
+          Map.entry(GATHER.getDeclaringClass(), GATHER_SIGNATURE),
           Map.entry(GATHER_ND.getDeclaringClass(), GATHER_ND_SIGNATURE),
           Map.entry(BOOLEAN_MASK.getDeclaringClass(), BOOLEAN_MASK_SIGNATURE),
           Map.entry(SLICE.getDeclaringClass(), SLICE_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+from tensorflow.keras import backend as K
+
+
+def consume_gathered(g):
+    pass
+
+
+def consume_backend_gathered(b):
+    pass
+
+
+# `tf.gather` selects whole slices along the first axis, so the result is indexed by the
+# indices' shape with each entry a row of the table. It is NOT the table's own shape, which
+# is what a pass-through model would report.
+table = tf.ones((5000, 8), dtype=tf.float32)
+indices = tf.ones((2, 256), dtype=tf.int32)
+
+gathered = tf.gather(table, indices)
+assert gathered.shape == (2, 256, 8) and gathered.dtype == tf.float32
+consume_gathered(gathered)
+
+# The Keras backend alias reaches the same operation, which is the form the corpus uses.
+backend_gathered = K.gather(table, indices)
+assert backend_gathered.shape == (2, 256, 8) and backend_gathered.dtype == tf.float32
+consume_backend_gathered(backend_gathered)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_rank.py
@@ -10,6 +10,10 @@ def consume_backend_gathered(b):
     pass
 
 
+def consume_scaled(s):
+    pass
+
+
 # `tf.gather` selects whole slices along the first axis, so the result is indexed by the
 # indices' shape with each entry a row of the table. It is NOT the table's own shape, which
 # is what a pass-through model would report.
@@ -24,3 +28,10 @@ consume_gathered(gathered)
 backend_gathered = K.gather(table, indices)
 assert backend_gathered.shape == (2, 256, 8) and backend_gathered.dtype == tf.float32
 consume_backend_gathered(backend_gathered)
+
+# Consuming the result as an operand rather than as a sink argument: the elementwise
+# operation reads the gathered shape, so the lookup's rank has to survive one hop past the
+# call that produced it.
+scaled = gathered * 2.0
+assert scaled.shape == (2, 256, 8) and scaled.dtype == tf.float32
+consume_scaled(scaled)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_paired_step_functions.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_paired_step_functions.py
@@ -1,0 +1,54 @@
+import tensorflow as tf
+
+
+def consume_train(a, b):
+    pass
+
+
+def consume_test(a, b):
+    pass
+
+
+# `gpt-2-tensorflow2.0`'s `Gpt2.fit` in miniature. Two step methods are handed out as a
+# tuple of function values, destructured by the caller, and invoked indirectly. The
+# arguments come from two datasets, and the second dataset is field 1 of a destructuring
+# whose field 0 rebinds the parameter it is destructuring.
+class Stepper:
+    def _train_step(self, inputs, targets):
+        consume_train(inputs, targets)
+        return inputs
+
+    def _test_step(self, inputs, targets):
+        consume_test(inputs, targets)
+        return targets
+
+    def get_train_test_function(self):
+        train_fuc = self._train_step
+        test_fuc = self._test_step
+        return train_fuc, test_fuc
+
+    def fit(self, train_dataset):
+        # The rebinding destructure: the parameter becomes its own field 0, and the second
+        # dataset is field 1 of the same tuple.
+        train_dataset, test_dataset = train_dataset
+        train_func, test_func = self.get_train_test_function()
+
+        for _, (inputs, targets) in enumerate(train_dataset):
+            assert inputs.shape == (8, 207) and inputs.dtype == tf.int32
+            assert targets.shape == (8, 207) and targets.dtype == tf.int32
+            train_func(inputs, targets)
+
+            for _, (test_inputs, test_targets) in enumerate(test_dataset):
+                assert test_inputs.shape == (8, 207) and test_inputs.dtype == tf.int32
+                assert test_targets.shape == (8, 207) and test_targets.dtype == tf.int32
+                test_func(test_inputs, test_targets)
+
+
+def make_dataset():
+    features = tf.ones((8, 207), dtype=tf.int32)
+    labels = tf.ones((8, 207), dtype=tf.int32)
+    return tf.data.Dataset.from_tensor_slices((features, labels)).batch(8)
+
+
+stepper = Stepper()
+stepper.fit((make_dataset(), make_dataset()))

--- a/com.ibm.wala.cast.python.test/data/tf2_test_rebinding_destructure.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_rebinding_destructure.py
@@ -1,0 +1,44 @@
+import tensorflow as tf
+
+
+def consume_plain_first(t):
+    pass
+
+
+def consume_plain_second(t):
+    pass
+
+
+def consume_rebound_first(t):
+    pass
+
+
+def consume_rebound_second(t):
+    pass
+
+
+# A destructuring assignment whose left-hand side does NOT mention the name being
+# destructured. Both fields keep their types.
+def plain(pair):
+    first, second = pair
+    assert first.shape == (2, 3) and first.dtype == tf.float32
+    consume_plain_first(first)
+    assert second.shape == (4, 5) and second.dtype == tf.float32
+    consume_plain_second(second)
+
+
+# The same destructuring, except that field 0's target rebinds the very name on the right.
+# This is `gpt-2-tensorflow2.0`'s `train_dataset, test_dataset = train_dataset`.
+def rebinding(pair):
+    pair, second = pair
+    assert pair.shape == (2, 3) and pair.dtype == tf.float32
+    consume_rebound_first(pair)
+    assert second.shape == (4, 5) and second.dtype == tf.float32
+    consume_rebound_second(second)
+
+
+a = tf.ones((2, 3), dtype=tf.float32)
+b = tf.ones((4, 5), dtype=tf.float32)
+
+plain((a, b))
+rebinding((a, b))

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ir/PythonCAstToIRTranslator.java
@@ -1315,6 +1315,16 @@ public class PythonCAstToIRTranslator extends AstTranslator {
 
   private void handleObjectLiteralAssign(
       CAstNode n, CAstNode lvalAst, int rval, WalkContext c, CAstVisitor<WalkContext> visitor) {
+    // Capture the right-hand side before any target is bound. Python evaluates it once and then
+    // binds, so `a, b = a` must read both fields out of the incoming tuple. Reading the symbol
+    // instead lets a target that rebinds the source name re-point the reads that follow it at its
+    // own definition: field 1 was read out of field 0's result rather than out of the tuple, which
+    // silently dropped every field but the first. A copy no symbol names cannot be re-pointed.
+    // See wala/ML#819.
+    int source = c.currentScope().allocateTempValue();
+    c.cfg().addInstruction(new AssignInstruction(c.cfg().getCurrentInstruction(), source, rval));
+    rval = source;
+
     for (int i = 1; i < lvalAst.getChildCount(); i += 2) {
       int idx = c.getValue(lvalAst.getChild(i));
       if (idx == -1) {


### PR DESCRIPTION
Fixes wala/ML#819.

A destructuring assignment whose left-hand side rebinds the name being destructured lost the type of every field but the first.

```python
def plain(pair):
    first, second = pair
    consume_plain_second(second)     # float32 (4, 5)

def rebinding(pair):
    pair, second = pair              # field 0's target IS the right-hand side
    consume_rebound_second(second)   # no tensor type at all
```

One token apart, and renaming the first target restored the second field. The consumer of the second field reported zero tensor parameters rather than one of the wrong type, so the value left the analysis rather than arriving imprecise.

## The Cause, From The IR

The two functions lower to the same instructions but for one operand:

```
plain:      0  v6 = fieldref v2.v3:#0     [6=[first]  2=[pair]]
            2  v8 = fieldref v2.v4:#1     [8=[second] 2=[pair]]

rebinding:  0  v5 = fieldref v2.v3:#0     [5=[pair]   2=[pair]]
            2  v7 = fieldref v5.v4:#1     [7=[second] 5=[pair]]
```

Field 1 is read out of field 0's result. `v5` is the first element, a rank-2 tensor, so `#1` of it is nothing.

The expansion is not where it goes wrong: probing it showed both fields being emitted against the same value number in both functions. The re-pointing happens afterwards, on the symbol: field 0 binds the name the reads were written against, and the read that follows is carried to the new definition. Python evaluates the right-hand side once and then binds, so the capture has to happen before any target is written. Copying the source into a temporary that no symbol names puts it out of reach.

## Why It Mattered

`gpt-2-tensorflow2.0` opens `Gpt2.fit` with `train_dataset, test_dataset = train_dataset` and draws the testing arm's arguments from the second field. Several calls later, `Gpt2._train_step`'s parameters typed as `int32 (None, None)` while `Gpt2._test_step`'s came out as non-tensors, though the two are structurally parallel, take the same parameters, and are handed to the same caller as a tuple of function values.

A function whose parameters all read as non-tensor is worse than one typed imprecisely: it yields no signature, and it is not recorded as having declined one, so it leaves the population with no reason attached.

## Ruled Out Before Fixing

Reachability. Both methods are in the call graph and both reach the consumer's optimizable set. The testing arm is guarded and nested in the subject, but the reduced witness above has no guards, no nesting, no classes and no indirect calls, and still lost the field.

## Testing

Two fixtures, each run to completion under `python3.10` with the assertions the JUnit expectations mirror, and four tests, all now positive guards:

| Test | Class |
|---|---|
| `testPlainDestructureSecondField` | `TestTupleBinding` |
| `testRebindingDestructure` | `TestTupleBinding` |
| `testPairedStepFunctionsTrainArm` | `TestDatasets` |
| `testPairedStepFunctionsTestArm` | `TestDatasets` |

The controls were written first and passed before the fix, so the fixtures isolate the rebinding rather than the machinery around it.

`TestTupleBinding` is new. Tuple destructuring is not a TensorFlow operation, so the minimal pair belongs with binding forms rather than in a feature-area class for an API; the dataset-shaped pair does involve datasets and stays in `TestDatasets`.

The change is in the CAst-to-IR translator, so it is not scoped to tensors and every fixture exercises it: full ML module suite 1200 tests, 0 failures, 3 skipped, plus 46 in the front-end modules.

