### PR TITLE
Give a `Conv2D` layer call an output shape

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -166,6 +166,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_1_5_INT32 = TensorType.of(INT_32, 1, 5);
 
+  protected static final TensorType TENSOR_128_10_FLOAT32 = TensorType.of(FLOAT_32, 128, 10);
+
   protected static final TensorType TENSOR_1_10_INT32 = TensorType.of(INT_32, 1, 10);
 
   protected static final TensorType TENSOR_2_2_FLOAT32 = TensorType.of(FLOAT_32, 2, 2);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestMisc.java
@@ -198,6 +198,10 @@ public class TestMisc extends AbstractTensorTest {
    * residual gap from 4 to the rule-based 5 is one intermediate that still doesn't register; see
    * wala/ML#389.
    *
+   * <p>The local count rose from four to five with wala/ML#820: the {@code Conv2D} layer call's
+   * result now carries a shape, so it counts as a tensor-typed local where before it carried
+   * nothing at all.
+   *
    * <p>With the count check passing, the test now fails on value 3's type: actual {@code {(32, 28)
    * float32, (16, 28) float32, (28, 28) float32, ? unknown}} &mdash; a union that contains an
    * over-peeled shape ({@code (32, 28)} / {@code (16, 28)} = batch applied to a peeled {@code
@@ -216,7 +220,7 @@ public class TestMisc extends AbstractTensorTest {
         "tensorflow_eager_execution.py",
         "MyModel.call",
         1,
-        4,
+        5,
         Map.of(3, Set.of(TENSOR_32_28_28_1_FLOAT32, TENSOR_16_28_28_1_FLOAT32)));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
@@ -1310,4 +1310,53 @@ public class TestModelCall extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_1_10_FLOAT32)));
   }
