### PR TITLE
Model the NumPy scalar types and `np.random`

### DIFF
--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -175,6 +175,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
 
   protected static final TensorType TENSOR_2_2_FLOAT32 = TensorType.of(FLOAT_32, 2, 2);
 
+  protected static final TensorType TENSOR_2_2_FLOAT64 = TensorType.of(FLOAT_64, 2, 2);
+
   protected static final TensorType TENSOR_NONE_32_FLOAT32 =
       new TensorType(FLOAT_32, asList(DynamicDim.INSTANCE, new NumericDim(32)));
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/AbstractTensorTest.java
@@ -107,6 +107,9 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
   protected static final TensorType SCALAR_TENSOR_OF_FLOAT32 =
       new TensorType(FLOAT_32, emptyList());
 
+  protected static final TensorType SCALAR_TENSOR_OF_FLOAT64 =
+      new TensorType(FLOAT_64, emptyList());
+
   protected static final TensorType SCALAR_TENSOR_OF_STRING = new TensorType(STRING, emptyList());
 
   protected static final TensorType SCALAR_TENSOR_OF_BOOL = new TensorType(BOOL, emptyList());
@@ -487,6 +490,8 @@ public abstract class AbstractTensorTest extends TestPythonMLCallGraphShape {
   protected static final TensorType TENSOR_3_5_FLOAT32 = TensorType.of(FLOAT_32, 3, 5);
 
   protected static final TensorType TENSOR_4_FLOAT64 = TensorType.of(FLOAT_64, 4);
+
+  protected static final TensorType TENSOR_5_2_FLOAT64 = TensorType.of(FLOAT_64, 5, 2);
 
   protected static final TensorType TENSOR_5_FLOAT32 = TensorType.of(FLOAT_32, 5);
 

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestConstructors.java
@@ -8,6 +8,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.INT_32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.INT_64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.SCALAR_TENSOR_OF_BOOL;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.SCALAR_TENSOR_OF_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.SCALAR_TENSOR_OF_INT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.STRING;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_0_0_FLOAT32;
@@ -1706,5 +1707,79 @@ public class TestConstructors extends AbstractTensorTest {
   public void testZerosBoolMask()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_bool_mask.py", "consume", 1, 1, Map.of(2, Set.of(TENSOR_2_2_BOOL)));
+  }
+
+  /**
+   * A NumPy scalar type called on a Python number (<a
+   * href="https://github.com/wala/ML/issues/827">wala/ML#827</a>): {@code np.float64(2.0)} is a
+   * rank-0 array of the type's own dtype, not of the argument's.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpScalarType()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_scalar_types.py",
+        "consume",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT64)));
+  }
+
+  /**
+   * The reported witness of <a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>: {@code
+   * tf.Variable(np.float64(2.0))} keeps the NumPy scalar's {@code float64}, where a Python number
+   * would have taken TensorFlow's {@code float32} weak default. The initializer propagation this
+   * exercises was never the gap; the scalar type being unmodeled was.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpScalarTypeVariableInitializer()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_scalar_types.py",
+        "consume2",
+        1,
+        1,
+        Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT64)));
+  }
+
+  /**
+   * The integral sibling of {@link #testNpScalarType()}: {@code np.int32(3)}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpScalarTypeInt()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test(
+        "tf2_test_np_scalar_types.py", "consume3", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_INT32)));
+  }
+
+  /**
+   * The scalar type's other role (<a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>):
+   * {@code np.zeros((2, 3), dtype=np.float64)} still resolves its dtype token, which making the
+   * name callable must not cost.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpScalarTypeAsDTypeToken()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_scalar_types.py", "consume4", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT64)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestElementwiseOps.java
@@ -1703,23 +1703,23 @@ public class TestElementwiseOps extends AbstractTensorTest {
   }
 
   /**
-   * Test a {@code W * x + b} chain whose {@code W} and {@code b} are scalar {@code tf.Variable}s.
-   * The runtime truth is {@code float32 (3,)}, but the {@code tf.Variable} allocation never reaches
-   * the {@code W} operand's points-to walk, and the one-sided broadcast rule discards the resolved
-   * {@code [3]} because the opaque co-operand is not structurally a scalar expression. Mirrors the
-   * TensorFlow-Examples linear-regression rows whose concrete member degraded to ⊤ at 0.52.73, when
-   * the wala/ML#796 null-skip removed the fabricated scalar member the broadcast had been riding.
+   * Test a {@code W * x + b} chain whose {@code W} and {@code b} are scalar {@code tf.Variable}s,
+   * against the runtime truth of {@code float32 (3,)}. Mirrors the TensorFlow-Examples
+   * linear-regression rows whose concrete member degraded to ⊤ at 0.52.73, when the wala/ML#796
+   * null-skip removed the fabricated scalar member the broadcast had been riding.
    *
-   * <p>TODO: Flip to a positive guard when <a
-   * href="https://github.com/wala/ML/issues/804">wala/ML#804</a> lands (scalar {@code tf.Variable}
-   * operands recognized by the one-sided elementwise broadcast).
+   * <p>The chain used to floor to ⊤ because {@code W}'s initializer is {@code rng.randn()} and
+   * {@code np.random} was unmodeled, so the operand was ⊤ rather than the rank-0 tensor it is. With
+   * the initializer resolving (<a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>) the
+   * operand is scalar outright, and the elementwise composition never reaches the one-sided
+   * broadcast rule that <a href="https://github.com/wala/ML/issues/804">wala/ML#804</a> reports on.
    *
    * @throws ClassHierarchyException On WALA class-hierarchy error.
    * @throws IllegalArgumentException On illegal argument.
    * @throws CancelException On analysis cancellation.
    * @throws IOException On I/O error reading the test file.
    */
-  @Test(expected = AssertionError.class)
+  @Test
   public void testScalarVariableBroadcast()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test(

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestRandomOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestRandomOps.java
@@ -4,6 +4,7 @@ import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_10_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_10_2_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_FLOAT64;
@@ -225,5 +226,36 @@ public class TestRandomOps extends AbstractTensorTest {
   public void testNpRandomNormal()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     test("tf2_test_np_random.py", "consume4", 1, 1, Map.of(2, Set.of(TENSOR_5_2_FLOAT64)));
+  }
+
+  /**
+   * The sibling distribution under the sized signature, {@code np.random.uniform(0.0, 1.0, (2,
+   * 2))}: the two share a generator, so this pins that both names reach it.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomUniform()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume5", 1, 1, Map.of(2, Set.of(TENSOR_2_2_FLOAT64)));
+  }
+
+  /**
+   * The sized family's own shapeless draw, {@code np.random.normal()}: omitting {@code size} is the
+   * scalar case that {@link #testNpRandomScalarDraw()} reaches through an empty argument list, so
+   * the two recognitions are pinned separately.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomSizedScalarDraw()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume6", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
   }
 }

--- a/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestRandomOps.java
+++ b/com.ibm.wala.cast.python.ml.test/source/com/ibm/wala/cast/python/ml/test/tensorflow/v2/TestRandomOps.java
@@ -1,11 +1,15 @@
 package com.ibm.wala.cast.python.ml.test.tensorflow.v2;
 
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.SCALAR_TENSOR_OF_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_10_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_10_2_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_3_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_2_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_30_3_2_FLOAT32;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_4_FLOAT64;
+import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_5_2_FLOAT64;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_7_5_2_FLOAT32;
 import static com.ibm.wala.cast.python.ml.test.tensorflow.v2.AbstractTensorTest.TENSOR_UNKNOWN_SHAPE_FLOAT32;
 
@@ -159,5 +163,67 @@ public class TestRandomOps extends AbstractTensorTest {
         1,
         1,
         Map.of(2, Set.of(TENSOR_UNKNOWN_SHAPE_FLOAT32)));
+  }
+
+  /**
+   * The reported witness of <a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>: {@code
+   * tf.Variable(rng.randn())} over the module-alias form. A shapeless draw is a Python number, so
+   * the variable takes TensorFlow's {@code float32} weak default rather than NumPy's {@code
+   * float64}.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomScalarDraw()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume", 1, 1, Map.of(2, Set.of(SCALAR_TENSOR_OF_FLOAT32)));
+  }
+
+  /**
+   * The array half of {@link #testNpRandomScalarDraw()}: {@code np.random.randn(2, 3)} names its
+   * shape variadically and draws {@code float64}, so the same call site's arity decides both axes.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomRandn()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume2", 1, 1, Map.of(2, Set.of(TENSOR_2_3_FLOAT64)));
+  }
+
+  /**
+   * The rank-1 variadic draw, {@code np.random.rand(4)}: the sibling distribution of {@link
+   * #testNpRandomRandn()} under the same signature shape.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomRand()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume3", 1, 1, Map.of(2, Set.of(TENSOR_4_FLOAT64)));
+  }
+
+  /**
+   * The sized draw, {@code np.random.normal(0.0, 1.0, (5, 2))}: the shape is the {@code size}
+   * argument, so the two distribution parameters ahead of it must not be read as dimensions.
+   *
+   * @throws ClassHierarchyException On WALA class-hierarchy error.
+   * @throws IllegalArgumentException On illegal argument.
+   * @throws CancelException On analysis cancellation.
+   * @throws IOException On I/O error reading the test file.
+   */
+  @Test
+  public void testNpRandomNormal()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+    test("tf2_test_np_random.py", "consume4", 1, 1, Map.of(2, Set.of(TENSOR_5_2_FLOAT64)));
   }
 }

