### PR TITLE
Source the vendored probes' expectations from a run

### DIFF
--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_conv1d.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_conv1d.py
@@ -11,4 +11,8 @@ def consume(t):
 
 c = Conv1d(8, 16)
 out = c(tf.ones((2, 3, 8)))
+# Observed by running this file under `python3.10` (wala/ML#808). The analysis pins this result at
+# unknown rank because the reshape's target shape is a runtime-built list (wala/ML#703); the
+# observation is what that gap costs, and the concrete answer closing it should reach.
+assert out.shape == (2, 3, 16) and out.dtype == tf.float32
 consume(out)

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_embedding.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_embedding.py
@@ -11,6 +11,7 @@ def consume(t):
 emb = EmbeddingLayer(10, 8)
 x = tf.constant([[1, 2, 3], [4, 5, 6]])
 out = emb(x)
+# Observed by running this file under `python3.10` (wala/ML#808). Asserted before the sink so the
+# check runs whether or not the sink is reached, and so the sink's parameter carries no extra reads.
+assert out.shape == (2, 3, 8) and out.dtype == tf.float32
 consume(out)
-assert out.shape == (2, 3, 8)
-assert out.dtype == tf.float32

--- a/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_ln.py
+++ b/com.ibm.wala.cast.python.test/data/gpt2_vendored/probe_ln.py
@@ -11,4 +11,6 @@ def consume(t):
 
 ln = LayerNormalization(8)
 out = ln(tf.ones((2, 3, 8)))
+# Observed by running this file under `python3.10` (wala/ML#808), not read off the source.
+assert out.shape == (2, 3, 8) and out.dtype == tf.float32
 consume(out)


### PR DESCRIPTION
First application of wala/ML#808 to the vendored probe fixtures: the probes' expected output types now come from executing them rather than from reading their construction.

## Method

Each probe runs under a tracing shim with the argument recorder pointed at its sink, which records the concrete type the sink receives. The recorded type becomes an `assert` in the probe, which then runs to completion under `python3.10`, and the JUnit expectation is compared against it.

The sinks are undecorated, so this was only possible once the recorder stopped keying on `tf.function`. A function that is a candidate for decoration is by definition not decorated yet, which is why decorator-keyed tracing has a blind spot exactly over the population of interest.

## Result

| Probe | JUnit pins | Observed | Reading |
|---|---|---|---|
| `probe_ln` | `float32 (2, 3, 8)` | `float32 (2, 3, 8)` | Agrees |
| `probe_embedding` | `float32 (2, 3, 8)` | `float32 (2, 3, 8)` | Agrees |
| `probe_conv1d` | unknown rank, `float32` | `float32 (2, 3, 16)` | Gap, already tracked |
| `probe_forward` | not applicable | not applicable | Does not run |

Two agreements are the outcome worth having on record rather than assumed: the expectations were derived by hand and are now confirmed against the runtime rather than against a second reading of the same source.

## The Third Is The Interesting One

`probe_conv1d` is pinned at unknown rank because the reshape's target shape is a runtime-built list, which wala/ML#703 tracks. The observation does not contradict that pin; it states what the imprecision costs and hands the issue a concrete target. Before this, the fixture recorded that the rank was not recovered but not what the recovered rank would be.

## What Could Not Be Sourced

`probe_forward` fails before reaching its sink, on an unset optimizer during the training step, so nothing can be recorded from it. Its expectations stay hand-derived and are marked by omission rather than by a claim I did not verify.

## A Note On Invocation

Two constraints surfaced, worth knowing for the next fixture:

The subject directory has to be the working directory, since a probe that reads a data file resolves it relative to the CWD. But invoking the shim as a module from there fails when the subject ships its own `scripts` package, because the CWD precedes `PYTHONPATH` under `-m`. Invoking the shim by absolute path from the subject directory satisfies both.

## Testing

`TestNetworkFixtures` 33 tests, `TestDatasets` 140 tests, no failures. All three edited probes run to completion under `python3.10` with their new assertions.