+
+  /**
+   * Control for {@link #testModelCallResultConsumerConv()}: a model whose {@code call} chains only
+   * {@code Flatten} and {@code Dense} keeps its output shape all the way to a sibling function that
+   * consumes the call result.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testModelCallResultConsumer()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_call_result_consumer.py",
+        "consume_plain",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_128_10_FLOAT32)));
+  }
+
+  /**
+   * The same chain with a {@code Conv2D} layer call in front loses the output shape entirely, so
+   * the consumer of the model call's result gets no rank. Minimal form of what {@code
+   * aymericdamien/TensorFlow-Examples}'s {@code ConvNet} does before handing {@code pred} to {@code
+   * accuracy} and {@code cross_entropy_loss}, which is the dominant shape behind the unknown-rank
+   * parameters observed on real subjects.
+   *
+   * <p>Before wala/ML#820, the dtype survived and the shape was lost entirely, because the model
+   * file described {@code conv2d}, the function, and nothing described {@code Conv2D}, the layer.
+   * The convolution's spatial extents remain unresolved, which does not matter here: {@code Dense}
+   * rewrites only the last axis, so the final shape is reached from a rank-4 input regardless.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testModelCallResultConsumerConv()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_model_call_result_consumer.py",
+        "consume_conv",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_128_10_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/data/tensorflow.xml
+++ b/com.ibm.wala.cast.python.ml/data/tensorflow.xml
@@ -435,6 +435,8 @@
         <putfield class="LRoot" field="Input" fieldType="LRoot" ref="layers" value="Input"/>
         <new def="Dense" class="Ltensorflow/keras/layers/class/Dense"/>
         <putfield class="LRoot" field="Dense" fieldType="LRoot" ref="layers" value="Dense"/>
+        <new def="Conv2DCls" class="Ltensorflow/keras/layers/class/Conv2D"/>
+        <putfield class="LRoot" field="Conv2D" fieldType="LRoot" ref="layers" value="Conv2DCls"/>
         <new def="FlattenLayerCls" class="Ltensorflow/keras/layers/class/Flatten"/>
         <putfield class="LRoot" field="Flatten" fieldType="LRoot" ref="layers" value="FlattenLayerCls"/>
         <new def="GlobalAveragePooling1DCls" class="Ltensorflow/keras/layers/class/GlobalAveragePooling1D"/>
@@ -2549,6 +2551,14 @@
           <return value="res"/>
         </method>
       </class>
+      <class name="Conv2D" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/Conv2D. `filters` fixes the output channel count; the `Conv2DCall` generator reads it back off the instance. -->
+        <method name="do" descriptor="()LRoot;" numArgs="17" paramNames="self filters kernel_size strides padding data_format dilation_rate groups activation use_bias kernel_initializer bias_initializer kernel_regularizer bias_regularizer activity_regularizer kernel_constraint bias_constraint">
+          <new def="res" class="Ltensorflow/keras/layers/Conv2D"/>
+          <putfield class="LRoot" field="filters" fieldType="LRoot" ref="res" value="filters"/>
+          <return value="res"/>
+        </method>
+      </class>
       <class name="Flatten" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/keras/layers/Flatten -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self data_format input_shape">
@@ -2610,6 +2620,18 @@
         <!-- FIXME: Workaround for https://github.com/wala/ML/issues/106. -->
         <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
           <!-- https://github.com/keras-team/keras/blob/07e13740fd181fc3ddec7d9a594d8a08666645f6/keras/layers/core/dense.py#L166-L240 -->
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
+        </method>
+      </class>
+      <class name="Conv2D" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/keras/layers/Conv2D#__call__ -->
+        <method name="__call__" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
+          <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
+          <return value="out"/>
+        </method>
+        <!-- Mirrors the `Dense` workaround for https://github.com/wala/ML/issues/106. -->
+        <method name="call" descriptor="()LRoot;" numArgs="3" paramNames="func self inputs">
           <new def="out" class="Ltensorflow/python/framework/ops/Tensor"/>
           <return value="out"/>
         </method>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Conv2DCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/Conv2DCall.java
@@ -1,0 +1,104 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for a {@code tf.keras.layers.Conv2D} layer call.
+ *
+ * <p>A convolution keeps the batch axis, rewrites the two spatial axes, and sets the channel axis
+ * to the layer's {@code filters}. Without this, the call result carried no shape at all and every
+ * value downstream of it lost its rank, which is a worse answer than a loose one: a specification
+ * with no rank admits every argument. See wala/ML#820.
+ *
+ * <p>The spatial extents are reported as {@link UnresolvedDim}. They are fixed integers at run
+ * time, determined by the input extent together with {@code kernel_size}, {@code strides}, {@code
+ * padding} and {@code dilation_rate}, and folding that arithmetic is separate work. Per the
+ * dimension conventions an extent the analysis cannot compute but which is not feed-dependent is
+ * {@code Unresolved} rather than {@code Dynamic}: nothing here carries evidence that the runtime
+ * shape would report {@code None}.
+ *
+ * <p>Recovering the rank is what unblocks the chain. A {@code Flatten} then {@code Dense} following
+ * a convolution reaches the correct final shape from a rank-4 input whatever the spatial extents
+ * are, because {@code Dense} rewrites only the last axis.
+ *
+ * @see <a href="https://www.tensorflow.org/api_docs/python/tf/keras/layers/Conv2D">Conv2D</a>
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class Conv2DCall extends DenseCall {
+
+  private static final Logger LOGGER = Logger.getLogger(Conv2DCall.class.getName());
+
+  /** The constructor argument the model file stores on the layer instance. */
+  private static final String FILTERS_FIELD_NAME = "filters";
+
+  /** Rank of a two-dimensional convolution's input: batch, two spatial axes, and channels. */
+  private static final int CONV2D_RANK = 4;
+
+  public Conv2DCall(PointsToSetVariable source) {
+    super(source);
+  }
+
+  /**
+   * Constructs anchored to a manual node.
+   *
+   * @param node The {@link CGNode} for the synthetic {@code do()} method.
+   */
+  public Conv2DCall(CGNode node) {
+    super(node);
+  }
+
+  @Override
+  protected String getUnitsFieldName() {
+    return FILTERS_FIELD_NAME;
+  }
+
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    Set<List<Dimension<?>>> inputShapes = this.getInputShapes(builder);
+    if (inputShapes == null) return null;
+
+    Set<Long> filterValues = this.getPossibleUnits(builder);
+
+    Set<List<Dimension<?>>> outputShapes = new HashSet<>();
+    for (List<Dimension<?>> inputShape : inputShapes) {
+      // Only a rank-4 input is a two-dimensional convolution's input. Anything else is not this
+      // operation being applied as documented, so say nothing rather than invent a shape.
+      if (inputShape.size() != CONV2D_RANK) continue;
+
+      for (Long filters :
+          filterValues.isEmpty() ? Collections.<Long>singleton(null) : filterValues) {
+        List<Dimension<?>> outShape = new ArrayList<>(CONV2D_RANK);
+        outShape.add(inputShape.get(0));
+        outShape.add(UnresolvedDim.INSTANCE);
+        outShape.add(UnresolvedDim.INSTANCE);
+        outShape.add(filters == null ? UnresolvedDim.INSTANCE : new NumericDim(filters.intValue()));
+        outputShapes.add(outShape);
+      }
+    }
+
+    if (outputShapes.isEmpty()) {
+      LOGGER.fine(
+          () ->
+              "No rank-"
+                  + CONV2D_RANK
+                  + " input shape for Conv2D call at: "
+                  + describe(this.getNode()));
+      return null;
+    }
+
+    return outputShapes;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/DenseCall.java
@@ -43,6 +43,19 @@ public class DenseCall extends TensorGenerator {
   private static final String DENSE_UNITS_FIELD_NAME = "units";
 
   /**
+   * Name of the constructor argument the model file stores on the layer instance, giving the size
+   * of the output's last axis.
+   *
+   * <p>Overridable because a sibling layer names the same idea differently: a convolution calls it
+   * {@code filters}. The lookup is otherwise identical, so it is shared rather than copied.
+   *
+   * @return The field name to read off the layer instance.
+   */
+  protected String getUnitsFieldName() {
+    return DENSE_UNITS_FIELD_NAME;
+  }
+
+  /**
    * Per-thread set of {@code Dense.__call__} nodes whose input shape is currently being computed.
    *
    * <p>Breaks unbounded recursion when a layer call's input flows back to itself. The motivating
@@ -128,7 +141,7 @@ public class DenseCall extends TensorGenerator {
         FieldReference unitsFieldRef =
             FieldReference.findOrCreate(
                 selfASIN.concreteType().getReference(),
-                findOrCreateAsciiAtom(DENSE_UNITS_FIELD_NAME),
+                findOrCreateAsciiAtom(this.getUnitsFieldName()),
                 Root);
 
         IField f = builder.getClassHierarchy().resolveField(unitsFieldRef);
@@ -251,7 +264,7 @@ public class DenseCall extends TensorGenerator {
    * @return The set of possible input shapes, or {@code null} if neither path resolves a shape or
    *     the node is already being resolved on this thread (cycle).
    */
-  private Set<List<Dimension<?>>> getInputShapes(PropagationCallGraphBuilder builder) {
+  protected Set<List<Dimension<?>>> getInputShapes(PropagationCallGraphBuilder builder) {
     CGNode self = this.getNode();
     // The thread-local guard breaks real recursion, which exists only on the null-engine path.
     // Under the engine, reads never recurse, and the guard's null was an engine-invisible cycle

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -8504,6 +8504,8 @@ public abstract class TensorGenerator {
       return new SliceBuiltinOperation(node);
     } else if (type.equals(PLACEHOLDER.getDeclaringClass())) {
       return new Placeholder(node);
+    } else if (type.equals(TensorFlowTypes.CONV2D_CALL.getDeclaringClass())) {
+      return new Conv2DCall(node);
     } else if (type.equals(TensorFlowTypes.DENSE_CALL.getDeclaringClass())) {
       return new DenseCall(node);
     } else if (type.equals(TensorFlowTypes.GLOBAL_AVERAGE_POOLING_1D_CALL.getDeclaringClass())) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -41,6 +41,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CIFAR10_Y_TRAIN;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CLIP_BY_VALUE;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONCAT;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONSTANT;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONV2D_CALL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.CONVERT_TO_TENSOR;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.COS;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.COSH;
@@ -1790,6 +1791,7 @@ public class TensorGeneratorFactory {
     else if (isType(calledFunction, COS.getDeclaringClass())) return new Cos(source);
     else if (isType(calledFunction, GRADIENT.getDeclaringClass())) return new Gradient(source);
     else if (isType(calledFunction, SOFTMAX.getDeclaringClass())) return new Softmax(source);
+    else if (isType(calledFunction, CONV2D_CALL.getDeclaringClass())) return new Conv2DCall(source);
     else if (isType(calledFunction, DENSE_CALL.getDeclaringClass())) return new DenseCall(source);
     else if (isType(calledFunction, ADD_WEIGHT.getDeclaringClass())) return new AddWeight(source);
     else if (isType(calledFunction, MODEL_CALL.getDeclaringClass())) return new ModelCall(source);

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/TensorFlowTypes.java
@@ -1975,6 +1975,17 @@ public class TensorFlowTypes extends PythonTypes {
 
   private static final String SOFTMAX_SIGNATURE = "tf.nn.softmax()";
 
+  /** https://www.tensorflow.org/api_docs/python/tf/keras/layers/Conv2D. */
+  public static final MethodReference CONV2D_CALL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader,
+              TypeName.string2TypeName("Ltensorflow/keras/layers/Conv2D/" + CALLABLE_METHOD_NAME)),
+          AstMethodReference.fnSelector);
+
+  private static final String CONV2D_CALL_SIGNATURE =
+      "tf.keras.layers.Conv2D." + CALLABLE_METHOD_NAME + "()";
+
   /**
    * https://github.com/keras-team/keras/blob/f6c4ac55692c132cd16211f4877fac6dbeead749/keras/src/layers/core/dense.py#L149-L155.
    */
@@ -2316,6 +2327,7 @@ public class TensorFlowTypes extends PythonTypes {
           Map.entry(STOP_GRADIENT.getDeclaringClass(), STOP_GRADIENT_SIGNATURE),
           Map.entry(GRADIENT.getDeclaringClass(), GRADIENT_SIGNATURE),
           Map.entry(SOFTMAX.getDeclaringClass(), SOFTMAX_SIGNATURE),
+          Map.entry(CONV2D_CALL.getDeclaringClass(), CONV2D_CALL_SIGNATURE),
           Map.entry(DENSE_CALL.getDeclaringClass(), DENSE_CALL_SIGNATURE),
           Map.entry(
               GLOBAL_AVERAGE_POOLING_1D_CALL.getDeclaringClass(),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_model_call_result_consumer.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_model_call_result_consumer.py
@@ -1,0 +1,46 @@
+import tensorflow as tf
+from tensorflow.keras import layers
+
+
+def consume_conv(t):
+    pass
+
+
+def consume_plain(t):
+    pass
+
+
+# A `Conv2D` layer call in the chain: the model's output shape is lost, so the consumer of the
+# call result gets no rank. Minimal form of what `aymericdamien/TensorFlow-Examples`'s `ConvNet`
+# does before handing `pred` to `accuracy` and `cross_entropy_loss`.
+class ConvNet(tf.keras.Model):
+    def __init__(self):
+        super(ConvNet, self).__init__()
+        self.conv1 = layers.Conv2D(32, kernel_size=5)
+        self.flatten = layers.Flatten()
+        self.out = layers.Dense(10)
+
+    def call(self, x):
+        return self.out(self.flatten(self.conv1(x)))
+
+
+# Control: the same chain without the convolution keeps its shape all the way to the consumer.
+class PlainNet(tf.keras.Model):
+    def __init__(self):
+        super(PlainNet, self).__init__()
+        self.flatten = layers.Flatten()
+        self.out = layers.Dense(10)
+
+    def call(self, x):
+        return self.out(self.flatten(x))
+
+
+conv_net = ConvNet()
+conv_pred = conv_net(tf.ones((128, 28, 28, 1)))
+assert conv_pred.shape == (128, 10) and conv_pred.dtype == tf.float32
+consume_conv(conv_pred)
+
+plain_net = PlainNet()
+plain_pred = plain_net(tf.ones((128, 28, 28, 1)))
+assert plain_pred.shape == (128, 10) and plain_pred.dtype == tf.float32
+consume_plain(plain_pred)


### PR DESCRIPTION
Fixes wala/ML#820.

A `Conv2D` layer call produced no output shape, so every value downstream of it lost its rank. The dtype survived; only the shape was lost.

## The Cause

The model file described `conv2d`, the function reachable as `tf.nn.conv2d`. Nothing described `tf.keras.layers.Conv2D`, the layer class whose instance is called. Layer calls are modeled selectively, with generators for `MaxPool` and `GlobalAveragePooling1D`, so this was a hole in that family rather than an absent capability.

## The Fix

Modeled the way `Dense` is, in three parts: a constructor keeping the argument that fixes the output's last axis, a callable allocating a fresh tensor, and a generator computing the result.

Both layers read that stored argument the same way and differ only in its name, `units` against `filters`, so the lookup became an overridable hook rather than a second copy of it.

## Why The Spatial Extents Are Unresolved

A convolution keeps the batch axis, rewrites the two spatial axes, and sets the channel axis to `filters`. The spatial extents are fixed integers at run time, determined by the input extent together with `kernel_size`, `strides`, `padding` and `dilation_rate`. Folding that arithmetic is separate work, and per the dimension conventions an extent the analysis cannot compute but which is not feed-dependent is `Unresolved` rather than `Dynamic`: nothing here carries evidence that the runtime shape would report `None`.

Recovering the rank is what unblocks the chain. `Dense` rewrites only the last axis, so a following `Flatten` and `Dense` reach the correct final shape from a rank-4 input whatever the spatial extents are, which is the pattern this distils:

```python
pred = conv_net(x)          # rank recovered here
loss = cross_entropy_loss(pred, y)
acc  = accuracy(pred, y)
```

## Testing

The reproduction committed with the issue flips from a known failure to a positive guard, and its control, the identical chain without the convolution, still passes.

One existing pin moves for the right reason. The test `testEagerExecution` sees its tensor-local count rise from four to five: that fixture builds a `Conv2D` and calls it, so its result now counts as tensor-typed where before it carried nothing at all.

## Scope

`MaxPool2D` is absent from the model file for the same reason and is untouched here. Whether the remaining convolution and pooling layer classes need the same treatment is worth a sweep rather than another single addition.