--- a/com.ibm.wala.cast.python.ml/data/numpy.xml
+++ b/com.ibm.wala.cast.python.ml/data/numpy.xml
@@ -4,21 +4,39 @@
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">
       <method name="import" static="true" descriptor="()Lnumpy;">
+        <!-- The `Lnumpy` module object must stay this method's FIRST allocation: the dtype-argument resolver reaches it as `NewSiteReference.make(0, NUMPY_TYPE)` in this node to test whether a candidate token is one of the fields below. -->
         <new def="x" class="Lnumpy"/>
-        <new def="float32" class="Ltensorflow/dtypes/DType"/>
+        <!-- https://numpy.org/doc/stable/reference/arrays.scalars.html -->
+        <!-- The scalar types are type objects, so each name has two roles: passed as `dtype=`, it names a dtype; called, it constructs a rank-0 array of that dtype (`np.float64(2.0)`). Both roles are served by a single allocation per name, whose class is the constructor's (dispatching `NpScalarType`) rather than `Ltensorflow/dtypes/DType`. The dtype role survives the class change because the dtype-argument resolver matches a token by its identity in the module field's points-to set, not by its allocated class; the class-keyed arms that back that resolution up read `NumpyTypes.SCALAR_TYPE_TO_DTYPE`. wala/ML#827. -->
+        <new def="float32" class="Lnumpy/float32"/>
         <putfield class="LRoot" field="float32" fieldType="LRoot" ref="x" value="float32"/>
-        <new def="float64" class="Ltensorflow/dtypes/DType"/>
+        <new def="float64" class="Lnumpy/float64"/>
         <putfield class="LRoot" field="float64" fieldType="LRoot" ref="x" value="float64"/>
-        <new def="int32" class="Ltensorflow/dtypes/DType"/>
+        <new def="int32" class="Lnumpy/int32"/>
         <putfield class="LRoot" field="int32" fieldType="LRoot" ref="x" value="int32"/>
-        <new def="int64" class="Ltensorflow/dtypes/DType"/>
+        <new def="int64" class="Lnumpy/int64"/>
         <putfield class="LRoot" field="int64" fieldType="LRoot" ref="x" value="int64"/>
-        <new def="uint8" class="Ltensorflow/dtypes/DType"/>
+        <new def="uint8" class="Lnumpy/uint8"/>
         <putfield class="LRoot" field="uint8" fieldType="LRoot" ref="x" value="uint8"/>
+        <!-- `np.bool` is not a scalar type: it was an alias of the Python builtin, deprecated in NumPy 1.20 and removed in 1.24, so it stays a bare dtype token. Its scalar-type sibling is `np.bool_`. -->
         <new def="bool" class="Ltensorflow/dtypes/DType"/>
         <putfield class="LRoot" field="bool" fieldType="LRoot" ref="x" value="bool"/>
-        <new def="bool_" class="Ltensorflow/dtypes/DType"/>
+        <new def="bool_" class="Lnumpy/bool_"/>
         <putfield class="LRoot" field="bool_" fieldType="LRoot" ref="x" value="bool_"/>
+        <!-- https://numpy.org/doc/stable/reference/random/legacy.html -->
+        <!-- `np.random`, the legacy module-level random surface, modeled as a plain module object (the pattern `tensorflow.xml` uses for `tf.random`) whose fields hold the per-function classes. The module-alias form `rng = np.random` reaches the same fields, since the alias copies the reference. wala/ML#827. -->
+        <new def="random" class="Lobject"/>
+        <putfield class="LRoot" field="random" fieldType="LRoot" ref="x" value="random"/>
+        <new def="randn_fn" class="Lnumpy/random/randn"/>
+        <putfield class="LRoot" field="randn" fieldType="LRoot" ref="random" value="randn_fn"/>
+        <new def="rand_fn" class="Lnumpy/random/rand"/>
+        <putfield class="LRoot" field="rand" fieldType="LRoot" ref="random" value="rand_fn"/>
+        <new def="np_normal_fn" class="Lnumpy/random/normal"/>
+        <putfield class="LRoot" field="normal" fieldType="LRoot" ref="random" value="np_normal_fn"/>
+        <new def="np_uniform_fn" class="Lnumpy/random/uniform"/>
+        <putfield class="LRoot" field="uniform" fieldType="LRoot" ref="random" value="np_uniform_fn"/>
+        <new def="seed_fn" class="Lnumpy/random/seed"/>
+        <putfield class="LRoot" field="seed" fieldType="LRoot" ref="random" value="seed_fn"/>
         <new def="ndarray_fn" class="Lnumpy/ndarray_constructor"/>
         <putfield class="LRoot" field="ndarray" fieldType="LRoot" ref="x" value="ndarray_fn"/>
         <new def="array_fn" class="Lnumpy/array"/>
