### PR TITLE
Cast a Keras `call` input to the layer's compute dtype

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -383,6 +383,10 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_20_10_FLOAT32 = TensorType.of(FLOAT_32, 20, 10);
 
+  protected static final TensorType TENSOR_20_28_FLOAT32 = TensorType.of(FLOAT_32, 20, 28);
+
+  protected static final TensorType TENSOR_20_28_FLOAT64 = TensorType.of(FLOAT_64, 20, 28);
+
   protected static final TensorType TENSOR_20_64_FLOAT32 = TensorType.of(FLOAT_32, 20, 64);
 
   protected static final TensorType TENSOR_60000_28_28_FLOAT32 =

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestModelCall.java
@@ -1359,4 +1359,47 @@ public class TestModelCall extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_128_10_FLOAT32)));
   }
+
+  /**
+   * A Keras layer casts its first floating-point argument to the layer's compute dtype before the
+   * body runs, so {@code call}'s parameter is {@code float32} where the caller holds {@code
+   * float64}. The caller's dtype used to flow through unchanged, which named a dtype no call ever
+   * passes (<a href="https://github.com/wala/ML/issues/821">wala/ML#821</a>).
+   *
+   * <p>The cast is the one Keras performs in {@code Layer.__call__}, so it applies to {@code call}
+   * and not to a user-written {@code __call__}, which replaces that entry rather than passing
+   * through it. {@link #testModelCall()} pins the untouched case.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testKerasAutocast()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_keras_autocast.py",
+        "MyModel.call",
+        1,
+        2,
+        Map.of(3, Set.of(TENSOR_20_28_FLOAT32)));
+  }
+
+  /**
+   * The caller's side of {@link #testKerasAutocast()}: the value handed to the model really is
+   * {@code float64}, so the cast is the parameter's own semantics rather than a repair of a
+   * mis-typed argument. Without this the test above would still pass if the caller stopped
+   * resolving.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testKerasAutocastCaller()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_keras_autocast.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_20_28_FLOAT64)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/analysis/TensorTypeAnalysis.java
@@ -342,6 +342,74 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
   }
 
   /**
+   * A transfer function for the first argument of a Keras {@code call} body (<a
+   * href="https://github.com/wala/ML/issues/821">wala/ML#821</a>): an incoming floating-point type
+   * is rewritten to the layer's compute dtype and everything else flows unchanged. {@code
+   * Layer.__call__} casts its first argument to {@code self.compute_dtype} before dispatching to
+   * {@code call}, so the caller's dtype is not the parameter's, and propagating it named a dtype no
+   * call ever passes.
+   *
+   * <p>Only floating-point cells are rewritten. Keras leaves an integral, boolean or complex
+   * argument alone, which is why a {@code uint8} label parameter keeps reporting the caller's type.
+   *
+   * <p>The compute dtype is taken to be {@link #COMPUTE_DTYPE}, the default policy. A layer
+   * constructed with an explicit {@code dtype=} is therefore reported as if it carried the default;
+   * that construction is rare and unmodeled, and the runtime evidence is what would catch it.
+   *
+   * <p>Origins are blocked exactly as {@link ParameterBarrierOp} blocks them, since this
+   * destination is a parameter and this operator replaces rather than supplements that barrier.
+   */
+  static final class ComputeDTypeCastOp extends UnaryOperator<TensorVariable> {
+    static final ComputeDTypeCastOp INSTANCE = new ComputeDTypeCastOp();
+
+    /** The compute dtype of a layer under the default policy. */
+    private static final DType COMPUTE_DTYPE = DType.FLOAT32;
+
+    private ComputeDTypeCastOp() {}
+
+    @Override
+    public byte evaluate(TensorVariable lhs, TensorVariable rhs) {
+      if (lhs == null || rhs == null || rhs.state == null) return NOT_CHANGED;
+      if (lhs.state == null) {
+        lhs.state = HashSetFactory.make();
+        for (TensorType t : rhs.state) lhs.state.add(cast(t));
+        return CHANGED;
+      }
+      boolean changed = false;
+      for (TensorType t : rhs.state) changed |= lhs.state.add(cast(t));
+      return changed ? CHANGED : NOT_CHANGED;
+    }
+
+    /**
+     * The type as the {@code call} body sees it.
+     *
+     * @param type The type the caller holds.
+     * @return {@code type} with a floating-point cell replaced by the compute dtype, or {@code
+     *     type} itself when Keras would not cast it.
+     */
+    private static TensorType cast(TensorType type) {
+      DType dtype = type.getDType();
+      if (dtype == null || !dtype.isFloatingPoint() || dtype == COMPUTE_DTYPE) return type;
+      return TensorType.of(COMPUTE_DTYPE, type.getDims(), type.layout());
+    }
+
+    @Override
+    public int hashCode() {
+      return 0x821CA57;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof ComputeDTypeCastOp;
+    }
+
+    @Override
+    public String toString() {
+      return "cast a floating-point argument to the layer's compute dtype (Keras call input)";
+    }
+  }
+
+  /**
    * Which axes of the suppressed seed a type feed trusts (wala/ML#758): a fill keeps the axis the
    * generator proved and composes only the unproven one from the operands' converged state, so
    * proven evidence is never lost to a weaker operand member.
@@ -397,6 +465,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> computeDTypeCasts,
       Set<PointsToSetVariable> iterationProducts,
       AtomicReference<Function<PointsToSetVariable, TensorVariable>> outAccessor,
       Map<PointerKey, AnalysisError> errorLog) {
@@ -948,6 +1017,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return new ConvOp(2, node);
             } else if (conv3ds.contains(node)) {
               return new ConvOp(3, node);
+            } else if (computeDTypeCasts.contains(node)) {
+              return ComputeDTypeCastOp.INSTANCE;
             } else if (parameters.contains(node)) {
               return ParameterBarrierOp.INSTANCE;
             } else if (iterationProducts.contains(node)) {
@@ -975,6 +1046,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
               return new SetShapeOp(set_shapes.get(dst));
             } else if (refinements.containsKey(dst)) {
               return new RefineShapeOp(refinements.get(dst), dst);
+            } else if (computeDTypeCasts.contains(dst)) {
+              return ComputeDTypeCastOp.INSTANCE;
             } else if (parameters.contains(dst)) {
               return ParameterBarrierOp.INSTANCE;
             } else if (iterationProducts.contains(dst)) {
@@ -1048,6 +1121,8 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
    * @param parameters Parameter destinations, whose types flow normally but whose origins are
    *     pinned to their {@link TensorOrigin#PARAMETER} seed by blocking caller-side origin inflow
    *     (wala/ML#726).
+   * @param computeDTypeCasts Keras {@code call} first-argument destinations, whose incoming
+   *     floating-point types are rewritten to the layer's compute dtype (wala/ML#821).
    * @param iterationProducts Iteration-product destinations, whose types flow normally but whose
    *     origin inflow drops {@link TensorOrigin#PARAMETER} (wala/ML#729).
    * @param errorLog The sink for shape-mismatch diagnostics.
@@ -1065,6 +1140,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> computeDTypeCasts,
       Set<PointsToSetVariable> iterationProducts,
       Map<PointerKey, AnalysisError> errorLog) {
     this(
@@ -1080,6 +1156,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
         conv3ds,
         drops,
         parameters,
+        computeDTypeCasts,
         iterationProducts,
         errorLog,
         new AtomicReference<>());
@@ -1108,6 +1185,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
       Set<PointsToSetVariable> conv3ds,
       Set<PointsToSetVariable> drops,
       Set<PointsToSetVariable> parameters,
+      Set<PointsToSetVariable> computeDTypeCasts,
       Set<PointsToSetVariable> iterationProducts,
       Map<PointerKey, AnalysisError> errorLog,
       AtomicReference<Function<PointsToSetVariable, TensorVariable>> outAccessor) {
@@ -1123,6 +1201,7 @@ public class TensorTypeAnalysis extends DataflowSolver<PointsToSetVariable, Tens
             conv3ds,
             drops,
             parameters,
+            computeDTypeCasts,
             iterationProducts,
             outAccessor,
             errorLog));

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/PythonTensorAnalysisEngine.java
@@ -2072,6 +2072,29 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
       for (PointsToSetVariable p : parameters)
         initOrigins.put(p, EnumSet.of(TensorOrigin.PARAMETER));
 
+      // A Keras layer casts its first floating-point argument to the layer's compute dtype before
+      // the body runs (wala/ML#821), so the caller's dtype is not the parameter's and propagating
+      // it names a dtype no call ever passes. Collected here are those first arguments; the cast
+      // itself is the edge transfer, which also does the parameter barrier's job.
+      //
+      // The recognizer is the class-name suffix `explicitBuildContractShapes` already uses for a
+      // Keras call body, and the parameter is `getParameter(2)` as `contractSeedForCallInput`
+      // already indexes it. `call` and not `__call__`: the cast happens inside Keras's own
+      // `Layer.__call__`, which a user-written `__call__` replaces rather than passes through.
+      Set<PointsToSetVariable> computeDTypeCasts = HashSetFactory.make();
+      for (PointsToSetVariable v : parameters) {
+        LocalPointerKey lpk = (LocalPointerKey) v.getPointerKey();
+        CGNode owner = lpk.getNode();
+        if (owner.getIR() == null || owner.getMethod().isStatic()) continue;
+        if (owner.getIR().getNumberOfParameters() < 3) continue;
+        if (owner.getIR().getParameter(2) != lpk.getValueNumber()) continue;
+        String declaringClass =
+            owner.getMethod().getDeclaringClass().getReference().getName().toString();
+        if (declaringClass.endsWith("/" + PythonTypes.CALLABLE_METHOD_NAME_FOR_KERAS_MODELS))
+          computeDTypeCasts.add(v);
+      }
+      LOGGER.fine(() -> "wala/ML#821 Keras call input destinations: " + computeDTypeCasts.size());
+
       // Iteration products do not inherit the hybridization-frame origin (wala/ML#729): iterating
       // a symbolic tensor raises under tf.function tracing, so a value iterated out of a parameter
       // is an eager-only product of the fed data, whose provenance comes from its own seed's
@@ -2250,6 +2273,7 @@ public class PythonTensorAnalysisEngine extends PythonAnalysisEngine<TensorTypeA
               conv3ds,
               drops,
               parameters,
+              computeDTypeCasts,
               iterationProducts,
               errorLog);
 

--- a/com.ibm.wala.cast.python.test/data/tf2_test_keras_autocast.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_keras_autocast.py
@@ -1,0 +1,30 @@
+import numpy as np
+import tensorflow as tf
+
+
+def consume(tensor):
+    pass
+
+
+class MyModel(tf.keras.Model):
+    def __init__(self):
+        super(MyModel, self).__init__()
+        self.d = tf.keras.layers.Dense(10)
+
+    def call(self, x):
+        # A Keras layer casts a floating-point input to the layer's compute dtype before the
+        # body runs, so this is float32 even though the caller holds float64.
+        assert x.dtype == tf.float32
+        return self.d(x)
+
+
+# The image-normalization idiom: NumPy promotes an integral array divided by a Python float
+# to float64.
+input_data = np.zeros((20, 28), dtype=np.uint8) / 255.0
+assert input_data.dtype == np.float64 and input_data.shape == (20, 28)
+consume(input_data)
+
+model = MyModel()
+result = model(input_data)
+assert result.shape == (20, 10)
+assert result.dtype == tf.float32


### PR DESCRIPTION
Fixes #821.

A Keras layer casts its first argument to the layer's compute dtype before the body runs, so the caller's dtype is not the parameter's. Propagating it unchanged named a dtype no call ever passes: a `float64` caller reported a `float64` parameter where the body sees `float32`.

## What Keras Actually Does

Measured on TensorFlow 2.9.3:

| Situation | What `call` sees |
|---|---|
| Caller holds `float64`, first argument | `float32` |
| Caller holds `float64`, second argument | `float64` |
| Caller holds `int32`, first argument | `int32` |
| Layer built with `dtype="float64"` | `float64` |

So the cast applies to the first argument only, to floating-point cells only, and to the layer's own compute dtype.

## The Fix

The new `ComputeDTypeCastOp` rewrites a floating-point incoming cell to the compute dtype and passes everything else through. It also does the parameter barrier's job, since the destination is a parameter and the cast replaces rather than supplements that barrier.

The recognizer reuses what is already here: the class-name suffix is the one `explicitBuildContractShapes` uses for a Keras call body, and the parameter is `getParameter(2)`, as `contractSeedForCallInput` already indexes it.

The target is `call` and not `__call__`. The cast happens inside Keras's own `Layer.__call__`, which a user-written `__call__` replaces rather than passes through. That case is pinned by `testModelCall`, which is unchanged.

## What Is Not Handled

The compute dtype is taken to be the default policy, so a layer constructed with an explicit `dtype=` is reported as if it carried the default. That is the last row of the table and is the one case this makes newly wrong where it was accidentally right. The construction is rare and the run-time evidence is what would catch it; filing it separately is better than guessing at a policy the analysis cannot see.

## Where It Came From

The #725 correction, `Type an integral array divided by a float literal as float64`, made the caller's dtype right and so exposed the missing cast one hop later. That correction stands; this is the second half of it.

## Tests

The new `testKerasAutocast` pins the parameter at `float32`, and `testKerasAutocastCaller` pins the caller at `float64` so the first test cannot pass by the caller silently ceasing to resolve. The fixture runs to completion under Python 3.10 with both asserts live.

Full module: 1204 tests, 0 failures.
