### PR TITLE
Recognize a slice object reached by lexical read

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -389,6 +389,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_30_INT32 = TensorType.of(INT_32, 30);
 
+  protected static final TensorType TENSOR_10_INT32 = TensorType.of(INT_32, 10);
+
   protected static final TensorType TENSOR_30_16_FLOAT32 = TensorType.of(FLOAT_32, 30, 16);
 
   protected static final TensorType TENSOR_20_28_FLOAT64 = TensorType.of(FLOAT_64, 20, 28);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -225,6 +225,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_1_1_3_2_FLOAT32 = TensorType.of(FLOAT_32, 1, 1, 3, 2);
 
+  protected static final TensorType TENSOR_1_1_2_2_FLOAT32 = TensorType.of(FLOAT_32, 1, 1, 2, 2);
+
   protected static final TensorType TENSOR_2_3_1_FLOAT32 = TensorType.of(FLOAT_32, 2, 3, 1);
 
   protected static final TensorType TENSOR_2_3_FLOAT64 = TensorType.of(FLOAT_64, 2, 3);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -385,6 +385,10 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_20_28_FLOAT32 = TensorType.of(FLOAT_32, 20, 28);
 
+  protected static final TensorType TENSOR_30_INT32 = TensorType.of(INT_32, 30);
+
+  protected static final TensorType TENSOR_30_16_FLOAT32 = TensorType.of(FLOAT_32, 30, 16);
+
   protected static final TensorType TENSOR_20_28_FLOAT64 = TensorType.of(FLOAT_64, 20, 28);
 
   protected static final TensorType TENSOR_20_64_FLOAT32 = TensorType.of(FLOAT_32, 20, 64);

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1503,4 +1503,26 @@ public class TestShapeOps extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_30_16_FLOAT32)));
   }
+
+  /**
+   * A slice whose bounds are variables reduces its axis like any other. The discriminator
+   * separating a slice construction from a two-dimensional application must not key on the bounds
+   * being constants, or this form falls back to passing the receiver's shape through, which is the
+   * rank error <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a> removes.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testSlicedVariableBoundsOffParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_unresolved_indices.py",
+        "consume_variable_bounds",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_10_INT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1408,4 +1408,95 @@ public class TestShapeOps extends AbstractTensorTest {
         1,
         Map.of(2, Set.of(TENSOR_2_256_8_FLOAT32)));
   }
+
+  /**
+   * A column sliced out of a parameter keeps the receiver's rank instead of dropping the indexed
+   * axis, so {@code adjacency[:, 0]} reports rank 2 where the run-time value is rank 1.
+   *
+   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testSlicedIndicesOffParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_unresolved_indices.py",
+        "consume_direct_indices",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_30_INT32)));
+  }
+
+  /**
+   * The gather one hop past that slice composes the leaked rank, giving {@code (30, 2, 16)} where
+   * the run-time value is {@code (30, 16)}. The gather model is correct; its indices are not.
+   *
+   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testGatherOnSlicedIndicesOffParameter()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_unresolved_indices.py",
+        "consume_direct",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_30_16_FLOAT32)));
+  }
+
+  /**
+   * The same slice one container hop further out, the message-passing idiom: the element of an
+   * enumerated sequence carries no tensor type to the slice at all, so the indices are untyped
+   * rather than merely over-ranked.
+   *
+   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testSlicedIndicesThroughEnumeratedSequence()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_unresolved_indices.py",
+        "consume_listed_indices",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_30_INT32)));
+  }
+
+  /**
+   * The gather downstream of that untyped index, which falls to ⊤ and discards the table's known
+   * trailing axis. This is the shape of the loss reported in <a
+   * href="https://github.com/wala/ML/issues/823">wala/ML#823</a>; its cause is the untyped index
+   * above, so it clears when that does.
+   *
+   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test(expected = AssertionError.class)
+  public void testGatherThroughEnumeratedSequence()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_gather_unresolved_indices.py",
+        "consume_listed",
+        1,
+        1,
+        Map.of(2, Set.of(TENSOR_30_16_FLOAT32)));
+  }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -3,7 +3,7 @@ package com.ibm.wala.cast.python.ml.test.tensorflow.v2;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.FLOAT_32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.INT_32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_16_UINT8;
-import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_3_2_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_1_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_1_28_28_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_1_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_256_8_FLOAT32;
@@ -1184,10 +1184,11 @@ public class TestShapeOps extends AbstractTensorTest {
    * com.ibm.wala.cast.python.ml.client.TensorGenerator#dtypesFromSSAChain} recurses through the
    * dtype-preserving chain to the concrete {@code float32} input.
    *
-   * <p>TODO: the shape stays {@code (1, 1, 3, 2)} (the reshape result) rather than {@code (1, 1, 2,
-   * 2)} &mdash; the {@code [:, :, 1:, :]} subscript isn't reducing axis 2, a shape-precision gap
-   * tracked by <a href="https://github.com/wala/ML/issues/607">wala/ML#607</a>. This test pins the
-   * dtype recovery and the currently-observed shape.
+   * <p>The shape is now the reduced {@code (1, 1, 2, 2)} rather than the reshape result {@code (1,
+   * 1, 3, 2)}: the {@code [:, :, 1:, :]} subscript reduces axis 2 from 3 to 2, which closes <a
+   * href="https://github.com/wala/ML/issues/607">wala/ML#607</a>. That subscript sits in a method
+   * body, so it was one of the subscripts left unparsed by the recognizer wala/ML#824 fixed, and
+   * the unparsed fallback passed the receiver's own shape through unreduced.
    */
   @Test
   public void testSliceReshapePadDtype()
@@ -1197,7 +1198,7 @@ public class TestShapeOps extends AbstractTensorTest {
         "consume",
         1,
         1,
-        Map.of(2, Set.of(TENSOR_1_1_3_2_FLOAT32)));
+        Map.of(2, Set.of(TENSOR_1_1_2_2_FLOAT32)));
   }
 
   /**
@@ -1410,17 +1411,18 @@ public class TestShapeOps extends AbstractTensorTest {
   }
 
   /**
-   * A column sliced out of a parameter keeps the receiver's rank instead of dropping the indexed
-   * axis, so {@code adjacency[:, 0]} reports rank 2 where the run-time value is rank 1.
-   *
-   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   * A column sliced out of a parameter drops the indexed axis, so {@code adjacency[:, 0]} over a
+   * rank-2 receiver is rank 1 (<a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>).
+   * The subscript is inside a function body, where the {@code slice} builtin arrives by lexical
+   * read rather than by allocation; recognizing only the allocation left every subscript in a
+   * method unparsed, and the unparsed fallback passed the receiver's own shape through.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSlicedIndicesOffParameter()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(
@@ -1432,10 +1434,12 @@ public class TestShapeOps extends AbstractTensorTest {
   }
 
   /**
-   * The gather one hop past that slice composes the leaked rank, giving {@code (30, 2, 16)} where
-   * the run-time value is {@code (30, 16)}. The gather model is correct; its indices are not.
+   * The gather one hop past that slice still composes the receiver's rank, giving {@code (30, 2,
+   * 16)} where the run-time value is {@code (30, 16)}, even though the slice itself now resolves.
+   * The generator-side shape query walks the points-to set rather than the pinned dataflow state,
+   * and the points-to set still carries the receiver's allocation.
    *
-   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/825">wala/ML#825</a>.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -558,10 +558,15 @@ public class SliceBuiltinOperation extends TensorGenerator {
    * indexed axis.
    *
    * <p>Arity alone does not separate a construction from a two-dimensional application, which has
-   * the same four uses. The discriminator is the one {@code
-   * PythonTensorAnalysisEngine#isNonTensorSliceConstructor} uses: a construction's first bound is a
-   * constant ({@code None} or a literal), whereas an application's first argument is the computed
-   * subscripted object.
+   * the same four uses. The discriminator is the per-dimension marker {@code
+   * PythonTensorAnalysisEngine#isNonTensorSliceConstructor} also uses: an application's arguments
+   * carry the results of other slice invokes, one per subscripted dimension, and a construction's
+   * bounds never do.
+   *
+   * <p>That sibling additionally requires the first bound to be a constant. Requiring it here would
+   * reject {@code adjacency[lo:hi, 0]}, whose bounds are variables, sending it back to the
+   * receiver-passthrough fallback this exists to remove and reintroducing the rank error in another
+   * form.
    *
    * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the callee.
    * @param caller The caller {@link CGNode}.
@@ -576,8 +581,31 @@ public class SliceBuiltinOperation extends TensorGenerator {
     // `slice(lower, upper, step)` is the callable plus exactly its three bounds; anything wider is
     // an application, which pads the bounds behind the subscripted object.
     if (inv.getNumberOfUses() != 4) return false;
-    if (!caller.getIR().getSymbolTable().isConstant(inv.getUse(1))) return false;
-    for (CGNode callee : builder.getCallGraph().getPossibleTargets(caller, inv.getCallSite()))
+    if (!resolvesToSliceBuiltin(builder, caller, inv)) return false;
+    // A two-dimensional application has the same arity. Its arguments carry the per-dimension
+    // slice objects, which a construction's bounds never do.
+    for (int u = 1; u < inv.getNumberOfUses(); u++) {
+      SSAInstruction boundDef = caller.getDU().getDef(inv.getUse(u));
+      if (boundDef instanceof SSAAbstractInvokeInstruction
+          && resolvesToSliceBuiltin(builder, caller, (SSAAbstractInvokeInstruction) boundDef))
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns whether an invoke reaches the {@code slice} builtin. Resolution goes through the call
+   * graph rather than the callable's defining instruction, which keeps the answer independent of
+   * how the name was reached and correct when an enclosing scope rebinds it.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the targets.
+   * @param caller The caller {@link CGNode}.
+   * @param invoke The invoke to test.
+   * @return {@code true} iff a resolved callee is the {@code slice} builtin.
+   */
+  private static boolean resolvesToSliceBuiltin(
+      PropagationCallGraphBuilder builder, CGNode caller, SSAAbstractInvokeInstruction invoke) {
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(caller, invoke.getCallSite()))
       if (callee.getMethod().getReference().getDeclaringClass().equals(PythonTypes.SLICE_BUILTIN))
         return true;
     return false;

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/SliceBuiltinOperation.java
@@ -479,7 +479,7 @@ public class SliceBuiltinOperation extends TensorGenerator {
    */
   private SubscriptDim classifyDim(PropagationCallGraphBuilder builder, CGNode caller, int argVn) {
     if (argVn <= 0) return null;
-    if (isSliceObject(caller, argVn)) {
+    if (isSliceObject(builder, caller, argVn)) {
       SSAAbstractInvokeInstruction inv =
           (SSAAbstractInvokeInstruction) caller.getDU().getDef(argVn);
       // slice(lower, upper, step): uses 1, 2, 3.
@@ -546,23 +546,41 @@ public class SliceBuiltinOperation extends TensorGenerator {
 
   /**
    * Returns whether {@code argVn}'s defining instruction is a {@code slice(...)} object
-   * construction (an invoke whose callee is the {@link PythonTypes#SLICE_BUILTIN} allocation).
+   * construction, i.e. the object a {@code :} compiles to inside a multi-dimensional subscript.
    *
+   * <p>Resolution goes through the call graph rather than the callable's defining instruction (<a
+   * href="https://github.com/wala/ML/issues/824">wala/ML#824</a>). A subscript written at module
+   * scope reaches the builtin through a {@link SSANewInstruction}, but one written inside a
+   * function body reaches it through an {@code AstLexicalRead} of the enclosing scope's binding,
+   * and requiring the {@code new} recognized only the first. Every subscript in a method body was
+   * therefore unparsed, which fell through to the single-bound path and passed the receiver's own
+   * shape through, so {@code adjacency[:, 0]} reported the receiver's rank instead of dropping the
+   * indexed axis.
+   *
+   * <p>Arity alone does not separate a construction from a two-dimensional application, which has
+   * the same four uses. The discriminator is the one {@code
+   * PythonTensorAnalysisEngine#isNonTensorSliceConstructor} uses: a construction's first bound is a
+   * constant ({@code None} or a literal), whereas an application's first argument is the computed
+   * subscripted object.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} whose call graph resolves the callee.
    * @param caller The caller {@link CGNode}.
    * @param argVn The argument value number.
    * @return {@code true} iff {@code argVn} is defined by a slice-object construction.
    */
-  private static boolean isSliceObject(CGNode caller, int argVn) {
+  private static boolean isSliceObject(
+      PropagationCallGraphBuilder builder, CGNode caller, int argVn) {
     SSAInstruction def = caller.getDU().getDef(argVn);
     if (!(def instanceof SSAAbstractInvokeInstruction)) return false;
     SSAAbstractInvokeInstruction inv = (SSAAbstractInvokeInstruction) def;
-    if (inv.getNumberOfUses() < 4) return false;
-    SSAInstruction funcDef = caller.getDU().getDef(inv.getUse(0));
-    return funcDef instanceof SSANewInstruction
-        && ((SSANewInstruction) funcDef)
-            .getNewSite()
-            .getDeclaredType()
-            .equals(PythonTypes.SLICE_BUILTIN);
+    // `slice(lower, upper, step)` is the callable plus exactly its three bounds; anything wider is
+    // an application, which pads the bounds behind the subscripted object.
+    if (inv.getNumberOfUses() != 4) return false;
+    if (!caller.getIR().getSymbolTable().isConstant(inv.getUse(1))) return false;
+    for (CGNode callee : builder.getCallGraph().getPossibleTargets(caller, inv.getCallSite()))
+      if (callee.getMethod().getReference().getDeclaringClass().equals(PythonTypes.SLICE_BUILTIN))
+        return true;
+    return false;
   }
 
   /**

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_unresolved_indices.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_unresolved_indices.py
@@ -49,3 +49,18 @@ adjacency = tf.ones((30, 2), dtype=tf.int32)
 
 propagate_direct(node_embeddings, adjacency)
 propagate_listed(node_embeddings, [adjacency])
+
+
+def consume_variable_bounds(v):
+    pass
+
+
+# A slice whose bounds are variables rather than literals. The construction is the same
+# `slice(lower, upper, step)`; only the bounds differ, and the axis still reduces.
+def propagate_variable_bounds(adjacency, lo, hi):
+    window = adjacency[lo:hi, 0]
+    assert window.shape == (10,)
+    consume_variable_bounds(window)
+
+
+propagate_variable_bounds(adjacency, 0, 10)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_gather_unresolved_indices.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_gather_unresolved_indices.py
@@ -1,0 +1,51 @@
+import tensorflow as tf
+
+
+def consume_direct_indices(i):
+    pass
+
+
+def consume_direct(g):
+    pass
+
+
+def consume_listed_indices(i):
+    pass
+
+
+def consume_listed(g):
+    pass
+
+
+# Tier 1: the indices are a column sliced out of a parameter. `tf.gather`'s result is indexed
+# by the indices' shape with each entry a row of the table, so the trailing axis is the
+# table's regardless of what the indices resolve to.
+def propagate_direct(node_embeddings, adjacency):
+    edge_sources = adjacency[:, 0]
+    assert edge_sources.shape == (30,)
+    consume_direct_indices(edge_sources)
+
+    edge_source_states = tf.gather(node_embeddings, edge_sources)
+    assert edge_source_states.shape == (30, 16)
+    consume_direct(edge_source_states)
+
+
+# Tier 2: the same, one container hop further out, which is the shape the message-passing
+# idiom actually takes: the adjacency lists arrive as a sequence and are enumerated before a
+# column is sliced from each.
+def propagate_listed(node_embeddings, adjacency_lists):
+    for edge_type_idx, adjacency_list in enumerate(adjacency_lists):
+        edge_sources = adjacency_list[:, 0]
+        assert edge_sources.shape == (30,)
+        consume_listed_indices(edge_sources)
+
+        edge_source_states = tf.gather(node_embeddings, edge_sources)
+        assert edge_source_states.shape == (30, 16)
+        consume_listed(edge_source_states)
+
+
+node_embeddings = tf.ones((100, 16), dtype=tf.float32)
+adjacency = tf.ones((30, 2), dtype=tf.int32)
+
+propagate_direct(node_embeddings, adjacency)
+propagate_listed(node_embeddings, [adjacency])


### PR DESCRIPTION
Fixes #824. Closes #607.

The `isSliceObject` check required the `slice` builtin to arrive as an `SSANewInstruction`. That holds at module scope and nowhere else: inside a function body the builtin comes from an `AstLexicalRead` of the enclosing scope's binding, so **every multi-dimensional subscript written in a method was unparsed**.

The IR makes it plain. For `adjacency[:, 0]` inside a function:

```
1   v9 = lexical:slice@Lscript ...                      <- not an SSANewInstruction
2   v8 = invokeFunction v9, v10:#null, v10:#null, v10:#null    <- slice(None, None, None)
3   v5 = invokeFunction v7, v3, v8, v12:#0                    <- adjacency[:, 0]
```

An unparsed subscript falls through to the single-bound path, which does not match either, and its fallback passes the receiver's own shape through:

```
[SliceBuiltinOperation] Resolved ... receiverShapes=[[D:Constant,30, D:Constant,2]]
[SliceBuiltinOperation] Non-[:k] pattern; passing receiver shape through
[TensorGenerator] Generator SliceBuiltinOperation produced types: [{[D:Constant,30, D:Constant,2] of int32}]
```

Over-ranking is the damaging direction: a rank-1 argument is not a subtype of a rank-2 specification, so a signature written from the leaked shape rejects every call the function actually receives.

## The Fix

Resolution goes through the call graph, which does not care how the callable was reached.

Arity alone cannot separate a construction from a two-dimensional application, since both have four uses. The discriminator is the one `isNonTensorSliceConstructor` already uses for the same ambiguity: a construction's first bound is a constant (`None` or a literal), whereas an application's first argument is the computed subscripted object.

## Why #607 Closes With It

The `reshaped[:, :, 1:, :]` subscript sits in `RelativeGlobalAttention._skewing`, a method body, so it was unparsed for exactly this reason and its axis 2 went unreduced. The `testSliceReshapePadDtype` guard pinned the unreduced `(1, 1, 3, 2)` with a `TODO` naming #607; it now pins the reduced `(1, 1, 2, 2)` and the `TODO` is gone. That test was the only one the change moved.

## What Stays Blocked

Three cases in the vendored reproduction keep their `TODO`s.

The `tf.gather` one hop past the now-fixed slice still composes the receiver's rank, giving `(30, 2, 16)` where the truth is `(30, 16)`. The slice resolves correctly at a sink, so the generator-side shape query is reading something else: it walks the points-to set rather than the pinned dataflow state, and the points-to set still aliases the subscript result with the receiver's allocation. Filed as #825.

The two `enumerate` cases are unchanged: an element of an enumerated sequence carries no tensor type to the slice at all, so there is nothing to reduce.

## Tests

1208 tests, 0 failures. The reproduction fixture runs to completion under `python3.10` with its shape asserts live.