@@ -37,6 +55,80 @@
       </method>
     </class>
     <package name="numpy">
+      <!-- https://numpy.org/doc/stable/reference/arrays.scalars.html -->
+      <!-- The scalar type constructors. Calling one coerces its argument to a rank-0 array of that type, so each `do` allocates an ndarray whose shape and dtype the paired `NpScalarType` fixes; the argument contributes neither axis. The same allocation doubles as the `dtype=` token — see the module method above. wala/ML#827. -->
+      <class name="float32" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <class name="float64" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <class name="int32" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <class name="int64" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <class name="uint8" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <class name="bool_" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self value">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
       <!-- https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html -->
       <!-- The `np.ndarray(shape, dtype, ...)` constructor: an uninitialized array of the given shape and dtype, so the typing model is the `zeros` allocator's (shape from arg 0, dtype from the `dtype` argument) and the dispatch reuses `NpZeros`. wala/ML#775. -->
       <class name="ndarray_constructor" allocatable="true">
@@ -167,6 +259,72 @@
           <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
           <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
           <return value="ret"/>
+        </method>
+      </class>
+    </package>
+    <package name="numpy/random">
+      <!-- The legacy module-level random surface. Every draw returns a `float64` array of the requested shape, except that a draw with no shape request returns a Python scalar instead; the shape request is spelled as variadic dimensions here and as a `size` argument in the `normal`/`uniform` family, which is why the two shapes of signature take different generators (`NpRandomVariadicDraw` and `NpRandomSizedDraw`). Both allocate the same `Lnumpy/ndarray` and let the generator decide which case a given call is. wala/ML#827. -->
+      <!-- https://numpy.org/doc/stable/reference/random/generated/numpy.random.randn.html -->
+      <!-- `np.random.randn(d0, d1, ...)`: standard-normal draws, dimensions given variadically. The rank comes from the call's own arity rather than from the parameter list below, so a call passing more dimensions than are modeled here keeps its rank; what it can lose is the individual sizes, which then read as unknown fixed axes. -->
+      <class name="randn" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self d0 d1 d2 d3 d4 d5">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/random/generated/numpy.random.rand.html -->
+      <!-- `np.random.rand(d0, d1, ...)`: uniform draws over [0, 1), variadic like `randn`. -->
+      <class name="rand" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self d0 d1 d2 d3 d4 d5">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html -->
+      <!-- `np.random.normal(loc, scale, size)`: the shape is the `size` argument, so the distribution parameters occupy the two positions before it. -->
+      <class name="normal" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self loc scale size">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/random/generated/numpy.random.uniform.html -->
+      <!-- `np.random.uniform(low, high, size)`: the `normal` signature with different distribution parameters. -->
+      <class name="uniform" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self low high size">
+          <new def="ret" class="Lnumpy/ndarray"/>
+          <new def="astype_fn" class="Lnumpy/ndarray/astype"/>
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn"/>
+          <new def="tolist_fn" class="Lnumpy/ndarray/tolist"/>
+          <putfield class="LRoot" field="tolist" fieldType="LRoot" ref="ret" value="tolist_fn"/>
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape"/>
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn"/>
+          <return value="ret"/>
+        </method>
+      </class>
+      <!-- https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html -->
+      <!-- `np.random.seed(seed)` mutates the global generator state and returns `None`. Modeled so that the call resolves to a target and its result is `None` rather than an unmodeled value; there is no generator, so the result is not a tensor source. -->
+      <class name="seed" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self seed">
+          <return value="null"/>
         </method>
       </class>
     </package>

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EyeBase.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/EyeBase.java
@@ -4,18 +4,14 @@ import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
 import com.ibm.wala.ipa.callgraph.CGNode;
