### PR TITLE
Model `enumerate` as yielding (index, element) tuples

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNetworkFixtures.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestNetworkFixtures.java
@@ -27,7 +27,6 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 import static com.ibm.wala.cast.python.util.Util.addPytestEntrypoints;
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -490,9 +489,12 @@ public class TestNetworkFixtures extends AbstractTensorTest {
    * is the same context-collapse class as <a
    * href="https://github.com/wala/ML/issues/570">wala/ML#570</a>.
    *
-   * <p>TODO(<a href="https://github.com/wala/ML/issues/659">wala/ML#659</a>): {@code index} should
-   * type as a tensor once the shared-summary context collapse is resolved. Flip this to assert vn=2
-   * <em>is</em> typed when it is fixed.
+   * <p>The chain no longer depends on that read. {@code enumerate} yields {@code (index, element)}
+   * tuples whose field 1 <em>is</em> the element rather than a field read off it (<a
+   * href="https://github.com/wala/ML/issues/826">wala/ML#826</a>), so the subscript sees the
+   * adjacency list and {@code index} types. Whether the underlying shared-summary context collapse
+   * of <a href="https://github.com/wala/ML/issues/659">wala/ML#659</a> is itself resolved is a
+   * separate question this fixture no longer witnesses.
    */
   @Test
   public void testGatMaybeNumNodesIndexUntyped()
@@ -544,10 +546,9 @@ public class TestNetworkFixtures extends AbstractTensorTest {
               typedParamVns.add(lpk.getValueNumber());
           }
         });
-    assertFalse(
-        "Captured gap for wala/ML#659: `maybe_num_nodes`'s `index` (vn=2) is currently untyped"
-            + " because `adjacency_lists` is context-collapsed on the shared message-passing"
-            + " summary. Flip this assertion when the collapse is resolved.",
+    assertTrue(
+        "`maybe_num_nodes`'s `index` (vn=2) types as a tensor: the element of an enumerated"
+            + " sequence now reaches the subscript that produces it (wala/ML#826).",
         typedParamVns.contains(2));
   }
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestShapeOps.java
@@ -1458,18 +1458,18 @@ public class TestShapeOps extends AbstractTensorTest {
   }
 
   /**
-   * The same slice one container hop further out, the message-passing idiom: the element of an
-   * enumerated sequence carries no tensor type to the slice at all, so the indices are untyped
-   * rather than merely over-ranked.
-   *
-   * <p>TODO: Blocked by <a href="https://github.com/wala/ML/issues/824">wala/ML#824</a>.
+   * The same slice one container hop further out, the message-passing idiom. The element of an
+   * enumerated sequence now carries its tensor type to the slice, so the index resolves here as it
+   * does in the direct form (<a href="https://github.com/wala/ML/issues/826">wala/ML#826</a>).
+   * Before that, {@code enumerate} returned its argument, so iterating yielded the sequence's
+   * elements and the destructuring read empty fields off one of them.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testSlicedIndicesThroughEnumeratedSequence()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
+++ b/com.ibm.wala.cast.python/source/com/ibm/wala/cast/python/ipa/summaries/BuiltinFunctions.java
@@ -146,6 +146,62 @@ public class BuiltinFunctions {
   }
 
   /**
+   * Builds the summary for {@code enumerate}: a freshly-allocated list holding one tuple whose
+   * field 0 is an {@code int} index and whose field 1 is an element of the argument. Iterating the
+   * result and unpacking each element (the {@code for i, x in enumerate(xs)} idiom) then binds
+   * {@code i} to the index and {@code x} to the input's element.
+   *
+   * <p>Previously {@code enumerate} returned its argument, so iterating it yielded the sequence's
+   * elements rather than {@code (index, element)} pairs, and the destructuring read fields 0 and 1
+   * off the element itself. Both reads were empty, so {@code x} was untyped and the element's type
+   * was stranded on the value nothing read. Same shape as {@code zip} (wala/ML#618), and the same
+   * starvation as {@code range} (wala/ML#599). See <a
+   * href="https://github.com/wala/ML/issues/826">wala/ML#826</a>.
+   *
+   * @param cls The builtin function class whose summary this is.
+   * @param name The builtin's name ({@code enumerate}).
+   * @return The populated summary.
+   */
+  private static IMethod enumerateSummary(IClass cls, String name) {
+    TypeReference type = builtinFunction(name);
+    MethodReference ref = MethodReference.findOrCreate(type, AstMethodReference.fnSelector);
+    PythonSummary x = new PythonSummary(ref, 10);
+
+    AstInstructionFactory factory = PythonLanguage.Python.instructionFactory();
+    int container = 11;
+    int tuple = 12;
+    int index = 13;
+    int nullKey = 14;
+    int zero = 15;
+    int one = 16;
+    int elementKey = 17;
+    int element = 18;
+    int idx = 0;
+
+    x.addStatement(
+        factory.NewInstruction(idx++, container, NewSiteReference.make(0, PythonTypes.list)));
+    x.addStatement(
+        factory.NewInstruction(idx++, tuple, NewSiteReference.make(1, PythonTypes.tuple)));
+    // The counter `enumerate` supplies, which is an int regardless of what is being enumerated.
+    x.addStatement(
+        factory.NewInstruction(idx++, index, NewSiteReference.make(2, TypeReference.Int)));
+    x.addConstant(nullKey, new ConstantValue(null));
+    x.addConstant(zero, new ConstantValue(0));
+    x.addConstant(one, new ConstantValue(1));
+
+    // The element of the enumerated argument, read the way `zip` reads its inputs'.
+    x.addStatement(factory.EachElementGetInstruction(idx++, elementKey, 2, nullKey));
+    x.addStatement(factory.PropertyRead(idx++, element, 2, elementKey));
+
+    x.addStatement(factory.PropertyWrite(idx++, tuple, zero, index));
+    x.addStatement(factory.PropertyWrite(idx++, tuple, one, element));
+    x.addStatement(factory.PropertyWrite(idx++, container, zero, tuple));
+    x.addStatement(factory.ReturnInstruction(idx++, container, false));
+
+    return new PythonSummarizedFunction(ref, x, cls);
+  }
+
+  /**
    * Builds the summary for {@code next}: a read of the {@value
    * PythonTypes#GENERATOR_CONTENT_FIELD_NAME} field off the argument. A generator function's object
    * accumulates every yielded value in that field (the front-end translates {@code yield x} as a
@@ -284,16 +340,21 @@ public class BuiltinFunctions {
                   // see `zipSummary` (wala/ML#618).
                   : name.equals("zip")
                       ? zipSummary(this, name)
-                      // `next` must read the yields accumulated on a generator object; see
-                      // `nextSummary` (wala/ML#696).
-                      : name.equals("next")
-                          ? nextSummary(this, name)
-                          // `iter` must carry its argument's generator content through the fresh
-                          // iterator so that `next(iter(gen()))` recovers the yields; see
-                          // `iterSummary` (wala/ML#698).
-                          : name.equals("iter")
-                              ? iterSummary(this, name)
-                              : typeSummary(this, name, returnedType);
+                      // `enumerate` must return a list of (index, element) tuples rather than its
+                      // argument; see `enumerateSummary` (wala/ML#826).
+                      : name.equals("enumerate")
+                          ? enumerateSummary(this, name)
+                          // `next` must read the yields accumulated on a generator object; see
+                          // `nextSummary` (wala/ML#696).
+                          : name.equals("next")
+                              ? nextSummary(this, name)
+                              // `iter` must carry its argument's generator content through the
+                              // fresh
+                              // iterator so that `next(iter(gen()))` recovers the yields; see
+                              // `iterSummary` (wala/ML#698).
+                              : name.equals("iter")
+                                  ? iterSummary(this, name)
+                                  : typeSummary(this, name, returnedType);
     }
 
     private BuiltinFunction(IClassHierarchy cha, String name, int arg) {
@@ -473,8 +534,11 @@ public class BuiltinFunctions {
       HashMapFactory.make();
 
   static {
-    //		builtinFunctions.put("enumerate", Either.forLeft(PythonTypes.enumerate));
-    builtinFunctions.put("enumerate", Either.forRight(2));
+    // Returns a list of `(index, element)` tuples, built by `enumerateSummary` (wala/ML#826). The
+    // previous `forRight(2)` returned the argument itself, so iterating the result yielded the
+    // sequence's elements and the `for i, x in enumerate(xs)` destructuring read empty fields off
+    // one of them.
+    builtinFunctions.put("enumerate", Either.forLeft(PythonTypes.list));
     builtinFunctions.put("int", Either.forLeft(TypeReference.Int));
     // https://docs.python.org/3/library/functions.html#float
     builtinFunctions.put("float", Either.forLeft(TypeReference.Double));


### PR DESCRIPTION
Fixes #826.

`enumerate` returned its argument. Iterating the result therefore yielded the sequence's **elements** rather than pairs, and `for i, x in enumerate(xs)` read fields 0 and 1 off an element. Both reads were empty: `x` was untyped, and the element's type sat on the value nothing read.

```
v14  (the yielded item)   -> the Tensor allocation
v18  (v14.field0 -> i)    -> []
v20  (v14.field1 -> x)    -> []
```

## The Fix

A list holding one tuple whose field 0 is an `int` index and whose field 1 is an element of the argument. This is the shape `zip` has carried since #618, and the same starvation `range` had in #599. `enumerateSummary` is `zipSummary` with a counter in field 0.

The element is read the way `zip` reads its inputs': field 1 **is** the element rather than a field read off it. That distinction is what makes the fix work where the chain was previously stalled.

The registration changes from `Either.forRight(2)`, which returns the argument, to `Either.forLeft(PythonTypes.list)`, with a dispatch arm alongside `zip`, `range`, `next` and `iter`.

## Tests

`testSlicedIndicesThroughEnumeratedSequence` becomes a positive guard: a column sliced out of an enumerated element now resolves as it does in the direct form.

`testGatMaybeNumNodesIndexUntyped` was pinning the same shape from the other end. It is a captured gap for #659, where `maybe_num_nodes`'s `index` never typed because the subscript of an enumerated element returned bottom. It types now, so the assertion is flipped and the `TODO` removed. **#659 stays open**: whether its shared-summary context collapse is itself resolved is a separate question this fixture no longer witnesses, and I would rather leave it open than close it on a witness that stopped witnessing.

`testGatherThroughEnumeratedSequence` stays blocked. The gather one hop past the now-resolved index still reads the points-to set rather than the pinned dataflow state, which is #825 and is identical in the direct form.

1209 tests, 0 failures.