-import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * Shared base for identity-matrix generators ({@code tf.eye} and {@code tf.sparse.eye}): the {@code
@@ -49,49 +45,6 @@ public abstract class EyeBase extends TensorTypeAllocator {
 
   public EyeBase(CGNode node) {
     super(node);
-  }
-
-  /**
-   * Retrieves the possible integer values for a specific argument.
-   *
-   * <p>It first checks the symbol table for constant values associated with the argument's value
-   * number. If not found, it falls back to the points-to analysis results to find potential integer
-   * values.
-   *
-   * @param builder the propagation call graph builder
-   * @param paramPosition the positional index of the argument
-   * @param paramName the keyword name of the argument
-   * @return a set of optional integers representing the possible values. An empty optional
-   *     indicates a null or non-integer value.
-   */
-  protected Set<Optional<Integer>> getPossibleArgumentValues(
-      PropagationCallGraphBuilder builder, int paramPosition, String paramName) {
-    int valNum = this.getArgumentValueNumber(builder, paramPosition, paramName, true);
-    if (valNum <= 0) return HashSetFactory.make();
-
-    if (this.getNode().getIR() != null
-        && this.getNode().getIR().getSymbolTable().isConstant(valNum)) {
-      Object c = this.getNode().getIR().getSymbolTable().getConstantValue(valNum);
-      Set<Optional<Integer>> ret = HashSetFactory.make();
-      if (c instanceof Number) {
-        ret.add(Optional.of(((Number) c).intValue()));
-      } else if (c == null) {
-        ret.add(Optional.empty());
-      }
-      if (!ret.isEmpty()) {
-        return ret;
-      }
-    }
-
-    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPosition, paramName);
-
-    if (pts == null || pts.isEmpty())
-      // Fallback to default (empty).
-      return HashSetFactory.make();
-
-    return StreamSupport.stream(pts.spliterator(), false)
-        .map(TensorTypeAllocator::getIntValueFromInstanceKey)
-        .collect(Collectors.toSet());
   }
 
   @Override

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomDraw.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomDraw.java
@@ -1,0 +1,133 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT64;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Shared base for the draws on NumPy's legacy module-level random surface, {@code np.random.randn}
+ * and friends. Every draw returns a {@code float64} array of the requested shape &mdash; except
+ * that a draw with no shape request returns a single Python {@code float} instead, which is why the
+ * return type is argument-dependent rather than fixed. Subclasses differ only in how their
+ * signature spells the shape request, and therefore in how they recognize its absence.
+ *
+ * <p>The no-request case matters more than its rarity suggests: {@code tf.Variable(rng.randn())} is
+ * the corpus idiom, and TensorFlow's weak default converts a Python number to {@code float32}, not
+ * to NumPy's {@code float64}. The dtype lattice has no element for "a Python number", so the case
+ * is modeled as a rank-0 {@code float32}, which is the encoding the analysis already gives a Python
+ * float literal ({@code TensorGenerator.getDTypesOfValue} reads one as {@code float32}) and is what
+ * every TensorFlow consumer computes for the value. It does diverge from NumPy's own promotion,
+ * which reads a Python float as {@code float64}: {@code np.array(np.random.randn())} is a {@code
+ * float64} array at runtime and a {@code float32} one here. See <a
+ * href="https://github.com/wala/ML/issues/827">wala/ML#827</a>.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/random/legacy.html">NumPy legacy random
+ *     generation</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public abstract class NpRandomDraw extends TensorTypeAllocator {
+
+  private static final Logger LOGGER = getLogger(NpRandomDraw.class.getName());
+
+  public NpRandomDraw(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpRandomDraw(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * Whether this call requests no shape, and so draws a single Python number rather than an array.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code true} iff the call makes no shape request.
+   */
+  protected abstract boolean isScalarDraw(PropagationCallGraphBuilder builder);
+
+  /**
+   * The shapes of an array draw, i.e. one whose call does make a shape request. Reached only when
+   * the request did not already resolve through the inherited shape-argument machinery, so the
+   * default is that base's ⊤.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The drawn array's shapes, or {@code null} (⊤) if the request does not resolve.
+   */
+  protected Set<List<Dimension<?>>> getArrayDrawShapes(PropagationCallGraphBuilder builder) {
+    return super.getDefaultShapes(builder);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>A draw with no shape request is a single Python number, so it is rank 0.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The singleton rank-0 shape for a scalar draw, else the array draw's shapes.
+   */
+  @Override
+  protected final Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    if (this.isScalarDraw(builder)) {
+      LOGGER.fine(
+          () ->
+              "No shape requested of "
+                  + this.getSignature()
+                  + " for source: "
+                  + describe(this.getSource())
+                  + "; the draw is a scalar.");
+      return Set.of(List.of());
+    }
+
+    return this.getArrayDrawShapes(builder);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>An array draw is {@code float64}, NumPy's floating-point default. A scalar draw is a Python
+   * {@code float}, which this analysis encodes as {@code float32}; see the class comment for why
+   * and for where that encoding diverges from NumPy's own promotion.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return A singleton set holding the drawn value's dtype.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return this.isScalarDraw(builder) ? EnumSet.of(FLOAT32) : EnumSet.of(FLOAT64);
+  }
+
+  /**
+   * Returns the producing library of the modeled value: a {@code np.random} draw, so the value is
+   * an ndarray or a Python number (wala/ML#724). Neither is a TensorFlow computation, which is the
+   * distinction the origin exists to record.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomSizedDraw.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomSizedDraw.java
@@ -1,0 +1,97 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+/**
+ * Generator for the {@code np.random} draws that spell their shape as a {@code size} argument,
+ * {@code np.random.normal(loc, scale, size)} and {@code np.random.uniform(low, high, size)}. The
+ * two distributions share a signature shape &mdash; two distribution parameters, then {@code size}
+ * &mdash; so one generator serves both; only the parameters' names differ, and those name nothing
+ * this analysis reads.
+ *
+ * <p>The {@code size} argument is an ordinary shape argument (an integer or a tuple of them), so
+ * the inherited {@link TensorTypeAllocator} machinery resolves it. Omitting it, or passing {@code
+ * None}, is the scalar draw {@link NpRandomDraw} describes.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html">
+ *     numpy.random.normal()</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpRandomSizedDraw extends NpRandomDraw {
+
+  private static final Logger LOGGER = getLogger(NpRandomSizedDraw.class.getName());
+
+  protected enum Parameters {
+    LOC,
+    SCALE,
+    SIZE;
+
+    public String getName() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+
+    public int getIndex() {
+      return ordinal();
+    }
+  }
+
+  public NpRandomSizedDraw(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpRandomSizedDraw(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The draw is a scalar when the call omits {@code size} altogether or passes an explicit
+   * {@code None}, which NumPy treats identically. A {@code size} that is present but unresolvable
+   * is not evidence of either, so it reads as an array draw and floors to ⊤.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code true} iff the call requests no size.
+   */
+  @Override
+  protected boolean isScalarDraw(PropagationCallGraphBuilder builder) {
+    int sizeVn =
+        this.getArgumentValueNumber(
+            builder, this.getShapeParameterPosition(), this.getShapeParameterName(), true);
+    if (sizeVn <= 0) return true;
+
+    OrdinalSet<InstanceKey> sizePointsToSet =
+        this.getArgumentPointsToSet(
+            builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+
+    if (allNullConstants(sizePointsToSet)) {
+      LOGGER.fine(
+          () ->
+              "Explicit `None` size for source: "
+                  + describe(this.getSource())
+                  + "; the draw is a scalar.");
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return Parameters.SIZE.getIndex();
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return Parameters.SIZE.getName();
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomSizedDraw.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomSizedDraw.java
@@ -59,19 +59,33 @@ public class NpRandomSizedDraw extends NpRandomDraw {
    * {@code None}, which NumPy treats identically. A {@code size} that is present but unresolvable
    * is not evidence of either, so it reads as an array draw and floors to ⊤.
    *
+   * <p>Whether the argument was passed is read off the call sites rather than off the callee
+   * frame's parameter. A manual anchoring has the parameter regardless, since the summary declares
+   * it, so its value number is present even for a call that supplied nothing; the call sites are
+   * what distinguish the two, and they are visible under both anchorings.
+   *
    * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
    * @return {@code true} iff the call requests no size.
    */
   @Override
   protected boolean isScalarDraw(PropagationCallGraphBuilder builder) {
-    int sizeVn =
-        this.getArgumentValueNumber(
-            builder, this.getShapeParameterPosition(), this.getShapeParameterName(), true);
-    if (sizeVn <= 0) return true;
+    int sizePosition = this.getShapeParameterPosition();
+    boolean passed =
+        this.getNumberOfPossiblePositionalArguments(builder).stream()
+                .anyMatch(count -> count > sizePosition)
+            || this.isKeywordArgumentPresent(builder, this.getShapeParameterName());
+
+    if (!passed) {
+      LOGGER.fine(
+          () ->
+              "No size argument for source: "
+                  + describe(this.getSource())
+                  + "; the draw is a scalar.");
+      return true;
+    }
 
     OrdinalSet<InstanceKey> sizePointsToSet =
-        this.getArgumentPointsToSet(
-            builder, this.getShapeParameterPosition(), this.getShapeParameterName());
+        this.getArgumentPointsToSet(builder, sizePosition, this.getShapeParameterName());
 
     if (allNullConstants(sizePointsToSet)) {
       LOGGER.fine(

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomVariadicDraw.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpRandomVariadicDraw.java
@@ -1,0 +1,121 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.UnresolvedDim;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Generator for the {@code np.random} draws that spell their shape as variadic dimensions, {@code
+ * np.random.randn(d0, d1, ...)} and {@code np.random.rand(d0, d1, ...)}. The call's arity is the
+ * drawn array's rank, so a call with no arguments is the scalar draw {@link NpRandomDraw}
+ * describes.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/random/generated/numpy.random.randn.html">
+ *     numpy.random.randn()</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpRandomVariadicDraw extends NpRandomDraw {
+
+  private static final Logger LOGGER = getLogger(NpRandomVariadicDraw.class.getName());
+
+  public NpRandomVariadicDraw(PointsToSetVariable source) {
+    super(source);
+  }
+
+  public NpRandomVariadicDraw(CGNode node) {
+    super(node);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Every dimension is variadic, so the draw is a scalar exactly when the call passes nothing.
+   * An arity that does not resolve to a single count &mdash; no call site was recovered, or several
+   * disagree &mdash; is not evidence of an empty call, so it reads as an array draw and floors to ⊤
+   * downstream.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@code true} iff the call passes no arguments.
+   */
+  @Override
+  protected boolean isScalarDraw(PropagationCallGraphBuilder builder) {
+    Set<Integer> arities = this.getNumberOfPossiblePositionalArguments(builder);
+    return arities.size() == 1 && arities.contains(0);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>One axis per argument, each sized by that argument's integer value. A dimension the analysis
+   * cannot fold is {@link UnresolvedDim} rather than {@link
+   * com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim}: the argument is a Python scalar, so
+   * the runtime size is a fixed integer this analysis could not compute rather than one the runtime
+   * reports as {@code None} (wala/ML#721). The rank is therefore recovered even when no size is.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The singleton drawn shape, or {@code null} (⊤) when the arity does not resolve.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getArrayDrawShapes(PropagationCallGraphBuilder builder) {
+    Set<Integer> arities = this.getNumberOfPossiblePositionalArguments(builder);
+
+    if (arities.size() != 1) {
+      LOGGER.fine(
+          () ->
+              "Ambiguous arity "
+                  + arities
+                  + " for source: "
+                  + describe(this.getSource())
+                  + "; returning ⊤ (unknown shape).");
+      return null;
+    }
+
+    int rank = arities.iterator().next();
+    List<Dimension<?>> shape = new ArrayList<>(rank);
+
+    for (int axis = 0; axis < rank; axis++)
+      shape.add(axisDim(this.getPossibleArgumentValues(builder, axis, null)));
+
+    LOGGER.fine(
+        () -> "Recovered shape " + shape + " for source: " + describe(this.getSource()) + ".");
+    return Set.of(shape);
+  }
+
+  /**
+   * Maps an axis argument's possible values to a dimension.
+   *
+   * @param values The argument's possible integer values, as {@link
+   *     TensorTypeAllocator#getPossibleArgumentValues} reports them.
+   * @return A {@link NumericDim} when the argument folds to exactly one integer, else {@link
+   *     UnresolvedDim#INSTANCE}.
+   */
+  private static Dimension<?> axisDim(Set<Optional<Integer>> values) {
+    if (values.size() == 1) {
+      Optional<Integer> only = values.iterator().next();
+      if (only.isPresent()) return new NumericDim(only.get());
+    }
+
+    return UnresolvedDim.INSTANCE;
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpScalarType.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/NpScalarType.java
@@ -1,0 +1,143 @@
+package com.ibm.wala.cast.python.ml.client;
+
+import static com.ibm.wala.cast.python.ml.client.Loggables.describe;
+import static java.util.logging.Logger.getLogger;
+
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
+import com.ibm.wala.cast.python.ml.types.TensorOrigin;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
+import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Generator for a call to one of NumPy's scalar types, {@code np.float64(2.0)} and its siblings.
+ * The type coerces its argument to its own dtype while preserving the argument's shape, so a Python
+ * number in yields a rank-0 array out and a sequence in yields an array of that sequence's shape.
+ * The dtype is the type's own and is fixed at dispatch, which is the only way this generator
+ * differs from {@link AstypeOperation}'s shape-preserving, dtype-changing contract &mdash; there
+ * the target dtype is an argument.
+ *
+ * <p>The same allocation that this generator is dispatched for also serves as the {@code dtype=}
+ * token of the same name; see the module method in {@code numpy.xml} for how one object carries
+ * both roles. See <a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>.
+ *
+ * @see <a href="https://numpy.org/doc/stable/reference/arrays.scalars.html">NumPy scalars</a>.
+ * @author <a href="mailto:khatchad@hunter.cuny.edu">Raffi Khatchadourian</a>
+ */
+public class NpScalarType extends TensorGenerator {
+
+  private static final Logger LOGGER = getLogger(NpScalarType.class.getName());
+
+  /** The positional index of the value being coerced. */
+  private static final int VALUE_PARAMETER_POSITION = 0;
+
+  /** The dtype this scalar type names, i.e. the dtype of every value it constructs. */
+  private final DType dtype;
+
+  /**
+   * Constructs a generator anchored to the call's result.
+   *
+   * @param source The {@link PointsToSetVariable} the call defines.
+   * @param dtype The dtype the called scalar type names.
+   */
+  public NpScalarType(PointsToSetVariable source, DType dtype) {
+    super(source);
+    this.dtype = dtype;
+  }
+
+  /**
+   * Constructs a generator anchored to the allocating synthetic node, for producer delegation.
+   *
+   * @param node The {@link CGNode} for the scalar type's {@code do()} method.
+   * @param dtype The dtype the called scalar type names.
+   */
+  public NpScalarType(CGNode node, DType dtype) {
+    super(node);
+    this.dtype = dtype;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The shape is the coerced value's: rank 0 for a Python number (the corpus idiom), and the
+   * sequence's shape when a sequence is coerced. An argument whose own shape does not resolve
+   * leaves the result at ⊤ rather than assuming rank 0, since {@code np.float32([1, 2])} is an
+   * array of shape {@code (2,)}, not a scalar.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return The coerced value's shapes, or {@code null} (⊤) if they do not resolve.
+   */
+  @Override
+  protected Set<List<Dimension<?>>> getDefaultShapes(PropagationCallGraphBuilder builder) {
+    int valueVn = this.getArgumentValueNumber(VALUE_PARAMETER_POSITION);
+    if (valueVn > 0)
+      try {
+        Set<List<Dimension<?>>> shapes = this.getShapes(builder, this.getNode(), valueVn);
+        if (shapes != null && !shapes.isEmpty()) return shapes;
+      } catch (IllegalArgumentException e) {
+        LOGGER.log(
+            Level.FINE,
+            "Coerced value's shape lookup failed for source: " + describe(this.getSource()) + ".",
+            e);
+      }
+
+    LOGGER.fine(
+        () ->
+            "Unresolved coerced value for source: "
+                + describe(this.getSource())
+                + "; returning ⊤ (unknown shape).");
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The dtype is the scalar type's own, whatever the argument's was: that coercion is the whole
+   * point of the call.
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return A singleton set containing the dtype this scalar type names.
+   */
+  @Override
+  protected Set<DType> getDefaultDTypes(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(this.dtype);
+  }
+
+  /**
+   * Returns the producing library of the modeled value: a NumPy scalar type constructs an array
+   * (wala/ML#724).
+   *
+   * @param builder The {@link PropagationCallGraphBuilder} used to build the call graph.
+   * @return {@link TensorOrigin#NUMPY}, singleton.
+   */
+  @Override
+  protected Set<TensorOrigin> getOrigins(PropagationCallGraphBuilder builder) {
+    return EnumSet.of(TensorOrigin.NUMPY);
+  }
+
+  @Override
+  protected int getShapeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getShapeParameterName() {
+    return null;
+  }
+
+  @Override
+  protected int getDTypeParameterPosition() {
+    return UNDEFINED_PARAMETER_POSITION;
+  }
+
+  @Override
+  protected String getDTypeParameterName() {
+    return null;
+  }
+}

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGenerator.java
@@ -4272,7 +4272,11 @@ public abstract class TensorGenerator {
               ret.add(shape);
             }
           }
-        } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
+        } else if (reference.equals(TensorFlowTypes.D_TYPE)
+            || NumpyTypes.SCALAR_TYPE_TO_DTYPE.containsKey(reference)) {
+          // A dtype token names a dtype; it has no shape of its own. A NumPy scalar type is such a
+          // token as well as a constructor (wala/ML#827), so it is ignored here for the same
+          // reason: the shape belongs to what the constructor returns, not to the type object.
           LOGGER.fine("Ignoring DType: " + describe(asin));
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
           LOGGER.fine("Ignoring feature: " + describe(asin));
@@ -4731,7 +4735,24 @@ public abstract class TensorGenerator {
       IClass concreteType = instanceKey.concreteType();
       TypeReference typeReference = concreteType.getReference();
 
-      if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
+      DType scalarTypeDType = NumpyTypes.SCALAR_TYPE_TO_DTYPE.get(typeReference);
+      if (scalarTypeDType != null) {
+        // A NumPy scalar type passed as a dtype token, e.g. `np.zeros(n, dtype=np.float64)`. The
+        // identity-keyed match above normally resolves it, since the token is the very object the
+        // module's field of that name holds; this arm keys on the type object's own class instead,
+        // so a token that reaches here by a route the module-field walk does not cover still names
+        // its dtype rather than falling to the terminal throw below. wala/ML#827.
+        LOGGER.fine(
+            () ->
+                "Found dtype: "
+                    + scalarTypeDType
+                    + " for source: "
+                    + describe(this.getSource())
+                    + " from the NumPy scalar type: "
+                    + describe(instanceKey)
+                    + ".");
+        ret.add(scalarTypeDType);
+      } else if (typeReference.equals(TensorFlowTypes.D_TYPE)) {
         // An unmodeled dtype: a `tf.DType` instance with no entry in `FIELD_REFERENCE_TO_DTYPE`
         // (e.g. a half-precision or quantized dtype not yet enumerated). Degrade to UNKNOWN (the ⊤
         // dtype) rather than throwing. When this resolves a parameter dtype during entrypoint
@@ -5282,8 +5303,12 @@ public abstract class TensorGenerator {
         } else if (reference.equals(TensorFlowTypes.FEATURE)) {
           // Ignore features.
           LOGGER.fine("Ignoring feature: " + describe(asin));
-        } else if (reference.equals(TensorFlowTypes.D_TYPE)) {
-          // Ignore DTypes.
+        } else if (reference.equals(TensorFlowTypes.D_TYPE)
+            || NumpyTypes.SCALAR_TYPE_TO_DTYPE.containsKey(reference)) {
+          // Ignore DTypes. A NumPy scalar type is such a token as well as a constructor
+          // (wala/ML#827); this walk asks what dtype a *tensor* has, and a type object is not one,
+          // so it is ignored here exactly as a `tf.DType` is. Reading a token as a dtype is the
+          // dtype-argument resolver's job, not this walk's.
           LOGGER.fine("Ignoring DType: " + describe(asin));
         } else {
           // Assume the value is a tensor and attempt to find the generator that created it

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java
@@ -521,6 +521,25 @@ public class TensorGeneratorFactory {
     if (isType(type, FROM_ROW_LIMITS.getDeclaringClass()))
       return anchor.makeGenerator(RaggedFromRowLimits::new, RaggedFromRowLimits::new);
 
+    // The NumPy scalar types and the legacy `np.random` draws (wala/ML#827). Both families
+    // allocate a plain `Lnumpy/ndarray`, so producer delegation reaches them only through the
+    // manual form, and both are written at call sites, so seeding reaches them only through the
+    // source form; registering here supplies both at once.
+    for (Map.Entry<TypeReference, DType> scalarType : NumpyTypes.SCALAR_TYPE_TO_DTYPE.entrySet())
+      if (isType(type, scalarType.getKey())) {
+        DType dtype = scalarType.getValue();
+        return anchor.makeGenerator(
+            source -> new NpScalarType(source, dtype), node -> new NpScalarType(node, dtype));
+      }
+
+    if (isType(type, NumpyTypes.RANDOM_RANDN.getDeclaringClass())
+        || isType(type, NumpyTypes.RANDOM_RAND.getDeclaringClass()))
+      return anchor.makeGenerator(NpRandomVariadicDraw::new, NpRandomVariadicDraw::new);
+
+    if (isType(type, NumpyTypes.RANDOM_NORMAL.getDeclaringClass())
+        || isType(type, NumpyTypes.RANDOM_UNIFORM.getDeclaringClass()))
+      return anchor.makeGenerator(NpRandomSizedDraw::new, NpRandomSizedDraw::new);
+
     // `enumerate` carries index/tuple element semantics its generator models; the manual-side
     // DATA_PACKAGE_PREFIX catch-all would otherwise swallow it into a plain pass-through
     // DatasetGenerator (the wala/ML#759 mis-dispatch class).

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorTypeAllocator.java
@@ -11,12 +11,16 @@ import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointsToSetVariable;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.intset.OrdinalSet;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Base for generators of TensorFlow/NumPy APIs that allocate a tensor from an explicit {@code
@@ -154,6 +158,49 @@ public abstract class TensorTypeAllocator extends TensorGenerator {
   @Override
   protected String getDTypeParameterName() {
     return Parameters.DTYPE.getName();
+  }
+
+  /**
+   * Retrieves the possible integer values for a specific argument.
+   *
+   * <p>It first checks the symbol table for constant values associated with the argument's value
+   * number. If not found, it falls back to the points-to analysis results to find potential integer
+   * values.
+   *
+   * @param builder the propagation call graph builder
+   * @param paramPosition the positional index of the argument
+   * @param paramName the keyword name of the argument
+   * @return a set of optional integers representing the possible values. An empty optional
+   *     indicates a null or non-integer value.
+   */
+  protected Set<Optional<Integer>> getPossibleArgumentValues(
+      PropagationCallGraphBuilder builder, int paramPosition, String paramName) {
+    int valNum = this.getArgumentValueNumber(builder, paramPosition, paramName, true);
+    if (valNum <= 0) return HashSetFactory.make();
+
+    if (this.getNode().getIR() != null
+        && this.getNode().getIR().getSymbolTable().isConstant(valNum)) {
+      Object c = this.getNode().getIR().getSymbolTable().getConstantValue(valNum);
+      Set<Optional<Integer>> ret = HashSetFactory.make();
+      if (c instanceof Number) {
+        ret.add(Optional.of(((Number) c).intValue()));
+      } else if (c == null) {
+        ret.add(Optional.empty());
+      }
+      if (!ret.isEmpty()) {
+        return ret;
+      }
+    }
+
+    OrdinalSet<InstanceKey> pts = this.getArgumentPointsToSet(builder, paramPosition, paramName);
+
+    if (pts == null || pts.isEmpty())
+      // Fallback to default (empty).
+      return HashSetFactory.make();
+
+    return StreamSupport.stream(pts.spliterator(), false)
+        .map(TensorTypeAllocator::getIntValueFromInstanceKey)
+        .collect(Collectors.toSet());
   }
 
   protected static Optional<Integer> getIntValueFromInstanceKey(InstanceKey instanceKey) {

--- a/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
+++ b/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/types/NumpyTypes.java
@@ -180,9 +180,135 @@ public class NumpyTypes extends PythonTypes {
       TypeReference.findOrCreate(
           PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/ndarray/tolist_result"));
 
+  /**
+   * The {@code np.float32} scalar type. Calling it coerces its argument to a rank-0 array of that
+   * dtype; the same object doubles as the {@code dtype=} token of the same name. See <a
+   * href="https://github.com/wala/ML/issues/827">wala/ML#827</a>.
+   */
+  public static final MethodReference FLOAT32_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/float32")),
+          AstMethodReference.fnSelector);
+
+  private static final String FLOAT32_CONSTRUCTOR_SIGNATURE = "numpy.float32()";
+
+  /** The {@code np.float64} scalar type. See {@link #FLOAT32_CONSTRUCTOR}. */
+  public static final MethodReference FLOAT64_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/float64")),
+          AstMethodReference.fnSelector);
+
+  private static final String FLOAT64_CONSTRUCTOR_SIGNATURE = "numpy.float64()";
+
+  /** The {@code np.int32} scalar type. See {@link #FLOAT32_CONSTRUCTOR}. */
+  public static final MethodReference INT32_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/int32")),
+          AstMethodReference.fnSelector);
+
+  private static final String INT32_CONSTRUCTOR_SIGNATURE = "numpy.int32()";
+
+  /** The {@code np.int64} scalar type. See {@link #FLOAT32_CONSTRUCTOR}. */
+  public static final MethodReference INT64_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/int64")),
+          AstMethodReference.fnSelector);
+
+  private static final String INT64_CONSTRUCTOR_SIGNATURE = "numpy.int64()";
+
+  /** The {@code np.uint8} scalar type. See {@link #FLOAT32_CONSTRUCTOR}. */
+  public static final MethodReference UINT8_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/uint8")),
+          AstMethodReference.fnSelector);
+
+  private static final String UINT8_CONSTRUCTOR_SIGNATURE = "numpy.uint8()";
+
+  /**
+   * The {@code np.bool_} scalar type. Its {@code np.bool} sibling is not a scalar type &mdash; it
+   * was an alias of the Python builtin, removed in NumPy 1.24 &mdash; so only this name is
+   * callable. See {@link #FLOAT32_CONSTRUCTOR}.
+   */
+  public static final MethodReference BOOL_CONSTRUCTOR =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/bool_")),
+          AstMethodReference.fnSelector);
+
+  private static final String BOOL_CONSTRUCTOR_SIGNATURE = "numpy.bool_()";
+
+  /**
+   * A mapping from a scalar type's allocated class to the dtype that type names. Backs the
+   * class-keyed arms of dtype-token recognition, which the identity-keyed match in {@code
+   * TensorGenerator.getDTypesFromDTypeArgument} would otherwise leave to the unmodeled-dtype
+   * fallback. See <a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>.
+   */
+  public static final Map<TypeReference, TensorFlowTypes.DType> SCALAR_TYPE_TO_DTYPE =
+      Map.ofEntries(
+          Map.entry(FLOAT32_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.FLOAT32),
+          Map.entry(FLOAT64_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.FLOAT64),
+          Map.entry(INT32_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.INT32),
+          Map.entry(INT64_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.INT64),
+          Map.entry(UINT8_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.UINT8),
+          Map.entry(BOOL_CONSTRUCTOR.getDeclaringClass(), TensorFlowTypes.DType.BOOL));
+
+  /**
+   * {@code np.random.randn(d0, d1, ...)}: standard-normal draws whose shape is given variadically.
+   * See <a href="https://github.com/wala/ML/issues/827">wala/ML#827</a>.
+   */
+  public static final MethodReference RANDOM_RANDN =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/random/randn")),
+          AstMethodReference.fnSelector);
+
+  private static final String RANDOM_RANDN_SIGNATURE = "numpy.random.randn()";
+
+  /** {@code np.random.rand(d0, d1, ...)}: uniform draws over [0, 1). See {@link #RANDOM_RANDN}. */
+  public static final MethodReference RANDOM_RAND =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/random/rand")),
+          AstMethodReference.fnSelector);
+
+  private static final String RANDOM_RAND_SIGNATURE = "numpy.random.rand()";
+
+  /** {@code np.random.normal(loc, scale, size)}. See {@link #RANDOM_RANDN}. */
+  public static final MethodReference RANDOM_NORMAL =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/random/normal")),
+          AstMethodReference.fnSelector);
+
+  private static final String RANDOM_NORMAL_SIGNATURE = "numpy.random.normal()";
+
+  /** {@code np.random.uniform(low, high, size)}. See {@link #RANDOM_RANDN}. */
+  public static final MethodReference RANDOM_UNIFORM =
+      MethodReference.findOrCreate(
+          TypeReference.findOrCreate(
+              PythonTypes.pythonLoader, TypeName.string2TypeName("Lnumpy/random/uniform")),
+          AstMethodReference.fnSelector);
+
+  private static final String RANDOM_UNIFORM_SIGNATURE = "numpy.random.uniform()";
+
   /** A mapping from a {@link TypeReference} to its associated NumPy signature. */
   public static final Map<TypeReference, String> TYPE_REFERENCE_TO_SIGNATURE =
       Map.ofEntries(
+          Map.entry(FLOAT32_CONSTRUCTOR.getDeclaringClass(), FLOAT32_CONSTRUCTOR_SIGNATURE),
+          Map.entry(FLOAT64_CONSTRUCTOR.getDeclaringClass(), FLOAT64_CONSTRUCTOR_SIGNATURE),
+          Map.entry(INT32_CONSTRUCTOR.getDeclaringClass(), INT32_CONSTRUCTOR_SIGNATURE),
+          Map.entry(INT64_CONSTRUCTOR.getDeclaringClass(), INT64_CONSTRUCTOR_SIGNATURE),
+          Map.entry(UINT8_CONSTRUCTOR.getDeclaringClass(), UINT8_CONSTRUCTOR_SIGNATURE),
+          Map.entry(BOOL_CONSTRUCTOR.getDeclaringClass(), BOOL_CONSTRUCTOR_SIGNATURE),
+          Map.entry(RANDOM_RANDN.getDeclaringClass(), RANDOM_RANDN_SIGNATURE),
+          Map.entry(RANDOM_RAND.getDeclaringClass(), RANDOM_RAND_SIGNATURE),
+          Map.entry(RANDOM_NORMAL.getDeclaringClass(), RANDOM_NORMAL_SIGNATURE),
+          Map.entry(RANDOM_UNIFORM.getDeclaringClass(), RANDOM_UNIFORM_SIGNATURE),
           Map.entry(ARRAY.getDeclaringClass(), ARRAY_SIGNATURE),
           Map.entry(ZEROS.getDeclaringClass(), ZEROS_SIGNATURE),
           Map.entry(ONES.getDeclaringClass(), ONES_SIGNATURE),

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_random.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_random.py
@@ -25,6 +25,14 @@ def consume4(c):
     pass
 
 
+def consume5(d):
+    pass
+
+
+def consume6(e):
+    pass
+
+
 # A Python float initializer takes TensorFlow's weak default, `float32`, not NumPy's `float64`.
 w = tf.Variable(rng.randn(), name="weight")
 assert w.dtype == tf.float32 and w.shape.as_list() == []
@@ -41,3 +49,12 @@ consume3(b)
 c = np.random.normal(0.0, 1.0, (5, 2))
 assert c.dtype == np.float64 and c.shape == (5, 2)
 consume4(c)
+
+d = np.random.uniform(0.0, 1.0, (2, 2))
+assert d.dtype == np.float64 and d.shape == (2, 2)
+consume5(d)
+
+# The sized family's own shapeless draw: no `size`, so a Python float rather than an array.
+e = tf.Variable(np.random.normal())
+assert e.dtype == tf.float32 and e.shape.as_list() == []
+consume6(e)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_random.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_random.py
@@ -1,0 +1,43 @@
+# The `np.random` surface of wala/ML#827. The return type is argument-dependent: with no size
+# argument the draw is a Python scalar, and with one it is a `float64` array of that shape. The
+# module-alias form (`rng = np.random`) is the idiom the reported subject uses.
+import numpy as np
+import tensorflow as tf
+
+rng = np.random
+
+np.random.seed(0)
+
+
+def consume(w):
+    pass
+
+
+def consume2(a):
+    pass
+
+
+def consume3(b):
+    pass
+
+
+def consume4(c):
+    pass
+
+
+# A Python float initializer takes TensorFlow's weak default, `float32`, not NumPy's `float64`.
+w = tf.Variable(rng.randn(), name="weight")
+assert w.dtype == tf.float32 and w.shape.as_list() == []
+consume(w)
+
+a = np.random.randn(2, 3)
+assert a.dtype == np.float64 and a.shape == (2, 3)
+consume2(a)
+
+b = np.random.rand(4)
+assert b.dtype == np.float64 and b.shape == (4,)
+consume3(b)
+
+c = np.random.normal(0.0, 1.0, (5, 2))
+assert c.dtype == np.float64 and c.shape == (5, 2)
+consume4(c)

--- a/com.ibm.wala.cast.python.test/data/tf2_test_np_scalar_types.py
+++ b/com.ibm.wala.cast.python.test/data/tf2_test_np_scalar_types.py
@@ -1,0 +1,38 @@
+# The NumPy scalar type constructors of wala/ML#827. `np.float64` and its siblings are type
+# objects, so each name has two roles: called, it builds a rank-0 array of its own dtype, and
+# passed as `dtype=`, it names that dtype. Both roles are exercised here.
+import numpy as np
+import tensorflow as tf
+
+
+def consume(a):
+    pass
+
+
+def consume2(b):
+    pass
+
+
+def consume3(c):
+    pass
+
+
+def consume4(d):
+    pass
+
+
+a = np.float64(2.0)
+assert a.dtype == np.float64 and a.shape == ()
+consume(a)
+
+b = tf.Variable(np.float64(2.0))
+assert b.dtype == tf.float64 and b.shape.as_list() == []
+consume2(b)
+
+c = np.int32(3)
+assert c.dtype == np.int32 and c.shape == ()
+consume3(c)
+
+d = np.zeros((2, 3), dtype=np.float64)
+assert d.dtype == np.float64 and d.shape == (2, 3)
+consume4(d)


### PR DESCRIPTION
## Summary

The file `numpy.xml` modeled neither the NumPy scalar types nor `np.random`, so `np.float64(2.0)` and `rng.randn()` were opaque values and anything typed from them stayed at the top of the lattice. Initializer propagation through `tf.Variable` was never the gap: a discriminator on the three initializer kinds showed a Python number and a zero-dimensional array both already correct, so nothing in `Variable` changes here.

## Changes

The scalar types are type objects with two roles, and one allocation per name now serves both. Called, the name constructs an array of its own dtype and the argument's shape, computed by the new `NpScalarType`. Passed as `dtype=`, the name is a token, which the dtype-argument resolver was already matching by identity in the module's field of that name rather than by allocated class, so changing the class costs nothing there. Class-keyed arms back that up: a token that reaches the resolver by a route the module-field walk does not cover now names its dtype instead of falling to the terminal throw, and a token read as a value is ignored on the shape and dtype walks exactly as a `tf.DType` is.

For `np.random` the return type is argument-dependent. A draw with a shape request is a `float64` array of that shape; a draw without one is a single Python `float`. The two signature shapes recognize the absence differently, `NpRandomVariadicDraw` by the call's arity and `NpRandomSizedDraw` by an omitted or `None` `size`, over a shared `NpRandomDraw`. The dtype lattice has no element for a Python number, so the shapeless draw is modeled as a rank-0 `float32`: the encoding the analysis already gives a Python float literal, and the dtype every TensorFlow consumer computes for one. Where that diverges from NumPy's own promotion is recorded on `NpRandomDraw`.

Both families allocate a plain `Lnumpy/ndarray`, so both register in the shared dispatch chain, which supplies the call-site and producer-delegation forms together.

The helper `getPossibleArgumentValues` moves from `EyeBase` up to `TensorTypeAllocator` in its own commit: the variadic draw needs it, and nothing in it is specific to an identity matrix.

## Notes

The test `testScalarVariableBroadcast` flips to a positive guard. Its `W * x + b` chain is initialized from `rng.randn()`, so the operand is now a rank-0 tensor and the composition resolves to `float32 (3,)` without reaching the one-sided broadcast rule that wala/ML#804 reports on. That leaves #804 without a live witness; see the comment there.

The fixtures are `tf2_test_np_scalar_types.py` (a scalar type called, one feeding `tf.Variable`, and one used as a `dtype=` token) and `tf2_test_np_random.py` (the shapeless draw through the `rng = np.random` alias, plus the variadic and sized array draws).

Closes wala/ML#827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjBoWuZnNorDJTkNpWQHuY